### PR TITLE
Add year to human_time when the date is not in the current year

### DIFF
--- a/src/theme.php
+++ b/src/theme.php
@@ -411,7 +411,8 @@ function format_past_date(int $j, int $difference, int $timestamp): string
         case $j === 3:
             return date("l \a\\t g:i a", $timestamp);
         case $j < 6 && !($j === 5 && $difference === 12):
-            return date("F j \a\\t g:i a", $timestamp);
+            $format = date('Y', $timestamp) !== date('Y') ? "F j, Y \a\\t g:i a" : "F j \a\\t g:i a";
+            return date($format, $timestamp);
         default:
             return date("F j, Y \a\\t g:i a", $timestamp);
     }

--- a/tests/Unit/ThemeTest.php
+++ b/tests/Unit/ThemeTest.php
@@ -180,13 +180,38 @@ class ThemeTest extends TestCase
         $this->assertMatchesRegularExpression('/^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)/', $result);
     }
 
-    public function testFormatPastDateMonthDayFormatWhenJIs4()
+    public function testFormatPastDateMonthDayIncludesYearWhenJIs4AndYearDiffers()
     {
         $ts = mktime(10, 0, 0, 6, 15, 2020);
         $result = format_past_date(4, 3, $ts);
-        // "June 15 at ..." format (no year)
         $this->assertStringContainsString('June 15', $result);
-        $this->assertStringNotContainsString('2020', $result);
+        $this->assertStringContainsString('2020', $result);
+    }
+
+    public function testFormatPastDateMonthDayOmitsYearWhenJIs4AndYearMatches()
+    {
+        $year = (int) date('Y');
+        $ts = mktime(10, 0, 0, 1, 15, $year);
+        $result = format_past_date(4, 3, $ts);
+        $this->assertStringContainsString('January 15', $result);
+        $this->assertStringNotContainsString((string) $year, $result);
+    }
+
+    public function testFormatPastDateMonthDayIncludesYearWhenJIs5AndYearDiffers()
+    {
+        $ts = mktime(10, 0, 0, 3, 10, 2020);
+        $result = format_past_date(5, 3, $ts);
+        $this->assertStringContainsString('March 10', $result);
+        $this->assertStringContainsString('2020', $result);
+    }
+
+    public function testFormatPastDateMonthDayOmitsYearWhenJIs5AndYearMatches()
+    {
+        $year = (int) date('Y');
+        $ts = mktime(10, 0, 0, 2, 10, $year);
+        $result = format_past_date(5, 3, $ts);
+        $this->assertStringContainsString('February 10', $result);
+        $this->assertStringNotContainsString((string) $year, $result);
     }
 
     public function testFormatPastDateFullDateWithYearWhenJIs6()


### PR DESCRIPTION
Dates displayed as "March 15 at 2:30 pm" were ambiguous for posts from
prior years. The format_past_date helper now includes the year (e.g.
"March 15, 2024 at 2:30 pm") whenever the timestamp's year differs
from the current year. Dates within the current year are unchanged.

Closes #43

https://claude.ai/code/session_015rVkEAYEKXYbMYsaLdxgZJ