### PR TITLE
Document theme system in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,200 @@ Slugs are immutable once set (changing a slug would break URLs).
 - `parts/_pagination.php` — pagination partial
 - `parts/_related.php` — related posts partial
 
+---
+
+## Theme System — Complete Reference
+
+### How themes are selected
+
+`index.php` reads `$config['theme']` (set via the INI config at `/settings`) and falls back to `'default'`:
+
+```php
+define("THEME",     $config['theme'] ?? 'default');
+define("THEME_DIR", ROOT_DIR . '/themes/' . THEME . '/');   // absolute FS path
+define("THEME_URL", 'themes/' . THEME . '/');               // URL prefix (relative)
+```
+
+`ROOT_DIR` is `src/`. So `THEME_DIR` for a theme named `news` resolves to `src/themes/news/`.
+
+To activate a theme add `theme = news` to the INI config in the DB (edit at `/settings`).
+
+### Part resolution (`Theme\part`)
+
+```php
+Theme\part($name, $dir = 'parts')
+```
+
+1. Looks for `THEME_DIR . $dir . '/' . $name . '.php'`
+2. Falls back to `src/themes/default/$dir/$name.php`
+3. Throws `RuntimeException` if neither exists
+
+`$name` and `$dir` are sanitised (only `[a-zA-Z0-9-_]` allowed — dots and slashes are stripped).
+
+`html.php` is the only file called with an empty `$dir`:
+
+```php
+Theme\part('html', '');   // → src/themes/<theme>/html.php
+```
+
+Everything else is called as `part($template)` from inside `html.php`, which uses the default `$dir = 'parts'`.
+
+### Render flow
+
+```
+index.php
+ └─ Theme\part('html', '')          → html.php
+     ├─ Theme\part($template)        → parts/<template>.php  (home / status / tag / …)
+     │   └─ Theme\part('_items')     → parts/_items.php
+     ├─ Theme\part('_related')       → parts/_related.php    (status only)
+     └─ Theme\part('_pagination')    → parts/_pagination.php
+```
+
+`$template` equals the first URL segment (`home`, `status`, `tag`, `search`, `edit`, `login`, `settings`, `404`, `drafts`). For a slugged post URL it is set to `'status'`.
+
+### Global variables available in every part
+
+| Variable | Type | Contents |
+|----------|------|----------|
+| `$config` | `array` | Full config: `site_title`, `author_name`, `author_email`, `menu_items`, `feeds`, `theme`, … |
+| `$data` | `array` | Route-specific data (see table below) |
+| `$template` | `string` | Current template name (`home`, `status`, `tag`, …) |
+
+### `$data` keys by template
+
+| Template | Keys always present | Keys sometimes present |
+|----------|--------------------|-----------------------|
+| `home` | `posts`, `pagination`, `title` | — |
+| `status` / slugged post | `posts` (single-item array), `title` | — |
+| `tag` | `posts`, `pagination`, `title`, `intro`, `feed_url` | — |
+| `search` | `posts`, `pagination`, `title`, `intro` | — |
+| `drafts` | `posts`, `pagination`, `title` | — |
+| `settings` | — | `ini_text` (on failed save) |
+| `404` | `action` | — |
+
+**`$data['posts']`** is an array of RedBeanPHP `OODBBean` objects. Each bean exposes:
+
+| Property | Description |
+|----------|-------------|
+| `$bean->id` | Integer primary key |
+| `$bean->title` | Post title (may be empty for status posts) |
+| `$bean->slug` | URL slug (immutable once set; empty for status posts) |
+| `$bean->body` | Raw Markdown source |
+| `$bean->transformed` | Pre-rendered HTML (use this in templates — never re-render `body`) |
+| `$bean->description` | Plain-text excerpt (auto-generated) |
+| `$bean->created` | Datetime string (e.g. `2024-03-01 12:00:00`) |
+| `$bean->updated` | Datetime string |
+| `$bean->feed_name` | Source feed name (only present for ingested feed items) |
+| `$bean->feeditem_uuid` | MD5 dedup key (only for feed items) |
+| `$bean->is_menu_item` | Truthy if the post is pinned as a menu item |
+
+**`$data['pagination']`** shape (when present):
+
+```php
+[
+  'current'     => int,    // current page number
+  'per_page'    => int,    // posts per page
+  'total_posts' => int,
+  'total_pages' => int,
+  'prev_page'   => int|null,
+  'next_page'   => int|null,
+  'offset'      => int,
+]
+```
+
+### Theme helper functions (`Lamb\Theme` namespace)
+
+All helpers must be imported with `use function Lamb\Theme\<name>` before use.
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `escape($str)` | `string` | `htmlspecialchars` for HTML5 output — use on every user-supplied value |
+| `site_title($type='html')` | `string` | `<h1>` wrapping `$config['site_title']`, or plain text if `$type !== 'html'` |
+| `page_title($type='html')` | `string` | `<h1>` wrapping `$data['title']` (falls back to `site_title`) |
+| `site_or_page_title($type)` | `string` | Page title if set, otherwise site title |
+| `page_intro()` | `string` | `<p>` wrapping `$data['intro']`, or `''` |
+| `li_menu_items()` | `string` | `<li><a>` tags from `$config['menu_items']` |
+| `date_created($bean)` | `string` | `<a><time>` linking to the post permalink with human-readable timestamp |
+| `link_source($bean)` | `string` | "Via <a>" attribution link for feed-ingested posts, or `''` |
+| `action_edit($bean)` | `string` | Edit button (logged-in only), or `''` |
+| `action_delete($bean)` | `string` | Delete form (logged-in only), or `''` |
+| `the_entry_form()` | `void` | Renders the quick-post `<form>` (logged-in only) |
+| `the_styles()` | `void` | Emits `<link rel="stylesheet">` for `styles/styles.css` in the active theme |
+| `the_scripts()` | `void` | Emits `<script defer>` for `scripts/shorthand.js` + admin scripts |
+| `the_opengraph()` | `void` | Emits `<meta>` OG/Twitter tags (status template only) |
+| `the_preconnect()` | `void` | Emits `<link rel="preconnect">` for `$config['preconnect']` origins |
+| `part($name, $dir='parts')` | `void` | Includes a theme part (see resolution rules above) |
+| `csrf_token()` | `string` | Returns (and creates if needed) the current session CSRF token |
+| `related_posts($body)` | `array` | Posts sharing hashtags with `$body`; returns `['posts' => OODBBean[]]` |
+| `human_time($timestamp)` | `string` | Human-readable relative time ("3 hours ago", "Monday at 2:15 pm", …) |
+| `redirect_to()` | `string` | Sanitised `?redirect_to=` query param value |
+
+Additional helper from `Lamb\Config`:
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `is_menu_item($slugOrId)` | `bool` | True if the value matches a configured menu-item slug/id — use to hide menu posts from feed lists |
+
+### Constants available in parts
+
+| Constant | Value / Description |
+|----------|---------------------|
+| `ROOT_URL` | Full base URL, e.g. `https://example.com` |
+| `ROOT_DIR` | Absolute path to `src/` |
+| `THEME` | Active theme name string |
+| `THEME_DIR` | Absolute path to active theme directory (trailing `/`) |
+| `THEME_URL` | Relative URL to active theme directory, e.g. `themes/news/` |
+| `SESSION_LOGIN` | Session key `'logged_in'` — check `isset($_SESSION[SESSION_LOGIN])` for auth |
+| `HIDDEN_CSRF_NAME` | CSRF field name `'csrf'` |
+| `SUBMIT_CREATE` | Submit button label `'Create post'` |
+| `SUBMIT_EDIT` | Submit button label `'Update post'` |
+
+### CSS asset loading
+
+`the_styles()` always loads `styles/styles.css` from the active theme. There is no multi-file or concatenation mechanism — put everything in one CSS file per theme.
+
+The URL served is `THEME_URL . 'styles/styles.css'` with a cache-buster query string (`?<md5-of-url>`).
+
+### `.gitignore` exemption
+
+`src/themes/` is ignored by default. Every new theme directory must be explicitly exempted:
+
+```
+# in .gitignore
+!/src/themes/news
+```
+
+This only un-ignores the directory entry; files inside are still matched by the parent pattern. Use `git add --force src/themes/<name>/` to stage new theme files for the first time.
+
+### Minimal new theme checklist
+
+A theme only needs to override the files that differ from `default`. The absolute minimum:
+
+```
+src/themes/<name>/
+└── styles/
+    └── styles.css     ← required (the_styles() always loads this path)
+```
+
+Add `html.php` only if the HTML shell (nav, header, footer) changes. Add individual `parts/*.php` files only for the page templates that differ visually. All other parts fall back to `default` automatically.
+
+### Typical file set (for a full redesign)
+
+```
+src/themes/<name>/
+├── html.php                  # header, nav, outer shell, footer
+├── styles/
+│   └── styles.css
+└── parts/
+    ├── home.php              # homepage (calls the_entry_form, site_title, part('_items'))
+    ├── _items.php            # post list / card grid
+    ├── status.php            # single post (usually just delegates to _items)
+    ├── tag.php               # tag archive
+    └── search.php            # search results
+```
+
+Parts you rarely need to override: `edit.php`, `login.php`, `settings.php`, `404.php`, `drafts.php`, `feed.php`, `_related.php`, `_pagination.php`.
+
 ### Security
 
 - CSRF: token stored in session, verified in `Security\require_csrf()`, consumed after use


### PR DESCRIPTION
Adds a complete Theme System reference section covering:
- Theme selection via config and THEME_DIR/THEME_URL constants
- Part resolution and fallback rules
- Full render flow diagram
- All global variables ($config, $data, $template) and $data keys per template
- OODBBean post properties
- All Theme helper functions with signatures and descriptions
- Available constants
- CSS asset loading behaviour
- .gitignore exemption gotcha and git add --force workaround
- Minimal and full theme file checklists

https://claude.ai/code/session_01CmC2XxooaRB2h76igdjNY5