### PR TITLE
docker: fix empty vendor/ on host by using selective bind mounts

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -7,13 +7,14 @@ services:
     ports:
       - "80:80"
     volumes:
-      - ..:/srv/app
+      - ../src:/srv/app/src
       - ./Caddyfile:/etc/caddy/Caddyfile
   composer:
     container_name: lamb-deps
     image: composer:2
     volumes:
-      - ..:/app
+      - ../composer.json:/app/composer.json:ro
+      - ../composer.lock:/app/composer.lock:ro
       - vendor:/app/vendor
     command: install --ignore-platform-reqs --no-interaction
 
@@ -22,11 +23,16 @@ services:
       context: ..
       dockerfile: .docker/Dockerfile
     container_name: lamb-app
+    depends_on:
+      composer:
+        condition: service_completed_successfully
     env_file:
       - ../.ddev/.env
     image: php:fpm
     volumes:
-      - ..:/srv/app
+      - ../src:/srv/app/src
+      - ../data:/srv/app/data
+      - vendor:/srv/app/vendor
 
 volumes:
   vendor:


### PR DESCRIPTION
Replace full project bind mounts with targeted mounts so the vendor
named volume is never overlaid on a bind-mounted parent directory.
Docker was creating an empty vendor/ folder on the host as a mount
point artifact.

- composer: mount only composer.json + composer.lock (ro) + vendor volume
- php: mount src/, data/, and vendor volume separately
- caddy: mount only src/ (its webroot)
- php now depends_on composer with service_completed_successfully

Fixes #5

https://claude.ai/code/session_011Tc4yEyM5WEcLP2dSv2RKo