### PR TITLE
Add 2026 'Notes' theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,13 @@
 /src/config.ini
 /todos.md
 
-# Ignore user-installed themes; the repo ships 'default' and '2024'.
+# Ignore user-installed themes; the repo ships 'default', '2024', and '2026'.
 # Ignore unknown subdirectories only — never the parent — so that git add
 # on tracked theme files works without -f.
 src/themes/*/
 !src/themes/default/
 !src/themes/2024/
+!src/themes/2026/
 .env
 
 # Playwright

--- a/src/themes/2026/README.md
+++ b/src/themes/2026/README.md
@@ -1,0 +1,119 @@
+# 2026 — Notes
+
+A Lamb theme designed for a single-author, attention-respecting personal microblog.
+
+## Brief
+
+The site is "Sander van Dragt's Notes": a maker of positive digital experiences, a Senior Web Engineer at Human Made (enterprise WordPress, Altis DXP), WordPress core contributor (5.5 sitemaps). Lamb itself is "bespoke microblogging software that doesn't demand your attention. Frictionless and fast."
+
+That last phrase is the design constraint. Personality has to be quiet, and it has to come from craft, not from chrome or color.
+
+## What it replaces
+
+The starting point was a token-cleanup of the original `2024` theme. That cleanup fixed inconsistencies (duplicate color tokens, mixed spacing units, hardcoded colors) but kept the visual shape: centered reading column with a left rule, yellow nav band, gray-on-white. A faintly 2000s blog template. The brief asked for a real visual modernization on top of that base.
+
+## Register and reflex-checks
+
+Brand register, not product: a personal site where design IS the experience.
+
+First-order reflex for "personal blog" is editorial-typographic (display serif, italic drop caps, broadsheet grid). Rejected: the content is mostly one-line status updates with occasional 400-600 word essays on Linux tooling and AI-assisted development. Magazine grammar is the wrong register.
+
+Second-order reflex for "developer who blogs" is monospace-everything or dark terminal mode. Rejected as costume by default, but partially adopted with intent: the author is genuinely technical, so mono headings read as voice, not costume. The body stays in a humanist sans so reading isn't fatiguing.
+
+## Direction: workshop / worklog
+
+A worklog feel. Time-stamped entries with a calm visual rhythm. The reader should feel they're looking at a journal, not a publication.
+
+Three concrete moves carry the voice:
+
+1. A hanging timestamp in the left margin of every post.
+2. Mono headings, humanist sans body.
+3. Almost no rules or borders. Whitespace and typography do the dividing work.
+
+## Theme: light
+
+Physical scene: someone reading short notes on a 13-inch laptop or phone, mixed daytime indoor light, on a break from other work; the mood is low-pressure, low-stakes browsing.
+
+That scene forced light, not dark. Dark would have been a category reflex (developer blog) without a forcing reason behind it.
+
+## Color: restrained, warm-tinted, deep amber accent
+
+Strategy: Restrained. Tinted neutrals plus one accent that shows up on under 10% of the surface.
+
+All neutrals are in OKLCH, tinted ~40-70° on the hue wheel (warm, away from blue and toward sand/amber). No raw `#fff` or `#000`. The paper surface is `oklch(98% 0.006 70)`: a near-white with a faint warm tint that reads as paper, not screen.
+
+Accent: deep amber `oklch(56% 0.135 65)`. The first attempt was a brick-red at higher chroma (`oklch(52% 0.17 28)`), which was rejected as too aggressive for a site whose tagline is "doesn't demand your attention." Amber at lower chroma keeps presence without volume.
+
+The accent appears only on: timestamps, link color, focus rings, the current nav indicator, hashtag-chip hover, blockquote curly quotes. No accent backgrounds. No accent panels.
+
+## Typography: Geist Mono and Public Sans
+
+Brand-voice words used to pick fonts: technical, warm, opinionated. Three reflex picks (Inter, Söhne, JetBrains Mono) were checked against the reflex-reject list. Inter is on the list; rejected. Geist Mono and Public Sans were chosen instead.
+
+- Geist Mono for all headings, timestamps, nav, form labels. The "voice" font. Tight letter-spacing on display sizes.
+- Public Sans for body. Calm, neutral, humanist enough to read for several hundred words without fatigue.
+
+Atkinson Hyperlegible was briefly considered for body (designed by the Braille Institute, thematic alignment with the "positive digital experiences" framing). It was dropped when feedback confirmed the existing fonts were working.
+
+Type scale uses a 1.25 ratio with a `clamp()`-fluid headline at the top.
+
+## Layout: 2-column grid, hanging timestamp
+
+Each post is a 2-column CSS grid:
+
+- Column 1 (6.5rem): timestamp, right-aligned, mono, amber.
+- Column 2: title, paragraphs, images, blockquotes, code, hashtags, logged-in actions.
+
+`align-items: baseline` aligns the timestamp baseline with the first content row. For a titled post, the timestamp baselines with the title. For a status post (no title), it baselines with the first paragraph. The visual balance is the same either way, which solved an earlier problem where the meta felt heavy beside short status posts.
+
+All body content (text, images, blockquotes, code) starts at the same left edge in column 2. An earlier float-based version had the first paragraph wrapping around the floated timestamp; that broke the vertical left edge the rest of the post lined up to. The grid fixes it.
+
+Reading column is capped at 44rem (~65ch body measure) and centered. Generous outer padding via `clamp()`.
+
+On viewports under 600px the grid collapses to a single column; timestamps stack above their post.
+
+## Lines: only two on the whole page
+
+Below the nav, above the footer. That's it.
+
+Removed in this overhaul: per-post border-bottom, dashed `<small>` divider, h1 underline, entry-form panel border, related-posts top border, pagination current-page border, flash background and border, search input border.
+
+The reasoning: each rule the eye crosses is a small attention demand. The brief explicitly asks the design not to demand attention. Vertical rhythm and typographic hierarchy do the dividing work that borders used to.
+
+## Author hidden from per-post meta
+
+Lamb is a single-author engine. Showing the author's name on every post is repetition that adds noise. The `<strong itemprop="author">` markup stays in the HTML for schema.org/BlogPosting, but is moved to `.screen-reader-text` so it doesn't render visually. Crawlers still see it; readers don't.
+
+## Personality details that don't shout
+
+Small, deliberate touches that reward attention but don't ask for it:
+
+- Hashtags get a soft `paper-raised` pill background, mono font. Reads as a tag, not as a link.
+- Blockquote opens and closes with accent-colored curly quotes via `::before` / `::after`.
+- `<hr>` renders as a `* * *` asterism in mono, letter-spaced. Old-typography pause-mark instead of a flat line.
+- Menu items in the nav are separated by a faint `·` glyph rather than padding alone.
+- Current nav item gets a 2px amber underline that sits just under the text, not a background fill.
+- Post titles get a hover underline that animates in via `background-size` (allowed: not animating a layout property).
+
+## Files
+
+- `html.php`: overrides the default to add Geist Mono + Public Sans via Google Fonts and a slightly tightened nav.
+- `styles/styles.css`: full visual definition.
+- `parts/_items.php`: minimal override to move the author into `screen-reader-text`.
+
+Everything else falls back to `themes/default/`.
+
+## Activate
+
+Edit the INI config at `/settings` and set:
+
+```ini
+theme = 2026
+```
+
+## Trade-offs and known limits
+
+- **Google Fonts dependency.** `html.php` loads Geist Mono and Public Sans from `fonts.googleapis.com`. That's an external request and a privacy consideration for a self-hosted blog. Drop the link from `html.php` and the design falls back to `ui-monospace` and `system-ui`, which works but loses the typographic personality. Self-hosting the woff2 files in `themes/2026/styles/fonts/` is the better long-term fix.
+- **`display: contents` on `<header>`.** Required to make grid placement work without changing the markup. Modern browsers handle this correctly; older screen readers might lose the `<header>` landmark, but in this template the header only contains the title and timestamp, so the impact is low.
+- **Long human-readable timestamps.** The 6.5rem time column comfortably fits "Monday at 2:15 pm" but will wrap on anything longer. Acceptable; longer values are uncommon.
+- **Single-post pages** (`.status`, `.post`) intentionally bypass the grid. The `<h1>` already carries the title, and a one-article page doesn't need a gutter to balance against. The CSS sets `display: block` on `.status article` and `.post article`.

--- a/src/themes/2026/html.php
+++ b/src/themes/2026/html.php
@@ -1,0 +1,83 @@
+<?php
+
+use function Lamb\Theme\escape;
+use function Lamb\Theme\li_menu_items;
+use function Lamb\Theme\part;
+use function Lamb\Theme\site_or_page_title;
+use function Lamb\Theme\the_opengraph;
+use function Lamb\Theme\the_preconnect;
+use function Lamb\Theme\the_scripts;
+use function Lamb\Theme\the_styles;
+
+global $config;
+global $data;
+global $template;
+?>
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+    <meta charset="utf-8">
+    <meta name="author" content="<?= escape($config['author_name'] ?? '') ?>">
+    <meta name="generator" content="Lamb">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= escape(site_or_page_title('text')) ?></title>
+    <link rel="alternate" type="application/atom+xml" href="<?= ROOT_URL . '/feed' ?>"
+          title="<?= escape($config['site_title']) ?>">
+    <?php foreach ($config['me'] ?? [] as $url) : ?>
+    <link rel="me" href="<?= escape($url) ?>">
+    <?php endforeach; ?>
+    <link rel="authorization_endpoint" href="<?= escape($config['authorization_endpoint']) ?>">
+    <link rel="token_endpoint" href="<?= escape($config['token_endpoint']) ?>">
+    <link rel="micropub" href="<?= ROOT_URL ?>/micropub">
+    <?php if (!empty($data['feed_url']) && $data['feed_url'] !== ROOT_URL . '/feed') : ?>
+    <link rel="alternate" type="application/atom+xml" href="<?= escape($data['feed_url']) ?>"
+          title="<?= escape($data['title'] ?? $config['site_title']) ?>">
+    <?php endif; ?>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Public+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap">
+
+    <?php the_preconnect(); ?>
+    <?php the_styles(); ?>
+    <?php the_opengraph(); ?>
+</head>
+<body class="<?= escape($template) ?>">
+<nav>
+    <ul>
+        <?php echo li_menu_items(); ?>
+        <li class="right">
+            <form action="/search" method="get" class="form-search">
+                <label for="s"><span class="screen-reader-text">Search</span></label>
+                <input type="text" name="s" id="s" placeholder="search" value="<?= escape($data['query'] ?? '') ?>" required>
+                <input type="submit" value="↵">
+            </form>
+            <?php if (!isset($_SESSION[SESSION_LOGIN])) : ?>
+                <a href="/login">Login</a>
+            <?php endif; ?>
+        </li>
+    </ul>
+</nav>
+<div class="container">
+    <main>
+        <?php
+        if (isset($_SESSION['flash'])) :
+            while (count($_SESSION['flash']) > 0) :
+                $flash = array_pop($_SESSION['flash']);
+                ?>
+                <div class="flash">⚠ <?= escape($flash) ?></div>
+                <?php
+            endwhile;
+        endif;
+        part($template);
+        part("_related");
+        ?>
+    </main>
+</div>
+<?php part("_pagination"); ?>
+<footer>
+    <small>Powered by <a href="https://github.com/svandragt/lamb">Lamb</a>.</small>
+</footer>
+<?php the_scripts(); ?>
+</body>
+</html>

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -1,0 +1,61 @@
+<?php
+
+global $data;
+global $config;
+global $template;
+
+use function Lamb\Theme\action_delete;
+use function Lamb\Theme\action_edit;
+use function Lamb\Theme\action_restore;
+use function Lamb\Theme\date_created;
+use function Lamb\Theme\escape;
+use function Lamb\Config\is_menu_item;
+use function Lamb\Theme\link_source;
+use function Lamb\Theme\title_link;
+
+if (empty($data['posts'])) :
+    ?><p>Sorry no items found.</p>
+    <?php
+else :
+    if (count($data['posts']) > 1) :
+        echo '<ul>';
+    endif;
+    foreach ($data['posts'] as $bean) :
+        if ($template !== 'status' && is_menu_item($bean->slug ?? $bean->id)) :
+            # Hide from timeline
+            continue;
+        endif;
+        if (count($data['posts']) > 1) :
+            echo '<li>';
+        endif;
+
+        ?>
+
+        <article itemscope itemtype="https://schema.org/BlogPosting">
+            <header>
+                <?php if ($template !== 'status') : ?>
+                    <?php $title = title_link($bean); ?>
+                    <?php if (!empty(trim(strip_tags($title)))) : ?>
+                        <h2><?= $title ?></h2>
+                    <?php endif; ?>
+                <?php endif; ?>
+                <div class="meta">
+                    <strong itemprop="author" class="screen-reader-text"><?= escape($config['author_name'] ?? '') ?></strong>
+                    <?= date_created($bean) ?>
+                </div>
+            </header>
+            <?= $bean->transformed ?>
+
+            <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
+                <small><?= link_source($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
+            <?php endif; ?>
+        </article>
+        <?php
+        if (count($data['posts']) > 1) :
+            echo '</li>';
+        endif;
+    endforeach;
+    if (count($data['posts']) > 1) :
+        echo '</ul>';
+    endif;
+endif;

--- a/src/themes/2026/styles/styles.css
+++ b/src/themes/2026/styles/styles.css
@@ -1,0 +1,661 @@
+/*
+ * Lamb 2026 — Notes
+ * Quiet by design: doesn't demand your attention.
+ * Personality lives in the hanging-timestamp typographic layout, not in chrome.
+ * Two horizontal lines on the whole page: under the nav, above the footer.
+ */
+
+:root {
+    /* Color. Warm-tinted neutrals around a deep amber accent.
+       Restrained strategy: accent appears only on timestamps, links, focus.
+       No accent backgrounds, no bordered panels. */
+    --paper:        oklch(98% 0.006 70);
+    --paper-raised: oklch(95% 0.010 70);
+    --ink:          oklch(22% 0.02 50);
+    --ink-soft:     oklch(50% 0.025 55);
+    --ink-faint:    oklch(70% 0.020 55);
+    --rule:         oklch(88% 0.012 70);
+    --accent:       oklch(56% 0.135 65);
+    --accent-hover: oklch(48% 0.140 60);
+    --accent-tint:  oklch(94% 0.045 70);
+    --selection:    oklch(89% 0.090 75);
+
+    /* Type */
+    --font-mono: "Geist Mono", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+    --font-body: "Public Sans", "Source Sans 3", system-ui, sans-serif;
+
+    /* Type scale (1.25 ratio, fluid headlines) */
+    --text-xs:   0.75rem;
+    --text-sm:   0.875rem;
+    --text-base: 1.0625rem;
+    --text-md:   1.1875rem;
+    --text-lg:   1.5rem;
+    --text-xl:   clamp(1.6rem, 1.3rem + 1vw, 2rem);
+
+    --leading:       1.65;
+    --leading-tight: 1.2;
+
+    /* Spacing */
+    --s-1: 0.25rem;
+    --s-2: 0.5rem;
+    --s-3: 0.75rem;
+    --s-4: 1rem;
+    --s-5: 1.5rem;
+    --s-6: 2rem;
+    --s-7: 3rem;
+    --s-8: 4.5rem;
+
+    /* Layout */
+    --measure:    65ch;
+    --time-col:   6.5rem;
+    --time-gap:   var(--s-5);
+    --radius:     3px;
+}
+
+/* Reset & base */
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; }
+
+body {
+    font: 400 var(--text-base)/var(--leading) var(--font-body);
+    color: var(--ink);
+    background: var(--paper);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+}
+
+::selection { background: var(--selection); color: var(--ink); }
+
+img { max-width: 100%; height: auto; display: block; }
+
+a {
+    color: var(--accent);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.18em;
+    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+a:hover { color: var(--accent-hover); }
+
+a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+button, input[type='submit'] { cursor: pointer; }
+
+/* Typography */
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-mono);
+    font-weight: 500;
+    line-height: var(--leading-tight);
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    margin: var(--s-6) 0 var(--s-3);
+}
+
+h1 {
+    font-size: var(--text-xl);
+    font-weight: 600;
+    margin: var(--s-7) 0 var(--s-6);
+    letter-spacing: -0.02em;
+}
+
+h2 { font-size: var(--text-md); }
+h3 { font-size: var(--text-base); }
+h4, h5, h6 {
+    font-size: var(--text-sm);
+    color: var(--ink-soft);
+    letter-spacing: 0.02em;
+}
+
+p { margin: 0.85em 0; }
+
+blockquote {
+    margin: var(--s-5) 0;
+    color: var(--ink-soft);
+    font-style: italic;
+}
+
+blockquote p::before { content: "“"; color: var(--accent); }
+blockquote p::after  { content: "”"; color: var(--accent); }
+
+code {
+    font: 0.9em/1.4 var(--font-mono);
+    color: var(--ink);
+    background: var(--paper-raised);
+    padding: 0.1em 0.35em;
+    border-radius: var(--radius);
+}
+
+pre {
+    background: var(--paper-raised);
+    border-radius: var(--radius);
+    padding: var(--s-4);
+    overflow-x: auto;
+    margin: var(--s-5) 0;
+}
+
+pre code { background: none; padding: 0; font-size: var(--text-sm); }
+
+hr {
+    border: 0;
+    text-align: center;
+    margin: var(--s-7) 0;
+    color: var(--ink-faint);
+    font-family: var(--font-mono);
+}
+
+hr::before {
+    content: "* * *";
+    letter-spacing: 0.6em;
+}
+
+ul, ol { padding-left: var(--s-5); }
+li { margin: var(--s-2) 0; }
+
+/* Site chrome — just two horizontal lines on the entire page */
+
+nav {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    border-bottom: 1px solid var(--rule);
+    background: var(--paper);
+    padding: 0 clamp(var(--s-4), 5vw, var(--s-7));
+}
+
+nav ul {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    gap: 0;
+}
+
+nav li {
+    display: flex;
+    align-items: center;
+    margin: 0;
+    padding: 0;
+}
+
+nav a, nav .current {
+    display: inline-block;
+    text-decoration: none;
+    color: var(--ink-soft);
+    padding: var(--s-4) var(--s-3);
+    letter-spacing: 0.01em;
+    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+nav a:hover,
+nav a:focus-visible {
+    color: var(--accent);
+    background: none;
+    outline: none;
+}
+
+nav .current {
+    color: var(--ink);
+    position: relative;
+}
+
+nav .current::after {
+    content: "";
+    position: absolute;
+    left: var(--s-3);
+    right: var(--s-3);
+    bottom: calc(var(--s-2) + 1px);
+    height: 2px;
+    background: var(--accent);
+}
+
+/* Subtle separator dots between top-level menu items */
+nav > ul > li:not(:first-child):not(.right)::before {
+    content: "·";
+    color: var(--ink-faint);
+    margin: 0 var(--s-1);
+}
+
+nav form {
+    display: flex;
+    align-items: center;
+    margin: 0;
+    gap: var(--s-2);
+}
+
+nav form input[type="text"] {
+    font: 400 var(--text-sm)/1 var(--font-mono);
+    color: var(--ink);
+    background: var(--paper-raised);
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    padding: var(--s-2) var(--s-3);
+    min-width: 0;
+    transition: border-color 140ms cubic-bezier(0.22, 1, 0.36, 1),
+                background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+nav form input[type="text"]::placeholder {
+    color: var(--ink-faint);
+}
+
+nav form input[type="text"]:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    background: var(--paper);
+}
+
+nav form input[type="submit"] {
+    font: var(--text-sm)/1 var(--font-mono);
+    color: var(--ink-soft);
+    background: none;
+    border: 0;
+    padding: var(--s-2);
+    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+nav form input[type="submit"]:hover { color: var(--accent); }
+
+nav li.right {
+    flex: 1;
+    justify-content: flex-end;
+    gap: var(--s-3);
+}
+
+nav a[href$="feed"] {
+    font-family: var(--font-mono);
+}
+
+@media (max-width: 599px) {
+    nav li.right {
+        flex-basis: 100%;
+        justify-content: stretch;
+        padding-bottom: var(--s-2);
+    }
+    nav li.right .form-search { flex: 1; }
+    nav li.right .form-search input[type="text"] { flex: 1; width: 100%; }
+}
+
+/* Reading column */
+
+.container {
+    padding: 0 clamp(var(--s-4), 5vw, var(--s-7));
+}
+
+main {
+    max-width: 44rem;
+    margin: 0 auto;
+    padding: var(--s-7) 0 var(--s-8);
+}
+
+main > h1 {
+    font-size: var(--text-md);
+    font-weight: 500;
+    color: var(--ink-soft);
+    letter-spacing: 0.01em;
+    margin: 0 0 var(--s-6);
+}
+
+main > h1 a {
+    color: inherit;
+    text-decoration: none;
+}
+
+main > ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+main > ul > li { margin: 0; padding: 0; }
+
+/* Post — the typographic signature.
+   Timestamp hangs in the left margin, body wraps around it.
+   Equal balance whether or not a title is present. */
+
+article {
+    display: grid;
+    grid-template-columns: var(--time-col) minmax(0, 1fr);
+    column-gap: var(--time-gap);
+    row-gap: 0;
+    align-items: baseline;
+    padding: 0;
+    margin: 0 0 var(--s-7);
+}
+
+main > ul > li:last-child > article,
+main > article:last-of-type { margin-bottom: 0; }
+
+article > * {
+    grid-column: 2;
+    min-width: 0;
+}
+
+article > header {
+    display: contents;
+}
+
+article > header > h2 {
+    grid-column: 2;
+}
+
+article > header > .meta {
+    grid-column: 1;
+    grid-row: 1;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--accent);
+    text-align: right;
+    line-height: 1.5;
+    letter-spacing: 0.01em;
+}
+
+/* First body element drops its top margin so it baselines with the meta. */
+article > header + * {
+    margin-top: 0;
+}
+
+article header .meta a {
+    color: inherit;
+    text-decoration: none;
+    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+article header .meta a:hover { color: var(--accent-hover); }
+
+article header h2 {
+    font-family: var(--font-mono);
+    font-size: var(--text-md);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin: 0 0 var(--s-2);
+    line-height: 1.3;
+}
+
+article header h2 a.title-link {
+    color: var(--ink);
+    text-decoration: none;
+    background-image: linear-gradient(var(--accent), var(--accent));
+    background-size: 0% 1px;
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    transition: background-size 260ms cubic-bezier(0.22, 1, 0.36, 1),
+                color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    padding-bottom: 1px;
+}
+
+article header h2 a.title-link:hover,
+article header h2 a.title-link:focus-visible {
+    color: var(--accent);
+    background-size: 100% 1px;
+}
+
+/* Hashtag chips inside post bodies */
+article a[href^="/tag/"],
+article a[href*="/tag/"] {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    color: var(--ink-soft);
+    text-decoration: none;
+    background: var(--paper-raised);
+    padding: 0.1em 0.4em;
+    border-radius: 2px;
+    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1),
+                background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+article a[href*="/tag/"]:hover {
+    color: var(--accent);
+    background: var(--accent-tint);
+}
+
+/* Edit/delete/source row for logged-in users */
+article > small {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--ink-faint);
+    margin: var(--s-3) 0 0;
+}
+
+article > small a {
+    color: var(--ink-faint);
+    text-decoration: none;
+    margin-right: var(--s-3);
+}
+
+article > small a:hover { color: var(--accent); }
+
+/* Single-post view: don't repeat the title (h1 is the title), drop the gutter,
+   give the body its full measure. */
+.status article,
+.post article {
+    display: block;
+    margin-bottom: 0;
+}
+
+.status article > header > h2,
+.post article > header > h2 { display: none; }
+
+.status article > header > .meta,
+.post article > header > .meta {
+    text-align: left;
+    margin: 0 0 var(--s-5);
+    font-size: var(--text-sm);
+}
+
+/* Related posts: quiet header, no border, no card */
+
+article.related-posts {
+    margin-top: var(--s-8);
+}
+
+article.related-posts span {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--ink-faint);
+    letter-spacing: 0.04em;
+    margin-bottom: var(--s-3);
+}
+
+article.related-posts p { margin: 0; }
+
+/* Entry form (logged-in only) — quiet, no panel */
+
+section.entry-form {
+    margin: 0 0 var(--s-7);
+}
+
+textarea {
+    font: 400 var(--text-sm)/1.5 var(--font-mono);
+    width: 100%;
+    max-width: 100%;
+    min-height: 7em;
+    display: block;
+    margin: 0 0 var(--s-3);
+    padding: var(--s-3);
+    color: var(--ink);
+    background: var(--paper-raised);
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    box-sizing: border-box;
+    resize: vertical;
+    transition: border-color 140ms cubic-bezier(0.22, 1, 0.36, 1),
+                background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+textarea:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    background: var(--paper);
+}
+
+input[type="text"], input[type="password"] {
+    font: 400 var(--text-base)/1.4 var(--font-body);
+    color: var(--ink);
+    background: var(--paper-raised);
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    padding: var(--s-2) var(--s-3);
+    transition: border-color 140ms cubic-bezier(0.22, 1, 0.36, 1),
+                background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+input[type="text"]:focus-visible,
+input[type="password"]:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    background: var(--paper);
+}
+
+input[type="submit"], button {
+    font: 500 var(--text-sm)/1 var(--font-mono);
+    color: var(--paper);
+    background: var(--ink);
+    border: 0;
+    border-radius: var(--radius);
+    padding: var(--s-3) var(--s-4);
+    letter-spacing: 0.01em;
+    transition: background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+input[type="submit"]:hover, button:hover {
+    background: var(--accent-hover);
+}
+
+article > small form,
+footer form { display: inline; }
+
+article > small input[type="submit"],
+article > small button {
+    font-size: var(--text-xs);
+    padding: 0;
+    background: none;
+    color: var(--ink-faint);
+    border: 0;
+    text-decoration: none;
+    margin-right: var(--s-3);
+}
+
+article > small input[type="submit"]:hover,
+article > small button:hover {
+    background: none;
+    color: var(--accent);
+}
+
+/* Pagination */
+
+nav.pagination {
+    max-width: 44rem;
+    margin: var(--s-7) auto 0;
+    padding: var(--s-5) clamp(var(--s-4), 5vw, var(--s-7));
+    background: none;
+    border: 0;
+    text-align: center;
+}
+
+nav.pagination ul { justify-content: center; gap: var(--s-1); }
+nav.pagination > ul > li:not(:first-child):not(.right)::before { content: none; }
+
+.pages .current {
+    color: var(--ink);
+    font-weight: 500;
+}
+
+.pages .current::after { display: none; }
+
+/* Flash */
+
+.flash {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    margin: 0 0 var(--s-5);
+    padding: var(--s-3) 0;
+    color: var(--accent-hover);
+    border: 0;
+    background: none;
+}
+
+/* Footer — second and last horizontal line on the page */
+
+footer {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--ink-faint);
+    text-align: center;
+    padding: var(--s-5) var(--s-4);
+    border-top: 1px solid var(--rule);
+    margin-top: var(--s-8);
+}
+
+footer a {
+    color: var(--ink-soft);
+    text-decoration: none;
+}
+
+footer a:hover { color: var(--accent); }
+
+/* Accessibility */
+
+.screen-reader-text {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    word-wrap: normal !important;
+}
+
+.screen-reader-text:focus {
+    background: var(--paper-raised);
+    clip: auto !important;
+    clip-path: none;
+    color: var(--ink);
+    display: block;
+    font-size: var(--text-base);
+    height: auto;
+    left: var(--s-1);
+    line-height: normal;
+    padding: var(--s-3) var(--s-4);
+    text-decoration: none;
+    top: var(--s-1);
+    width: auto;
+    z-index: 100000;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+    }
+}
+
+/* Narrow viewports — collapse to a single column, timestamp stacked above */
+
+@media (max-width: 599px) {
+    main { padding: var(--s-6) 0 var(--s-7); }
+
+    article {
+        display: block;
+        margin-bottom: var(--s-6);
+    }
+
+    article > * { grid-column: auto; }
+
+    article > header > .meta {
+        text-align: left;
+        margin: 0 0 var(--s-2);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new theme `2026` for Lamb: a workshop/worklog visual direction tailored for a single-author personal microblog whose ethos is "doesn't demand your attention."

- Mono headings (Geist Mono), humanist sans body (Public Sans), deep amber accent
- 2-column grid layout: timestamp hangs in a left gutter, all body content (text, images, blockquotes, code) shares one consistent left edge
- Only two horizontal rules on the whole page (under the nav, above the footer); per-post borders removed in favour of vertical rhythm
- Author hidden from per-post meta visually but kept in markup as `screen-reader-text` so schema.org/BlogPosting `itemprop="author"` is preserved
- Falls back to the `default` theme for any parts it does not override

Design rationale (register, reflex-checks, color strategy, font selection, layout, trade-offs) is documented in `src/themes/2026/README.md`.

Activate by setting `theme = 2026` in `/settings`.

## Test plan

- [ ] `composer serve`, set `theme = 2026` at `/settings`, walk:
  - [ ] `/home` mixed titled and untitled posts (timestamp baselines correctly in both cases)
  - [ ] `/status/<id>` single-post view (no gutter, body uses full measure)
  - [ ] `/tag/<slug>` (tag chips render, pagination works)
  - [ ] `/search` and `/edit` (form inputs, search bar in nav)
  - [ ] Logged-in entry form, edit/delete actions
  - [ ] Narrow viewport (timestamp stacks above content; nav search expands to full width)
- [ ] `composer lint` clean
- [ ] `vendor/bin/codecept run Unit` green (511 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)