### PR TITLE
Fix periodic slow page loads caused by session GC and redundant upgrade_posts

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -21,6 +21,11 @@ function bootstrap_db(string $data_dir): void
     }
     R::setup(sprintf("sqlite:%s/lamb.db", $data_dir));
     R::useWriterCache(true);
+
+    // One-time migration: mark pre-versioning posts as version 1.
+    // transformed is already populated for these posts (parse_bean ran at creation/edit time);
+    // we only need to stamp the version column so upgrade_posts() never writes them again.
+    R::exec('UPDATE post SET version = 1 WHERE version IS NULL');
 }
 
 /**

--- a/src/post.php
+++ b/src/post.php
@@ -47,6 +47,7 @@ function populate_bean(string $text, Item $feed_item = null, string $feed_name =
     }
 
     parse_bean($bean);
+    $bean->version = 1;
 
     // Auto-draft new feed items when feeds_draft is enabled (applied after parse_bean
     // so frontmatter-driven draft:false cannot inadvertently publish a feed item).

--- a/src/response.php
+++ b/src/response.php
@@ -217,6 +217,7 @@ function redirect_edited(): void
     $bean->body = $contents;
 
     parse_bean($bean);
+    $bean->version = 1;
     $bean->updated = date("Y-m-d H:i:s");
 
     if (is_reserved_route($bean->slug)) {

--- a/tests/Unit/PopulateBeanTest.php
+++ b/tests/Unit/PopulateBeanTest.php
@@ -181,4 +181,10 @@ class PopulateBeanTest extends TestCase
 
         $this->assertNotSame(1, $bean->draft);
     }
+
+    public function testPopulateBeanSetsVersionOne(): void
+    {
+        $bean = populate_bean('Hello world');
+        $this->assertSame(1, $bean->version);
+    }
 }


### PR DESCRIPTION
Actual fix (3 parts):

    bootstrap_db(): runs UPDATE post SET version = 1 WHERE version IS NULL once at startup — cheaply stamps all pre-versioning posts without re-parsing Markdown. After first deploy this is a no-op.
    populate_bean(): new posts created via UI or feed ingestion start with version = 1
    redirect_edited(): edited posts get version = 1 on save

This means upgrade_posts() — which was the actual culprit doing Markdown re-parsing + R::store() on every page load — will never find any post to upgrade.

https://claude.ai/code/session_019rzDnNARma1fSQf4n5saV4