### PR TITLE
Split CI into quality and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,32 @@ on:
 
 jobs:
 
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Validate Composer
+        run: composer validate
+
+      - name: Security audit
+        run: composer audit
+
+      - name: Run PHPCS
+        run: composer run lint
+
+      - name: Run PHPStan
+        run: composer run analyse
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -27,24 +53,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: pcov
+          coverage: ${{ matrix.php-version == '8.2' && 'pcov' || 'none' }}
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
-
-      - name: Validate Composer
-        run: composer validate
-
-      - name: Security audit
-        run: composer audit
-
-      - name: Run PHPCS
-        run: |
-          composer run lint
-
-      - name: Run PHPStan
-        if: matrix.php-version == '8.2'
-        run: composer run analyse
 
       - name: Run Codeception tests
         run: |
@@ -52,6 +64,5 @@ jobs:
           vendor/bin/codecept run --steps
 
       - name: Check code coverage
+        if: matrix.php-version == '8.2'
         run: composer coverage
-
-


### PR DESCRIPTION
## Summary

- New `quality` job runs once on PHP 8.2: `validate`, `audit`, `lint`, `PHPStan`
- `test` job matrix keeps all 4 PHP versions but only runs Codeception tests + coverage
- `pcov` extension only installed on the PHP 8.2 test runner where coverage actually runs
- `coverage` step gated with `if: matrix.php-version == '8.2'`

**Before:** 6 steps × 4 runners = 24 step executions  
**After:** 4 quality steps × 1 + 2 test steps × 4 = 12 step executions

🤖 Generated with [Claude Code](https://claude.com/claude-code)