### PR TITLE
Fix status posts hidden by NULL draft column

### DIFF
--- a/src/post.php
+++ b/src/post.php
@@ -118,7 +118,7 @@ function posts_by_tag(string $tag): array
     $conditions = get_tag_search_conditions($tag);
     return R::find(
         'post',
-        '(' . $conditions['sql'] . ') AND draft != 1 ORDER BY created DESC',
+        '(' . $conditions['sql'] . ') AND (draft IS NULL OR draft != 1) ORDER BY created DESC',
         $conditions['params']
     );
 }

--- a/src/response.php
+++ b/src/response.php
@@ -267,7 +267,7 @@ function respond_home(): array
     $data['title'] = $config['site_title'];
 
     // Use the shared paginator for posts; paginate_posts will read config and $_GET when needed
-    $where_parts = [' draft != 1 '];
+    $where_parts = [' (draft IS NULL OR draft != 1) '];
     $where_params = [];
     $clause = build_exclude_slugs_clause(Config\get_menu_slugs());
     if ($clause !== null) {
@@ -494,11 +494,11 @@ function respond_feed(): void
     if ($clause !== null) {
         $posts = R::find(
             'post',
-            $clause['sql'] . ' AND draft != 1 ORDER BY updated DESC LIMIT 20',
+            $clause['sql'] . ' AND (draft IS NULL OR draft != 1) ORDER BY updated DESC LIMIT 20',
             $clause['params']
         );
     } else {
-        $posts = R::findAll('post', ' draft != 1 ORDER BY updated DESC LIMIT 20 ');
+        $posts = R::findAll('post', ' (draft IS NULL OR draft != 1) ORDER BY updated DESC LIMIT 20 ');
     }
 
     $first_post = reset($posts);
@@ -561,7 +561,7 @@ function respond_tag_feed(array $args): void
 function respond_post(array $args): array
 {
     [$slug] = $args;
-    $data['posts'] = [R::findOne('post', ' slug = ? AND draft != 1 ', [$slug])];
+    $data['posts'] = [R::findOne('post', ' slug = ? AND (draft IS NULL OR draft != 1) ', [$slug])];
 
     upgrade_posts($data['posts']);
 
@@ -632,7 +632,7 @@ function respond_search(array $args): array
         $where_clauses[] = 'body LIKE ?';
         $params[] = "%$word%";
     }
-    $where_sql = '(' . implode(' AND ', $where_clauses) . ') AND draft != 1';
+    $where_sql = '(' . implode(' AND ', $where_clauses) . ') AND (draft IS NULL OR draft != 1)';
 
     // Use the shared paginator which supports WHERE + params; omit per_page/page so helper reads config/$_GET
     $paginated = paginate_posts('post', 'created DESC', $where_sql, $params);

--- a/tests/Unit/PostDraftVisibilityTest.php
+++ b/tests/Unit/PostDraftVisibilityTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Post\posts_by_tag;
+
+class PostDraftVisibilityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::exec('DELETE FROM post');
+    }
+
+    protected function tearDown(): void
+    {
+        R::exec('DELETE FROM post');
+    }
+
+    public function testPostsWithNullDraftAreReturnedByPostsByTag(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Hello world #php';
+        $bean->draft = null;
+        $bean->created = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $results = posts_by_tag('php');
+
+        $this->assertNotEmpty($results, 'Posts with NULL draft should be visible in tag pages');
+    }
+
+    public function testPostsWithDraftZeroAreReturnedByPostsByTag(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Hello world #php';
+        $bean->draft = 0;
+        $bean->created = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $results = posts_by_tag('php');
+
+        $this->assertNotEmpty($results, 'Posts with draft=0 should be visible in tag pages');
+    }
+
+    public function testDraftPostsAreNotReturnedByPostsByTag(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Draft post #php';
+        $bean->draft = 1;
+        $bean->created = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $results = posts_by_tag('php');
+
+        $this->assertEmpty($results, 'Posts with draft=1 should NOT be visible in tag pages');
+    }
+}


### PR DESCRIPTION
Posts created before draft support was added have draft=NULL in SQLite.
The WHERE clause `draft != 1` evaluates NULL comparisons as NULL (not TRUE),
making these posts invisible on home, tag, search, and feed pages.

Replace all `draft != 1` conditions with `(draft IS NULL OR draft != 1)`
across response.php and post.php so legacy posts remain visible until
upgrade_posts() normalises their draft column to 0 on next view.

https://claude.ai/code/session_012nHytcXZLrcrcMarzvTY24