### PR TITLE
Persist search query in the search box across paginated results

### DIFF
--- a/src/response.php
+++ b/src/response.php
@@ -687,6 +687,7 @@ function respond_search(array $args): array
     $paginated = paginate_posts('post', 'created DESC', $where_sql, $params);
 
     // Results
+    $data['query'] = $query;
     $data['title'] = 'Searched for "' . $query . '"';
     $pagination = $paginated['pagination'];
     return get_results(

--- a/src/themes/default/html.php
+++ b/src/themes/default/html.php
@@ -42,7 +42,7 @@ global $template;
         <li class="right">
             <form action="/search" method="get" class="form-search">
                 <label for="s"><span class="screen-reader-text">Search</span></label>
-                <input type="text" name="s" id="s" required>
+                <input type="text" name="s" id="s" value="<?= escape($data['query'] ?? '') ?>" required>
                 <input type="submit" value="🔎">
             </form>
             <?php

--- a/tests/Unit/ResponseExtendedTest.php
+++ b/tests/Unit/ResponseExtendedTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
 use function Lamb\Response\get_results;
+use function Lamb\Response\respond_search;
 use function Lamb\Response\upgrade_posts;
 
 class ResponseExtendedTest extends TestCase
@@ -86,6 +87,21 @@ class ResponseExtendedTest extends TestCase
     {
         $result = get_results(25, [], [], 3, 10, 3, 20);
         $this->assertNull($result['pagination']['next_page']);
+    }
+
+    // respond_search
+
+    public function testRespondSearchIncludesQueryInResult(): void
+    {
+        $result = respond_search(['hello']);
+        $this->assertArrayHasKey('query', $result);
+        $this->assertSame('hello', $result['query']);
+    }
+
+    public function testRespondSearchQueryIsHtmlEscaped(): void
+    {
+        $result = respond_search(['<script>']);
+        $this->assertSame('&lt;script&gt;', $result['query']);
     }
 
     // upgrade_posts


### PR DESCRIPTION
When navigating between search result pages, the search input was cleared. Now respond_search() includes the query in $data, and html.php pre-fills the search input with that value.

Closes #92

https://claude.ai/code/session_01MKsodgYHx2qG1XJz8cQmn1