### PR TITLE
Remove author email from Atom feed; add author URI

### DIFF
--- a/src/themes/default/feed.php
+++ b/src/themes/default/feed.php
@@ -25,7 +25,7 @@ $Link->addAttribute('href', escape($channel_link));
 
 $Author = $Xml->addChild('author');
 $Author->addChild('name', escape($config['author_name']));
-$Author->addChild('email', escape($config['author_email']));
+$Author->addChild('uri', ROOT_URL);
 
 foreach ($data['posts'] as $bean) {
     $Entry = $Xml->addChild('entry');

--- a/tests/Unit/FeedTemplateTest.php
+++ b/tests/Unit/FeedTemplateTest.php
@@ -124,6 +124,24 @@ class FeedTemplateTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
+    public function testFeedAuthorHasNoEmailAndIncludesUri(): void
+    {
+        $xml = $this->renderFeedWithPost([
+            'title'       => 'Post',
+            'description' => 'Excerpt',
+            'transformed' => '<p>Body</p>',
+        ]);
+
+        $author = $xml->author;
+        $this->assertSame('Test Author', (string) $author->name);
+        $this->assertSame(ROOT_URL, (string) $author->uri);
+        $this->assertFalse(isset($author->email), 'Author email should not be exposed in the feed');
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testFeedEntryLinkHasRelAlternateAndTypeHtml(): void
     {
         $xml = $this->renderFeedWithPost([


### PR DESCRIPTION
## Summary
- Drop `<email>` child from Atom feed `<author>` (privacy leak per micro.blog guidance)
- Add `<uri>` pointing to `ROOT_URL` as the canonical author identifier
- Add test asserting no `<email>` and presence of `<uri>` and `<name>`

Closes #243

## Test plan
- [x] `vendor/bin/codecept run Unit` passes (517 tests)
- [x] `composer lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)