### PR TITLE
Exclude scheduled posts from related posts

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -182,6 +182,27 @@ function not_scheduled_clause(): array
 }
 
 /**
+ * Returns the SQL fragment and bound parameters selecting only posts that are
+ * publicly visible to anonymous visitors: not draft, not deleted, and not
+ * scheduled for the future.
+ *
+ * This is the single allow-list definition of "visible". Every public listing
+ * query should use it instead of re-assembling SQL_PUBLISHED with
+ * not_scheduled_clause(), so a new query cannot accidentally omit one of the
+ * conditions (which is how scheduled posts leaked into related posts).
+ *
+ * @return array{sql: string, params: array}
+ */
+function visible_clause(): array
+{
+    $not_scheduled = not_scheduled_clause();
+    return [
+        'sql'    => SQL_PUBLISHED . 'AND' . $not_scheduled['sql'],
+        'params' => $not_scheduled['params'],
+    ];
+}
+
+/**
  * Rewrites the `created` value inside a body's leading YAML front-matter block to
  * the given resolved (absolute) datetime, leaving all other front-matter intact.
  *

--- a/src/post.php
+++ b/src/post.php
@@ -142,12 +142,11 @@ function body_has_tag(string $tag, string $body): bool
 function posts_by_tag(string $tag): array
 {
     $conditions = get_tag_search_conditions($tag);
-    $not_scheduled = \Lamb\not_scheduled_clause();
+    $visible = \Lamb\visible_clause();
     $posts = R::find(
         'post',
-        '(' . $conditions['sql'] . ') AND (draft IS NULL OR draft != 1) AND'
-            . $not_scheduled['sql'] . 'ORDER BY created DESC',
-        array_merge($conditions['params'], $not_scheduled['params'])
+        '(' . $conditions['sql'] . ') AND' . $visible['sql'] . 'ORDER BY created DESC',
+        array_merge($conditions['params'], $visible['params'])
     );
 
     return array_values(array_filter($posts, fn($post) => body_has_tag($tag, (string) $post->body)));

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -15,7 +15,6 @@ use function Lamb\Theme\part;
 use const Lamb\SQL_IS_DELETED;
 use const Lamb\SQL_IS_DRAFT;
 use const Lamb\SQL_IS_SCHEDULED;
-use const Lamb\SQL_PUBLISHED;
 use const ROOT_URL;
 
 /**
@@ -32,16 +31,14 @@ function respond_home(): array
 
     $data['title'] = $config['site_title'];
 
-    $where_sql = SQL_PUBLISHED;
-    $where_params = [];
+    $visible = \Lamb\visible_clause();
+    $where_sql = $visible['sql'];
+    $where_params = $visible['params'];
     $clause = build_exclude_slugs_clause(Config\get_menu_slugs());
     if ($clause !== null) {
         $where_sql .= ' AND ' . $clause['sql'];
-        $where_params = $clause['params'];
+        $where_params = array_merge($where_params, $clause['params']);
     }
-    $not_scheduled = \Lamb\not_scheduled_clause();
-    $where_sql .= ' AND ' . $not_scheduled['sql'];
-    $where_params = array_merge($where_params, $not_scheduled['params']);
     $paginated = paginate_posts('post', 'created DESC', $where_sql, $where_params);
     $data['posts'] = $paginated['items'];
     $data['pagination'] = $paginated['pagination'];
@@ -164,20 +161,19 @@ function get_feed_data(): array
 {
     global $config;
 
-    $not_scheduled = \Lamb\not_scheduled_clause();
+    $visible = \Lamb\visible_clause();
     $clause = build_exclude_slugs_clause(Config\get_menu_slugs());
     if ($clause !== null) {
         $posts = R::find(
             'post',
-            $clause['sql'] . ' AND' . SQL_PUBLISHED . 'AND' . $not_scheduled['sql']
-                . 'ORDER BY updated DESC LIMIT 20',
-            array_merge($clause['params'], $not_scheduled['params'])
+            $clause['sql'] . ' AND' . $visible['sql'] . 'ORDER BY updated DESC LIMIT 20',
+            array_merge($clause['params'], $visible['params'])
         );
     } else {
         $posts = R::find(
             'post',
-            SQL_PUBLISHED . 'AND' . $not_scheduled['sql'] . 'ORDER BY updated DESC LIMIT 20',
-            $not_scheduled['params']
+            $visible['sql'] . 'ORDER BY updated DESC LIMIT 20',
+            $visible['params']
         );
     }
 
@@ -362,9 +358,9 @@ function respond_search(array $args): array
         $where_clauses[] = 'body LIKE ?';
         $params[] = "%$word%";
     }
-    $not_scheduled = \Lamb\not_scheduled_clause();
-    $where_sql = '(' . implode(' AND ', $where_clauses) . ') AND' . SQL_PUBLISHED . 'AND' . $not_scheduled['sql'];
-    $params = array_merge($params, $not_scheduled['params']);
+    $visible = \Lamb\visible_clause();
+    $where_sql = '(' . implode(' AND ', $where_clauses) . ') AND' . $visible['sql'];
+    $params = array_merge($params, $visible['params']);
 
     $paginated = paginate_posts('post', 'created DESC', $where_sql, $params);
 

--- a/src/theme.php
+++ b/src/theme.php
@@ -19,8 +19,7 @@ use function Lamb\Network\get_feeds;
 use function Lamb\permalink;
 use function Lamb\Post\body_has_tag;
 use function Lamb\Post\get_tag_search_conditions;
-
-use const Lamb\SQL_PUBLISHED;
+use function Lamb\visible_clause;
 
 /**
  * Returns true when the user is authenticated and the bean has an ID.
@@ -223,8 +222,9 @@ function get_posts_by_tags(array $tags, int $exclude_id = 0, int $limit = 10): a
     $related_posts = [];
     foreach ($tags as $tag) {
         $conditions = get_tag_search_conditions($tag);
-        $sql = '(' . $conditions['sql'] . ') AND' . SQL_PUBLISHED;
-        $params = $conditions['params'];
+        $visible = visible_clause();
+        $sql = '(' . $conditions['sql'] . ') AND' . $visible['sql'];
+        $params = array_merge($conditions['params'], $visible['params']);
         if ($exclude_id > 0) {
             $sql .= ' AND id != ?';
             $params[] = $exclude_id;

--- a/tests/Unit/ThemeExtendedTest.php
+++ b/tests/Unit/ThemeExtendedTest.php
@@ -18,9 +18,13 @@ class ThemeExtendedTest extends TestCase
             R::setup('sqlite::memory:');
         }
         R::freeze(false);
-        // Ensure the draft column exists (RedBeanPHP fluid mode only creates columns on first store)
+        // Ensure visibility columns exist (RedBeanPHP fluid mode only creates columns on first store).
+        // Without deleted/created present, the visibility SQL errors and fluid mode silently returns
+        // an empty result set, masking the behaviour under test.
         $seed = R::dispense('post');
         $seed->draft = 0;
+        $seed->deleted = 0;
+        $seed->created = date('Y-m-d H:i:s');
         R::store($seed);
         R::exec("DELETE FROM post");
 
@@ -300,6 +304,19 @@ class ThemeExtendedTest extends TestCase
         R::store($bean);
 
         $result = get_posts_by_tags(['trashme']);
+        $this->assertCount(0, $result);
+    }
+
+    public function testGetPostsByTagsExcludesScheduledPosts(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Scheduled post about #scheduleme end';
+        $bean->version = 1;
+        $bean->draft = 0;
+        $bean->created = date('Y-m-d H:i:s', time() + 86400);
+        R::store($bean);
+
+        $result = get_posts_by_tags(['scheduleme']);
         $this->assertCount(0, $result);
     }
 }


### PR DESCRIPTION
## Problem

Related posts (`get_posts_by_tags`) filtered with `SQL_PUBLISHED` (not-draft + not-deleted) but missed the scheduled check, so **future-dated (scheduled) posts leaked into the related list**. Every other public listing already combined `SQL_PUBLISHED` with `not_scheduled_clause()` — only this path had drifted.

## Changes

- Add a single canonical `Lamb\visible_clause()` allow-list: **not draft + not deleted + not scheduled**.
- Route all public listing queries through it — related posts, home index, Atom feed, search, and tag pages — so a query can no longer silently omit a visibility condition.
- **Bonus correctness fix:** `posts_by_tag` previously excluded drafts but *not* deleted posts on tag pages; the shared clause now excludes both.
- Fix the `ThemeExtendedTest` seed to create the `deleted`/`created` columns. The fluid-mode in-memory test DB only creates columns on first store, so the old draft-only seed made the visibility query error and silently return empty — masking this bug.

## Left unchanged

`latest_content_timestamp()` keeps `SQL_PUBLISHED` on purpose — it's a cache validator, not a visitor-facing list, and must move forward when a post is scheduled/edited so caches refresh when it goes live.

## Testing

- Added a failing-first regression test (`testGetPostsByTagsExcludesScheduledPosts`); drafts/trashed coverage already existed and still passes.
- Full unit suite: 608 passing. PHPStan clean. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)