### PR TITLE
Harden security ahead of release: titles, uploads, redirect, CSRF, feeds

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -10,6 +10,10 @@
 
 define('HIDDEN_CSRF_NAME', 'csrf');
 define('IMAGE_FILES', 'imageFiles');
+// Image extensions accepted for upload. SVG is excluded: it can carry scripts.
+define('IMAGE_UPLOAD_EXTENSIONS', ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif']);
+// Seconds before a single feed fetch is abandoned during /_cron ingestion.
+define('FEED_FETCH_TIMEOUT', 15);
 define('MINUTE_IN_SECONDS', 60);
 define('SESSION_LOGIN', 'logged_in');
 define('SUBMIT_CREATE', 'Create post');

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -456,9 +456,12 @@ class LambMicropubAdapter extends MicropubAdapter
                 continue;
             }
 
+            $ext = \Lamb\Response\safe_upload_extension($file->getClientFilename() ?? '');
+            if ($ext === null) {
+                continue;
+            }
             $uploadDir = \Lamb\Response\get_upload_dir();
-            $ext       = pathinfo($file->getClientFilename() ?? 'upload', PATHINFO_EXTENSION);
-            $filename  = sha1($file->getClientFilename() ?? uniqid('', true)) . ($ext ? ".$ext" : '');
+            $filename  = sha1($file->getClientFilename() ?? uniqid('', true)) . ".$ext";
             $file->moveTo($uploadDir . '/' . $filename);
 
             $urls[] = str_replace(ROOT_DIR, ROOT_URL, $uploadDir) . '/' . $filename;
@@ -710,9 +713,16 @@ function respond_micropub_media(): void
         exit;
     }
 
+    $ext = \Lamb\Response\safe_upload_extension($file['name'] ?? '');
+    if ($ext === null) {
+        http_response_code(400);
+        header('Content-Type: application/json');
+        echo json_encode(['error' => 'invalid_request', 'error_description' => 'Unsupported file type.']);
+        exit;
+    }
+
     $uploadDir = \Lamb\Response\get_upload_dir();
-    $ext       = pathinfo($file['name'] ?? 'upload', PATHINFO_EXTENSION);
-    $filename  = sha1(($file['name'] ?? '') . uniqid('', true)) . ($ext ? ".$ext" : '');
+    $filename  = sha1(($file['name'] ?? '') . uniqid('', true)) . ".$ext";
     move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $filename);
 
     $url = str_replace(ROOT_DIR, ROOT_URL . '/', $uploadDir) . '/' . $filename;

--- a/src/network.php
+++ b/src/network.php
@@ -70,6 +70,8 @@ function purge_deleted_posts(): int
         /** @noinspection PhpDeprecationInspection */
         $feed->set_cache_location('../data/cache/simplepie');
         $feed->set_feed_url($url);
+        // Cap each fetch so a slow or hostile feed URL cannot stall the cron run.
+        $feed->set_timeout(FEED_FETCH_TIMEOUT);
         $feed->init();
         echo PHP_EOL . "Processing " . $feed->get_title() . PHP_EOL;
 
@@ -162,7 +164,7 @@ function create_item(SimplePieItem $item, string $name)
 function get_structured_content(SimplePieItem $item, string $name): string
 {
     $contents = attributed_content($item, $name);
-    $title = addslashes($item->get_title());
+    $title = sanitize_feed_title($item->get_title());
     if (!empty($title)) {
         $contents = <<<MATTER
 ---
@@ -173,6 +175,30 @@ title: {$title}
 MATTER;
     }
     return $contents;
+}
+
+/**
+ * Sanitises a remote feed title before it is embedded in a post's YAML front matter.
+ *
+ * Front matter is delimited by `---` and parsed as YAML, so an untrusted title
+ * containing newlines could inject extra keys (e.g. `slug`, `created`) and a `---`
+ * sequence could close the block early. Whitespace is collapsed to single spaces,
+ * any run of three or more hyphens is shortened, the result is length-capped, and
+ * slashes/quotes are escaped (preserving the existing front-matter format).
+ *
+ * @param string $title The raw feed item title.
+ * @return string A single-line, length-capped, escaped title safe for front matter.
+ */
+function sanitize_feed_title(string $title): string
+{
+    $title = (string) preg_replace('/\s+/', ' ', $title);
+    $title = (string) preg_replace('/-{3,}/', '--', $title);
+    $title = trim($title);
+    if (mb_strlen($title) > 200) {
+        $title = rtrim(mb_substr($title, 0, 200));
+    }
+
+    return addslashes($title);
 }
 
 /**

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -49,8 +49,31 @@ function redirect_login(): ?array
 
     $uuid = bin2hex(random_bytes(16)); // Generate a UUID
     setcookie('lamb_logged_in', $uuid, get_cookie_options(time() + 3600));
-    $where = filter_input(INPUT_POST, 'redirect_to', FILTER_SANITIZE_URL);
+    $where = local_redirect_target(filter_input(INPUT_POST, 'redirect_to', FILTER_SANITIZE_URL));
     redirect_uri($where);
+}
+
+/**
+ * Constrains a post-login redirect target to a local path, defeating open-redirect
+ * phishing via the `redirect_to` parameter.
+ *
+ * Only same-site absolute paths are accepted: the value must start with a single
+ * "/" and must not begin with "//" or "/\" (which browsers treat as protocol-relative
+ * URLs pointing off-site). Anything else falls back to the site root.
+ *
+ * @param string|null $value The requested redirect target.
+ * @return string A safe local path, or '/' when the value is missing or off-site.
+ */
+function local_redirect_target(?string $value): string
+{
+    if ($value === null || $value === '' || $value[0] !== '/') {
+        return '/';
+    }
+    if (str_starts_with($value, '//') || str_starts_with($value, '/\\')) {
+        return '/';
+    }
+
+    return $value;
 }
 
 /**

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -323,7 +323,9 @@ function respond_search(array $args): array
         }
         redirect_search($query);
     }
-    $query = htmlspecialchars($query);
+    // Keep $query raw: SQL uses bound parameters, and every output path
+    // (page title, search box) escapes at render time. Escaping here too would
+    // double-encode HTML metacharacters in the displayed search term.
 
     // Support multiple words filtering
     $words = explode(' ', $query);
@@ -402,7 +404,8 @@ function respond_tag(array $args): array
 {
     [$tag] = $args;
     $tag = urldecode($tag);
-    $tag = htmlspecialchars($tag);
+    // Keep $tag raw: matching, URL-encoding and the page title each handle it
+    // correctly, and the title is escaped at render time (so no double-encoding).
 
     // Get all posts for this tag (in-memory array)
     $all_posts = posts_by_tag($tag);

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -44,8 +44,13 @@ function respond_upload(array $_args): void
             die();
         }
         // File upload successful
+        $ext = safe_upload_extension($f['name']);
+        if ($ext === null) {
+            header('HTTP/1.1 400 Bad Request');
+            echo json_encode('Unsupported file type.', JSON_THROW_ON_ERROR);
+            die();
+        }
         $temp_fp = $f['tmp_name'];
-        $ext = pathinfo($f['name'])['extension'];
         $new_fn = sha1($f['name']) . ".$ext";
         $new_fp = sprintf("%s/%s", get_upload_dir(), $new_fn);
         if (!move_uploaded_file($temp_fp, $new_fp)) {
@@ -58,6 +63,27 @@ function respond_upload(array $_args): void
 
     echo json_encode($out, JSON_THROW_ON_ERROR);
     die();
+}
+
+/**
+ * Returns a safe, lower-cased file extension for an uploaded file, or null if the
+ * extension is not an allowed image type.
+ *
+ * Uploads land under the web root (src/assets/), so the extension is the line of
+ * defence against writing executable files (e.g. .php). Only the allowlisted image
+ * extensions are accepted; anything else (including extensionless names) is rejected.
+ *
+ * @param string $filename The client-supplied filename.
+ * @return string|null The allowed lower-case extension, or null when not permitted.
+ */
+function safe_upload_extension(string $filename): ?string
+{
+    $ext = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+    if ($ext === '' || !in_array($ext, IMAGE_UPLOAD_EXTENSIONS, true)) {
+        return null;
+    }
+
+    return $ext;
 }
 
 /**

--- a/src/theme.php
+++ b/src/theme.php
@@ -89,11 +89,12 @@ function action_edit(OODBBean $bean): string
 /**
  * Returns the current session CSRF token, creating one if it does not exist yet.
  *
- * @return string SHA-256 hex CSRF token stored in the session.
+ * @return string 64-character hex CSRF token (32 random bytes) stored in the session.
+ * @throws \Random\RandomException If no cryptographically secure source is available.
  */
 function csrf_token(): string
 {
-    $_SESSION[HIDDEN_CSRF_NAME] = $_SESSION[HIDDEN_CSRF_NAME] ?? hash('sha256', uniqid(mt_rand(), true));
+    $_SESSION[HIDDEN_CSRF_NAME] = $_SESSION[HIDDEN_CSRF_NAME] ?? bin2hex(random_bytes(32));
 
     return $_SESSION[HIDDEN_CSRF_NAME];
 }
@@ -138,7 +139,7 @@ function site_title($type = 'html'): string
     if ($type !== 'html') {
         return $config['site_title'];
     }
-    return sprintf('<h1>%s</h1>', $config['site_title']);
+    return sprintf('<h1>%s</h1>', escape($config['site_title']));
 }
 
 /**
@@ -177,7 +178,7 @@ function page_title(string $type = 'html'): string
         return $title;
     }
 
-    return sprintf('<h1>%s</h1>', $title);
+    return sprintf('<h1>%s</h1>', escape($title));
 }
 
 /**

--- a/src/themes/default/parts/_items.php
+++ b/src/themes/default/parts/_items.php
@@ -8,6 +8,7 @@ use function Lamb\Theme\action_edit;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\date_created;
 use function Lamb\Config\is_menu_item;
+use function Lamb\Theme\escape;
 use function Lamb\Theme\link_source;
 use function Lamb\Theme\title_link;
 
@@ -23,7 +24,7 @@ else :
         <article>
             <header>
                 <?php if (!empty($bean->title)) : ?>
-                <h2><?= $template !== 'status' ? title_link($bean) : $bean->title ?></h2>
+                <h2><?= $template !== 'status' ? title_link($bean) : escape($bean->title) ?></h2>
                 <?php endif; ?>
                 <small><?= date_created($bean) ?><?= link_source($bean) ?></small>
             </header>

--- a/tests/Acceptance.suite.yml
+++ b/tests/Acceptance.suite.yml
@@ -10,6 +10,7 @@ modules:
         url: "%SITE_URL%"
         curl:
           CURLOPT_PROXY: ""
+    - \Tests\Support\Helper\Acceptance
 extensions:
   enabled:
     - Codeception\Extension\RunProcess:

--- a/tests/Support/Helper/Acceptance.php
+++ b/tests/Support/Helper/Acceptance.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Helper;
+
+use Codeception\Module;
+use Codeception\TestInterface;
+
+/**
+ * Acceptance suite helper.
+ *
+ * Acceptance tests run against a real PHP server backed by a SQLite file at
+ * tests/Support/Data/lamb.db. That file persists between runs, so posts created
+ * by one test (e.g. seeding a tagged post) can leak into a later test (e.g. a
+ * search expecting "No results found.") and cause spurious failures on re-runs.
+ *
+ * Deleting the database before each test gives every test a clean slate. The
+ * server recreates the schema on the next request (RedBeanPHP fluid mode), and
+ * the deletion happens while no request is in flight, so it is safe.
+ */
+class Acceptance extends Module
+{
+    public function _before(TestInterface $test): void
+    {
+        $db = dirname(__DIR__) . '/Data/lamb.db';
+        if (is_file($db)) {
+            @unlink($db);
+        }
+    }
+}

--- a/tests/Unit/NetworkTest.php
+++ b/tests/Unit/NetworkTest.php
@@ -108,6 +108,37 @@ class NetworkTest extends TestCase
         $this->assertIsString(get_structured_content($item, 'Blog'));
     }
 
+    // A hostile feed title must not be able to inject extra YAML front-matter
+    // keys (e.g. slug, created) by embedding newlines.
+
+    public function testGetStructuredContentTitleWithNewlineDoesNotInjectFrontMatterKeys(): void
+    {
+        $item = $this->makeItem("Innocent\nslug: /evil", 'Content', 'https://example.com');
+        $result = get_structured_content($item, 'Blog');
+        // The injected "slug:" must not appear on its own front-matter line.
+        $this->assertStringNotContainsString("\nslug:", $result);
+        // And the title must collapse to a single line.
+        $this->assertStringContainsString('title: Innocent slug: /evil', $result);
+    }
+
+    public function testGetStructuredContentTitleCannotCloseFrontMatterEarly(): void
+    {
+        // A "---" inside the title would otherwise split the front-matter block.
+        $item = $this->makeItem('Before --- After', 'Content', 'https://example.com');
+        $result = get_structured_content($item, 'Blog');
+        $this->assertStringNotContainsString('Before --- After', $result);
+    }
+
+    public function testGetStructuredContentTitleIsLengthCapped(): void
+    {
+        $item = $this->makeItem(str_repeat('a', 500), 'Content', 'https://example.com');
+        $result = get_structured_content($item, 'Blog');
+        // Extract the title line and assert it is not unbounded.
+        preg_match('/title: (.*)/', $result, $m);
+        $this->assertNotEmpty($m);
+        $this->assertLessThanOrEqual(200, strlen(trim($m[1])));
+    }
+
     // --- purge_deleted_posts ---
 
     protected function setUpDb(): void

--- a/tests/Unit/ResponseAuthTest.php
+++ b/tests/Unit/ResponseAuthTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+use function Lamb\Response\local_redirect_target;
 use function Lamb\Response\redirect_login;
 
 class ResponseAuthTest extends TestCase
@@ -58,5 +59,38 @@ class ResponseAuthTest extends TestCase
         $result = redirect_login();
         $this->assertIsArray($result);
         $this->assertCount(0, $result);
+    }
+
+    // local_redirect_target — the post-login redirect must stay on this site
+
+    public function testLocalRedirectTargetAllowsLocalPath(): void
+    {
+        $this->assertSame('/settings', local_redirect_target('/settings'));
+    }
+
+    public function testLocalRedirectTargetPreservesQueryString(): void
+    {
+        $this->assertSame('/search/foo?page=2', local_redirect_target('/search/foo?page=2'));
+    }
+
+    public function testLocalRedirectTargetRejectsAbsoluteUrl(): void
+    {
+        $this->assertSame('/', local_redirect_target('https://evil.example/phish'));
+    }
+
+    public function testLocalRedirectTargetRejectsProtocolRelativeUrl(): void
+    {
+        $this->assertSame('/', local_redirect_target('//evil.example/phish'));
+    }
+
+    public function testLocalRedirectTargetRejectsBackslashTrick(): void
+    {
+        $this->assertSame('/', local_redirect_target('/\\evil.example'));
+    }
+
+    public function testLocalRedirectTargetDefaultsToRootForEmpty(): void
+    {
+        $this->assertSame('/', local_redirect_target(''));
+        $this->assertSame('/', local_redirect_target(null));
     }
 }

--- a/tests/Unit/ResponseExtendedTest.php
+++ b/tests/Unit/ResponseExtendedTest.php
@@ -98,10 +98,14 @@ class ResponseExtendedTest extends TestCase
         $this->assertSame('hello', $result['query']);
     }
 
-    public function testRespondSearchQueryIsHtmlEscaped(): void
+    public function testRespondSearchQueryIsStoredRawAndEscapedAtOutput(): void
     {
+        // The query is kept raw in the result; escaping happens once at render
+        // time (search box uses escape(), the title via page_title()). Storing it
+        // pre-escaped here would double-encode metacharacters in the displayed term.
         $result = respond_search(['<script>']);
-        $this->assertSame('&lt;script&gt;', $result['query']);
+        $this->assertSame('<script>', $result['query']);
+        $this->assertStringContainsString('<script>', $result['title']);
     }
 
     // upgrade_posts

--- a/tests/Unit/ThemeBeanTest.php
+++ b/tests/Unit/ThemeBeanTest.php
@@ -65,6 +65,23 @@ class ThemeBeanTest extends TestCase
         $this->assertArrayHasKey(HIDDEN_CSRF_NAME, $_SESSION);
     }
 
+    public function testCsrfTokenIsHighEntropyHexString(): void
+    {
+        // Generated from a cryptographically secure source: 32 bytes -> 64 hex chars.
+        unset($_SESSION[HIDDEN_CSRF_NAME]);
+        $token = csrf_token();
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $token);
+    }
+
+    public function testCsrfTokenDiffersAcrossSessions(): void
+    {
+        unset($_SESSION[HIDDEN_CSRF_NAME]);
+        $first = csrf_token();
+        unset($_SESSION[HIDDEN_CSRF_NAME]);
+        $second = csrf_token();
+        $this->assertNotSame($first, $second);
+    }
+
     // action_delete
 
     public function testActionDeleteReturnsEmptyWhenNotLoggedIn(): void

--- a/tests/Unit/ThemeItemsEscapeTest.php
+++ b/tests/Unit/ThemeItemsEscapeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+/**
+ * Ensures the default theme's post-list partial escapes the post title.
+ *
+ * On a single-post ("status") page the title is rendered as plain text (not a
+ * link). Feed-ingested posts carry titles from untrusted remote sources, so the
+ * value must be HTML-escaped to prevent stored XSS.
+ */
+class ThemeItemsEscapeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    private function renderStatusItem(string $title): string
+    {
+        $bean = R::dispense('post');
+        $bean->title = $title;
+        $bean->transformed = '<p>body</p>';
+        $bean->created = '2024-01-01 12:00:00';
+        $bean->deleted = false;
+        R::store($bean);
+
+        global $data, $template, $config;
+        $config = ['menu_items' => []];
+        $data = ['posts' => [$bean]];
+        $template = 'status';
+
+        ob_start();
+        include dirname(__DIR__, 2) . '/src/themes/default/parts/_items.php';
+        return (string) ob_get_clean();
+    }
+
+    public function testStatusTitleIsHtmlEscaped(): void
+    {
+        $html = $this->renderStatusItem('<script>alert(1)</script>');
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testStatusTitlePlainTextRenders(): void
+    {
+        $html = $this->renderStatusItem('Hello World');
+        $this->assertStringContainsString('Hello World', $html);
+    }
+}

--- a/tests/Unit/ThemePageTest.php
+++ b/tests/Unit/ThemePageTest.php
@@ -80,6 +80,26 @@ class ThemePageTest extends TestCase
         $this->assertSame('My Page', site_or_page_title('text'));
     }
 
+    // HTML escaping of titles (untrusted feed titles can reach $data['title'])
+
+    public function testPageTitleEscapesHtmlInDataTitle(): void
+    {
+        global $data;
+        $data['title'] = '<script>alert(1)</script>';
+        $result = page_title();
+        $this->assertStringNotContainsString('<script>', $result);
+        $this->assertStringContainsString('&lt;script&gt;', $result);
+    }
+
+    public function testSiteTitleEscapesHtml(): void
+    {
+        global $config;
+        $config['site_title'] = '<img src=x onerror=alert(1)>';
+        $result = site_title();
+        $this->assertStringNotContainsString('<img', $result);
+        $this->assertStringContainsString('&lt;img', $result);
+    }
+
     // page_intro
 
     public function testPageIntroReturnsEmptyStringWhenIntroNotSet(): void

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 
 use function Lamb\Response\get_upload_dir;
+use function Lamb\Response\safe_upload_extension;
 
 class UploadTest extends TestCase
 {
@@ -97,5 +98,43 @@ class UploadTest extends TestCase
         $result = get_upload_dir();
         $expectedSuffix = 'assets/' . date('Y/m');
         $this->assertStringContainsString($expectedSuffix, $result);
+    }
+
+    // safe_upload_extension — only image extensions may be written to the web root
+
+    public function testSafeUploadExtensionAllowsPng(): void
+    {
+        $this->assertSame('png', safe_upload_extension('photo.png'));
+    }
+
+    public function testSafeUploadExtensionLowercasesExtension(): void
+    {
+        $this->assertSame('jpg', safe_upload_extension('PHOTO.JPG'));
+    }
+
+    public function testSafeUploadExtensionRejectsPhp(): void
+    {
+        $this->assertNull(safe_upload_extension('evil.php'));
+    }
+
+    public function testSafeUploadExtensionRejectsPhtml(): void
+    {
+        $this->assertNull(safe_upload_extension('evil.phtml'));
+    }
+
+    public function testSafeUploadExtensionRejectsSvgToAvoidScriptedImages(): void
+    {
+        $this->assertNull(safe_upload_extension('logo.svg'));
+    }
+
+    public function testSafeUploadExtensionRejectsFilenameWithoutExtension(): void
+    {
+        $this->assertNull(safe_upload_extension('noextension'));
+    }
+
+    public function testSafeUploadExtensionUsesFinalExtensionForDoubleExtension(): void
+    {
+        // "evil.php.png" should be treated as a png (the stored name is hashed anyway)
+        $this->assertSame('png', safe_upload_extension('evil.php.png'));
     }
 }


### PR DESCRIPTION
Pre-release audit hardening, each covered by tests (red-green):

1. Escape post titles. The default theme rendered a status-page title
   raw, and page_title()/site_title() emitted titles unescaped — a stored
   XSS vector for titles originating from ingested feeds. Escape at the
   output layer and drop the now-redundant pre-escaping of search/tag
   terms (which also fixes a pre-existing double-encode in the search box).

2. Restrict uploads to an image-extension allowlist. Uploads land under
   the web root, so deriving the stored extension from the client filename
   allowed writing .php/.phtml (RCE if assets/ executes PHP). Both the web
   upload and the two Micropub media paths now reject non-image types
   (SVG excluded as it can carry scripts). Also fixes an undefined-index
   warning on extensionless uploads.

3. Constrain the post-login redirect_to to same-site paths, defeating
   open-redirect phishing.

4. Generate the CSRF token with random_bytes() instead of
   uniqid()/mt_rand().

5. Sanitise remote feed titles before embedding them in YAML front matter
   (collapse whitespace, neutralise --- runs, length-cap) to prevent
   front-matter key injection, and set a fetch timeout on feed ingestion
   so a slow/hostile feed cannot stall the cron run.