### PR TITLE
Fix styling robustness and uniformity issues in 2024 theme

### DIFF
--- a/src/themes/2024/parts/_items.php
+++ b/src/themes/2024/parts/_items.php
@@ -8,6 +8,7 @@ use function Lamb\Theme\action_delete;
 use function Lamb\Theme\action_edit;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\date_created;
+use function Lamb\Theme\escape;
 use function Lamb\Config\is_menu_item;
 use function Lamb\Theme\link_source;
 use function Lamb\Theme\title_link;
@@ -36,7 +37,7 @@ else :
                     <h2><?= title_link($bean) ?></h2>
                 <?php endif; ?>
                 <div class="meta">
-                    <strong itemprop="author"><?= $config['author_name'] ?></strong> @
+                    <strong itemprop="author"><?= escape($config['author_name'] ?? '') ?></strong> @
                     <?= date_created($bean) ?>
                 </div>
             </header>

--- a/src/themes/2024/styles/styles.css
+++ b/src/themes/2024/styles/styles.css
@@ -92,7 +92,7 @@ main {
 }
 
 nav {
-    background: #fee684ff;
+    background: var(--info);
     color: var(--fg);
     margin: 0;
     padding: 0 5%;
@@ -132,8 +132,8 @@ nav a[href$="feed"] {
 }
 
 nav a:hover {
-    background: white;
-    color: black;
+    background: var(--bg-alt);
+    color: var(--text);
 }
 
 nav form {
@@ -201,7 +201,8 @@ article {
 
 }
 
-article:last-of-type {
+main > article:last-of-type,
+li:last-child > article {
     border-bottom: none;
 }
 
@@ -215,18 +216,13 @@ small form {
     display: inline;
 }
 
-article footer {
+article > small {
     overflow: auto;
     border-top: 1px dotted var(--bg2);
     display: block;
     margin: 1em 0 0;
     padding: 0 2em;
     line-height: 2rem;
-    align-self: flex-end;
-
-    a {
-        margin-right: 1em;
-    }
 }
 
 
@@ -262,7 +258,7 @@ textarea {
     margin: 1em 0;
     padding: 0.25em 0.5em;
     background: var(--info);
-    border: 1px solid var(--bg);
+    border: 1px solid var(--bg2);
     border-radius: 4px;
 }
 
@@ -322,7 +318,7 @@ textarea {
         max-width: 10vw;
     }
 
-    article footer {
+    article > small {
         margin: 1em -2em 0;
         width: 100%;
     }


### PR DESCRIPTION
- Replace dead `article footer` selectors with `article > small` to
  match what _items.php actually renders; gives the actions bar a
  block display and border-top separator it was missing
- Fix `article:last-of-type` removing borders from every article in
  list view (each <li> has only one article, so all matched);
  use `main > article:last-of-type, li:last-child > article` instead
- Use `var(--info)` for nav background instead of hardcoded `#fee684ff`
- Use CSS variables in `nav a:hover` instead of hardcoded white/black
- Fix flash border using `var(--bg)` (#fefefe, white on yellow =
  invisible); use `var(--bg2)` (#aaa) for a visible border
- Escape `$config['author_name']` output in _items.php

https://claude.ai/code/session_01UN5PPpuNDiudw69UiNeSYq