### PR TITLE
Fix /scheduled page: add missing default theme part

### DIFF
--- a/src/themes/default/parts/scheduled.php
+++ b/src/themes/default/parts/scheduled.php
@@ -1,0 +1,9 @@
+<?php
+
+use function Lamb\Theme\page_title;
+use function Lamb\Theme\part;
+
+echo page_title();
+
+part('_items');
+part('_pagination');

--- a/tests/Unit/ThemeScheduledPartTest.php
+++ b/tests/Unit/ThemeScheduledPartTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class ThemeScheduledPartTest extends TestCase
+{
+    private function partsDir(): string
+    {
+        return dirname(__DIR__, 2) . '/src/themes/default/parts';
+    }
+
+    public function testScheduledTemplatePartExists(): void
+    {
+        // html.php renders part($template); when $template is "scheduled" the default
+        // theme must provide parts/scheduled.php or part() throws and the page dies.
+        $this->assertFileExists(
+            $this->partsDir() . '/scheduled.php',
+            'The default theme must provide a scheduled template part'
+        );
+    }
+
+    public function testScheduledPartRendersPostListAndPagination(): void
+    {
+        $source = file_get_contents($this->partsDir() . '/scheduled.php');
+        $this->assertStringContainsString("part('_items')", $source);
+        $this->assertStringContainsString("part('_pagination')", $source);
+    }
+}


### PR DESCRIPTION
Follow-up to #232 / #268. The scheduled-posts feature shipped without the theme part that renders the `/scheduled` page, so the page died mid-render (output stopped at `<main>`).

## Cause

The `/scheduled` route sets `$template = 'scheduled'`, and `html.php` calls `part($template)` → `parts/scheduled.php`. That file was never added (the route, count, and toolbar link were), so `part()` threw a `RuntimeException` and rendering aborted.

## Fix

- Add `src/themes/default/parts/scheduled.php` (page title + post list + pagination, mirroring `drafts`/`trash`). The `2026` theme inherits it via the default-theme fallback.
- Add `tests/Unit/ThemeScheduledPartTest.php` as a regression test so the part can't go missing again.

Full unit suite green; `composer lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)