### PR TITLE
Handle scheduling posts in the future (#232)

### DIFF
--- a/docs/cron-scheduled-tasks.md
+++ b/docs/cron-scheduled-tasks.md
@@ -6,6 +6,8 @@ title: Cron Scheduled Tasks
 
 Lamb has an scheduled task endpoint that can be called periodically to run tasks in the background, available at `/_cron`.
 
+(Looking to publish a post at a future date instead? See [Scheduling]({% link scheduling.md %}).)
+
 The following tasks run periodically:
 
 1. [Crossposting]({% link cross-posting.md %}) new content from feeds.
@@ -27,3 +29,4 @@ For example the linux cron system can be setup as follows:
 
 * [Cross-posting]({% link cross-posting.md %}): Feed syndication that runs via the cron endpoint.
 * [Drafts]({% link drafts.md %}): Feed-ingested posts are saved as drafts by default.
+* [Scheduling]({% link scheduling.md %}): Publishing a post at a future date (a different feature, despite the similar name).

--- a/docs/drafts.md
+++ b/docs/drafts.md
@@ -13,5 +13,6 @@ Feed ingested posts are saved as drafts by default to prioritize authorship over
 ## Related
 
 - [Post Types]({% link post-types.md %}): Front-matter is used to set `draft: true`.
+- [Scheduling]({% link scheduling.md %}): Hide a post until a future `created` date.
 - [Cross-posting]({% link cross-posting.md %}): Feed ingestion that produces drafts.
 - [Cron Scheduled Tasks]({% link cron-scheduled-tasks.md %}): The cron endpoint triggers feed ingestion.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ Devtools / local environments / sandbox:
 * [Post Types]({% link post-types.md %})
 * [Preconnect]({% link preconnect.md %})
 * [Redirections]({% link redirections.md %})
+* [Scheduling]({% link scheduling.md %})
 * [Search]({% link search.md %})
 * [Site Configuration]({% link site-configuration.md %})
 * [Themes]({% link themes.md %})

--- a/docs/micropub.md
+++ b/docs/micropub.md
@@ -56,3 +56,4 @@ Visit [MicroPub Rocks](https://micropub.rocks/) and enter your site. Lamb's impl
 ## Related
 
 * [Site Configuration]({% link site-configuration.md %}): The `[me]`, `authorization_endpoint`, and `token_endpoint` settings.
+* [Scheduling]({% link scheduling.md %}): Send a future `published` date or `post-status: scheduled` to schedule a post.

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -32,6 +32,8 @@ Slugs for pages are derived from the title on creation unless you explicitly pro
 
 A slug is preserved after creation. Changing the title later does not automatically reslug the post. _Good URLs don't change_, so although it's possible to set a slug in the front-matter when creating a page, Lamb will derive it from the title if it isn't set.
 
+You can also set a `created:` date in the front-matter. A future date schedules the post — see [Scheduling]({% link scheduling.md %}).
+
 # System types
 
 The following sections of the site are special:
@@ -44,4 +46,5 @@ The following sections of the site are special:
 ## Related
 
 * [Drafts]({% link drafts.md %}): Add `draft: true` to front-matter to save a post as a draft.
+* [Scheduling]({% link scheduling.md %}): Add a future `created:` date to publish a post later.
 * [Menu Items]({% link menu-items.md %}): Page posts with slugs can be pinned as menu items.

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -19,7 +19,22 @@ created: 2099-01-01 09:00:00
 Wishing you all the best for the year ahead. #news
 ```
 
-The date is interpreted in the server's timezone and uses the `YYYY-MM-DD HH:MM:SS` format. A date in the past publishes immediately (and back-dates the post); a date in the future schedules it.
+A date in the past publishes immediately (and back-dates the post); a date in the future schedules it.
+
+### Accepted date formats
+
+The `created` value is flexible. All of these work:
+
+| Example | Result |
+|---|---|
+| `2099-01-01 09:00:00` | Exact date and time |
+| `2099-01-01` | That date at midnight |
+| `next friday 3pm` | The coming Friday at 15:00 |
+| `+1 week` | One week from now |
+| `tomorrow` | Tomorrow at midnight |
+| `1 Jan 2099 18:30` | Named-month form |
+
+The time you write is the time the post publishes — it is taken at face value and **not** shifted between timezones. Relative phrases like `next friday` or `+1 week` are resolved against the server's clock. If the value can't be understood as a date, the post simply publishes immediately.
 
 ## Viewing scheduled posts
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,36 @@
+---
+title: Scheduling
+---
+
+# Scheduling
+
+You can schedule a post to publish in the future by giving it a `created` date that is later than now. Until that date arrives the post is hidden from the homepage, feeds, tag pages, search, and its public URL. When the time passes it appears automatically — no cron job or extra step required.
+
+## Scheduling a post
+
+Add a `created` date to the front-matter:
+
+```
+---
+title: Happy New Year
+created: 2099-01-01 09:00:00
+---
+
+Wishing you all the best for the year ahead. #news
+```
+
+The date is interpreted in the server's timezone and uses the `YYYY-MM-DD HH:MM:SS` format. A date in the past publishes immediately (and back-dates the post); a date in the future schedules it.
+
+## Viewing scheduled posts
+
+When logged in and one or more posts are scheduled, a **Scheduled** link appears in the admin toolbar, listing future-dated posts soonest-first at `/scheduled`. You can still open a scheduled post directly via its `/status/<id>` URL to preview it before it goes live.
+
+## Via Micropub
+
+Micropub clients can schedule a post by sending a future `published` date. Sending `post-status: scheduled` is also accepted; the post stays hidden until its `published` date arrives and is never treated as a draft.
+
+## Related
+
+* [Post Types]({% link post-types.md %}): Front-matter is used to set the `created` date.
+* [Drafts]({% link drafts.md %}): Drafts are hidden until published; scheduled posts are hidden until their date.
+* [Micropub]({% link micropub.md %}): Scheduling posts from a Micropub client.

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -34,7 +34,17 @@ The `created` value is flexible. All of these work:
 | `tomorrow` | Tomorrow at midnight |
 | `1 Jan 2099 18:30` | Named-month form |
 
-The time you write is the time the post publishes — it is taken at face value and **not** shifted between timezones. Relative phrases like `next friday` or `+1 week` are resolved against the server's clock. If the value can't be understood as a date, the post simply publishes immediately.
+The time you write is the time the post publishes — it is taken at face value and **not** shifted between timezones. If the value can't be understood as a date, the post simply publishes immediately.
+
+## Timezone
+
+Servers are usually set to UTC, which may not be your timezone. Set yours once in the site configuration at `/settings` so post dates, scheduling, and relative phrases like `next friday` all use your local clock:
+
+```ini
+timezone = Europe/London
+```
+
+Use a name from the [list of supported timezones](https://www.php.net/manual/en/timezones.php). It defaults to `UTC`.
 
 ## Viewing scheduled posts
 
@@ -46,6 +56,7 @@ Micropub clients can schedule a post by sending a future `published` date. Sendi
 
 ## Related
 
+* [Site Configuration]({% link site-configuration.md %}): Set your `timezone` so scheduled posts go live at the right local time.
 * [Post Types]({% link post-types.md %}): Front-matter is used to set the `created` date.
 * [Drafts]({% link drafts.md %}): Drafts are hidden until published; scheduled posts are hidden until their date.
 * [Micropub]({% link micropub.md %}): Scheduling posts from a Micropub client.

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -24,6 +24,10 @@ The full default configuration (all keys commented out = use built-in defaults):
 ;; Number of posts per page (default: 10)
 ;posts_per_page = 10
 
+;; Your timezone, used for post dates and scheduling (the server is often UTC).
+;; Use a name from https://www.php.net/manual/en/timezones.php (default: UTC)
+;timezone = Europe/London
+
 ;; When content is not found, instead of a 404, the user is redirected to the same
 ;; relative path on another site. Useful for archived or under-construction sites.
 ;404_fallback = https://my.oldsite.com
@@ -80,4 +84,5 @@ The full default configuration (all keys commented out = use built-in defaults):
 * [Micropub]({% link micropub.md %}): The `[me]`, `authorization_endpoint`, and `token_endpoint` settings enable Micropub publishing.
 * [Preconnect]({% link preconnect.md %})
 * [Redirections]({% link redirections.md %})
+* [Scheduling]({% link scheduling.md %}): The `timezone` setting determines when scheduled posts go live.
 * [Themes]({% link themes.md %}): The `theme` key selects the active theme.

--- a/src/config.php
+++ b/src/config.php
@@ -24,6 +24,10 @@ function get_default_ini_text(): string
 ;; Title of the site, in html and feed views
 ;site_title = My Microblog
 
+;; Your timezone, used for post dates and scheduling (the server is often UTC).
+;; Use a name from https://www.php.net/manual/en/timezones.php. Defaults to UTC.
+;timezone = Europe/London
+
 ;; When content is not found, instead of a 404 by setting the following value the user is redirected to the same
 ;; relative path on another site.
 ;; Useful where old content is archived to an archive site, or the lamb blog is still under construction but public.
@@ -90,9 +94,32 @@ function load(): array
         'site_title'             => 'My Microblog',
         'authorization_endpoint' => 'https://indieauth.com/auth',
         'token_endpoint'         => 'https://tokens.indieauth.com/token',
+        'timezone'               => 'UTC',
     ];
 
     return array_merge($defaults, $config ?: []);
+}
+
+/**
+ * Applies the author's configured timezone as the default for all date handling.
+ *
+ * The server clock is often UTC while the author lives elsewhere; setting the
+ * timezone here makes scheduling, "now", post dates, and human times all use the
+ * author's wall clock. Falls back to UTC when the configured value is missing or
+ * not a recognised timezone identifier.
+ *
+ * @param array $config The loaded configuration.
+ * @return string The timezone identifier that was applied.
+ */
+function apply_timezone(array $config): string
+{
+    $timezone = $config['timezone'] ?? 'UTC';
+    if (!in_array($timezone, \DateTimeZone::listIdentifiers(), true)) {
+        $timezone = 'UTC';
+    }
+    date_default_timezone_set($timezone);
+
+    return $timezone;
 }
 
 /**

--- a/src/index.php
+++ b/src/index.php
@@ -13,6 +13,7 @@ Bootstrap\bootstrap_db(getenv('LAMB_DATA_DIR') ?: '../data');
 Bootstrap\bootstrap_session();
 
 $config = Config\load();
+Config\apply_timezone($config);
 
 define('ROOT_URL', (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://" . $_SERVER["HTTP_HOST"]);
 define("THEME", $config['theme'] ?? 'default');

--- a/src/index.php
+++ b/src/index.php
@@ -38,6 +38,7 @@ Route\register_route('404', __NAMESPACE__ . '\\Response\respond_404');
 Route\register_route('delete', __NAMESPACE__ . '\\Response\redirect_deleted', $lookup);
 Route\register_route('restore', __NAMESPACE__ . '\\Response\redirect_restored', $lookup);
 Route\register_route('drafts', __NAMESPACE__ . '\\Response\respond_drafts');
+Route\register_route('scheduled', __NAMESPACE__ . '\\Response\respond_scheduled');
 Route\register_route('trash', __NAMESPACE__ . '\\Response\respond_trash');
 Route\register_route('edit', __NAMESPACE__ . '\\Response\respond_edit', $lookup);
 Route\register_route('feed', __NAMESPACE__ . '\\Response\respond_feed');

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -101,18 +101,23 @@ function parse_bean(OODBBean $bean): void
 
     $front_matter['transformed'] = (parse_tags($markdown));
 
+    // Preserve the existing created date (now for new posts, the stored value for
+    // edits, the feed date for ingested items) so an unparseable front-matter date
+    // falls back to it rather than leaving a non-date string in the column.
+    $previous_created = $bean->created;
+
     foreach ($front_matter as $key => $value) {
         $bean->$key = $value;
     }
 
     // Normalise a front-matter `created` date into the canonical Y-m-d H:i:s string.
-    // YAML parses bare dates into Unix timestamps, which would otherwise break date
-    // sorting/formatting and the scheduling comparison. A future date schedules the post.
+    // Accepts absolute dates (kept as the typed wall-clock) and relative strings such
+    // as "next friday 3pm" (resolved in the server timezone). A future date schedules
+    // the post; an unparseable value falls back to the previous date so the post still
+    // publishes rather than staying hidden forever.
     if (isset($front_matter['created'])) {
-        $normalised = normalize_datetime($front_matter['created']);
-        if ($normalised !== null) {
-            $bean->created = $normalised;
-        }
+        $bean->created = normalize_datetime($front_matter['created'])
+            ?? ($previous_created ?: date('Y-m-d H:i:s'));
     }
 
     // Explicitly normalise draft: 1 if truthy in frontmatter, 0 otherwise.

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -10,6 +10,8 @@ const SQL_NOT_DELETED = ' (deleted IS NULL OR deleted != 1) ';
 const SQL_PUBLISHED  = ' (draft IS NULL OR draft != 1) AND (deleted IS NULL OR deleted != 1) ';
 const SQL_IS_DRAFT   = ' draft = 1 AND (deleted IS NULL OR deleted != 1) ';
 const SQL_IS_DELETED = ' deleted = 1 ';
+// SQL fragment selecting posts that are scheduled for the future (and not draft/deleted).
+const SQL_IS_SCHEDULED = ' created > ? AND (draft IS NULL OR draft != 1) AND (deleted IS NULL OR deleted != 1) ';
 use RedBeanPHP\R;
 use RedBeanPHP\RedException\SQL;
 
@@ -103,6 +105,16 @@ function parse_bean(OODBBean $bean): void
         $bean->$key = $value;
     }
 
+    // Normalise a front-matter `created` date into the canonical Y-m-d H:i:s string.
+    // YAML parses bare dates into Unix timestamps, which would otherwise break date
+    // sorting/formatting and the scheduling comparison. A future date schedules the post.
+    if (isset($front_matter['created'])) {
+        $normalised = normalize_datetime($front_matter['created']);
+        if ($normalised !== null) {
+            $bean->created = $normalised;
+        }
+    }
+
     // Explicitly normalise draft: 1 if truthy in frontmatter, 0 otherwise.
     // This ensures removing "draft: true" from frontmatter publishes the post on next save.
     $bean->draft = !empty($front_matter['draft']) ? 1 : 0;
@@ -145,6 +157,58 @@ function set_option(OODBBean $bean, mixed $value): void
 }
 
 /**
+ * Returns the SQL fragment and bound parameter that exclude posts scheduled for
+ * the future. A post is publicly visible only once its `created` date has arrived.
+ *
+ * The current time is bound as a parameter so the comparison uses the same
+ * timezone basis as the stored `created` values (both produced by PHP's date()).
+ *
+ * @return array{sql: string, params: array}
+ */
+function not_scheduled_clause(): array
+{
+    return [
+        'sql'    => ' (created IS NULL OR created <= ?) ',
+        'params' => [date('Y-m-d H:i:s')],
+    ];
+}
+
+/**
+ * Normalises a date value (YAML timestamp int, DateTime, or parseable string)
+ * into the canonical `Y-m-d H:i:s` string used throughout the app.
+ *
+ * @param mixed $value The raw date value.
+ * @return string|null The normalised string, or null when the value is unparseable.
+ */
+function normalize_datetime(mixed $value): ?string
+{
+    if ($value instanceof \DateTimeInterface) {
+        return $value->format('Y-m-d H:i:s');
+    }
+    if (is_int($value)) {
+        return date('Y-m-d H:i:s', $value);
+    }
+    if (is_string($value) && $value !== '') {
+        $timestamp = strtotime($value);
+        if ($timestamp !== false) {
+            return date('Y-m-d H:i:s', $timestamp);
+        }
+    }
+    return null;
+}
+
+/**
+ * Returns true when the post's `created` date lies in the future (scheduled).
+ *
+ * @param OODBBean $post The post to inspect.
+ * @return bool
+ */
+function is_scheduled(OODBBean $post): bool
+{
+    return !empty($post->created) && $post->created > date('Y-m-d H:i:s');
+}
+
+/**
  * Checks if a post with the given slug exists in the database.
  *
  * @param string $lookup The slug of the post to look up.
@@ -154,7 +218,7 @@ function set_option(OODBBean $bean, mixed $value): void
 function post_has_slug(string $lookup): string|null
 {
     $post = R::findOne('post', ' slug = ? ', [$lookup]);
-    if ($post === null || $post->id === 0 || $post->draft == 1) {
+    if ($post === null || $post->id === 0 || $post->draft == 1 || is_scheduled($post)) {
         return '';
     }
 

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -229,9 +229,13 @@ class LambMicropubAdapter extends MicropubAdapter
             $bean->created = date('Y-m-d H:i:s', strtotime($published));
         }
 
-        if (($props['post-status'][0] ?? null) === 'draft') {
+        $postStatus = $props['post-status'][0] ?? null;
+        if ($postStatus === 'draft') {
             $bean->draft = 1;
         }
+        // A "scheduled" post is a published-intent post with a future `published` date;
+        // it is never a draft. Visibility is driven by the future `created` date set
+        // above, so it stays hidden from public listings until that time arrives.
 
         R::store($bean);
 

--- a/src/post.php
+++ b/src/post.php
@@ -71,7 +71,10 @@ function parse_matter(string $body): array
     $text = explode('---', $body);
     try {
         if (isset($text[1])) {
-            $matter = Yaml::parse($text[1]);
+            // PARSE_DATETIME keeps absolute dates as DateTime objects carrying the
+            // author's typed wall-clock time, instead of coercing them to UTC Unix
+            // timestamps (which would shift the time by the server's timezone offset).
+            $matter = Yaml::parse($text[1], Yaml::PARSE_DATETIME);
         }
     } catch (ParseException) {
         // Invalid YAML

--- a/src/post.php
+++ b/src/post.php
@@ -139,10 +139,12 @@ function body_has_tag(string $tag, string $body): bool
 function posts_by_tag(string $tag): array
 {
     $conditions = get_tag_search_conditions($tag);
+    $not_scheduled = \Lamb\not_scheduled_clause();
     $posts = R::find(
         'post',
-        '(' . $conditions['sql'] . ') AND (draft IS NULL OR draft != 1) ORDER BY created DESC',
-        $conditions['params']
+        '(' . $conditions['sql'] . ') AND (draft IS NULL OR draft != 1) AND'
+            . $not_scheduled['sql'] . 'ORDER BY created DESC',
+        array_merge($conditions['params'], $not_scheduled['params'])
     );
 
     return array_values(array_filter($posts, fn($post) => body_has_tag($tag, (string) $post->body)));

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -14,6 +14,7 @@ use function Lamb\Theme\part;
 
 use const Lamb\SQL_IS_DELETED;
 use const Lamb\SQL_IS_DRAFT;
+use const Lamb\SQL_IS_SCHEDULED;
 use const Lamb\SQL_PUBLISHED;
 use const ROOT_URL;
 
@@ -38,6 +39,9 @@ function respond_home(): array
         $where_sql .= ' AND ' . $clause['sql'];
         $where_params = $clause['params'];
     }
+    $not_scheduled = \Lamb\not_scheduled_clause();
+    $where_sql .= ' AND ' . $not_scheduled['sql'];
+    $where_params = array_merge($where_params, $not_scheduled['params']);
     $paginated = paginate_posts('post', 'created DESC', $where_sql, $where_params);
     $data['posts'] = $paginated['items'];
     $data['pagination'] = $paginated['pagination'];
@@ -100,6 +104,33 @@ function count_trash(): int
 }
 
 /**
+ * Responds with the scheduled page showing posts dated in the future (login required).
+ *
+ * @return array The scheduled page data including posts and pagination.
+ */
+function respond_scheduled(): array
+{
+    Security\require_login();
+
+    $data['title'] = 'Scheduled';
+    $paginated = paginate_posts('post', 'created ASC', SQL_IS_SCHEDULED, [date('Y-m-d H:i:s')]);
+    $data['posts'] = $paginated['items'];
+    $data['pagination'] = $paginated['pagination'];
+
+    return $data;
+}
+
+/**
+ * Returns the count of scheduled (future-dated) posts.
+ *
+ * @return int
+ */
+function count_scheduled(): int
+{
+    return R::count('post', SQL_IS_SCHEDULED, [date('Y-m-d H:i:s')]);
+}
+
+/**
  * Redirects the user to a search page with the provided query.
  *
  * @param string $query The search query to be included in the redirected URL.
@@ -133,15 +164,21 @@ function get_feed_data(): array
 {
     global $config;
 
+    $not_scheduled = \Lamb\not_scheduled_clause();
     $clause = build_exclude_slugs_clause(Config\get_menu_slugs());
     if ($clause !== null) {
         $posts = R::find(
             'post',
-            $clause['sql'] . ' AND' . SQL_PUBLISHED . 'ORDER BY updated DESC LIMIT 20',
-            $clause['params']
+            $clause['sql'] . ' AND' . SQL_PUBLISHED . 'AND' . $not_scheduled['sql']
+                . 'ORDER BY updated DESC LIMIT 20',
+            array_merge($clause['params'], $not_scheduled['params'])
         );
     } else {
-        $posts = R::findAll('post', SQL_PUBLISHED . 'ORDER BY updated DESC LIMIT 20');
+        $posts = R::find(
+            'post',
+            SQL_PUBLISHED . 'AND' . $not_scheduled['sql'] . 'ORDER BY updated DESC LIMIT 20',
+            $not_scheduled['params']
+        );
     }
 
     $first_post = reset($posts);
@@ -296,7 +333,9 @@ function respond_search(array $args): array
         $where_clauses[] = 'body LIKE ?';
         $params[] = "%$word%";
     }
-    $where_sql = '(' . implode(' AND ', $where_clauses) . ') AND' . SQL_PUBLISHED;
+    $not_scheduled = \Lamb\not_scheduled_clause();
+    $where_sql = '(' . implode(' AND ', $where_clauses) . ') AND' . SQL_PUBLISHED . 'AND' . $not_scheduled['sql'];
+    $params = array_merge($params, $not_scheduled['params']);
 
     $paginated = paginate_posts('post', 'created DESC', $where_sql, $params);
 

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -272,7 +272,7 @@ function respond_post(array $args): array
 {
     [$slug] = $args;
     $post = R::findOne('post', ' slug = ? ', [$slug]);
-    if ($post === null || $post->draft == 1 || $post->deleted == 1) {
+    if ($post === null || $post->draft == 1 || $post->deleted == 1 || \Lamb\is_scheduled($post)) {
         return respond_404([]);
     }
     $data['posts'] = [$post];

--- a/src/theme.php
+++ b/src/theme.php
@@ -369,14 +369,21 @@ function the_entry_form(): void
  */
 function admin_toolbar_html(): string
 {
-    $drafts = \Lamb\Response\count_drafts();
-    $trash  = \Lamb\Response\count_trash();
+    $drafts    = \Lamb\Response\count_drafts();
+    $scheduled = \Lamb\Response\count_scheduled();
+    $trash     = \Lamb\Response\count_trash();
 
-    $draftsLabel = 'Drafts' . ($drafts > 0 ? " ($drafts)" : '');
-    $trashLabel  = 'Trash'  . ($trash  > 0 ? " ($trash)"  : '');
+    $draftsLabel    = 'Drafts'    . ($drafts > 0 ? " ($drafts)" : '');
+    $scheduledLabel = 'Scheduled' . ($scheduled > 0 ? " ($scheduled)" : '');
+    $trashLabel     = 'Trash'     . ($trash  > 0 ? " ($trash)"  : '');
+
+    $scheduledLink = $scheduled > 0
+        ? '<a href="/scheduled">' . escape($scheduledLabel) . '</a>'
+        : '';
 
     return '<div id="admin-toolbar">'
         . '<a href="/drafts">'   . escape($draftsLabel) . '</a>'
+        . $scheduledLink
         . '<a href="/trash">'    . escape($trashLabel)  . '</a>'
         . '<a href="/settings">Settings</a>'
         . '<a href="/logout">Logout</a>'

--- a/tests/Unit/ConfigTimezoneTest.php
+++ b/tests/Unit/ConfigTimezoneTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Config\apply_timezone;
+use function Lamb\Config\load;
+
+class ConfigTimezoneTest extends TestCase
+{
+    private string $originalTz;
+
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::exec("DELETE FROM option WHERE name = 'site_config_ini'");
+        $this->originalTz = date_default_timezone_get();
+    }
+
+    protected function tearDown(): void
+    {
+        date_default_timezone_set($this->originalTz);
+    }
+
+    public function testLoadDefaultsTimezoneToUtc(): void
+    {
+        $config = load();
+        $this->assertSame('UTC', $config['timezone']);
+    }
+
+    public function testApplyTimezoneSetsValidConfiguredZone(): void
+    {
+        $applied = apply_timezone(['timezone' => 'Asia/Tokyo']);
+        $this->assertSame('Asia/Tokyo', $applied);
+        $this->assertSame('Asia/Tokyo', date_default_timezone_get());
+    }
+
+    public function testApplyTimezoneFallsBackToUtcForInvalidZone(): void
+    {
+        $applied = apply_timezone(['timezone' => 'Mars/Olympus_Mons']);
+        $this->assertSame('UTC', $applied);
+        $this->assertSame('UTC', date_default_timezone_get());
+    }
+
+    public function testApplyTimezoneDefaultsToUtcWhenUnset(): void
+    {
+        $applied = apply_timezone([]);
+        $this->assertSame('UTC', $applied);
+    }
+
+    public function testDefaultIniDocumentsTimezoneSetting(): void
+    {
+        $this->assertStringContainsString('timezone', \Lamb\Config\get_default_ini_text());
+    }
+}

--- a/tests/Unit/DateParsingTest.php
+++ b/tests/Unit/DateParsingTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\is_scheduled;
+use function Lamb\Post\populate_bean;
+
+class DateParsingTest extends TestCase
+{
+    private string $originalTz;
+
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        $this->originalTz = date_default_timezone_get();
+        global $config;
+        $config = [];
+    }
+
+    protected function tearDown(): void
+    {
+        date_default_timezone_set($this->originalTz);
+    }
+
+    private function created(string $frontMatterValue): string
+    {
+        $bean = populate_bean("---\ncreated: $frontMatterValue\n---\n\nBody #tag");
+        return (string) $bean->created;
+    }
+
+    private const DATETIME_RE = '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/';
+
+    public function testNaiveDateKeepsTypedWallClockRegardlessOfServerTimezone(): void
+    {
+        date_default_timezone_set('Asia/Tokyo');
+        $this->assertSame('2099-01-01 09:00:00', $this->created('2099-01-01 09:00:00'));
+
+        date_default_timezone_set('America/New_York');
+        $this->assertSame('2099-01-01 09:00:00', $this->created('2099-01-01 09:00:00'));
+    }
+
+    public function testDateOnlyDefaultsToMidnight(): void
+    {
+        date_default_timezone_set('Asia/Tokyo');
+        $this->assertSame('2099-01-01 00:00:00', $this->created('2099-01-01'));
+    }
+
+    public function testIsoDateWithOffsetPreservesTypedWallClock(): void
+    {
+        date_default_timezone_set('UTC');
+        $this->assertSame('2099-01-01 09:00:00', $this->created('2099-01-01T09:00:00+05:00'));
+    }
+
+    public function testRelativeDateIsParsedToAFutureDatetime(): void
+    {
+        date_default_timezone_set('UTC');
+        $created = $this->created('+1 week');
+        $this->assertMatchesRegularExpression(self::DATETIME_RE, $created);
+        $this->assertGreaterThan(date('Y-m-d H:i:s'), $created);
+    }
+
+    public function testHumanRelativeDateNextFriday(): void
+    {
+        date_default_timezone_set('UTC');
+        $created = $this->created('next friday 3pm');
+        $this->assertMatchesRegularExpression(self::DATETIME_RE, $created);
+        $this->assertStringEndsWith('15:00:00', $created);
+    }
+
+    public function testUnparseableDateFallsBackToAValidDatetimeAndPublishes(): void
+    {
+        date_default_timezone_set('UTC');
+        $bean = populate_bean("---\ncreated: sometime soon\n---\n\nBody #tag");
+
+        $this->assertMatchesRegularExpression(
+            self::DATETIME_RE,
+            (string) $bean->created,
+            'An unparseable date must not be stored verbatim'
+        );
+        $this->assertFalse(
+            is_scheduled($bean),
+            'An unparseable date must not leave the post scheduled forever'
+        );
+    }
+}

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -557,6 +557,43 @@ class MicropubAdapterTest extends TestCase
         $this->assertEmpty($post->draft);
     }
 
+    public function testCreateCallbackWithScheduledPostStatusIsNotMarkedDraft(): void
+    {
+        $adapter = new LambMicropubAdapter();
+        $future = date('Y-m-d\TH:i:sP', strtotime('+1 day'));
+        $data = [
+            'type' => ['h-entry'],
+            'properties' => [
+                'content'     => ['A scheduled micropub post'],
+                'post-status' => ['scheduled'],
+                'published'   => [$future],
+            ],
+        ];
+        $adapter->createCallback($data, []);
+        $post = R::findOne('post', ' body = ? ', ['A scheduled micropub post']);
+        $this->assertNotNull($post);
+        $this->assertEmpty($post->draft, 'Scheduled posts must not be marked as drafts');
+        $this->assertGreaterThan(date('Y-m-d H:i:s'), $post->created, 'Scheduled post keeps its future publish date');
+    }
+
+    public function testCreateCallbackWithFuturePublishedDateHidesFromHome(): void
+    {
+        $adapter = new LambMicropubAdapter();
+        $future = date('Y-m-d\TH:i:sP', strtotime('+1 day'));
+        $data = [
+            'type' => ['h-entry'],
+            'properties' => [
+                'content'   => ['A future dated micropub post'],
+                'published' => [$future],
+            ],
+        ];
+        $adapter->createCallback($data, []);
+
+        $result = \Lamb\Response\respond_home();
+        $bodies = array_map(static fn($p) => $p->body, $result['posts']);
+        $this->assertNotContains('A future dated micropub post', $bodies, 'Future-dated micropub posts must not appear on the homepage');
+    }
+
     public function testCreateCallbackReturnsInvalidRequestForMissingContent(): void
     {
         $adapter = new LambMicropubAdapter();

--- a/tests/Unit/ScheduledPostTest.php
+++ b/tests/Unit/ScheduledPostTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\post_has_slug;
+use function Lamb\Post\populate_bean;
+use function Lamb\Post\posts_by_tag;
+use function Lamb\Response\count_scheduled;
+use function Lamb\Response\respond_home;
+use function Lamb\Response\respond_post;
+use function Lamb\Response\respond_scheduled;
+use function Lamb\Response\respond_search;
+
+class ScheduledPostTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+
+        // Ensure schema columns exist regardless of test order.
+        $schema = R::dispense('post');
+        $schema->draft   = null;
+        $schema->deleted = null;
+        R::store($schema);
+
+        R::exec('DELETE FROM post');
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        global $config;
+        $config = [
+            'site_title'     => 'Test Blog',
+            'posts_per_page' => 10,
+            'menu_items'     => [],
+            'feeds'          => [],
+        ];
+
+        $_SESSION = [];
+        $_POST    = [];
+        $_GET     = [];
+    }
+
+    protected function tearDown(): void
+    {
+        R::exec('DELETE FROM post');
+    }
+
+    private function makePost(string $body, string $created, ?string $slug = null): \RedBeanPHP\OODBBean
+    {
+        $bean = R::dispense('post');
+        $bean->body    = $body;
+        $bean->draft   = null;
+        $bean->deleted = null;
+        $bean->version = 1;
+        $bean->created = $created;
+        $bean->updated = $created;
+        if ($slug !== null) {
+            $bean->slug = $slug;
+        }
+        R::store($bean);
+        return $bean;
+    }
+
+    private function future(): string
+    {
+        return date('Y-m-d H:i:s', strtotime('+1 day'));
+    }
+
+    private function past(): string
+    {
+        return date('Y-m-d H:i:s', strtotime('-1 day'));
+    }
+
+    public function testFutureCreatedPostIsHiddenFromHome(): void
+    {
+        $this->makePost('Scheduled for later', $this->future());
+
+        $result = respond_home();
+        $this->assertCount(0, $result['posts'], 'Future-dated posts must not appear on the homepage');
+    }
+
+    public function testPastCreatedPostIsVisibleOnHome(): void
+    {
+        $this->makePost('Already published', $this->past());
+
+        $result = respond_home();
+        $this->assertCount(1, $result['posts'], 'Past-dated posts must appear on the homepage');
+    }
+
+    public function testFutureCreatedPostIsHiddenFromTagPages(): void
+    {
+        $this->makePost('A scheduled post #php', $this->future());
+
+        $this->assertEmpty(posts_by_tag('php'), 'Future-dated posts must not appear on tag pages');
+    }
+
+    public function testFutureCreatedPostIsHiddenFromSearch(): void
+    {
+        $this->makePost('uniquescheduledword in body', $this->future());
+
+        $result = respond_search(['uniquescheduledword']);
+        $this->assertCount(0, $result['posts'], 'Future-dated posts must not appear in search results');
+    }
+
+    public function testRespondScheduledReturnsFuturePosts(): void
+    {
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->makePost('Scheduled item', $this->future());
+        $this->makePost('Published item', $this->past());
+
+        $result = respond_scheduled();
+        $this->assertCount(1, $result['posts'], 'Scheduled view should list only future-dated posts');
+    }
+
+    public function testCountScheduledCountsOnlyFuturePublishedPosts(): void
+    {
+        $this->makePost('Scheduled item', $this->future());
+        $this->makePost('Published item', $this->past());
+
+        // A future-dated draft is a draft, not a scheduled post.
+        $draft = $this->makePost('Future draft', $this->future());
+        $draft->draft = 1;
+        R::store($draft);
+
+        $this->assertSame(1, count_scheduled());
+    }
+
+    public function testPostHasSlugHidesFutureSluggedPost(): void
+    {
+        $this->makePost('A scheduled page', $this->future(), 'scheduled-page');
+
+        $this->assertSame('', post_has_slug('scheduled-page'), 'Future-dated slugged posts must not resolve publicly');
+    }
+
+    public function testRespondPostReturns404ForFutureSluggedPost(): void
+    {
+        $this->makePost('A scheduled page', $this->future(), 'scheduled-page');
+
+        $result = respond_post(['scheduled-page']);
+        $this->assertSame('404', $result['action'] ?? null, 'Future-dated slugged posts must 404 publicly');
+    }
+
+    public function testFrontMatterCreatedDateIsNormalisedToDatetimeString(): void
+    {
+        global $config;
+        $config = [];
+        $body = "---\ntitle: Future Post\ncreated: 2099-01-01 09:00:00\n---\n\nHello from the future #news";
+
+        $bean = populate_bean($body);
+
+        $this->assertSame('2099-01-01 09:00:00', $bean->created, 'Front-matter created must be stored as a Y-m-d H:i:s string');
+        $this->assertTrue(\Lamb\is_scheduled($bean), 'A future front-matter created date schedules the post');
+    }
+}


### PR DESCRIPTION
Closes #232.

Adds native and Micropub support for **scheduling posts** to publish in the future, with proper timezone handling.

## Behaviour

A post whose `created` date is in the future is **scheduled**: hidden from the homepage, feeds, tag pages, search, and its public slug/`/status` URL until that date arrives — then it appears automatically. No cron job or extra step; visibility is purely query-time.

## How to schedule

**Natively** — give a post a future `created` date in front-matter:

```
---
title: Happy New Year
created: 2099-01-01 09:00:00
---
```

Many formats are accepted (`2099-01-01`, `next friday 3pm`, `+1 week`, `tomorrow`, `1 Jan 2099 18:30`). The time is taken at **face value** — what you type is when it publishes. An unparseable value publishes immediately rather than disappearing.

**Via Micropub** — a future `published` date schedules the post; `post-status: scheduled` is accepted and never treated as a draft.

## Timezone

Servers are commonly UTC while the author lives elsewhere, so a new `timezone` config setting (set at `/settings`) is applied app-wide at bootstrap. Every `date()` — the scheduling "now", `created`/`updated`, feeds, human times — and all absolute front-matter dates resolve in the **author's** local clock. Defaults to `UTC`; an unrecognised value falls back to `UTC`.

## Author experience

When logged in and posts are scheduled, a **Scheduled** link appears in the admin toolbar linking to `/scheduled` (future posts, soonest first). A scheduled post can still be previewed directly via `/status/<id>`.

## Implementation

- `Lamb\not_scheduled_clause()`, `is_scheduled()`, `normalize_datetime()` and the `SQL_IS_SCHEDULED` constant in `lamb.php`.
- The not-scheduled filter is applied to home, main + JSON feeds, tag pages/feeds (`posts_by_tag`), search, slug routing (`post_has_slug`), and slug posts (`respond_post`).
- `respond_scheduled()` / `count_scheduled()` + route + toolbar entry.
- Front matter is parsed with `Yaml::PARSE_DATETIME` so absolute dates keep their typed wall-clock instead of being coerced to UTC timestamps (which silently shifted the time by the server's offset).
- `Config\apply_timezone()` validates and applies the configured timezone at bootstrap.
- The scheduling "now" boundary is bound as a query parameter (not SQLite's own clock) so the comparison uses the same timezone basis as the stored `created` values.

## Tests

- `tests/Unit/ScheduledPostTest.php` — visibility across listings/feeds/slug routing, the scheduled listing/count, front-matter date normalisation.
- `tests/Unit/DateParsingTest.php` — timezone stability of absolute dates, relative parsing (`next friday 3pm`, `+1 week`), explicit-offset wall-clock, and the unparseable-date fallback.
- `tests/Unit/ConfigTimezoneTest.php` — timezone default, applied valid zone, invalid → UTC fallback, documented in the default INI.
- New Micropub tests for future `published` and `post-status: scheduled`.
- Full suite green: **549 tests, 814 assertions**. `composer lint` and `composer analyse` clean.

## Docs

- New `docs/scheduling.md` (formats, timezone, viewing scheduled posts, Micropub).
- `timezone` documented in `site-configuration.md` and the default config INI.
- Cross-links added from `index.md`, `drafts.md`, `micropub.md`, `post-types.md`, and `cron-scheduled-tasks.md` (the last disambiguating the similarly-named cron feature).

## Known limitation

Absolute dates are stored as the author's local wall-clock and compared against the author's local "now" — internally consistent, but DST transitions are treated as naive wall-clock (no offset math), a reasonable simplification for a single-author blog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)