### PR TITLE
Enable running Codeception inside the Docker container

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -30,8 +30,10 @@ services:
       - ../.ddev/.env
     image: php:fpm
     volumes:
-      - ../src:/srv/app/src
-      - ../data:/srv/app/data
+      # Mount the whole project so Codeception config and tests are available
+      # inside the container. The vendor volume is overlaid on top so the
+      # container uses the dependencies installed by the composer service.
+      - ..:/srv/app
       - vendor:/srv/app/vendor
 
 volumes:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -38,6 +38,23 @@ $ docker compose up --build -d
 
 The `-d` flag is used to start the containers in the background (detached mode).
 
-## Known issues
+## Running tests
 
-- Codeception cannot be run from within the docker container
+Codeception runs inside the `lamb-app` container. The whole project is mounted
+at `/srv/app`, so the test suites and configuration are available there.
+
+The test runner reads `.env` for its parameters, so make sure you have generated
+one with the `make-password.php` step from [Setup](#setup) before running the
+tests.
+
+```shell
+# Unit tests (fast, no server required)
+$ docker exec -it lamb-app vendor/bin/codecept run Unit
+
+# Full suite, including acceptance tests against the running stack
+$ docker exec -it lamb-app vendor/bin/codecept run
+```
+
+Acceptance tests use `SITE_URL`, which `make-password.php` automatically sets to
+`http://lamb-web` (the Caddy container) when run inside the container, so they
+exercise the live Docker stack.


### PR DESCRIPTION
The php (lamb-app) container only mounted src, data and the vendor volume,
so the Codeception config and tests were not present inside the container
and vendor/bin/codecept had nothing to run.

Mount the whole project at /srv/app (with the vendor volume overlaid on
top) so the test suites and codeception.yml are available. make-password.php
already sets SITE_URL to the Caddy container when run in /srv/app, so
acceptance tests exercise the live stack.

Replace the docker docs 'Known issues' note with instructions for running
the Unit suite and the full suite inside the container.

https://claude.ai/code/session_01RbbGrFxD44jVER9qxtWuHX