### PR TITLE
2026 theme: amber-text/graphical split, motion+radius tokens, PRODUCT/DESIGN docs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,236 @@
+# Design
+
+Visual system for the Lamb 2026 "Notes" theme. Captures the tokens, type, layout, and component grammar so future variants stay on-brand.
+
+## Theme
+
+**Light by default; dark via `prefers-color-scheme`.** Light is forced by the physical scene: someone reading short notes on a 13" laptop or phone in mixed daytime indoor light, on a break from other work. Mood is low-pressure browsing. Dark wasn't picked as the category reflex (developer blog) but is provided as an opt-in OS-level preference. Dark-mode neutrals stay warm-tinted (60° hue) so the variant reads as evening, not cold.
+
+## Color
+
+**Strategy: Restrained.** Tinted warm neutrals plus one accent that appears on under 10% of the surface. No accent backgrounds, no bordered panels, no color blocks.
+
+All values in OKLCH, tinted 50-70° on the hue wheel (warm, away from blue, toward sand and amber).
+
+### Tokens (light mode)
+
+| Token | Value | Role |
+|---|---|---|
+| `--paper` | `oklch(98% 0.006 70)` | Page background. Near-white with faint warm tint, reads as paper not screen. |
+| `--paper-raised` | `oklch(95% 0.010 70)` | Subtle elevation: code, inputs, hashtag chips. |
+| `--ink` | `oklch(22% 0.02 50)` | Primary text. Not pure black. |
+| `--ink-soft` | `oklch(50% 0.025 55)` | Secondary text, nav, blockquote, h4-h6, related excerpt. |
+| `--ink-faint` | `oklch(58% 0.025 55)` | Tertiary text: footer, edit/delete row, related h6 label, nav `·` separator. |
+| `--rule` | `oklch(88% 0.012 70)` | The two horizontal lines on the page. |
+| `--accent` | `oklch(56% 0.135 65)` | Graphical only: focus ring, current-nav 2px underline, 1px title-link underline, `--accent-tint` pair. |
+| `--accent-link` | `oklch(46% 0.140 60)` | Text-bearing: `a`, timestamps, blockquote quotes, flash, hashtag-hover, related-time, post `.meta`, every hover text color. |
+| `--accent-hover` | `oklch(38% 0.140 58)` | Link hover, primary button hover. |
+| `--accent-tint` | `oklch(94% 0.045 70)` | Hashtag-chip hover background only. |
+| `--selection` | `oklch(89% 0.090 75)` | Text selection. |
+
+Accent rule: any amber that *carries text* uses `--accent-link`; any amber that is a graphical object (focus ring, 2px nav underline, 1px title underline) uses `--accent`. No accent backgrounds. No accent panels.
+
+### Tokens (dark mode)
+
+Engaged via `@media (prefers-color-scheme: dark)`. Same hue family, inverted lightness, amber kicks up in brightness for legibility on dark.
+
+| Token | Value |
+|---|---|
+| `--paper` | `oklch(20% 0.012 60)` |
+| `--paper-raised` | `oklch(25% 0.014 60)` |
+| `--ink` | `oklch(92% 0.012 70)` |
+| `--ink-soft` | `oklch(75% 0.020 65)` |
+| `--ink-faint` | `oklch(60% 0.020 65)` |
+| `--rule` | `oklch(32% 0.015 60)` |
+| `--accent` | `oklch(74% 0.140 70)` |
+| `--accent-link` | `oklch(82% 0.130 72)` |
+| `--accent-hover` | `oklch(88% 0.115 75)` |
+| `--accent-tint` | `oklch(28% 0.040 70)` |
+| `--selection` | `oklch(38% 0.110 75)` |
+
+### Earlier rejection
+
+`oklch(52% 0.17 28)` (brick-red, higher chroma) was tried and rejected as too aggressive for a "doesn't demand your attention" brief. Amber at lower chroma keeps presence without volume.
+
+## Typography
+
+Brand voice: technical, warm, opinionated.
+
+| Family | Stack | Use |
+|---|---|---|
+| Geist Mono | `"Geist Mono", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace` | All headings, timestamps, nav, form labels, flash, footer, hashtags. The "voice" font. |
+| Public Sans | `"Public Sans", "Source Sans 3", system-ui, sans-serif` | Body. Calm, neutral, humanist enough to read for several hundred words. |
+
+**Self-hosted woff2** under `themes/2026/styles/fonts/`. Subsets cover Latin + Latin-Extended; `font-display: swap` on every face. No third-party fetch; stack falls back to `ui-monospace` and `system-ui` if the woff2 files are missing.
+
+### Scale
+
+1.25 ratio, fluid at the top:
+
+| Token | Value |
+|---|---|
+| `--text-xs` | `0.75rem` |
+| `--text-sm` | `0.875rem` |
+| `--text-base` | `1.0625rem` |
+| `--text-md` | `1.1875rem` |
+| `--text-lg` | `1.5rem` |
+| `--text-xl` | `clamp(1.6rem, 1.3rem + 1vw, 2rem)` |
+
+Body: `--leading: 1.65`. Headings: `--leading-tight: 1.2`.
+
+Heading letter-spacing: `-0.01em` (subheads), `-0.02em` (h1, tighter on display sizes). Small caps-feel via `letter-spacing: 0.02em` + `--ink-soft` on h4-h6.
+
+## Spacing
+
+Scale (rem-based, eyeballed to a roughly geometric progression):
+
+| Token | Value |
+|---|---|
+| `--s-1` | `0.25rem` |
+| `--s-2` | `0.5rem` |
+| `--s-3` | `0.75rem` |
+| `--s-4` | `1rem` |
+| `--s-5` | `1.5rem` |
+| `--s-6` | `2rem` |
+| `--s-7` | `3rem` |
+| `--s-8` | `4.5rem` |
+
+Vary spacing for rhythm. Larger steps (`--s-7`, `--s-8`) separate sections (post-to-post, related-posts top, footer top). Smaller steps tighten within an entry.
+
+## Layout
+
+### Reading column
+
+- `main` max-width: `44rem` (≈65ch body measure).
+- Outer padding: `clamp(var(--s-4), 5vw, var(--s-7))`.
+- Centered, no container wrapper outside `main`.
+
+### Post grid (signature pattern)
+
+Each post is a 2-column CSS grid:
+
+| Column | Width | Content |
+|---|---|---|
+| 1 | `--time-col` (`6.5rem`) | Timestamp. Right-aligned. Mono. Amber. |
+| 2 | `minmax(0, 1fr)` | Title, paragraphs, images, blockquotes, code, hashtags, logged-in actions. |
+
+Gap: `--time-gap` (= `--s-5`).
+
+`align-items: baseline` aligns the timestamp baseline with the first content row. Works identically whether or not a title is present, which solved the "meta feels heavy beside short status posts" problem.
+
+`article > header { display: contents; }` lets the header's children participate directly in the grid without changing the markup.
+
+### Single-post bypass
+
+`.status article` and `.post article` use `display: block`. The `<h1>` already carries the title; a one-article page doesn't need a gutter.
+
+### Narrow viewports (≤599px)
+
+Grid collapses to a single column. Timestamps stack above their post, left-aligned.
+
+### Two lines on the entire page
+
+`border-bottom` on `nav`, `border-top` on `footer`. That's it. No per-post dividers, no panel borders, no h1 underline, no entry-form border, no flash border, no search-input border. Whitespace and type carry the dividing work.
+
+## Radii
+
+| Token | Value | Role |
+|---|---|---|
+| `--radius` | `3px` | Code blocks, inputs, primary buttons. |
+| `--radius-sm` | `2px` | Hashtag chips, focus-ring rounding. |
+
+## Components
+
+### Nav
+
+- Bottom border `1px solid var(--rule)`, mono, small.
+- Items separated by a faint `·` glyph (`::before` on non-first children), not by padding alone.
+- Current item: `--ink` color + a 2px amber underline absolute-positioned under the text (not a background fill).
+- Search input on the right; `flex: 1; justify-content: flex-end`. Wraps to full width under 600px.
+
+### Article header
+
+- Mono `<h2>` title; `font-weight: 600`, `letter-spacing: -0.01em`.
+- Title hover: `background-image` linear-gradient amber underline animating `background-size: 0% 1px → 100% 1px` over 260ms ease-out-quart. Allowed motion: not a layout property.
+- `.meta` timestamp in grid column 1, mono, `--text-xs`, amber, right-aligned, `letter-spacing: 0.01em`.
+
+### Body content
+
+- Paragraphs: `margin: 0.85em 0`.
+- Blockquote: italic, `--ink-soft`, no left border. Opens/closes with amber `"` `"` via `::before` / `::after` on `<p>`.
+- `<code>`: mono `0.9em/1.4`, `--paper-raised` background, `0.1em 0.35em` padding, `3px` radius.
+- `<pre>`: same background, `--s-4` padding, `--s-5` vertical margin, overflow-x auto.
+- `<hr>`: no border. Renders an asterism `* * *` in mono, `letter-spacing: 0.6em`, `--ink-faint`, `--s-7` vertical margin.
+- Lists: `padding-left: var(--s-5)`, `li { margin: var(--s-2) 0 }`.
+
+### Hashtag chip
+
+- Mono, `0.85em`, `--ink-soft`, `--paper-raised` background, `0.1em 0.4em` padding, `2px` radius.
+- Hover: `--accent` color, `--accent-tint` background.
+
+### Logged-in action row
+
+- `<small>` block, mono, `--text-xs`, `--ink-faint`.
+- Inline forms; buttons styled as link-like text (no background, `--ink-faint`, hover `--accent`).
+
+### Related posts
+
+- Top border `1px solid var(--rule)` (the only per-post divider, scoped to this block).
+- `h6` label: mono, xs, uppercase, `letter-spacing: 0.08em`, `--ink-faint`.
+- Items reuse the post grid: amber timestamp on the left, title + single-line excerpt on the right.
+- Titles and excerpts clamped to one line with ellipsis on desktop; two-line clamp on narrow viewports.
+
+### Entry form (logged-in only)
+
+- No panel, no border around the section.
+- `<textarea>`: mono `--text-sm`, `--paper-raised` background, transparent 1px border, focus changes border to `--accent` and background to `--paper`.
+- Primary `<button>` / `input[type="submit"]`: mono 500, `--paper` text on `--ink` background, `3px` radius, `--s-3 --s-4` padding. Hover: background → `--accent-hover`.
+
+### Pagination
+
+- Centered, `--s-7` top margin, no background, no border.
+- Separator dots from nav suppressed inside `nav.pagination`.
+- Current page: bold, `--ink`; underline removed.
+
+### Flash
+
+- Mono `--text-sm`, `--accent-hover` text, no background, no border, no padding-box.
+
+### Footer
+
+- Mono `--text-xs`, `--ink-faint`, centered.
+- Top border `1px solid var(--rule)` (the second of the two page lines).
+
+## Motion
+
+Single easing curve across the system: `--ease-out-quart` = `cubic-bezier(0.22, 1, 0.36, 1)`.
+
+| Token | Value | Where |
+|---|---|---|
+| `--t-fast` | `140ms` | Color, background, border transitions on links, buttons, inputs, nav items, hashtag chips. |
+| `--t-slow` | `260ms` | `background-size` on the title-link underline reveal. |
+
+No layout-property animations. No bounce, no elastic. `prefers-reduced-motion: reduce` clamps all durations to `0.01ms`.
+
+## Accessibility
+
+- WCAG AA target.
+- `:focus-visible`: `2px solid var(--accent)` outline, `2px` offset, `2px` border-radius on generic elements.
+- `.screen-reader-text` utility for visually hidden but crawlable content (author name kept for schema.org/BlogPosting; skip-link support on `:focus`).
+- Single-column collapse at 599px; timestamps stack, related-link items expand to two-line clamp.
+- Known limitation: `display: contents` on `<header>` may suppress the landmark role in older screen readers. Accepted; the header only contains title + timestamp in this template.
+
+## File map
+
+- `themes/2026/html.php` — HTML shell, Google Fonts link, tightened nav markup.
+- `themes/2026/styles/styles.css` — full visual definition.
+- `themes/2026/parts/_items.php` — moves `<strong itemprop="author">` into `.screen-reader-text`.
+- Everything else falls back to `themes/default/`.
+
+## Activation
+
+```ini
+theme = 2026
+```
+
+In the INI config at `/settings`.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,51 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+A single author publishing short status posts and occasional 400-600 word essays on Linux tooling and AI-assisted development. Readers arrive from feeds, links, and search; their context is mixed daytime reading on a 13" laptop or phone, on a break from other work. Mood is low-pressure, low-stakes browsing.
+
+The site is "Sander van Dragt's Notes": a Senior Web Engineer at Human Made (enterprise WordPress, Altis DXP), WordPress core contributor (5.5 sitemaps), and maker of positive digital experiences.
+
+## Product Purpose
+
+Lamb is bespoke microblogging software that "doesn't demand your attention. Frictionless and fast." The 2026 "Notes" theme is a personal-site instance of that philosophy: a worklog. Time-stamped entries with a calm visual rhythm. The reader should feel they're looking at a journal, not a publication.
+
+Success: the design recedes. The text and timestamps carry the experience. Nothing on the page asks for attention it didn't earn.
+
+## Brand Personality
+
+Three words: **technical, warm, opinionated**.
+
+Voice: quiet craftsmanship. Personality comes from typographic decisions and restraint, not from chrome, color, or motion. The author is genuinely technical; mono headings read as voice, not costume.
+
+Emotional goal: calm presence. Like a well-kept notebook, not a publication or a product.
+
+## Anti-references
+
+- **Editorial-magazine grammar.** Display serif, italic drop caps, broadsheet grids. Wrong register for short status updates.
+- **Developer-blog dark mode by default.** Costume, not voice. The scene (daytime, mixed light, break time) doesn't force dark.
+- **Inter, Söhne, JetBrains Mono.** First-reflex picks for "technical and modern"; on the saturated list.
+- **2000s blog template.** Yellow nav band, centered column with a left rule, gray-on-white. What the previous 2024 theme was. The 2026 overhaul exists to move past this.
+- **SaaS chrome.** Card grids, hero-metric layouts, gradient accents, bordered panels, glassmorphism.
+- **High-chroma accents that shout.** An earlier brick-red `oklch(52% 0.17 28)` was rejected as too aggressive for a site whose tagline is "doesn't demand your attention."
+
+## Design Principles
+
+1. **Doesn't demand attention.** Every rule, panel, border, or color block must justify itself. The default answer is no.
+2. **Personality from craft, not chrome.** Hanging timestamps, asterism `hr`, curly-quote blockquotes, mono headings, separator dots between nav items. Quiet details that reward attention but don't ask for it.
+3. **Whitespace and typography do the dividing work.** Two horizontal rules on the entire page (under nav, above footer). That's it.
+4. **Warm, not cold.** Tinted neutrals toward sand and amber; never raw `#fff` or `#000`. Light theme because the physical scene forces it, not because light is "safe."
+5. **Single-author, single-purpose.** Author name hidden from per-post meta (kept in schema markup for crawlers). Repetition is noise.
+
+## Accessibility & Inclusion
+
+- WCAG AA target. Atkinson Hyperlegible was briefly considered; rejected when feedback confirmed existing fonts were working.
+- `prefers-reduced-motion` honored: transitions and animations clamped to 0.01ms.
+- `.screen-reader-text` utility for visually hidden but crawlable content (author name, skip links).
+- Focus indicators visible (`:focus-visible` with 2px amber outline + offset).
+- Single-column collapse under 600px; timestamps stack above their post.
+- Known limitation: `display: contents` on `<header>` may lose the landmark role in older screen readers. Accepted because the header only contains title and timestamp in this template.

--- a/src/themes/2026/styles/styles.css
+++ b/src/themes/2026/styles/styles.css
@@ -142,8 +142,11 @@
     --ink-soft:     oklch(50% 0.025 55);
     --ink-faint:    oklch(58% 0.025 55);
     --rule:         oklch(88% 0.012 70);
+    /* --accent is graphical-only (focus ring, current-nav 2px underline, accent-tint pair).
+       Text-bearing amber uses --accent-link, tuned darker to clear WCAG AA on --paper. */
     --accent:       oklch(56% 0.135 65);
-    --accent-hover: oklch(48% 0.140 60);
+    --accent-link:  oklch(46% 0.140 60);
+    --accent-hover: oklch(38% 0.140 58);
     --accent-tint:  oklch(94% 0.045 70);
     --selection:    oklch(89% 0.090 75);
 
@@ -177,6 +180,12 @@
     --time-col:   6.5rem;
     --time-gap:   var(--s-5);
     --radius:     3px;
+    --radius-sm:  2px;
+
+    /* Motion */
+    --ease-out-quart: cubic-bezier(0.22, 1, 0.36, 1);
+    --t-fast: 140ms;
+    --t-slow: 260ms;
 }
 
 /* Reset & base */
@@ -198,10 +207,10 @@ body {
 img { max-width: 100%; height: auto; display: block; }
 
 a {
-    color: var(--accent);
+    color: var(--accent-link);
     text-decoration-thickness: 1px;
     text-underline-offset: 0.18em;
-    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: color var(--t-fast) var(--ease-out-quart);
 }
 
 a:hover { color: var(--accent-hover); }
@@ -209,7 +218,7 @@ a:hover { color: var(--accent-hover); }
 a:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
-    border-radius: 2px;
+    border-radius: var(--radius-sm);
 }
 
 button, input[type='submit'] { cursor: pointer; }
@@ -248,8 +257,8 @@ blockquote {
     font-style: italic;
 }
 
-blockquote p::before { content: "“"; color: var(--accent); }
-blockquote p::after  { content: "”"; color: var(--accent); }
+blockquote p::before { content: "“"; color: var(--accent-link); }
+blockquote p::after  { content: "”"; color: var(--accent-link); }
 
 code {
     font: 0.9em/1.4 var(--font-mono);
@@ -318,12 +327,12 @@ nav a, nav .current {
     color: var(--ink-soft);
     padding: var(--s-4) var(--s-3);
     letter-spacing: 0.01em;
-    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: color var(--t-fast) var(--ease-out-quart);
 }
 
 nav a:hover,
 nav a:focus-visible {
-    color: var(--accent);
+    color: var(--accent-link);
     background: none;
     outline: none;
 }
@@ -365,8 +374,8 @@ nav form input[type="text"] {
     border-radius: var(--radius);
     padding: var(--s-2) var(--s-3);
     min-width: 0;
-    transition: border-color 140ms cubic-bezier(0.22, 1, 0.36, 1),
-                background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: border-color var(--t-fast) var(--ease-out-quart),
+                background-color var(--t-fast) var(--ease-out-quart);
 }
 
 nav form input[type="text"]::placeholder {
@@ -385,10 +394,10 @@ nav form input[type="submit"] {
     background: none;
     border: 0;
     padding: var(--s-2);
-    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: color var(--t-fast) var(--ease-out-quart);
 }
 
-nav form input[type="submit"]:hover { color: var(--accent); }
+nav form input[type="submit"]:hover { color: var(--accent-link); }
 
 nav li.right {
     flex: 1;
@@ -478,7 +487,7 @@ article > header > .meta {
     grid-row: 1;
     font-family: var(--font-mono);
     font-size: var(--text-xs);
-    color: var(--accent);
+    color: var(--accent-link);
     text-align: right;
     line-height: 1.5;
     letter-spacing: 0.01em;
@@ -492,7 +501,7 @@ article > header + * {
 article header .meta a {
     color: inherit;
     text-decoration: none;
-    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: color var(--t-fast) var(--ease-out-quart);
 }
 
 article header .meta a:hover { color: var(--accent-hover); }
@@ -513,14 +522,14 @@ article header h2 a.title-link {
     background-size: 0% 1px;
     background-position: 0 100%;
     background-repeat: no-repeat;
-    transition: background-size 260ms cubic-bezier(0.22, 1, 0.36, 1),
-                color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: background-size var(--t-slow) var(--ease-out-quart),
+                color var(--t-fast) var(--ease-out-quart);
     padding-bottom: 1px;
 }
 
 article header h2 a.title-link:hover,
 article header h2 a.title-link:focus-visible {
-    color: var(--accent);
+    color: var(--accent-link);
     background-size: 100% 1px;
 }
 
@@ -533,13 +542,13 @@ article a[href*="/tag/"] {
     text-decoration: none;
     background: var(--paper-raised);
     padding: 0.1em 0.4em;
-    border-radius: 2px;
-    transition: color 140ms cubic-bezier(0.22, 1, 0.36, 1),
-                background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    border-radius: var(--radius-sm);
+    transition: color var(--t-fast) var(--ease-out-quart),
+                background-color var(--t-fast) var(--ease-out-quart);
 }
 
 article a[href*="/tag/"]:hover {
-    color: var(--accent);
+    color: var(--accent-link);
     background: var(--accent-tint);
 }
 
@@ -558,7 +567,7 @@ article > small a {
     margin-right: var(--s-3);
 }
 
-article > small a:hover { color: var(--accent); }
+article > small a:hover { color: var(--accent-link); }
 
 /* Single-post view: don't repeat the title (h1 is the title), drop the gutter,
    give the body its full measure. */
@@ -624,7 +633,7 @@ article.related-posts h6 {
     grid-row: 1;
     font-family: var(--font-mono);
     font-size: var(--text-xs);
-    color: var(--accent);
+    color: var(--accent-link);
     text-align: right;
     letter-spacing: 0.01em;
     line-height: 1.5;
@@ -645,13 +654,13 @@ article.related-posts h6 {
     background-position: 0 100%;
     background-repeat: no-repeat;
     padding-bottom: 1px;
-    transition: background-size 220ms cubic-bezier(0.22, 1, 0.36, 1),
-                color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: background-size 220ms var(--ease-out-quart),
+                color var(--t-fast) var(--ease-out-quart);
 }
 
 .related-title a:hover,
 .related-title a:focus-visible {
-    color: var(--accent);
+    color: var(--accent-link);
     background-size: 100% 1px;
     outline: none;
 }
@@ -680,7 +689,7 @@ article.related-posts h6 {
     text-decoration: none;
 }
 
-.related-more a:hover { color: var(--accent); }
+.related-more a:hover { color: var(--accent-link); }
 
 @media (max-width: 599px) {
     .related-item {
@@ -714,8 +723,8 @@ textarea {
     border-radius: var(--radius);
     box-sizing: border-box;
     resize: vertical;
-    transition: border-color 140ms cubic-bezier(0.22, 1, 0.36, 1),
-                background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: border-color var(--t-fast) var(--ease-out-quart),
+                background-color var(--t-fast) var(--ease-out-quart);
 }
 
 textarea:focus-visible {
@@ -731,8 +740,8 @@ input[type="text"], input[type="password"] {
     border: 1px solid transparent;
     border-radius: var(--radius);
     padding: var(--s-2) var(--s-3);
-    transition: border-color 140ms cubic-bezier(0.22, 1, 0.36, 1),
-                background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: border-color var(--t-fast) var(--ease-out-quart),
+                background-color var(--t-fast) var(--ease-out-quart);
 }
 
 input[type="text"]:focus-visible,
@@ -750,7 +759,7 @@ input[type="submit"], button {
     border-radius: var(--radius);
     padding: var(--s-3) var(--s-4);
     letter-spacing: 0.01em;
-    transition: background-color 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: background-color var(--t-fast) var(--ease-out-quart);
 }
 
 input[type="submit"]:hover, button:hover {
@@ -774,7 +783,7 @@ article > small button {
 article > small input[type="submit"]:hover,
 article > small button:hover {
     background: none;
-    color: var(--accent);
+    color: var(--accent-link);
 }
 
 /* Pagination */
@@ -827,7 +836,7 @@ footer a {
     text-decoration: none;
 }
 
-footer a:hover { color: var(--accent); }
+footer a:hover { color: var(--accent-link); }
 
 /* Accessibility */
 
@@ -914,7 +923,8 @@ footer a:hover { color: var(--accent); }
         --ink-faint:    oklch(60% 0.020 65);
         --rule:         oklch(32% 0.015 60);
         --accent:       oklch(74% 0.140 70);
-        --accent-hover: oklch(82% 0.130 72);
+        --accent-link:  oklch(82% 0.130 72);
+        --accent-hover: oklch(88% 0.115 75);
         --accent-tint:  oklch(28% 0.040 70);
         --selection:    oklch(38% 0.110 75);
     }


### PR DESCRIPTION
## Summary

This PR was originally a broader audit pass; main has since landed a sibling PR with overlapping work (self-hosted fonts, dark mode, touch targets, contrast bump). After rebasing onto main, this PR is now reduced to the **non-overlapping deltas** plus the design docs.

**Color split**
- `--accent` is now graphical-only: focus ring, current-nav 2px underline, 1px title underline, the `--accent-tint` pair.
- `--accent-link` is the text-bearing token: `a`, timestamps, blockquote curly quotes, flash, related-time, post `.meta`, every hover text color. Tuned darker on light (`oklch(46% 0.140 60)`) and brighter on dark (`oklch(82% 0.130 72)`) to clear WCAG AA against its surface.
- `--accent-hover` deepened in both light and dark for a clearer hover step.

**Token extraction**
- `--radius-sm` (2px) replaces hardcoded 2px radii (focus-visible, hashtag chips).
- `--ease-out-quart`, `--t-fast` (140ms), `--t-slow` (260ms) added; all matching `cubic-bezier(0.22, 1, 0.36, 1)` / `140ms` / `260ms` literals collapsed.

**Docs**
- `PRODUCT.md` at the project root: register (brand), users, purpose, brand personality, anti-references, design principles, accessibility posture.
- `DESIGN.md` at the project root: live token system for both light and dark, typography (now self-hosted woff2), spacing, layout, motion, components, a11y. Synthesized from `src/themes/2026/README.md` and the current CSS.

## Test plan
- [x] `vendor/bin/codecept run Unit` — 511 tests, 736 assertions, green
- [x] `composer lint` — clean
- [x] `php -l src/themes/2026/html.php` — no syntax errors
- [ ] Visual smoke test on `composer serve`: hover transitions, link readability, dark mode toggle
- [ ] OKLCH contrast verification on `--accent-link` over `--paper` (light) and `--paper` (dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)