### PR TITLE
Wrap selected text in markdown link when pasting a URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,7 @@ When the user is logged in, it also loads:
 - `src/scripts/logged_in/confirm-delete.js`
 - `src/scripts/logged_in/link-edit-buttons.js`
 - `src/scripts/logged_in/upload-image.js`
+- `src/scripts/logged_in/paste-link.js`
 
 ### Upload asset storage
 

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -10,6 +10,8 @@ The default, add some words into the textarea and press the publish button. Any 
 
 Any tags are automatically linked to tag archives.
 
+Select some text and paste a link over it to turn the selection into a markdown link, e.g. selecting `Lamb` and pasting `https://example.com` produces `[Lamb](https://example.com)`.
+
 Permalinks for statuses are in the form of `/status/<integer>`.
 
 ```markdown

--- a/src/scripts/logged_in/paste-link.js
+++ b/src/scripts/logged_in/paste-link.js
@@ -1,0 +1,36 @@
+onLoaded(() => {
+    const ta = $('textarea')
+    if (!ta) return
+    ta.on('paste', (ev) => {
+        const start = ta.selectionStart
+        const end = ta.selectionEnd
+        if (start === end) return // nothing selected
+
+        const pasted = (ev.clipboardData || window.clipboardData).getData('text')
+        if (!isUrl(pasted)) return
+
+        cancel(ev)
+
+        const selected = ta.value.slice(start, end)
+        const markdown = `[${selected}](${pasted.trim()})`
+        ta.setRangeText(markdown, start, end, 'end')
+        ta.dispatchEvent(new Event('input'))
+    })
+})
+
+/**
+ * Tests whether a string is a single http(s) URL.
+ *
+ * @param {string} str - The candidate string.
+ * @returns {boolean} True when str is one http(s) URL with no surrounding whitespace.
+ */
+function isUrl(str) {
+    const trimmed = str.trim()
+    if (!trimmed || /\s/.test(trimmed)) return false
+    try {
+        const url = new URL(trimmed)
+        return url.protocol === 'http:' || url.protocol === 'https:'
+    } catch {
+        return false
+    }
+}

--- a/src/theme/assets.php
+++ b/src/theme/assets.php
@@ -34,7 +34,7 @@ function the_scripts(): void
 {
     $scripts = [
         '' => ['shorthand.js'],
-        'logged_in' => ['growing-input.js', 'confirm-delete.js', 'link-edit-buttons.js', 'upload-image.js'],
+        'logged_in' => ['growing-input.js', 'confirm-delete.js', 'link-edit-buttons.js', 'upload-image.js', 'paste-link.js'],
         'search' => ['search-highlight.js'],
     ];
     $assets = asset_loader($scripts, 'scripts');

--- a/tests/Unit/ThemeAssetsTest.php
+++ b/tests/Unit/ThemeAssetsTest.php
@@ -120,6 +120,35 @@ class ThemeAssetsTest extends TestCase
         $this->assertStringContainsString('confirm-delete.js', $output);
         $this->assertStringContainsString('link-edit-buttons.js', $output);
         $this->assertStringContainsString('upload-image.js', $output);
+        $this->assertStringContainsString('paste-link.js', $output);
+    }
+
+    public function testTheScriptsDoesNotIncludePasteLinkJsWhenNotLoggedIn(): void
+    {
+        unset($_SESSION[SESSION_LOGIN]);
+
+        ob_start();
+        the_scripts();
+        $output = ob_get_clean();
+
+        $this->assertStringNotContainsString('paste-link.js', $output);
+    }
+
+    public function testTheScriptsPasteLinkJsUrlPointsToExistingFile(): void
+    {
+        $_SESSION[SESSION_LOGIN] = true;
+
+        ob_start();
+        the_scripts();
+        $output = ob_get_clean();
+
+        preg_match('/src="([^"]*paste-link\.js[^"]*)"/', $output, $m);
+        $this->assertNotEmpty($m, 'paste-link.js src attribute not found in output');
+
+        $url_path = parse_url($m[1], PHP_URL_PATH);
+        $project_src = dirname(__DIR__, 2) . '/src/';
+        $file = $project_src . ltrim($url_path, '/');
+        $this->assertFileExists($file, "Script file not found at $file — URL '$url_path' does not resolve to a real file");
     }
 
     public function testTheScriptsIncludesSearchHighlightJsWhenTemplateIsSearch(): void


### PR DESCRIPTION
Closes #198.

## What

In the post editor, selecting some text and pasting an `http(s)` URL over it now produces a markdown link `[selected text](url)` instead of replacing the selection with the raw URL.

Example: select `Lamb`, paste `https://example.com` → `[Lamb](https://example.com)`.

## How

- **`src/scripts/logged_in/paste-link.js`** (new) — on `paste` over a non-empty selection, validates the clipboard is a single `http(s)` URL (`new URL()`), then uses `setRangeText()` (which preserves native undo) to wrap the selection. Falls through to the default paste when there's no selection or the clipboard isn't a URL. Follows the existing `onLoaded`/`$`/`cancel` shorthand helpers.
- **`src/theme/assets.php`** — registered the script in the `logged_in` group of `the_scripts()` so it loads only for authenticated users.
- **`docs/post-types.md`** and **`CLAUDE.md`** — documented the behaviour and added the script to the asset list.

## Tests

Added unit coverage in `tests/Unit/ThemeAssetsTest.php` (written red-first): the script is registered when logged in, absent when logged out, and its URL resolves to a real file.

- `vendor/bin/codecept run Unit` → 580 tests, 860 assertions, OK
- `composer lint` → clean

Also verified end-to-end in a headless browser against the running dev server: pasting a URL over a selection wraps it; no-selection and non-URL pastes are left untouched; both `http` and `https` work (5/5 checks passed).

https://claude.ai/code/session_01PVNomNUBbXFLUovJnp9Yey

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVNomNUBbXFLUovJnp9Yey)_