### PR TITLE
Fix mobile display issues in both themes

### DIFF
--- a/src/themes/2024/styles/styles.css
+++ b/src/themes/2024/styles/styles.css
@@ -45,10 +45,6 @@ img {
     max-width: 100%;
 }
 
-nav input {
-    max-width: 10vw;
-}
-
 input[type='submit'], button {
     cursor: pointer;
 }
@@ -208,8 +204,7 @@ article footer {
     overflow: auto;
     border-top: 1px dotted var(--bg2);
     display: block;
-    margin: 1em -2em 0;
-    width: 100%;
+    margin: 1em 0 0;
     padding: 0 2em;
     line-height: 2rem;
     align-self: flex-end;
@@ -231,7 +226,7 @@ p {
 section {
 
     &.entry-form {
-        margin-left: -11rem;
+        margin-left: 0;
         margin-bottom: -1vw;
         background: white;
         border-bottom: 1px solid var(--shadow);
@@ -308,6 +303,19 @@ textarea {
 
 /* Desktop styles */
 @media (min-width: 600px) {
+    nav input {
+        max-width: 10vw;
+    }
+
+    article footer {
+        margin: 1em -2em 0;
+        width: 100%;
+    }
+
+    section.entry-form {
+        margin-left: -11rem;
+    }
+
     article header {
         position: relative;
         /* keep the border to avoid layout shift */

--- a/src/themes/default/styles/styles.css
+++ b/src/themes/default/styles/styles.css
@@ -136,7 +136,7 @@ main small {
     overflow: auto;
     border-top: 1px dotted var(--bg2);
     display: block;
-    margin: 2em -2em 0;
+    margin: 2em 0 0;
     padding: 1px 2em;
 }
 
@@ -203,5 +203,11 @@ textarea {
 
     article header + h2 {
         display: none
+    }
+}
+
+@media (min-width: 600px) {
+    main small {
+        margin: 2em -2em 0;
     }
 }


### PR DESCRIPTION
Closes #186

## Summary
- Default theme: negative margin on `main small` moved inside `@media (min-width: 600px)` to prevent horizontal overflow on narrow screens
- 2024 theme: `section.entry-form { margin-left: -11rem }` moved to desktop media query so the post editor is visible on mobile
- 2024 theme: `article footer` negative margin + `width: 100%` moved to desktop media query to stop horizontal scroll
- 2024 theme: `nav input { max-width: 10vw }` moved to desktop media query so the search box is usable on mobile

## Test plan
- [ ] View site on a narrow viewport (< 600 px) — no horizontal scrollbar on home or status pages
- [ ] Post editor form (logged in) visible and usable on mobile
- [ ] Nav search input is full-width on mobile, constrained on desktop
- [ ] Desktop layout (≥ 600 px) unchanged — negative margins still apply, sidebar meta still positioned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)