### PR TITLE
Fix stale docs links and the pdo_mysql runtime requirement

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Sander van Dragt <sander@vandragt.com>"
 RUN apt-get update -y && \
 	apt-get install libyaml-dev -y && \
 	pecl install yaml && echo "extension=yaml.so" > /usr/local/etc/php/conf.d/ext-yaml.ini && docker-php-ext-enable yaml && \
-	docker-php-ext-install gettext
+	docker-php-ext-install gettext pdo_mysql
 
 WORKDIR /srv/app/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Lamb is a self-hosted, single-author microblog. It uses PHP 8.2+, SQLite (via Re
 
 The end-user documentation lives in `docs/` (tracked in the repository, served via GitHub Pages). It is the end-user manual. When working on user-facing features:
 
-- Check whether a wiki page exists for the feature and update it if needed.
-- When adding new user-facing behaviour, consider whether a new wiki page is warranted.
-- Ensure wiki pages that are topically related link to each other via a "Related" section.
+- Check whether a docs page exists for the feature and update it if needed.
+- When adding new user-facing behaviour, consider whether a new docs page is warranted.
+- Ensure docs pages that are topically related link to each other via a "Related" section.
 
 ## Key Commands
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -20,7 +20,7 @@ Entries marked **[deduced]** were reconstructed from code and history rather tha
 **Status:** Accepted
 **Context:** Lamb is a single-author writer's blog. Previous behaviour published feed-ingested posts immediately, which prioritised syndication use over authorship. This was the wrong default for a tool aimed at individual writers.
 **Decision:** Feed items are now saved as drafts by default. Authors must review and publish them explicitly. Users who want syndication behaviour (publish immediately) can opt out by setting `feeds_draft = false` in the `[feeds]` config section.
-**Consequences:** Existing installs with no `feeds_draft` config will silently change behaviour on upgrade — new feed items will land as drafts. Documented in config comments and wiki.
+**Consequences:** Existing installs with no `feeds_draft` config will silently change behaviour on upgrade — new feed items will land as drafts. Documented in config comments and the docs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@ Barrier free super simple blogging, self-hosted.
 - Friction
   free [Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
   entry, with drag and drop image support.
-- Generates a discoverable Atom feed (/feed) from recently published blogs.
 - Hashtags support, by just typing them `#ahyeah`.
-- 404 fallback redirection to your old site, optionally.
-- Friendly user theming, if you don't like my two shades of 2000s retro themes. ;)
+- Drafts, scheduled posts, and friction free trash with restore.
+- Discoverable Atom feeds (`/feed`, plus a feed per tag).
 - Pull external content into the blog by subscribing to feeds; ingested posts land as drafts by default.
+- Publish from other apps through a Micropub endpoint.
+- Full text search and configurable menu items.
+- 404 fallback redirection to your old site, plus automatic 301s when a post's slug changes.
+- Friendly user theming, if you don't like my retro themes. ;)
 
 # Getting started
 
-[Visit the wiki](https://github.com/svandragt/lamb/wiki) to get started.
+[Read the documentation](https://svandragt.github.io/lamb) to get started.
 
 # Screenshots
 
@@ -35,4 +38,4 @@ Friction free post deletion:
 - Opinionated defaults over settings.
 - Assume success, communicate failure.
 
-[![Built with Devbox](https://jetpack.io/img/devbox/shield_moon.svg)](https://jetpack.io/devbox/docs/contributor-quickstart/)
+[![Built with Devbox](https://www.jetify.com/img/devbox/shield_moon.svg)](https://www.jetify.com/docs/devbox/)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,94 @@
+# Releasing Lamb
+
+Maintainer checklist for cutting a release. Lamb ships from the `release`
+branch (see `BRANCHES`); `main` is the active development branch. Versions are
+plain SemVer tags (`0.9.0`); pre-releases use a suffix (`0.9.0-rc1`). There is
+no version string in the code — **the Git tag is the source of truth**.
+
+## 1. Pre-flight (on `main`)
+
+- [ ] All intended PRs are merged into `main`; nothing release-worthy is still open.
+- [ ] Working tree is clean and `main` is up to date: `git checkout main && git pull`.
+- [ ] Tests pass: `vendor/bin/codecept run` (Unit + Acceptance).
+      Acceptance needs `.env` (`SITE_URL`, `LAMB_TEST_PASSWORD`); it starts its
+      own server, so don't have another server on the test port.
+- [ ] Static checks pass: `composer lint` && `composer analyse`.
+- [ ] Docs are accurate for any user-facing change (`docs/`, `README.md`).
+
+## 2. Choose the version
+
+- [ ] Decide the new version from the change set (SemVer):
+      patch = fixes only, minor = new features, major = breaking changes.
+- [ ] Confirm it's unused: `git tag | sort -V | tail`.
+- [ ] If cutting a pre-release first, use an `-rcN` suffix and mark it
+      pre-release in step 6.
+
+## 3. Generate end-user release notes
+
+Notes are for **people running a Lamb blog**, not contributors. Start from the
+commit list, then curate.
+
+```sh
+# Everything on main since the last release tag (use the previous final tag):
+git log --format='- %s' <last-tag>..main
+```
+
+- [ ] **Keep** changes an end user would notice: new/changed features, bug
+      fixes affecting the blog or admin, new config keys, install/upgrade
+      requirements (e.g. a newly required PHP extension), deployment changes
+      (Docker/Caddy/Nginx/DDev/Devbox).
+- [ ] **Drop** internal-only changes: dev-environment tooling (e.g. Workshop),
+      CI, tests, refactors, code-comments/`CLAUDE.md`/`DECISIONS.md`, and
+      dependency bumps with no user-visible effect.
+- [ ] Rewrite each kept line in plain language (what changed for the user, not
+      the PR title). Group under **Added / Changed / Fixed**.
+- [ ] Call out anything requiring action on upgrade in an **Upgrade notes**
+      section (e.g. "install the `pdo_mysql` PHP extension", config changes).
+- [ ] Save the notes to a temp file (e.g. `/tmp/notes.md`) for step 6.
+
+## 4. Merge `main` into `release`
+
+```sh
+git checkout release && git pull
+git merge --no-ff main -m "Release <version>"
+git push origin release
+```
+
+- [ ] Resolve any conflicts (rare — `release` should only trail `main`).
+- [ ] Re-run `vendor/bin/codecept run` on `release` to confirm green.
+
+## 5. Tag
+
+```sh
+git tag -a <version> -m "Lamb <version>"   # e.g. 0.9.0
+git push origin <version>
+```
+
+- [ ] Tag is created on the `release` branch tip.
+
+## 6. Create the GitHub release
+
+```sh
+gh release create <version> \
+  --target release \
+  --title "Lamb <version>" \
+  --notes-file /tmp/notes.md
+# add --prerelease for an -rcN tag
+# add --latest to mark a final release as the latest
+```
+
+- [ ] Final releases: pass `--latest`. Pre-releases: pass `--prerelease` and
+      do **not** mark latest.
+- [ ] Verify on GitHub: `gh release view <version>`.
+
+## 7. Post-release
+
+- [ ] Announce / update any demo site if applicable.
+- [ ] Note that the Docker/Devbox/DDev users pull from `release`; confirm a
+      clean checkout of `release` installs and runs.
+
+## Related
+
+- `BRANCHES` — branch roles (`main`, `release`, `next`, pinned).
+- `CONTRIBUTING` — contribution workflow.
+- `docs/upgrading.md` — what end users run to upgrade.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Barrier free super simple blogging, self-hosted. [Read about the features](https
 ## Requirements
 
 - PHP 8.2 – 8.5
-- SQLite3, gettext, simplexml, mbstring extensions
+- SQLite3, gettext, simplexml, mbstring, pdo_mysql extensions (pdo_mysql is required by the database library even though Lamb uses SQLite)
 
 ## Getting started
 

--- a/docs/local-php-setup.md
+++ b/docs/local-php-setup.md
@@ -9,8 +9,9 @@ Make sure everything is installed:
 ```bash
 # Install required system packages, for example on Debian Linux derivatives like Ubuntu
 sudo apt update
-sudo apt install php8.4 php8.4-gettext php8.4-mbstring php8.4-sqlite3 php8.4-xml composer
+sudo apt install php8.4 php8.4-gettext php8.4-mbstring php8.4-sqlite3 php8.4-xml php8.4-mysql composer
 # PHP 8.2–8.5 are supported; replace 8.4 with your preferred version
+# php8.4-mysql (pdo_mysql) is required by the database library even though Lamb uses SQLite
 
 # install project packages
 composer install

--- a/src/themes/default/parts/settings.php
+++ b/src/themes/default/parts/settings.php
@@ -9,7 +9,7 @@ use function Lamb\Theme\escape;
 <h1>Settings</h1>
 <p>
     Edit the application configuration in INI format. Changes are validated before saving.
-    Refer to the <a href="https://github.com/svandragt/lamb/wiki" target="_blank">wiki</a> for available keys and examples.
+    Refer to the <a href="https://svandragt.github.io/lamb/site-configuration" target="_blank">documentation</a> for available keys and examples.
 </p>
 
 <form method="post" action="/settings" id="settingsform">


### PR DESCRIPTION
## Why

Two issues, both surfaced while standing up a fresh environment:

1. **Stale GitHub-wiki references.** The wiki was retired in favour of the GitHub Pages docs (`docs/`), but several places still linked to / referenced it.
2. **`pdo_mysql` is an undeclared runtime requirement.** RedBeanPHP 5.7 references `PDO::MYSQL_ATTR_INIT_COMMAND` at file load (`RedBeanPHP/Functions.php`), so PHP without the `pdo_mysql` extension **fatals on load** — even though Lamb only uses SQLite. This breaks the Docker image and minimal hand-rolled PHP installs.

## Changes

- **Wiki → Pages docs:** `README.md` ("Visit the wiki" → "Read the documentation"), `src/themes/default/parts/settings.php` (→ `/site-configuration`), and "wiki" wording in `CLAUDE.md` / `DECISIONS.md`.
- **README:** refreshed the feature list (drafts, scheduled posts, trash/restore, Micropub, full-text search, menu items, per-tag feeds, slug 301s) and fixed the Devbox badge (`jetpack.io` → `jetify.com`).
- **pdo_mysql:** documented in `docs/index.md` and `docs/local-php-setup.md`; installed in `.docker/Dockerfile` (`docker-php-ext-install gettext pdo_mysql`).

## Verification

- `php:8.2-fpm` lacks `pdo_mysql`; loading `RedBeanPHP/Functions.php` there fatals. After `docker-php-ext-install pdo_mysql` it loads cleanly (confirmed via `docker run`).
- **DDev is unaffected** — its web image (`ddev/ddev-webserver`) already bundles `pdo_mysql` for PHP 8.2; no DDev change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also

- Add `RELEASING.md` — maintainer release checklist (pre-flight, version, end-user release notes, merge main→release, tag, gh release create).
