### PR TITLE
chore: upgrade GitHub Actions to latest versions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         php-version: [ '8.2', '8.3' ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,25 +8,25 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.2'
         extensions: sqlite3, gettext, simplexml
     - name: Cache Composer dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: vendor
         key: composer-${{ hashFiles('composer.lock') }}
     - name: Install Composer dependencies
       run: composer install --no-dev --no-interaction --no-scripts
     - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: lts/*
     - name: Cache pnpm store
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.local/share/pnpm/store
         key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
@@ -34,7 +34,7 @@ jobs:
       run: pnpm install
     - name: Cache Playwright browsers
       id: playwright-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -46,7 +46,7 @@ jobs:
       run: pnpm exec playwright install-deps chromium
     - name: Run Playwright tests
       run: pnpm exec playwright test
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ !cancelled() }}
       with:
         name: playwright-report


### PR DESCRIPTION
Upgrades all actions from v4 to their latest major versions:
- actions/checkout: v4 → v6
- actions/cache: v4 → v5
- actions/setup-node: v4 → v6
- actions/upload-artifact: v4 → v6

Resolves Node.js 20 deprecation warnings ahead of the June 2, 2026 deadline.

https://claude.ai/code/session_012iThFW1YfoXCHi4nx21QNW