### PR TITLE
Add <icon> and <logo> to Atom feed via web-root convention

### DIFF
--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -21,6 +21,22 @@ Both formats are autodiscoverable via `<link rel="alternate">` tags in the HTML 
 
 Status-style posts without a title produce a feed entry with an empty `<title>` (Atom) or no `title` field at all (JSON Feed). This follows the [micro.blog convention](https://book.micro.blog/) so timeline-style readers can render them as short notes rather than empty-titled articles.
 
+## Feed icon and logo
+
+The Atom feed can advertise an avatar and a banner image. Feed readers such as
+micro.blog render the icon as the feed's avatar in their timeline.
+
+These are sourced by convention from the web root (next to `index.php`) — no
+configuration is needed:
+
+| File | Atom element | Shape |
+|------|--------------|-------|
+| `favicon.png` | `<icon>` | small square avatar |
+| `logo.png` | `<logo>` | wider banner (roughly 2:1) |
+
+Drop either file into the `src/` directory (the web root). Each element is only
+included when its file exists, so the feed never points at a missing image.
+
 ## Related
 
 * [Cross-posting From Feeds]({{ site.baseurl }}{% link cross-posting.md %}) — consuming external feeds into Lamb

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -29,12 +29,13 @@ micro.blog render the icon as the feed's avatar in their timeline.
 These are sourced by convention from the web root (next to `index.php`) — no
 configuration is needed:
 
-| File | Atom element | Shape |
-|------|--------------|-------|
-| `favicon.png` | `<icon>` | small square avatar |
-| `logo.png` | `<logo>` | wider banner (roughly 2:1) |
+| File | Atom element | Aspect ratio ([RFC 4287](https://www.rfc-editor.org/rfc/rfc4287)) |
+|------|--------------|------------------------------------------------------------------|
+| `favicon.png` | `<icon>` | 1:1 — small square avatar ([§4.2.5](https://www.rfc-editor.org/rfc/rfc4287#section-4.2.5)) |
+| `logo.png` | `<logo>` | 2:1 — twice as wide as tall ([§4.2.8](https://www.rfc-editor.org/rfc/rfc4287#section-4.2.8)) |
 
-Drop either file into the `src/` directory (the web root). Each element is only
+The RFC recommends these aspect ratios but does not mandate pixel sizes. Drop
+either file into the `src/` directory (the web root). Each element is only
 included when its file exists, so the feed never points at a missing image.
 
 ## Related

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -19,6 +19,18 @@ $Xml->addChild('id', escape($channel_link));
 $Xml->addChild('updated', date(DATE_ATOM, strtotime($data['updated'])));
 $Xml->addChild('generator', 'Lamb');
 
+// Atom <icon> (square avatar) and <logo> (wider banner) are sourced by
+// convention from the web root: drop favicon.png / logo.png next to index.php.
+// Only emitted when the file actually exists, so we never advertise a broken
+// image URL to feed readers (e.g. micro.blog renders <icon> as the avatar).
+if (defined('ROOT_DIR')) {
+    foreach (['favicon.png' => 'icon', 'logo.png' => 'logo'] as $file => $element) {
+        if (file_exists(ROOT_DIR . '/' . $file)) {
+            $Xml->addChild($element, escape(ROOT_URL . '/' . $file));
+        }
+    }
+}
+
 $Link = $Xml->addChild('atom:link');
 $Link->addAttribute('rel', 'self');
 $Link->addAttribute('href', escape($channel_link));

--- a/tests/Unit/FeedTemplateTest.php
+++ b/tests/Unit/FeedTemplateTest.php
@@ -156,7 +156,56 @@ class FeedTemplateTest extends TestCase
         $this->assertNotEmpty((string) $link['href']);
     }
 
-    private function renderFeedWithPost(array $fields): \SimpleXMLElement
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedOmitsIconAndLogoWhenConventionFilesAbsent(): void
+    {
+        $xml = $this->renderFeedWithPost(
+            ['title' => 'Post', 'transformed' => '<p>Body</p>'],
+            []
+        );
+
+        $this->assertFalse(isset($xml->icon), 'Feed should not emit <icon> when favicon.png is absent');
+        $this->assertFalse(isset($xml->logo), 'Feed should not emit <logo> when logo.png is absent');
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedIncludesIconFromFaviconConvention(): void
+    {
+        $xml = $this->renderFeedWithPost(
+            ['title' => 'Post', 'transformed' => '<p>Body</p>'],
+            ['favicon.png']
+        );
+
+        $this->assertSame(ROOT_URL . '/favicon.png', (string) $xml->icon);
+        $this->assertFalse(isset($xml->logo), 'No logo.png means no <logo>');
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedIncludesLogoFromLogoConvention(): void
+    {
+        $xml = $this->renderFeedWithPost(
+            ['title' => 'Post', 'transformed' => '<p>Body</p>'],
+            ['favicon.png', 'logo.png']
+        );
+
+        $this->assertSame(ROOT_URL . '/favicon.png', (string) $xml->icon);
+        $this->assertSame(ROOT_URL . '/logo.png', (string) $xml->logo);
+    }
+
+    /**
+     * @param array $fields        Post bean fields.
+     * @param array $conventionFiles Names of web-root convention files to create (e.g. favicon.png).
+     */
+    private function renderFeedWithPost(array $fields, array $conventionFiles = []): \SimpleXMLElement
     {
         require_once __DIR__ . '/../../vendor/autoload.php';
 
@@ -167,6 +216,23 @@ class FeedTemplateTest extends TestCase
 
         if (!defined('ROOT_URL')) {
             define('ROOT_URL', 'http://localhost');
+        }
+
+        // ROOT_DIR is a constant defined once per process (Codeception does not
+        // isolate test methods), so the web-root path is fixed and convention-file
+        // presence is controlled per render by writing/removing the files on disk.
+        $webRoot = sys_get_temp_dir() . '/lamb_feed_test_' . getmypid();
+        if (!is_dir($webRoot)) {
+            mkdir($webRoot, 0777, true);
+        }
+        foreach (['favicon.png', 'logo.png'] as $file) {
+            @unlink($webRoot . '/' . $file);
+        }
+        foreach ($conventionFiles as $file) {
+            file_put_contents($webRoot . '/' . $file, 'x');
+        }
+        if (!defined('ROOT_DIR')) {
+            define('ROOT_DIR', $webRoot);
         }
 
         $bean = R::dispense('post');


### PR DESCRIPTION
Closes #245.

The Atom spec defines `<icon>` (small square avatar) and `<logo>` (wider banner). Micro.blog and many readers render `<icon>` as the feed avatar.

## What

- `<icon>` sourced from `favicon.png` in the web root → `<icon>{ROOT_URL}/favicon.png</icon>`
- `<logo>` sourced from `logo.png` in the web root → `<logo>{ROOT_URL}/logo.png</logo>`
- Each element is emitted **only when the file exists**, so the feed never points at a missing image ("assume success, communicate failure").
- **No config key** — convention only, per maintainer guidance and the "opinionated defaults over settings" philosophy.

## Tests (TDD)

Added to `FeedTemplateTest`:
- omits both elements when neither convention file is present
- emits `<icon>` from `favicon.png`
- emits `<logo>` from `logo.png`

Full unit suite (635 tests), `composer lint`, and `composer analyse` all pass.

## Docs

Added a "Feed icon and logo" section to `docs/feeds.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)