### PR TITLE
Fix tag archive missing posts where tag is followed by punctuation

### DIFF
--- a/src/post.php
+++ b/src/post.php
@@ -95,7 +95,12 @@ function slugify(string $text): string
 }
 
 /**
- * Returns SQL conditions and parameters for matching posts that contain the given tag.
+ * Returns a broad SQL prefilter for posts whose body contains the given tag.
+ *
+ * The SQL is deliberately permissive (it also matches longer tags that share
+ * this prefix, e.g. `#tildes` for `til`); callers must refine the result set
+ * with body_has_tag() so the match honours the same delimiter rules as the
+ * inline tag renderer (Lamb\parse_tags).
  *
  * @param string $tag The tag to match.
  * @return array{sql: string, params: array}
@@ -103,9 +108,25 @@ function slugify(string $text): string
 function get_tag_search_conditions(string $tag): array
 {
     return [
-        'sql'    => 'body LIKE ? OR body LIKE ? OR body LIKE ?',
-        'params' => ["%#$tag %", "%\n#$tag %", "%#$tag"],
+        'sql'    => 'body LIKE ?',
+        'params' => ["%#$tag%"],
     ];
+}
+
+/**
+ * Returns true if $body contains $tag as a hashtag, using the same boundary
+ * rules as the inline tag renderer (Lamb\parse_tags): the tag must follow the
+ * start of the string, whitespace, or `>`, and be followed by whitespace, the
+ * end of the string, or one of the tag-terminating punctuation characters.
+ *
+ * @param string $tag  The tag to look for (without the leading `#`).
+ * @param string $body The raw post body.
+ * @return bool
+ */
+function body_has_tag(string $tag, string $body): bool
+{
+    $pattern = '/(^|[\s>])#' . preg_quote($tag, '/') . '(?=[\s#&.,!?;:()\[\]{}<]|$)/iu';
+    return (bool) preg_match($pattern, $body);
 }
 
 /**
@@ -118,9 +139,11 @@ function get_tag_search_conditions(string $tag): array
 function posts_by_tag(string $tag): array
 {
     $conditions = get_tag_search_conditions($tag);
-    return R::find(
+    $posts = R::find(
         'post',
         '(' . $conditions['sql'] . ') AND (draft IS NULL OR draft != 1) ORDER BY created DESC',
         $conditions['params']
     );
+
+    return array_values(array_filter($posts, fn($post) => body_has_tag($tag, (string) $post->body)));
 }

--- a/src/theme.php
+++ b/src/theme.php
@@ -17,6 +17,7 @@ use RuntimeException;
 use function Lamb\get_tags;
 use function Lamb\Network\get_feeds;
 use function Lamb\permalink;
+use function Lamb\Post\body_has_tag;
 use function Lamb\Post\get_tag_search_conditions;
 
 use const Lamb\SQL_PUBLISHED;
@@ -230,6 +231,9 @@ function get_posts_by_tags(array $tags, int $exclude_id = 0, int $limit = 10): a
         $sql .= ' ORDER BY created DESC';
         $tag_posts = R::find('post', $sql, $params);
         foreach ($tag_posts as $tag_post) {
+            if (!body_has_tag($tag, (string) $tag_post->body)) {
+                continue;
+            }
             $related_posts[$tag_post->id] = $tag_post;
         }
         if (count($related_posts) >= $limit) {

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\Post\body_has_tag;
 use function Lamb\Post\get_tag_search_conditions;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\posts_by_tag;
@@ -35,29 +36,49 @@ class PostTest extends TestCase
         }
     }
 
-    public function testGetTagSearchConditionsMatchesTagWithTrailingSpace()
+    public function testGetTagSearchConditionsPrefiltersOnHashTag()
     {
         $result = get_tag_search_conditions('php');
-        $this->assertContains('%#php %', $result['params']);
+        $this->assertContains('%#php%', $result['params']);
     }
 
-    public function testGetTagSearchConditionsMatchesTagAtEndOfString()
+    // body_has_tag
+
+    public function testBodyHasTagMatchesTagFollowedBySpace()
     {
-        $result = get_tag_search_conditions('php');
-        $this->assertContains('%#php', $result['params']);
+        $this->assertTrue(body_has_tag('php', 'Hello #php world'));
     }
 
-    public function testGetTagSearchConditionsMatchesNewlineBeforeTag()
+    public function testBodyHasTagMatchesTagAtEndOfBody()
     {
-        $result = get_tag_search_conditions('php');
-        $found = false;
-        foreach ($result['params'] as $param) {
-            if (str_contains($param, "\n#php")) {
-                $found = true;
-                break;
-            }
-        }
-        $this->assertTrue($found, 'Expected a param containing newline before #tag');
+        $this->assertTrue(body_has_tag('php', 'Hello #php'));
+    }
+
+    public function testBodyHasTagMatchesTagFollowedByPunctuation()
+    {
+        $this->assertTrue(body_has_tag('til', "PO Box does #til."));
+        $this->assertTrue(body_has_tag('php', 'Love #php, really'));
+        $this->assertTrue(body_has_tag('php', 'Really? #php!'));
+    }
+
+    public function testBodyHasTagMatchesTagAtStartOfBody()
+    {
+        $this->assertTrue(body_has_tag('php', '#php is great'));
+    }
+
+    public function testBodyHasTagIsCaseInsensitive()
+    {
+        $this->assertTrue(body_has_tag('php', 'Hello #PHP world'));
+    }
+
+    public function testBodyHasTagDoesNotMatchLongerTag()
+    {
+        $this->assertFalse(body_has_tag('til', 'Today #tildes everywhere'));
+    }
+
+    public function testBodyHasTagDoesNotMatchMidWordHash()
+    {
+        $this->assertFalse(body_has_tag('php', 'colour#php inline'));
     }
 
     // slugify
@@ -242,6 +263,36 @@ class PostTest extends TestCase
 
         $result = posts_by_tag('endtag');
         $this->assertCount(1, $result);
+    }
+
+    public function testPostsByTagMatchesTagFollowedByPunctuation(): void
+    {
+        $this->setUpDb();
+
+        $post = R::dispense('post');
+        $post->body    = "I guess that's a PO Box does #til.";
+        $post->version = 1;
+        $post->draft   = null;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $result = posts_by_tag('til');
+        $this->assertCount(1, $result);
+    }
+
+    public function testPostsByTagDoesNotMatchLongerTagPrefix(): void
+    {
+        $this->setUpDb();
+
+        $post = R::dispense('post');
+        $post->body    = 'Today I used #tildes everywhere.';
+        $post->version = 1;
+        $post->draft   = null;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $result = posts_by_tag('til');
+        $this->assertCount(0, $result);
     }
 
     public function testPostsByTagReturnsMultipleMatchingPosts(): void


### PR DESCRIPTION
## Problem

`https://vandragt.com/status/232` was not appearing on `/tag/til`. Its body ends with `#til.` — a hashtag immediately followed by a period.

`parse_tags()` renders `#til.` correctly as a tag link (it treats `.` as a delimiter), but the tag-archive query used different logic. `get_tag_search_conditions()` only matched three SQL `LIKE` patterns:

- `#til ` (followed by a space)
- `\n#til ` (line start + space)
- `#til` (only as the very last characters of the body)

`#til.` matches none of these, so the post was silently excluded from its own tag archive. The same prefilter is used by the related-posts query, so it had the same gap.

## Fix

- Broaden `get_tag_search_conditions()` to a permissive SQL prefilter (`body LIKE %#tag%`).
- Add `body_has_tag()`, which refines matches in PHP using the **same delimiter rules as `Lamb\parse_tags`** — so search and rendering can no longer disagree.
- Apply the refinement in both `posts_by_tag()` and `get_posts_by_tags()` (related posts).

## Tests (red first)

Added a failing test reproducing `#til.` being excluded, plus a guard that `#tildes` does not match `til`. Added direct `body_has_tag()` coverage (space/end/punctuation/start, case-insensitivity, longer-tag and mid-word-hash negatives). Replaced the obsolete `get_tag_search_conditions` param-shape assertions with the new prefilter contract.

All 527 unit tests pass; `composer lint` and `composer analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)