### PR TITLE
Self-documenting config INI + single source of truth for defaults (#282)

### DIFF
--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -6,7 +6,8 @@ title: Site Configuration
 
 Lamb does not need a configuration file, it will run happily without it. It does provide a settings page after logging in where the instance can be configured.
 
-The full default configuration (all keys commented out = use built-in defaults):
+The default configuration. Real defaults ship as active lines so you can edit
+one value rather than write it from scratch; personal details stay commented:
 
 ```
 ;; Title of the site, shown in the HTML and feed views
@@ -21,12 +22,20 @@ The full default configuration (all keys commented out = use built-in defaults):
 ;; Active theme directory name. New installs default to 2026; `base` is the fallback library.
 theme = 2026
 
-;; Number of posts per page (default: 10)
-;posts_per_page = 10
+;; Number of posts shown per page in lists and feeds.
+posts_per_page = 10
 
 ;; Your timezone, used for post dates and scheduling (the server is often UTC).
-;; Use a name from https://www.php.net/manual/en/timezones.php (default: UTC)
-;timezone = Europe/London
+;; Use a name from https://www.php.net/manual/en/timezones.php.
+timezone = UTC
+
+;; Feed-ingested posts are saved as drafts by default for editorial review.
+;; Set to false to publish feed items directly.
+feeds_draft = true
+
+;; IndieAuth endpoints used for Micropub discovery. Override to use your own server.
+authorization_endpoint = https://indieauth.com/auth
+token_endpoint = https://tokens.indieauth.com/token
 
 ;; When content is not found, instead of a 404, the user is redirected to the same
 ;; relative path on another site. Useful for archived or under-construction sites.
@@ -54,20 +63,11 @@ theme = 2026
 ;; Test feed compatibility at https://simplepie.org/demo/
 ;lamb-releases=https://github.com/svandragt/lamb/releases.atom
 
-;; Feed-ingested posts are saved as drafts by default for editorial review.
-;; Set to false to publish feed items directly.
-;feeds_draft = false
-
 [preconnect]
 ;; List external origins to preconnect to, improving load time for external resources.
 ;; Format: <label>=<origin>
 ;google-fonts = https://fonts.googleapis.com
 ;google-fonts-static = https://fonts.gstatic.com
-
-;; IndieAuth endpoints used for Micropub discovery.
-;; Override to use your own IndieAuth server.
-;authorization_endpoint = https://indieauth.com/auth
-;token_endpoint = https://tokens.indieauth.com/token
 
 [me]
 ;; Add rel="me" identity links for IndieAuth verification.

--- a/src/config.php
+++ b/src/config.php
@@ -29,8 +29,19 @@ theme = 2026
 ;site_title = My Microblog
 
 ;; Your timezone, used for post dates and scheduling (the server is often UTC).
-;; Use a name from https://www.php.net/manual/en/timezones.php. Defaults to UTC.
-;timezone = Europe/London
+;; Use a name from https://www.php.net/manual/en/timezones.php.
+timezone = UTC
+
+;; Number of posts shown per page in lists and feeds.
+posts_per_page = 10
+
+;; Feed-ingested posts are saved as drafts by default for editorial review before
+;; publishing. Set to false to publish feed items directly without review.
+feeds_draft = true
+
+;; IndieAuth endpoints used for Micropub discovery. Override to use your own server.
+authorization_endpoint = https://indieauth.com/auth
+token_endpoint = https://tokens.indieauth.com/token
 
 ;; When content is not found, instead of a 404 by setting the following value the user is redirected to the same
 ;; relative path on another site.
@@ -52,20 +63,11 @@ theme = 2026
 ;; Feeds can be tested for compatibility here: https://simplepie.org/demo/
 ;lamb-releases=https://github.com/svandragt/lamb/releases.atom
 
-;; Feed-ingested posts are saved as drafts by default for editorial review before publishing.
-;; Set to false to publish feed items directly without review.
-;feeds_draft = false
-
 [preconnect]
 ;; List external origins to preconnect to, improving load time for external resources.
 ;; Each item is in the format of <label>=<origin>.
 ;google-fonts = https://fonts.googleapis.com
 ;google-fonts-static = https://fonts.gstatic.com
-
-;; IndieAuth endpoints used for Micropub discovery.
-;; Override to use your own IndieAuth server.
-;authorization_endpoint = https://indieauth.com/auth
-;token_endpoint = https://tokens.indieauth.com/token
 
 [me]
 ;; Add rel="me" identity links for IndieAuth verification.
@@ -131,20 +133,41 @@ function ensure_explicit_theme(string $ini_text, string $default_theme = 'base')
  */
 function load(): array
 {
-    $ini_text = get_ini_text();
-    $config = @parse_ini_string($ini_text, true, INI_SCANNER_RAW);
+    return compose_config(get_ini_text(), get_default_ini_text());
+}
 
-    // Hardcoded defaults as fallback for missing keys
-    $defaults = [
-        'author_email'           => 'joe.sheeple@example.com',
-        'author_name'            => 'Joe Sheeple',
-        'site_title'             => 'My Microblog',
-        'authorization_endpoint' => 'https://indieauth.com/auth',
-        'token_endpoint'         => 'https://tokens.indieauth.com/token',
-        'timezone'               => 'UTC',
+/**
+ * Merges stored config over the seeded defaults to produce the effective config.
+ *
+ * The seeded INI (`get_default_ini_text()`) is the single source of truth for the
+ * real defaults (timezone, posts_per_page, feeds_draft, IndieAuth endpoints), so
+ * they no longer live in a parallel hardcoded array. Precedence (lowest to
+ * highest): identity placeholders → seeded defaults → stored config.
+ *
+ * @param string $stored_ini  The raw stored INI text.
+ * @param string $default_ini The seeded default INI text.
+ * @return array The effective configuration.
+ */
+function compose_config(string $stored_ini, string $default_ini): array
+{
+    $config = @parse_ini_string($stored_ini, true, INI_SCANNER_RAW) ?: [];
+    $defaults = @parse_ini_string($default_ini, true, INI_SCANNER_RAW) ?: [];
+
+    // Theme is intentionally not defaulted here. An install without an explicit
+    // theme is resolved/migrated per-install (see resolve_theme / get_ini_text),
+    // so inheriting the seeded theme would silently re-theme existing sites.
+    unset($defaults['theme']);
+
+    // Personal-identity values are kept commented in the seeded INI, so supply
+    // them as a last-resort fallback for consumers without an inline default
+    // (e.g. feed.php reads author_name directly).
+    $fallback = [
+        'author_email' => 'joe.sheeple@example.com',
+        'author_name'  => 'Joe Sheeple',
+        'site_title'   => 'My Microblog',
     ];
 
-    return array_merge($defaults, $config ?: []);
+    return array_merge($fallback, $defaults, $config);
 }
 
 /**

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+use function Lamb\Config\compose_config;
 use function Lamb\Config\ensure_explicit_theme;
 use function Lamb\Config\get_default_ini_text;
 use function Lamb\Config\get_menu_slugs;
@@ -145,5 +146,69 @@ class ConfigTest extends TestCase
     {
         $this->assertSame('2026', resolve_theme('2026'));
         $this->assertSame('my-custom', resolve_theme('my-custom'));
+    }
+
+    public function testDefaultIniExposesRealDefaultsAtTopLevel(): void
+    {
+        $parsed = parse_ini_string(get_default_ini_text(), true, INI_SCANNER_RAW);
+
+        $this->assertSame('UTC', $parsed['timezone']);
+        $this->assertSame('10', $parsed['posts_per_page']);
+        $this->assertSame('https://indieauth.com/auth', $parsed['authorization_endpoint']);
+        $this->assertSame('https://tokens.indieauth.com/token', $parsed['token_endpoint']);
+        $this->assertArrayHasKey('feeds_draft', $parsed);
+    }
+
+    public function testDefaultIniKeepsRealDefaultsOutOfSections(): void
+    {
+        $parsed = parse_ini_string(get_default_ini_text(), true, INI_SCANNER_RAW);
+
+        // Regression: these were previously commented inside [feeds]/[preconnect],
+        // so uncommenting them in place parsed as nested keys the code never read.
+        $this->assertArrayNotHasKey('feeds_draft', $parsed['feeds'] ?? []);
+        $this->assertArrayNotHasKey('authorization_endpoint', $parsed['preconnect'] ?? []);
+        $this->assertArrayNotHasKey('token_endpoint', $parsed['preconnect'] ?? []);
+    }
+
+    public function testComposeConfigFillsRealDefaultsForMissingKeys(): void
+    {
+        $config = compose_config("site_title = Mine\n", get_default_ini_text());
+
+        $this->assertSame('UTC', $config['timezone']);
+        $this->assertSame('10', $config['posts_per_page']);
+        $this->assertSame('https://indieauth.com/auth', $config['authorization_endpoint']);
+    }
+
+    public function testComposeConfigLetsStoredValuesOverrideDefaults(): void
+    {
+        $config = compose_config("timezone = Europe/London\n", get_default_ini_text());
+
+        $this->assertSame('Europe/London', $config['timezone']);
+    }
+
+    public function testComposeConfigSuppliesIdentityPlaceholderFallback(): void
+    {
+        // author_name is kept commented in the seeded INI, so it must come from
+        // the in-code fallback for consumers (feed.php) that have no inline default.
+        $config = compose_config("site_title = Mine\n", get_default_ini_text());
+
+        $this->assertSame('Joe Sheeple', $config['author_name']);
+    }
+
+    public function testComposeConfigNeverInheritsThemeFromDefaults(): void
+    {
+        // A stored config without a theme must not be silently re-themed by the
+        // seeded default (theme is resolved/migrated per-install instead).
+        $config = compose_config("site_title = Mine\n", "theme = 2026\nposts_per_page = 10\n");
+
+        $this->assertArrayNotHasKey('theme', $config);
+        $this->assertSame('10', $config['posts_per_page']);
+    }
+
+    public function testComposeConfigHonorsTopLevelFeedsDraftFalse(): void
+    {
+        $config = compose_config("feeds_draft = false\n", get_default_ini_text());
+
+        $this->assertFalse(filter_var($config['feeds_draft'], FILTER_VALIDATE_BOOLEAN));
     }
 }


### PR DESCRIPTION
Part 3 of 3 for #282.

## Problem
The seeded INI (`get_default_ini_text()`) kept every setting as a commented example, while `Config\load()` hardcoded a **parallel** `$defaults` array — so real defaults lived in two places. Worse, three keys were commented under the wrong `[section]`:
- `feeds_draft` under `[feeds]`, `authorization_endpoint`/`token_endpoint` under `[preconnect]` — but the code reads them as **top-level** keys. So uncommenting them where they were documented parsed as nested keys that were silently ignored.

## Changes
- **Promote real defaults to active top-level lines** in the seeded INI: `timezone = UTC`, `posts_per_page = 10`, `feeds_draft = true`, and the two IndieAuth endpoints — moving the mis-sectioned ones out of `[feeds]`/`[preconnect]`. Editing config is now "change a line", not "write it from scratch". Personal identity (`author_*`, `site_title`) stays commented.
- **Single source of truth:** `load()` now delegates to a pure `compose_config($stored_ini, $default_ini)` that parses the seeded INI as the default source, layered under stored config, over a small identity-placeholder fallback for consumers without an inline default (e.g. `feed.php` reads `author_name` directly). The hardcoded `$defaults` array is gone.
- `theme` is excluded from the default merge so a stored config without a theme is never silently re-themed (it's resolved/migrated per-install — see #289).
- Docs updated.

## Tests
TDD-first. New `ConfigTest` coverage: real defaults exposed at top level, the sectioning regression (`feeds_draft`/endpoints not nested), `compose_config` fill/override/identity-fallback/theme-exclusion, and top-level `feeds_draft = false` honored. `vendor/bin/codecept run Unit` → 624 passing. `composer lint` + `composer analyse` clean.

## Merge note
Touches `get_default_ini_text()` / `load()`, same as #288 and #289 — expect small, trivial conflicts depending on merge order; I'll rebase whichever lands later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)