### PR TITLE
Add CI aggregator job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,9 @@ jobs:
       - name: Check code coverage
         if: matrix.php-version == '8.2'
         run: composer coverage
+
+  ci:
+    runs-on: ubuntu-latest
+    needs: [quality, test]
+    steps:
+      - run: echo "All checks passed"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,7 +4,7 @@ on:
     branches: [ main, master ]
   pull_request:
 jobs:
-  test:
+  playwright:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Adds a `ci` aggregator job that `needs: [quality, test]` — succeeds only when both pass across all matrix versions
- Updates the required status check from `test` to `ci` so branch protection actually gates on a check that gets reported

The previous required check `test` was never satisfied because the matrix job produces `test (8.2)`, `test (8.3)` etc., not a bare `test` check. This caused PRs to hang at "Waiting for status to be reported" even after all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)