### PR TITLE
Apply best practices from Simon Willison's agentic engineering talk

### DIFF
--- a/src/security.php
+++ b/src/security.php
@@ -41,9 +41,9 @@ function require_login(): void
  */
 function require_csrf(): void
 {
-    $token = htmlspecialchars($_POST[HIDDEN_CSRF_NAME]);
-    $csrf = $_SESSION[HIDDEN_CSRF_NAME] ?? null;
-    if (! $token || $token !== $csrf) {
+    $token = $_POST[HIDDEN_CSRF_NAME] ?? '';
+    $csrf = $_SESSION[HIDDEN_CSRF_NAME] ?? '';
+    if (! $token || ! hash_equals($csrf, $token)) {
         $txt = $_SERVER['SERVER_PROTOCOL'] . ' 405 Method Not Allowed';
         header($txt);
         die($txt);

--- a/tests/Unit/LambDownTest.php
+++ b/tests/Unit/LambDownTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit;
+
+use Lamb\LambDown;
+use PHPUnit\Framework\TestCase;
+
+class LambDownTest extends TestCase
+{
+    private LambDown $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new LambDown();
+        $this->parser->setSafeMode(true);
+    }
+
+    public function testH1WithSpaceRendersAsHeading(): void
+    {
+        $html = $this->parser->text('# Hello');
+        $this->assertStringContainsString('<h1>', $html);
+        $this->assertStringContainsString('Hello', $html);
+    }
+
+    public function testH2WithSpaceRendersAsHeading(): void
+    {
+        $html = $this->parser->text('## Hello');
+        $this->assertStringContainsString('<h2>', $html);
+    }
+
+    public function testHashWithoutSpaceDoesNotRenderAsHeading(): void
+    {
+        $html = $this->parser->text('#nospace');
+        $this->assertStringNotContainsString('<h1>', $html);
+    }
+
+    public function testDoubleHashWithoutSpaceDoesNotRenderAsHeading(): void
+    {
+        $html = $this->parser->text('##nospace');
+        $this->assertStringNotContainsString('<h2>', $html);
+    }
+
+    public function testHashtagInTextDoesNotRenderAsHeading(): void
+    {
+        $html = $this->parser->text('#lamb microblog software');
+        $this->assertStringNotContainsString('<h1>', $html);
+    }
+
+    public function testSafeModeEscapesScriptTags(): void
+    {
+        $html = $this->parser->text('<script>alert("xss")</script>');
+        $this->assertStringNotContainsString('<script>', $html);
+    }
+
+    public function testSafeModeEscapesInlineHtml(): void
+    {
+        $html = $this->parser->text('Hello <b>world</b>');
+        $this->assertStringNotContainsString('<b>', $html);
+    }
+}


### PR DESCRIPTION
- Fix require_csrf() to use hash_equals() for timing-attack-safe token
  comparison and null-coalesce the POST lookup to avoid undefined key
  deprecation warnings

- Add LambDownTest.php with 7 unit tests covering the custom heading
  restriction logic (requires space after #) and safe mode XSS escaping;
  LambDown was previously untested despite being the core content parser

https://claude.ai/code/session_01KQg9VUSd5yxXzNLWMZ4qNa