### PR TITLE
Add unit tests for post, config, lamb, and theme helpers

### DIFF
--- a/tests/Unit/ConfigValidateTest.php
+++ b/tests/Unit/ConfigValidateTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Config\get_default_ini_text;
+use function Lamb\Config\is_menu_item;
+use function Lamb\Config\validate_ini;
+
+class ConfigValidateTest extends TestCase
+{
+    // validate_ini
+
+    public function testValidateIniReturnsTrueForValidIni()
+    {
+        $ini = "[section]\nkey=value\n";
+        $result = validate_ini($ini);
+        $this->assertTrue($result['valid']);
+        $this->assertNull($result['error']);
+    }
+
+    public function testValidateIniReturnsTrueForEmptyString()
+    {
+        $result = validate_ini('');
+        $this->assertTrue($result['valid']);
+        $this->assertNull($result['error']);
+    }
+
+    public function testValidateIniReturnsTrueForCommentOnlyIni()
+    {
+        $ini = "; This is a comment\n;; Another comment\n";
+        $result = validate_ini($ini);
+        $this->assertTrue($result['valid']);
+    }
+
+    public function testValidateIniReturnsTrueForDefaultConfig()
+    {
+        $ini = get_default_ini_text();
+        $result = validate_ini($ini);
+        $this->assertTrue($result['valid'], 'Default INI text should be valid');
+    }
+
+    public function testValidateIniReturnsFalseForInvalidIni()
+    {
+        // A value-less key (starts with =) is invalid INI syntax
+        $ini = "= orphan_value\n";
+        $result = validate_ini($ini);
+        $this->assertFalse($result['valid']);
+        $this->assertNotNull($result['error']);
+    }
+
+    // get_default_ini_text
+
+    public function testGetDefaultIniTextReturnsNonEmptyString()
+    {
+        $ini = get_default_ini_text();
+        $this->assertIsString($ini);
+        $this->assertNotEmpty($ini);
+    }
+
+    public function testGetDefaultIniTextContainsExpectedSections()
+    {
+        $ini = get_default_ini_text();
+        $this->assertStringContainsString('[menu_items]', $ini);
+        $this->assertStringContainsString('[feeds]', $ini);
+    }
+
+    // is_menu_item
+
+    public function testIsMenuItemReturnsTrueForKnownSlug()
+    {
+        global $config;
+        $original = $config;
+        $config['menu_items'] = ['About' => 'about'];
+
+        $this->assertTrue(is_menu_item('about'));
+
+        $config = $original;
+    }
+
+    public function testIsMenuItemReturnsFalseForUnknownSlug()
+    {
+        global $config;
+        $original = $config;
+        $config['menu_items'] = ['About' => 'about'];
+
+        $this->assertFalse(is_menu_item('contact'));
+
+        $config = $original;
+    }
+
+    public function testIsMenuItemReturnsFalseForExternalUrl()
+    {
+        global $config;
+        $original = $config;
+        $config['menu_items'] = ['External' => 'https://example.com'];
+
+        $this->assertFalse(is_menu_item('https://example.com'));
+
+        $config = $original;
+    }
+
+    public function testIsMenuItemReturnsFalseWhenNoMenuItems()
+    {
+        global $config;
+        $original = $config;
+        $config['menu_items'] = [];
+
+        $this->assertFalse(is_menu_item('about'));
+
+        $config = $original;
+    }
+}

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\get_tags;
+use function Lamb\parse_tags;
+
+class LambTest extends TestCase
+{
+    // get_tags
+
+    public function testGetTagsExtractsSingleTag()
+    {
+        $tags = get_tags('<p>Hello #world</p>');
+        $this->assertSame(['world'], $tags);
+    }
+
+    public function testGetTagsExtractsMultipleTags()
+    {
+        $tags = get_tags('<p>Hello #world and #php</p>');
+        $this->assertContains('world', $tags);
+        $this->assertContains('php', $tags);
+    }
+
+    public function testGetTagsIgnoresHashWithoutSpace()
+    {
+        // "#Hello" at start of word (no preceding space or >) should not match
+        $tags = get_tags('#Hello, World! #til');
+        $this->assertContains('til', $tags);
+        $this->assertNotContains('Hello,', $tags);
+    }
+
+    public function testGetTagsReturnsEmptyArrayWhenNoTags()
+    {
+        $tags = get_tags('<p>No tags here.</p>');
+        $this->assertSame([], $tags);
+    }
+
+    public function testGetTagsSupportsEmojiTags()
+    {
+        $tags = get_tags('<p>Hello #🐑</p>');
+        $this->assertContains('🐑', $tags);
+    }
+
+    public function testGetTagsExtractsTagAfterHtmlTag()
+    {
+        // Tag preceded by > (end of HTML tag)
+        $tags = get_tags('<p>#lamb</p>');
+        $this->assertContains('lamb', $tags);
+    }
+
+    public function testGetTagsDoesNotIncludePunctuation()
+    {
+        $tags = get_tags('<p>Hello #world.</p>');
+        $this->assertContains('world', $tags);
+        // The dot should not be included in the tag
+        $this->assertNotContains('world.', $tags);
+    }
+
+    // parse_tags
+
+    public function testParseTagsConvertsHashtagToLink()
+    {
+        $result = parse_tags('<p>Hello #world</p>');
+        $this->assertStringContainsString('<a href="/tag/world">#world</a>', $result);
+    }
+
+    public function testParseTagsLowercasesTagInHref()
+    {
+        $result = parse_tags('<p>Hello #World</p>');
+        $this->assertStringContainsString('href="/tag/world"', $result);
+    }
+
+    public function testParseTagsPreservesOriginalCaseInLinkText()
+    {
+        $result = parse_tags('<p>Hello #World</p>');
+        $this->assertStringContainsString('>#World</a>', $result);
+    }
+
+    public function testParseTagsConvertsMultipleTags()
+    {
+        $result = parse_tags('<p>Hello #foo and #bar</p>');
+        $this->assertStringContainsString('<a href="/tag/foo">#foo</a>', $result);
+        $this->assertStringContainsString('<a href="/tag/bar">#bar</a>', $result);
+    }
+
+    public function testParseTagsSupportsEmojiTags()
+    {
+        $result = parse_tags('<p>Hello #🐑</p>');
+        $this->assertStringContainsString('<a href="/tag/🐑">#🐑</a>', $result);
+    }
+
+    public function testParseTagsDoesNotAlterTextWithNoTags()
+    {
+        $input = '<p>No tags here.</p>';
+        $this->assertSame($input, parse_tags($input));
+    }
+
+    public function testParseTagsDoesNotConvertInlineHash()
+    {
+        // "#tag" embedded inside a word (no space/> before it) should not be converted
+        $result = parse_tags('word#tag end');
+        $this->assertStringNotContainsString('<a href', $result);
+    }
+}

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Post\parse_matter;
+use function Lamb\Post\slugify;
+
+class PostTest extends TestCase
+{
+    // slugify
+
+    public function testSlugifyLowercasesText()
+    {
+        $this->assertSame('hello-world', slugify('Hello World'));
+    }
+
+    public function testSlugifyReplacesSpacesWithHyphens()
+    {
+        $this->assertSame('foo-bar-baz', slugify('foo bar baz'));
+    }
+
+    public function testSlugifyReplacesSpecialCharacters()
+    {
+        $this->assertSame('hello-world-', slugify('Hello, World!'));
+    }
+
+    public function testSlugifyHandlesMultipleConsecutiveNonWordChars()
+    {
+        $this->assertSame('foo-bar', slugify('foo---bar'));
+    }
+
+    public function testSlugifyHandlesAlreadySluggedInput()
+    {
+        $this->assertSame('already-a-slug', slugify('already-a-slug'));
+    }
+
+    public function testSlugifyHandlesEmptyString()
+    {
+        $this->assertSame('', slugify(''));
+    }
+
+    // parse_matter
+
+    public function testParseMatterReturnsEmptyArrayWhenNoFrontMatter()
+    {
+        $result = parse_matter('Just plain text with no front matter.');
+        $this->assertSame([], $result);
+    }
+
+    public function testParseMatterExtractsTitleAndDerivesSlug()
+    {
+        $body = "---\ntitle: My Post Title\n---\n\nContent here.";
+        $result = parse_matter($body);
+        $this->assertSame('My Post Title', $result['title']);
+        $this->assertSame('my-post-title', $result['slug']);
+    }
+
+    public function testParseMatterExtractsArbitraryKeys()
+    {
+        $body = "---\ntitle: Hello\ndescription: A short summary\n---\nContent.";
+        $result = parse_matter($body);
+        $this->assertSame('A short summary', $result['description']);
+    }
+
+    public function testParseMatterReturnsEmptyArrayForInvalidYaml()
+    {
+        $body = "---\n: this is: invalid yaml\n---\nContent.";
+        $result = parse_matter($body);
+        $this->assertIsArray($result);
+    }
+
+    public function testParseMatterReturnsListWhenFrontMatterIsSequence()
+    {
+        // YAML sequences (lists) are returned as-is since they are arrays
+        $body = "---\n- item1\n- item2\n---\nContent.";
+        $result = parse_matter($body);
+        $this->assertIsArray($result);
+        $this->assertContains('item1', $result);
+    }
+
+    public function testParseMatterSlugifiesTitle()
+    {
+        $body = "---\ntitle: Hello World!\n---\n";
+        $result = parse_matter($body);
+        $this->assertSame('hello-world-', $result['slug']);
+    }
+
+    public function testParseMatterWithNoTitleHasNoSlug()
+    {
+        $body = "---\nauthor: Someone\n---\nContent.";
+        $result = parse_matter($body);
+        $this->assertArrayNotHasKey('slug', $result);
+        $this->assertSame('Someone', $result['author']);
+    }
+}

--- a/tests/Unit/ThemeTest.php
+++ b/tests/Unit/ThemeTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Theme\escape;
+use function Lamb\Theme\human_time;
+use function Lamb\Theme\og_escape;
+use function Lamb\Theme\sanitize_filename;
+
+class ThemeTest extends TestCase
+{
+    // escape
+
+    public function testEscapeConvertsAngleBrackets()
+    {
+        $this->assertSame('&lt;b&gt;bold&lt;/b&gt;', escape('<b>bold</b>'));
+    }
+
+    public function testEscapeConvertsDoubleQuotes()
+    {
+        $this->assertSame('say &quot;hello&quot;', escape('say "hello"'));
+    }
+
+    public function testEscapeConvertsSingleQuotes()
+    {
+        // ENT_HTML5 encodes single quotes as &apos;
+        $this->assertSame('it&apos;s', escape("it's"));
+    }
+
+    public function testEscapePassesThroughSafeText()
+    {
+        $this->assertSame('Hello, world!', escape('Hello, world!'));
+    }
+
+    public function testEscapeHandlesEmptyString()
+    {
+        $this->assertSame('', escape(''));
+    }
+
+    public function testEscapeConvertsAmpersand()
+    {
+        $this->assertSame('foo &amp; bar', escape('foo & bar'));
+    }
+
+    // og_escape
+
+    public function testOgEscapeConvertsAngleBrackets()
+    {
+        $result = og_escape('<b>bold</b>');
+        $this->assertStringNotContainsString('<b>', $result);
+    }
+
+    public function testOgEscapeDoesNotDoubleEncodeEntities()
+    {
+        // og_escape decodes then re-encodes, so &amp; should stay as &amp;
+        $result = og_escape('foo &amp; bar');
+        $this->assertSame('foo &amp; bar', $result);
+    }
+
+    public function testOgEscapeHandlesPlainText()
+    {
+        $this->assertSame('Hello world', og_escape('Hello world'));
+    }
+
+    // sanitize_filename
+
+    public function testSanitizeFilenameAllowsAlphanumeric()
+    {
+        $this->assertSame('hello123', sanitize_filename('hello123'));
+    }
+
+    public function testSanitizeFilenameAllowsHyphensAndUnderscores()
+    {
+        $this->assertSame('hello-world_test', sanitize_filename('hello-world_test'));
+    }
+
+    public function testSanitizeFilenameReplacesSpacesWithUnderscores()
+    {
+        $this->assertSame('hello_world', sanitize_filename('hello world'));
+    }
+
+    public function testSanitizeFilenameReplacesSlashesWithUnderscores()
+    {
+        $this->assertSame('path_to_file', sanitize_filename('path/to/file'));
+    }
+
+    public function testSanitizeFilenameReplacesDotsWithUnderscores()
+    {
+        $this->assertSame('file_php', sanitize_filename('file.php'));
+    }
+
+    public function testSanitizeFilenameHandlesEmptyString()
+    {
+        $this->assertSame('', sanitize_filename(''));
+    }
+
+    // human_time
+
+    public function testHumanTimeReturnsSecondsAgo()
+    {
+        $timestamp = time() - 30;
+        $result = human_time($timestamp);
+        $this->assertStringContainsString('ago', $result);
+        $this->assertStringContainsString('second', $result);
+    }
+
+    public function testHumanTimeReturnsMinutesAgo()
+    {
+        $timestamp = time() - 120;
+        $result = human_time($timestamp);
+        $this->assertStringContainsString('ago', $result);
+        $this->assertStringContainsString('minute', $result);
+    }
+
+    public function testHumanTimeReturnsHoursAgo()
+    {
+        $timestamp = time() - 7200;
+        $result = human_time($timestamp);
+        $this->assertStringContainsString('ago', $result);
+        $this->assertStringContainsString('hour', $result);
+    }
+
+    public function testHumanTimeReturnsYesterdayForOneDayAgo()
+    {
+        $timestamp = time() - 86400;
+        $result = human_time($timestamp);
+        $this->assertStringContainsString('Yesterday', $result);
+    }
+
+    public function testHumanTimeReturnsToGoForFutureTimestamp()
+    {
+        $timestamp = time() + 30;
+        $result = human_time($timestamp);
+        $this->assertStringContainsString('to go', $result);
+    }
+
+    public function testHumanTimeReturnsTomorrowForOneDayAhead()
+    {
+        $timestamp = time() + 86400;
+        $result = human_time($timestamp);
+        $this->assertStringContainsString('Tomorrow', $result);
+    }
+}


### PR DESCRIPTION
Covers slugify, parse_matter, validate_ini, is_menu_item,
get_default_ini_text, get_tags, parse_tags, escape, og_escape,
human_time, and sanitize_filename. Brings unit test count from
1 to 60.

https://claude.ai/code/session_01J9pxuH9b8fCm7Um8kapBxw