### PR TITLE
Preload entry form textarea from ?text= query string parameter

### DIFF
--- a/src/theme.php
+++ b/src/theme.php
@@ -359,15 +359,18 @@ function sanitize_filename($filename): string
     return (string)$filename;
 }
 
+function preload_text(): string
+{
+    return htmlspecialchars($_GET['text'] ?? '', ENT_QUOTES, 'UTF-8');
+}
+
 function the_entry_form(): void
 {
-    if (isset($_SESSION[SESSION_LOGIN])) :
-        $preload = htmlspecialchars($_GET['text'] ?? '', ENT_QUOTES, 'UTF-8');
-        ?>
+    if (isset($_SESSION[SESSION_LOGIN])) : ?>
         <section class="entry-form">
             <form id="entry" method="post" action="/" enctype="multipart/form-data">
                 <label>
-                    <textarea placeholder="What's happening?" name="contents" required><?= $preload ?></textarea>
+                    <textarea placeholder="What's happening?" name="contents" required><?= preload_text() ?></textarea>
                 </label>
                 <input type="submit" name="submit" value="<?= SUBMIT_CREATE ?>">
                 <input type="hidden" name="<?= HIDDEN_CSRF_NAME ?>" value="<?= csrf_token() ?>"/>

--- a/tests/Unit/ThemePreloadTest.php
+++ b/tests/Unit/ThemePreloadTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Theme\preload_text;
+
+class ThemePreloadTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($_GET['text']);
+    }
+
+    public function testPreloadTextReturnsEmptyStringWhenNotSet()
+    {
+        unset($_GET['text']);
+        $this->assertSame('', preload_text());
+    }
+
+    public function testPreloadTextReturnsValueFromQueryString()
+    {
+        $_GET['text'] = 'Hello world';
+        $this->assertSame('Hello world', preload_text());
+    }
+
+    public function testPreloadTextEscapesHtml()
+    {
+        $_GET['text'] = '<script>alert("xss")</script>';
+        $this->assertSame('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;', preload_text());
+    }
+
+    public function testPreloadTextEscapesSingleQuotes()
+    {
+        $_GET['text'] = "it's a test";
+        $this->assertSame('it&#039;s a test', preload_text());
+    }
+}


### PR DESCRIPTION
Allows tools like the "Capture This" Firefox extension to prepopulate
the new post form by crafting a URL such as /?text=content.

Closes #65