### PR TITLE
Speed up Playwright CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   test:
-    timeout-minutes: 60
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -30,14 +30,16 @@ jobs:
       with:
         path: ~/.local/share/pnpm/store
         key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: pnpm-
     - name: Install dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Cache Playwright browsers
       id: playwright-cache
       uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: playwright-
     - name: Install Playwright Browsers
       if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: pnpm exec playwright install --with-deps chromium


### PR DESCRIPTION
## Summary

- Reduce job timeout from 60 → 15 minutes (fails faster if something hangs)
- Add `restore-keys` fallback to pnpm store and Playwright browser caches so a partial cache is used when lock files change, avoiding a full re-download
- Use `--frozen-lockfile` on `pnpm install` to skip dependency resolution in CI

## Test plan

- [x] Playwright CI job passes on this PR
- [x] Verify cache hits are reported in subsequent runs after the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)