### PR TITLE
Refactor feed updated time

### DIFF
--- a/src/response.php
+++ b/src/response.php
@@ -473,6 +473,18 @@ function respond_edit(array $args): array
     return ['post' => R::load('post', (int)$id)];
 }
 
+/**
+ * Returns the updated timestamp for the feed.
+ *
+ * @param array $posts List of post beans.
+ * @return string Date string suitable for strtotime(), falls back to current time when empty.
+ */
+function get_feed_updated_date(array $posts): string
+{
+    $first = reset($posts);
+    return $first !== false ? $first->updated : date('Y-m-d H:i:s');
+}
+
 # Atom feed
 /**
  * Returns the data needed to render the main Atom feed.
@@ -544,9 +556,8 @@ function get_tag_feed_data(string $tag): array
     usort($posts, fn($a, $b) => strtotime($b->updated) - strtotime($a->updated));
     $posts = array_slice($posts, 0, 20);
 
-    $first_post = reset($posts);
     return [
-        'updated'  => $first_post ? $first_post->updated : date('Y-m-d H:i:s'),
+        'updated'  => get_feed_updated_date($posts),
         'title'    => $config['site_title'] . ' — #' . $tag,
         'feed_url' => ROOT_URL . '/tag/' . rawurlencode($tag) . '/feed',
         'posts'    => $posts,

--- a/src/themes/default/feed.php
+++ b/src/themes/default/feed.php
@@ -14,7 +14,7 @@ $channel_link = $data['feed_url'] ?? ROOT_URL . '/feed';
 $Xml = new SimpleXMLElement('<feed xmlns="http://www.w3.org/2005/Atom"></feed>');
 $Xml->addChild('title', escape($data['title'] ?? $config['site_title']));
 $Xml->addChild('id', escape($channel_link));
-$Xml->addChild('updated', date(DATE_ATOM, strtotime(reset($data['posts'])->updated)));
+$Xml->addChild('updated', date(DATE_ATOM, strtotime($data['updated'])));
 $Xml->addChild('generator', 'Lamb');
 
 $Link = $Xml->addChild('atom:link');

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use function Lamb\Response\build_exclude_slugs_clause;
 use function Lamb\Response\build_pagination_meta;
 use function Lamb\Response\get_cookie_options;
+use function Lamb\Response\get_feed_updated_date;
 use function Lamb\Response\paginate_posts;
 
 class ResponseTest extends TestCase
@@ -181,5 +182,40 @@ class ResponseTest extends TestCase
         $result = paginate_posts($items, 'created DESC', null, [], 5, 3);
         $this->assertSame(3, $result['pagination']['current']);
         $this->assertNull($result['pagination']['next_page']);
+    }
+
+    // get_feed_updated_date
+
+    public function testGetFeedUpdatedDateReturnsCurrentDateWhenPostsEmpty()
+    {
+        $before = time();
+        $result = get_feed_updated_date([]);
+        $after = time();
+
+        $ts = strtotime($result);
+        $this->assertGreaterThanOrEqual($before, $ts);
+        $this->assertLessThanOrEqual($after, $ts);
+    }
+
+    public function testGetFeedUpdatedDateReturnsUpdatedFromFirstPost()
+    {
+        $bean = new \stdClass();
+        $bean->updated = '2024-06-15 12:00:00';
+
+        $result = get_feed_updated_date([$bean]);
+
+        $this->assertSame('2024-06-15 12:00:00', $result);
+    }
+
+    public function testGetFeedUpdatedDateUsesFirstPostNotLast()
+    {
+        $first = new \stdClass();
+        $first->updated = '2024-06-15 12:00:00';
+        $second = new \stdClass();
+        $second->updated = '2024-01-01 00:00:00';
+
+        $result = get_feed_updated_date([$first, $second]);
+
+        $this->assertSame('2024-06-15 12:00:00', $result);
     }
 }


### PR DESCRIPTION
This change extracts the logic for determining the feed’s “updated” timestamp into a dedicated helper, instead of calculating it inline during feed generation.  
The helper returns the first post’s update time when posts exist, and falls back to the current timestamp when the feed is empty.  
The feed rendering now uses that precomputed value directly, which makes the behavior more consistent and avoids duplicating timestamp-selection logic.  
Overall, it’s a small refactor that improves clarity and makes the feed timestamp handling easier to validate and maintain.