### PR TITLE
Use squash merge for Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --rebase "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The Dependabot auto-merge workflow used `gh pr merge --auto --rebase`. Rebase merges rewrite the PR commit as a new commit on `main`, and GitHub does **not** sign rebased commits. Combined with the `main` branch protection rules (`require signed commits` + `include administrators`), the rebased commit fails the signature requirement, branch protection rejects the merge, and auto-merge is disabled — surfacing as a "branch protection rule" failure (e.g. PR #286).

## Fix

Switch to `--squash`. Squash merge commits are created and signed by GitHub's web-flow key, so they satisfy the signed-commits rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)