### PR TITLE
Add rel="alternate" and type="text/html" to Atom entry links

### DIFF
--- a/src/themes/default/feed.php
+++ b/src/themes/default/feed.php
@@ -36,6 +36,8 @@ foreach ($data['posts'] as $bean) {
     $Content = $Entry->addChild('content', $bean->transformed);
     $Content->addAttribute('type', 'html');
     $Link = $Entry->addChild('link');
+    $Link->addAttribute('rel', 'alternate');
+    $Link->addAttribute('type', 'text/html');
     $Link->addAttribute('href', Lamb\permalink($bean));
 }
 echo $Xml->asXML();

--- a/tests/Unit/FeedTemplateTest.php
+++ b/tests/Unit/FeedTemplateTest.php
@@ -120,6 +120,24 @@ class FeedTemplateTest extends TestCase
         $this->assertStringContainsString('alt="A cat"', $content);
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedEntryLinkHasRelAlternateAndTypeHtml(): void
+    {
+        $xml = $this->renderFeedWithPost([
+            'title'       => 'Linked Post',
+            'description' => 'Excerpt',
+            'transformed' => '<p>Body</p>',
+        ]);
+
+        $link = $xml->entry[0]->link;
+        $this->assertSame('alternate', (string) $link['rel']);
+        $this->assertSame('text/html', (string) $link['type']);
+        $this->assertNotEmpty((string) $link['href']);
+    }
+
     private function renderFeedWithPost(array $fields): \SimpleXMLElement
     {
         require_once __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
## Summary
- Adds `rel="alternate"` and `type="text/html"` to each Atom `<entry>`'s `<link>` per RFC 4287 §4.2.7.
- Adds a FeedTemplateTest assertion covering the new attributes.

Closes #247.

## Test plan
- [x] `vendor/bin/codecept run Unit` (516 tests pass)
- [x] `composer lint`
- [x] `composer analyse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)