### PR TITLE
Compact related-posts list for 2026 theme

### DIFF
--- a/src/themes/2026/parts/_related.php
+++ b/src/themes/2026/parts/_related.php
@@ -1,0 +1,73 @@
+<?php
+
+global $data;
+global $template;
+
+use function Lamb\Theme\escape;
+use function Lamb\Theme\human_time;
+use function Lamb\Theme\related_posts;
+use function Lamb\get_tags;
+
+if ($template !== 'status') {
+    return;
+}
+
+$current = $data['posts'][0] ?? null;
+if ($current === null) {
+    return;
+}
+
+$current_id = (int) $current->id;
+$body = (string) $current->body;
+$related = related_posts($body, $current_id)['posts'] ?? [];
+
+// Hide menu items from the related list.
+$related = array_values(array_filter($related, static function ($bean) {
+    return empty($bean->is_menu_item);
+}));
+
+if (empty($related)) {
+    return;
+}
+
+$cap = 5;
+$overflow = count($related) > $cap;
+$shown = array_slice($related, 0, $cap);
+
+// Pick the first tag from the current post to use as the overflow link target.
+$tags = get_tags($body);
+$primary_tag = $tags[0] ?? null;
+
+?>
+<article class="related-posts">
+    <h6>Related</h6>
+    <ul class="related-list">
+        <?php foreach ($shown as $bean) : ?>
+            <?php
+            $permalink = '/' . ltrim(!empty($bean->slug) ? $bean->slug : "status/{$bean->id}", '/');
+            $title = trim(strip_tags($bean->title ?? ''));
+            $excerpt = trim(strip_tags($bean->description ?? ''));
+            // If the post has no title, promote a short excerpt to the title slot.
+            if ($title === '' && $excerpt !== '') {
+                $title = mb_strimwidth($excerpt, 0, 90, '…');
+                $excerpt = '';
+            }
+            $human = isset($bean->created) ? human_time(strtotime((string) $bean->created)) : '';
+            ?>
+            <li class="related-item">
+                <a class="related-link" href="<?= escape($permalink) ?>">
+                    <?php if ($human !== '') : ?>
+                        <time class="related-time" datetime="<?= escape((string) $bean->created) ?>"><?= escape($human) ?></time>
+                    <?php endif; ?>
+                    <span class="related-title"><?= escape($title !== '' ? $title : 'Untitled note') ?></span>
+                    <?php if ($excerpt !== '') : ?>
+                        <span class="related-excerpt"><?= escape(mb_strimwidth($excerpt, 0, 140, '…')) ?></span>
+                    <?php endif; ?>
+                </a>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+    <?php if ($overflow && $primary_tag !== null) : ?>
+        <p class="related-more"><a href="/tag/<?= escape(strtolower($primary_tag)) ?>">More in #<?= escape($primary_tag) ?> →</a></p>
+    <?php endif; ?>
+</article>

--- a/src/themes/2026/styles/styles.css
+++ b/src/themes/2026/styles/styles.css
@@ -453,20 +453,134 @@ article > small a:hover { color: var(--accent); }
 
 /* Related posts: quiet header, no border, no card */
 
+/* Related posts — compact index, capped to 5, with a tag link for overflow. */
+
 article.related-posts {
+    display: block;
     margin-top: var(--s-8);
+    padding-top: var(--s-5);
+    border-top: 1px solid var(--rule);
 }
 
-article.related-posts span {
-    display: block;
+article.related-posts h6 {
     font-family: var(--font-mono);
     font-size: var(--text-xs);
     color: var(--ink-faint);
-    letter-spacing: 0.04em;
-    margin-bottom: var(--s-3);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin: 0 0 var(--s-4);
 }
 
-article.related-posts p { margin: 0; }
+.related-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.related-item {
+    margin: 0;
+    padding: 0;
+}
+
+.related-item + .related-item {
+    margin-top: var(--s-3);
+}
+
+.related-link {
+    display: grid;
+    grid-template-columns: var(--time-col) minmax(0, 1fr);
+    column-gap: var(--time-gap);
+    row-gap: 0;
+    align-items: baseline;
+    padding: var(--s-2) 0;
+    color: var(--ink);
+    text-decoration: none;
+    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.related-link:hover,
+.related-link:focus-visible {
+    color: var(--accent);
+    outline: none;
+}
+
+.related-link:focus-visible .related-title {
+    text-decoration: underline;
+    text-underline-offset: 0.18em;
+}
+
+.related-time {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--accent);
+    text-align: right;
+    letter-spacing: 0.01em;
+    line-height: 1.5;
+}
+
+.related-title {
+    font-weight: 500;
+    line-height: 1.35;
+    grid-column: 2;
+    /* Single-line title with ellipsis when long. */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.related-excerpt {
+    grid-column: 2;
+    font-size: var(--text-sm);
+    color: var(--ink-soft);
+    line-height: 1.5;
+    margin-top: 0.15rem;
+    /* Clamp to a single line. */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.related-more {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    margin: var(--s-4) 0 0;
+}
+
+.related-more a {
+    color: var(--ink-soft);
+    text-decoration: none;
+}
+
+.related-more a:hover { color: var(--accent); }
+
+@media (max-width: 599px) {
+    .related-link {
+        display: block;
+        padding: var(--s-2) 0;
+    }
+    .related-time {
+        display: block;
+        text-align: left;
+        margin-bottom: 0.15rem;
+    }
+    .related-title,
+    .related-excerpt {
+        white-space: normal;
+    }
+    .related-title {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+    .related-excerpt {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        white-space: normal;
+    }
+}
 
 /* Entry form (logged-in only) — quiet, no panel */
 


### PR DESCRIPTION
## Summary

Pages with many related items (e.g. [/sidewing](https://vandragt.com/sidewing), 9 related posts) currently render each related item's **full body** below the main post, which doubles the page height with secondary content. This is from the default `_related.php` part using `\$bean->transformed` for every entry.

Override `_related.php` in the 2026 theme so each related item is rendered as:

- timestamp (mono, amber, right-aligned in the same gutter the timeline uses)
- linked title (or a 90-char excerpt promoted to title slot when the post has no title)
- one-line description, truncated at 140 chars, muted

The list is capped at 5 entries. When there's overflow, an appended line reads `More in #firsttag →`, linking to the first hashtag found in the current post.

Default theme is unchanged.

## Visual change

Before: 9 full-body related posts stacked under the main post.
After: 5-line compact index, ~5 short rows, with a tag link out for the rest.

## Test plan

- [x] `composer lint` clean
- [x] `vendor/bin/codecept run Unit` green (511 tests pass)
- [ ] Visit a status page with many related posts on the 2026 theme (e.g. `/sidewing` once deployed); confirm:
  - [ ] At most 5 items render
  - [ ] Titles link to permalinks
  - [ ] Timestamps render in the gutter on desktop, stacked on mobile
  - [ ] \"More in #tag →\" appears when there are more than 5
- [ ] Visit a status page with **no** related posts; section should be omitted entirely
- [ ] Visit a status page with related posts that have no title; first ~90 chars of description should appear in place of the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)