### PR TITLE
Scope Playwright workflow to relevant file paths

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,19 @@ name: Playwright Tests
 on:
   push:
     branches: [ main, master ]
+    paths:
+      - 'src/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
   pull_request:
+    paths:
+      - 'src/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
 jobs:
   test:
     timeout-minutes: 15


### PR DESCRIPTION
## Summary

- Adds `paths` filter to the Playwright workflow so it only runs when files that affect browser-rendered output change
- Skips the workflow on changes to `composer.json`, PHP tooling config, unit tests, docs, and other CI files

## Affected paths

Workflow now triggers on changes to: `src/**`, `e2e/**`, `playwright.config.ts`, `package.json`, `pnpm-lock.yaml`

## Test plan

- [x] Merge this PR — confirm Playwright is skipped (only workflow file changed)
- [ ] Open a follow-up PR touching `src/` — confirm Playwright runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)