### PR TITLE
Gate draft/scheduled permalink visibility behind login

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -280,6 +280,30 @@ function is_scheduled(OODBBean $post): bool
 }
 
 /**
+ * Returns true when a post may be shown for a direct permalink request
+ * (/status/<id> or a slug URL).
+ *
+ * Deleted posts are never visible. Drafts and posts scheduled for the future
+ * are visible only to the logged-in author, so they can preview their own
+ * work by permalink; anonymous visitors get a 404. This is the single-post
+ * counterpart to visible_clause() (the SQL allow-list for listings), with the
+ * added logged-in preview exception.
+ *
+ * @param OODBBean $post The post to inspect (an unsaved/missing bean has id 0).
+ * @return bool
+ */
+function is_visible(OODBBean $post): bool
+{
+    if (empty($post->id) || $post->deleted == 1) {
+        return false;
+    }
+    if (isset($_SESSION[SESSION_LOGIN])) {
+        return true;
+    }
+    return $post->draft != 1 && !is_scheduled($post);
+}
+
+/**
  * Checks if a post with the given slug exists in the database.
  *
  * @param string $lookup The slug of the post to look up.

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -228,7 +228,7 @@ function respond_status(array $args): array
 {
     [$id] = $args;
     $bean = R::load('post', (int)$id);
-    if (!$bean->id || $bean->deleted) {
+    if (!\Lamb\is_visible($bean)) {
         return respond_404([], true);
     }
 
@@ -272,7 +272,7 @@ function respond_post(array $args): array
 {
     [$slug] = $args;
     $post = R::findOne('post', ' slug = ? ', [$slug]);
-    if ($post === null || $post->draft == 1 || $post->deleted == 1 || \Lamb\is_scheduled($post)) {
+    if ($post === null || !\Lamb\is_visible($post)) {
         return respond_404([]);
     }
     $data['posts'] = [$post];

--- a/tests/Unit/PostVisibilityTest.php
+++ b/tests/Unit/PostVisibilityTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\is_visible;
+use function Lamb\Response\respond_post;
+use function Lamb\Response\respond_status;
+
+class PostVisibilityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+
+        // Seed schema columns so WHERE/visibility filters work regardless of test order.
+        $schema = R::dispense('post');
+        $schema->draft   = 0;
+        $schema->deleted = 0;
+        $schema->created = date('Y-m-d H:i:s');
+        $schema->slug    = '';
+        R::store($schema);
+        R::exec('DELETE FROM post');
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        global $config;
+        $config = ['site_title' => 'Test Blog', 'posts_per_page' => 10];
+
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        R::exec('DELETE FROM post');
+        $_SESSION = [];
+    }
+
+    private function makePost(array $fields): \RedBeanPHP\OODBBean
+    {
+        $bean = R::dispense('post');
+        $bean->body        = $fields['body'] ?? 'Body';
+        $bean->title       = $fields['title'] ?? 'Title';
+        $bean->transformed = '<p>Body</p>';
+        $bean->version     = 1;
+        $bean->draft       = $fields['draft'] ?? 0;
+        $bean->deleted     = $fields['deleted'] ?? 0;
+        $bean->slug        = $fields['slug'] ?? '';
+        $bean->created     = $fields['created'] ?? date('Y-m-d H:i:s');
+        R::store($bean);
+        return $bean;
+    }
+
+    // ---- is_visible() predicate -------------------------------------------
+
+    public function testPublishedPostIsVisibleToAnonymous(): void
+    {
+        $bean = $this->makePost([]);
+        $this->assertTrue(is_visible($bean));
+    }
+
+    public function testDeletedPostIsNeverVisible(): void
+    {
+        $bean = $this->makePost(['deleted' => 1]);
+        $this->assertFalse(is_visible($bean));
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertFalse(is_visible($bean), 'Deleted posts stay hidden even when logged in');
+    }
+
+    public function testDraftHiddenFromAnonymousButVisibleToAuthor(): void
+    {
+        $bean = $this->makePost(['draft' => 1]);
+        $this->assertFalse(is_visible($bean), 'Draft hidden from anonymous visitors');
+
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertTrue(is_visible($bean), 'Logged-in author can preview a draft');
+    }
+
+    public function testScheduledHiddenFromAnonymousButVisibleToAuthor(): void
+    {
+        $bean = $this->makePost(['created' => date('Y-m-d H:i:s', time() + 86400)]);
+        $this->assertFalse(is_visible($bean), 'Scheduled post hidden from anonymous visitors');
+
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertTrue(is_visible($bean), 'Logged-in author can preview a scheduled post');
+    }
+
+    public function testMissingPostIsNotVisible(): void
+    {
+        $bean = R::load('post', 999999);
+        $this->assertFalse(is_visible($bean));
+    }
+
+    // ---- respond_status (/status/<id>) ------------------------------------
+
+    public function testRespondStatusHidesDraftFromAnonymous(): void
+    {
+        $bean = $this->makePost(['draft' => 1]);
+        $data = respond_status([$bean->id]);
+        $this->assertSame('404', $data['action'] ?? null);
+    }
+
+    public function testRespondStatusShowsDraftToAuthor(): void
+    {
+        $_SESSION[SESSION_LOGIN] = true;
+        $bean = $this->makePost(['draft' => 1]);
+        $data = respond_status([$bean->id]);
+        $this->assertArrayHasKey('posts', $data);
+        $this->assertCount(1, $data['posts']);
+    }
+
+    // ---- respond_post (slug) ----------------------------------------------
+
+    public function testRespondPostShowsDraftToAuthorBySlug(): void
+    {
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->makePost(['draft' => 1, 'slug' => 'my-draft']);
+        $data = respond_post(['my-draft']);
+        $this->assertArrayHasKey('posts', $data);
+        $this->assertCount(1, $data['posts']);
+    }
+
+    public function testRespondPostHidesDraftFromAnonymousBySlug(): void
+    {
+        $this->makePost(['draft' => 1, 'slug' => 'my-draft']);
+        $data = respond_post(['my-draft']);
+        $this->assertSame('404', $data['action'] ?? null);
+    }
+}


### PR DESCRIPTION
## Problem

`respond_status` (`/status/<id>`) only rejected **deleted** posts, so any **anonymous** visitor could view a draft or scheduled post via its numeric permalink. Meanwhile `respond_post` (slug) rejected draft/deleted/scheduled for **everyone** — so the logged-in author couldn't preview their own draft by slug either. The two permalink shapes disagreed.

## Fix

Single `Lamb\is_visible(OODBBean)` predicate — the single-post counterpart to `visible_clause()` (#283):

```
never show deleted
show drafts & future-scheduled only to the logged-in author (permalink preview)
anonymous → 404
```

Used in both `respond_status` and `respond_post`.

## Alignment with docs

`docs/scheduling.md` already says a scheduled post is hidden at "its public URL" and frames `/status/<id>` preview as a logged-in capability. This change makes the code enforce what was already documented; no doc edit needed.

## Micropub impact (tracked for monitoring)

Micropub `createCallback` returns a draft's `/status/<id>` as the `Location` URL. An **anonymous** GET of that URL now 404s. Micropub **update/delete is unaffected** — it locates posts via `findPostByUrl` → `R::load`, independent of `respond_status`. Follow-up issue filed to watch for any client that relied on anonymously GET-previewing a freshly created draft.

## Testing

- New `PostVisibilityTest` (9 cases): predicate + both handlers, anonymous vs logged-in.
- Full suite: 617 passing (+9). PHPStan clean. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)