### PR TITLE
Fix link affordance in related list

### DIFF
--- a/src/themes/2026/parts/_related.php
+++ b/src/themes/2026/parts/_related.php
@@ -55,15 +55,13 @@ $primary_tag = $tags[0] ?? null;
             $human = isset($bean->created) ? human_time(strtotime((string) $bean->created)) : '';
             ?>
             <li class="related-item">
-                <a class="related-link" href="<?= escape($permalink) ?>">
-                    <?php if ($human !== '') : ?>
-                        <time class="related-time" datetime="<?= escape((string) $bean->created) ?>"><?= escape($human) ?></time>
-                    <?php endif; ?>
-                    <span class="related-title"><?= escape($title !== '' ? $title : 'Untitled note') ?></span>
-                    <?php if ($excerpt !== '') : ?>
-                        <span class="related-excerpt"><?= escape(mb_strimwidth($excerpt, 0, 140, '…')) ?></span>
-                    <?php endif; ?>
-                </a>
+                <?php if ($human !== '') : ?>
+                    <time class="related-time" datetime="<?= escape((string) $bean->created) ?>"><?= escape($human) ?></time>
+                <?php endif; ?>
+                <p class="related-title"><a href="<?= escape($permalink) ?>"><?= escape($title !== '' ? $title : 'Untitled note') ?></a></p>
+                <?php if ($excerpt !== '') : ?>
+                    <p class="related-excerpt"><?= escape(mb_strimwidth($excerpt, 0, 140, '…')) ?></p>
+                <?php endif; ?>
             </li>
         <?php endforeach; ?>
     </ul>

--- a/src/themes/2026/styles/styles.css
+++ b/src/themes/2026/styles/styles.css
@@ -478,38 +478,23 @@ article.related-posts h6 {
 }
 
 .related-item {
-    margin: 0;
-    padding: 0;
-}
-
-.related-item + .related-item {
-    margin-top: var(--s-3);
-}
-
-.related-link {
+    list-style: none;
     display: grid;
     grid-template-columns: var(--time-col) minmax(0, 1fr);
     column-gap: var(--time-gap);
     row-gap: 0;
     align-items: baseline;
-    padding: var(--s-2) 0;
-    color: var(--ink);
-    text-decoration: none;
-    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    margin: 0;
+    padding: var(--s-3) 0;
 }
 
-.related-link:hover,
-.related-link:focus-visible {
-    color: var(--accent);
-    outline: none;
-}
-
-.related-link:focus-visible .related-title {
-    text-decoration: underline;
-    text-underline-offset: 0.18em;
+.related-item + .related-item {
+    border-top: 1px dashed var(--rule);
 }
 
 .related-time {
+    grid-column: 1;
+    grid-row: 1;
     font-family: var(--font-mono);
     font-size: var(--text-xs);
     color: var(--accent);
@@ -519,25 +504,42 @@ article.related-posts h6 {
 }
 
 .related-title {
+    grid-column: 2;
+    margin: 0;
     font-weight: 500;
     line-height: 1.35;
-    grid-column: 2;
-    /* Single-line title with ellipsis when long. */
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+}
+
+.related-title a {
+    color: var(--ink);
+    text-decoration: none;
+    background-image: linear-gradient(var(--accent), var(--accent));
+    background-size: 0% 1px;
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    padding-bottom: 1px;
+    transition: background-size 220ms cubic-bezier(0.22, 1, 0.36, 1),
+                color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.related-title a:hover,
+.related-title a:focus-visible {
+    color: var(--accent);
+    background-size: 100% 1px;
+    outline: none;
 }
 
 .related-excerpt {
     grid-column: 2;
+    margin: 0.25rem 0 0;
     font-size: var(--text-sm);
     color: var(--ink-soft);
-    line-height: 1.5;
-    margin-top: 0.15rem;
-    /* Clamp to a single line. */
+    line-height: 1.45;
+    /* Clamp to two lines so excerpts do not run on. */
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 .related-more {
@@ -554,31 +556,14 @@ article.related-posts h6 {
 .related-more a:hover { color: var(--accent); }
 
 @media (max-width: 599px) {
-    .related-link {
+    .related-item {
         display: block;
-        padding: var(--s-2) 0;
+        padding: var(--s-3) 0;
     }
     .related-time {
         display: block;
         text-align: left;
         margin-bottom: 0.15rem;
-    }
-    .related-title,
-    .related-excerpt {
-        white-space: normal;
-    }
-    .related-title {
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-    }
-    .related-excerpt {
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-        white-space: normal;
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #257. The compact related list wrapped each whole row in a single `<a>`, so timestamp + title + excerpt all inherited link styling and the row read as one long underlined link instead of readable text.

Restructure so only the **title** is the clickable link. Timestamp and excerpt are plain elements positioned in the same hanging-timestamp grid as before.

### Changes

- `_related.php`: each `<li>` now contains a bare `<time>`, a `<p class="related-title">` with an `<a>` wrapping just the title, and a `<p class="related-excerpt">` for the description.
- `styles/styles.css`: dropped `.related-link` rules; `.related-item` now owns the 2-column grid. `.related-title a` gets the animated-underline hover treatment used elsewhere on the site. Added `list-style: none` on `.related-item` as well as `.related-list` to defeat UA bullet defaults that were leaking through. Item separator changed from spacing to a thin dashed rule for quieter visual rhythm.

## Test plan

- [x] `composer lint` clean
- [x] `vendor/bin/codecept run Unit` green (511 tests pass)
- [ ] Visit a status page with several related items on the 2026 theme; confirm:
  - [ ] Only the title is visually link-styled (color, hover underline)
  - [ ] Timestamp and excerpt read as plain text
  - [ ] No `•` UA bullets in the list
  - [ ] Hover on title animates the underline in

🤖 Generated with [Claude Code](https://claude.com/claude-code)