### PR TITLE
Make network and feed response logic unit-testable

### DIFF
--- a/src/response.php
+++ b/src/response.php
@@ -475,21 +475,14 @@ function respond_edit(array $args): array
 
 # Atom feed
 /**
- * Responds to a feed request by fetching and rendering the necessary data.
+ * Returns the data needed to render the main Atom feed.
  *
- * This method fetches the feed data by excluding pages with slugs and ordering the posts by the most recent updates.
- * It limits the number of posts returned to 20.
- * After fetching the data, it merges it with the existing data array and renders the feed view.
- *
- * @return void
+ * @return array{posts: array, title: string, feed_url: string, updated: string}
  */
-#[NoReturn]
-function respond_feed(): void
+function get_feed_data(): array
 {
     global $config;
-    global $data;
 
-    // Exclude pages with slugs and drafts
     $clause = build_exclude_slugs_clause(Config\get_menu_slugs());
     if ($clause !== null) {
         $posts = R::find(
@@ -502,15 +495,62 @@ function respond_feed(): void
     }
 
     $first_post = reset($posts);
-    $data['updated'] = $first_post['updated'] ?? date('Y-m-d H:i:s');
-    $data['title'] = $config['site_title'];
-    $data['feed_url'] = ROOT_URL . '/feed';
+    return [
+        'updated'  => $first_post['updated'] ?? date('Y-m-d H:i:s'),
+        'title'    => $config['site_title'],
+        'feed_url' => ROOT_URL . '/feed',
+        'posts'    => $posts,
+    ];
+}
 
-    $data['posts'] = $posts;
-    upgrade_posts($posts);
+/**
+ * Responds to a feed request by fetching and rendering the necessary data.
+ *
+ * This method fetches the feed data by excluding pages with slugs and ordering the posts by the most recent updates.
+ * It limits the number of posts returned to 20.
+ * After fetching the data, it merges it with the existing data array and renders the feed view.
+ *
+ * @return void
+ */
+#[NoReturn]
+function respond_feed(): void
+{
+    global $data;
+
+    $feed_data = get_feed_data();
+    foreach ($feed_data as $key => $value) {
+        $data[$key] = $value;
+    }
+    upgrade_posts($data['posts']);
 
     part("feed", '');
     die();
+}
+
+/**
+ * Returns the data needed to render a tag Atom feed.
+ *
+ * @param string $tag The already-sanitised tag name.
+ * @return array{posts: array, title: string, feed_url: string, updated: string}
+ */
+function get_tag_feed_data(string $tag): array
+{
+    global $config;
+
+    $all_posts = posts_by_tag($tag);
+
+    // Sort by updated DESC and limit to 20
+    $posts = array_values($all_posts);
+    usort($posts, fn($a, $b) => strtotime($b->updated) - strtotime($a->updated));
+    $posts = array_slice($posts, 0, 20);
+
+    $first_post = reset($posts);
+    return [
+        'updated'  => $first_post ? $first_post->updated : date('Y-m-d H:i:s'),
+        'title'    => $config['site_title'] . ' — #' . $tag,
+        'feed_url' => ROOT_URL . '/tag/' . rawurlencode($tag) . '/feed',
+        'posts'    => $posts,
+    ];
 }
 
 /**
@@ -523,27 +563,17 @@ function respond_feed(): void
 #[NoReturn]
 function respond_tag_feed(array $args): void
 {
-    global $config;
     global $data;
 
     [$tag] = $args;
     $tag = urldecode($tag);
     $tag = htmlspecialchars($tag);
 
-    $all_posts = posts_by_tag($tag);
-
-    // Sort by updated DESC and limit to 20
-    $posts = array_values($all_posts);
-    usort($posts, fn($a, $b) => strtotime($b->updated) - strtotime($a->updated));
-    $posts = array_slice($posts, 0, 20);
-
-    $first_post = reset($posts);
-    $data['updated'] = $first_post ? $first_post->updated : date('Y-m-d H:i:s');
-    $data['title'] = $config['site_title'] . ' — #' . $tag;
-    $data['feed_url'] = ROOT_URL . '/tag/' . rawurlencode($tag) . '/feed';
-
-    $data['posts'] = $posts;
-    upgrade_posts($posts);
+    $feed_data = get_tag_feed_data($tag);
+    foreach ($feed_data as $key => $value) {
+        $data[$key] = $value;
+    }
+    upgrade_posts($data['posts']);
 
     part("feed", '');
     die();
@@ -807,7 +837,7 @@ function get_upload_dir(): string
  *
  * @return array An array containing paginated items and pagination details such as current page, total posts, total pages, and offsets.
  */
-function paginate_posts(mixed $source, string $order_by_clause = 'created DESC', ?string $where_sql = null, array $params = [], ?int $per_page = null): array
+function paginate_posts(mixed $source, string $order_by_clause = 'created DESC', ?string $where_sql = null, array $params = [], ?int $per_page = null, ?int $page = null): array
 {
     // Explicit $per_page avoids the global; fall back to config only when not provided.
     if ($per_page === null) {
@@ -815,8 +845,8 @@ function paginate_posts(mixed $source, string $order_by_clause = 'created DESC',
         $per_page = (int)($config['posts_per_page'] ?? 10);
     }
 
-    // determine page now (same behavior for all cases)
-    $page = max(1, (int)($_GET['page'] ?? 1));
+    // Explicit $page avoids the superglobal; fall back to $_GET only when not provided.
+    $page = $page ?? max(1, (int)($_GET['page'] ?? 1));
 
     // If source is an array, do array pagination
     if (is_array($source)) {

--- a/tests/Unit/NetworkTest.php
+++ b/tests/Unit/NetworkTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SimplePie\Item as SimplePieItem;
+
+use function Lamb\Network\attributed_content;
+use function Lamb\Network\get_structured_content;
+
+class NetworkTest extends TestCase
+{
+    private function makeItem(string $title = '', string $description = '', string $permalink = ''): SimplePieItem
+    {
+        $item = $this->createMock(SimplePieItem::class);
+        $item->method('get_title')->willReturn($title);
+        $item->method('get_description')->willReturn($description);
+        $item->method('get_permalink')->willReturn($permalink);
+        return $item;
+    }
+
+    // attributed_content
+
+    public function testAttributedContentIncludesFeedName(): void
+    {
+        $item = $this->makeItem('', 'Hello world', 'https://example.com/post');
+        $result = attributed_content($item, 'ExampleBlog');
+        $this->assertStringContainsString('ExampleBlog', $result);
+    }
+
+    public function testAttributedContentIncludesPermalink(): void
+    {
+        $item = $this->makeItem('', 'Content', 'https://example.com/post');
+        $result = attributed_content($item, 'Blog');
+        $this->assertStringContainsString('https://example.com/post', $result);
+    }
+
+    public function testAttributedContentStripsHtmlTags(): void
+    {
+        $item = $this->makeItem('', '<p>Hello <b>world</b></p>', 'https://example.com');
+        $result = attributed_content($item, 'Blog');
+        $this->assertStringNotContainsString('<p>', $result);
+        $this->assertStringNotContainsString('<b>', $result);
+    }
+
+    public function testAttributedContentQuotesEachLine(): void
+    {
+        $item = $this->makeItem('', "Line one\nLine two", 'https://example.com');
+        $result = attributed_content($item, 'Blog');
+        $this->assertStringContainsString('> Line one', $result);
+        $this->assertStringContainsString('> Line two', $result);
+    }
+
+    public function testAttributedContentLimitsToFiveLines(): void
+    {
+        $description = implode("\n", range(1, 10));
+        $item = $this->makeItem('', $description, 'https://example.com');
+        $result = attributed_content($item, 'Blog');
+        // Lines 6-10 should not appear as quoted lines
+        $this->assertStringNotContainsString('> 6', $result);
+        $this->assertStringNotContainsString('> 10', $result);
+    }
+
+    public function testAttributedContentEmptyDescriptionReturnsAttribution(): void
+    {
+        $item = $this->makeItem('', '', 'https://example.com');
+        $result = attributed_content($item, 'Blog');
+        $this->assertStringContainsString('Originally written on', $result);
+    }
+
+    // get_structured_content
+
+    public function testGetStructuredContentWithTitleAddsFrontMatter(): void
+    {
+        $item = $this->makeItem('My Post Title', 'Some content', 'https://example.com');
+        $result = get_structured_content($item, 'Blog');
+        $this->assertStringContainsString('---', $result);
+        $this->assertStringContainsString('title: My Post Title', $result);
+    }
+
+    public function testGetStructuredContentWithoutTitleHasNoFrontMatter(): void
+    {
+        $item = $this->makeItem('', 'Some content', 'https://example.com');
+        $result = get_structured_content($item, 'Blog');
+        $this->assertStringNotContainsString('---', $result);
+        $this->assertStringNotContainsString('title:', $result);
+    }
+
+    public function testGetStructuredContentIncludesAttributedBody(): void
+    {
+        $item = $this->makeItem('', 'Hello world', 'https://example.com');
+        $result = get_structured_content($item, 'Blog');
+        $this->assertStringContainsString('Originally written on', $result);
+    }
+
+    public function testGetStructuredContentEscapesTitleSlashes(): void
+    {
+        $item = $this->makeItem("It's a test", 'Content', 'https://example.com');
+        $result = get_structured_content($item, 'Blog');
+        $this->assertStringContainsString("title: It\\'s a test", $result);
+    }
+
+    public function testGetStructuredContentReturnsString(): void
+    {
+        $item = $this->makeItem('Title', 'Body', 'https://example.com');
+        $this->assertIsString(get_structured_content($item, 'Blog'));
+    }
+}

--- a/tests/Unit/ResponseFeedTest.php
+++ b/tests/Unit/ResponseFeedTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Response\get_feed_data;
+use function Lamb\Response\get_tag_feed_data;
+
+class ResponseFeedTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::exec("DELETE FROM post");
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        global $config;
+        $config = ['site_title' => 'Test Blog'];
+    }
+
+    // get_feed_data
+
+    public function testGetFeedDataReturnsArray(): void
+    {
+        $result = get_feed_data();
+        $this->assertIsArray($result);
+    }
+
+    public function testGetFeedDataHasRequiredKeys(): void
+    {
+        $result = get_feed_data();
+        foreach (['posts', 'title', 'feed_url', 'updated'] as $key) {
+            $this->assertArrayHasKey($key, $result);
+        }
+    }
+
+    public function testGetFeedDataTitleMatchesConfig(): void
+    {
+        $result = get_feed_data();
+        $this->assertSame('Test Blog', $result['title']);
+    }
+
+    public function testGetFeedDataFeedUrlEndsWithFeed(): void
+    {
+        $result = get_feed_data();
+        $this->assertStringEndsWith('/feed', $result['feed_url']);
+    }
+
+    public function testGetFeedDataPostsIsArray(): void
+    {
+        $result = get_feed_data();
+        $this->assertIsArray($result['posts']);
+    }
+
+    public function testGetFeedDataUpdatedIsStringWhenNoPosts(): void
+    {
+        $result = get_feed_data();
+        $this->assertIsString($result['updated']);
+    }
+
+    // get_tag_feed_data
+
+    public function testGetTagFeedDataReturnsArray(): void
+    {
+        $result = get_tag_feed_data('lamb');
+        $this->assertIsArray($result);
+    }
+
+    public function testGetTagFeedDataHasRequiredKeys(): void
+    {
+        $result = get_tag_feed_data('lamb');
+        foreach (['posts', 'title', 'feed_url', 'updated'] as $key) {
+            $this->assertArrayHasKey($key, $result);
+        }
+    }
+
+    public function testGetTagFeedDataTitleIncludesTag(): void
+    {
+        $result = get_tag_feed_data('lamb');
+        $this->assertStringContainsString('lamb', $result['title']);
+    }
+
+    public function testGetTagFeedDataFeedUrlIncludesTag(): void
+    {
+        $result = get_tag_feed_data('lamb');
+        $this->assertStringContainsString('lamb', $result['feed_url']);
+    }
+
+    public function testGetTagFeedDataPostsIsArray(): void
+    {
+        $result = get_tag_feed_data('lamb');
+        $this->assertIsArray($result['posts']);
+    }
+
+    public function testGetTagFeedDataUpdatedIsStringWhenNoPosts(): void
+    {
+        $result = get_tag_feed_data('lamb');
+        $this->assertIsString($result['updated']);
+    }
+}

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -167,4 +167,19 @@ class ResponseTest extends TestCase
         $this->assertSame(1, $result['pagination']['total_pages']);
         $this->assertSame(0, $result['pagination']['total_posts']);
     }
+
+    public function testPaginatePostsExplicitPageSelectsCorrectSlice()
+    {
+        $items = array_map(fn($i) => "post$i", range(1, 15));
+        $result = paginate_posts($items, 'created DESC', null, [], 5, 2);
+        $this->assertSame(['post6', 'post7', 'post8', 'post9', 'post10'], $result['items']);
+    }
+
+    public function testPaginatePostsExplicitPageReflectedInPaginationMeta()
+    {
+        $items = range(1, 15);
+        $result = paginate_posts($items, 'created DESC', null, [], 5, 3);
+        $this->assertSame(3, $result['pagination']['current']);
+        $this->assertNull($result['pagination']['next_page']);
+    }
 }


### PR DESCRIPTION
- Add unit tests for attributed_content() and get_structured_content()
  in network.php using mocked SimplePieItem; both were pure functions
  with zero test coverage
- Extract get_feed_data() from respond_feed() and get_tag_feed_data()
  from respond_tag_feed() so the data-preparation logic is testable
  independently of the NoReturn HTTP response wrapper
- Add $page parameter to paginate_posts() so callers can supply the
  page number directly instead of relying on $_GET['page'], eliminating
  the superglobal dependency in unit tests
- Add unit tests (red-green) for all three changes (237 tests total, all green)

https://claude.ai/code/session_01XHRSb89ySNqi6kP1vW3sqt