### PR TITLE
Allow q=config Micropub query without authentication

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -122,6 +122,16 @@ class LambMicropubAdapter extends MicropubAdapter
             ]));
         }
 
+        // q=config is a discovery endpoint; return it without requiring a token.
+        if (strtolower($request->getMethod()) === 'get' && ($request->getQueryParams()['q'] ?? '') === 'config') {
+            $this->request = $request;
+            $configResult = $this->configurationQueryCallback($request->getQueryParams());
+            if ($configResult instanceof \Psr\Http\Message\ResponseInterface) {
+                return $configResult;
+            }
+            return new Response(200, ['content-type' => 'application/json'], json_encode($configResult));
+        }
+
         return parent::handleRequest($request);
     }
 

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -29,6 +29,23 @@ class MicropubAdapterTest extends TestCase
 
     // --- handleRequest (RFC 6750 multi-auth rejection) ---
 
+    public function testConfigQueryResponds200WithoutAccessToken(): void
+    {
+        $adapter = new StubMicropubAdapter();
+
+        $request = new \Nyholm\Psr7\ServerRequest(
+            'GET',
+            ROOT_URL . '/micropub?q=config'
+        );
+        $request = $request->withQueryParams(['q' => 'config']);
+
+        $response = $adapter->handleRequest($request);
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('media-endpoint', $body);
+        $this->assertArrayHasKey('syndicate-to', $body);
+    }
+
     public function testHandleRequestRejects400WhenTokenInBothHeaderAndBody(): void
     {
         $adapter = new StubMicropubAdapter();


### PR DESCRIPTION
The Micropub spec defines q=config as a discovery endpoint that clients
use to learn endpoint capabilities before they have a token. Requiring
auth here broke the setup handshake for Micropub clients.

Fix: intercept GET ?q=config in handleRequest() before delegating to the
parent adapter, which always requires a token first.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
