### PR TITLE
Fix double-encoded HTML entities in post descriptions

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -90,7 +90,12 @@ function parse_bean(OODBBean $bean): void
     $markdown = $parser->text($md_text);
 
     $front_matter = parse_matter($bean->body);
-    $front_matter['description'] = strtok(strip_tags($markdown), "\n");
+    $description = strtok(strip_tags($markdown), "\n");
+    // Decode twice: feed-ingested bodies already contain HTML entities (e.g. `&#039;`),
+    // which Parsedown then re-encodes (`&amp;#039;`). A single decode only undoes one layer.
+    $description = html_entity_decode($description, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $description = html_entity_decode($description, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $front_matter['description'] = $description;
 
     $front_matter['transformed'] = (parse_tags($markdown));
 

--- a/tests/Unit/ParseBeanDescriptionTest.php
+++ b/tests/Unit/ParseBeanDescriptionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\parse_bean;
+
+class ParseBeanDescriptionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+    }
+
+    public function testDescriptionIsPlainTextWithoutHtmlEntities()
+    {
+        $bean = R::dispense('post');
+        $bean->body = "It seems sometimes I&#039;m researching and want the previous tab to become active.";
+        $bean->slug = '';
+
+        parse_bean($bean);
+
+        $this->assertStringNotContainsString('&#039;', $bean->description);
+        $this->assertStringNotContainsString('&amp;', $bean->description);
+        $this->assertStringContainsString("I'm researching", $bean->description);
+    }
+}


### PR DESCRIPTION
## Summary
- Feed-ingested post bodies contain HTML entities like `&#039;` from SimplePie's `get_description()`.
- Parsedown then re-encodes the ampersand, leaving `&amp;#039;` in the stored `description`.
- The 2026 theme's related-posts list re-escapes on output, surfacing the literal `&#039;` in the browser (seen in the related-list title for a status post).
- Decode entities twice in `parse_bean()` so the description is stored as genuine plain text.

Note: existing posts retain the bad description until they're re-saved or their source feed is reingested.

## Test plan
- [x] New unit test `ParseBeanDescriptionTest` covers the regression
- [x] All 512 unit tests pass
- [x] `composer lint` and `composer analyse` clean