### PR TITLE
Paste images from the clipboard into the editor (#7)

### DIFF
--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -12,6 +12,8 @@ Any tags are automatically linked to tag archives.
 
 Select some text and paste a link over it to turn the selection into a markdown link, e.g. selecting `Lamb` and pasting `https://example.com` produces `[Lamb](https://example.com)`.
 
+Add images by dragging files onto the editor, or by pasting an image straight from the clipboard (for example a screenshot). Either way the image is uploaded and a markdown image link is inserted at the cursor.
+
 Permalinks for statuses are in the form of `/status/<integer>`.
 
 ```markdown

--- a/src/scripts/logged_in/upload-image.js
+++ b/src/scripts/logged_in/upload-image.js
@@ -10,7 +10,42 @@ onLoaded(() => {
             handleFiles(files, ta)
         }
     })
+    ta.on('paste', (ev) => {
+        const files = clipboardImageFiles(ev.clipboardData || window.clipboardData)
+        if (files.length === 0) return // let other paste handlers run (e.g. links)
+
+        cancel(ev)
+        handleFiles(files, ta)
+    })
 })
+
+/**
+ * Extract image files from a paste event's clipboard data.
+ *
+ * Pasted screenshots arrive as a file item with a generic or empty name, so each
+ * is given a unique name with a real image extension. This keeps the upload
+ * endpoint's extension check happy and stops repeated pastes overwriting each
+ * other server-side (the filename is hashed into the stored path).
+ *
+ * @param {DataTransfer|null} clipboardData
+ * @returns {File[]}
+ */
+function clipboardImageFiles(clipboardData) {
+    const items = clipboardData?.items
+    if (!items) return []
+
+    const files = []
+    for (const item of items) {
+        if (item.kind !== 'file' || !item.type.startsWith('image/')) continue
+        const file = item.getAsFile()
+        if (!file) continue
+
+        const ext = file.type.split('/')[1] || 'png'
+        const name = `pasted-${Date.now()}-${files.length}.${ext}`
+        files.push(new File([file], name, { type: file.type }))
+    }
+    return files
+}
 
 /**
  * Handle files dropped into the textarea.


### PR DESCRIPTION
Closes #7

## What

Adds clipboard image pasting to the post editor. Pasting an image (e.g. a screenshot) now uploads it and inserts a markdown image link at the cursor — matching the existing drag-and-drop behaviour.

## How

- `src/scripts/logged_in/upload-image.js` gains a `paste` handler that extracts image files from `clipboardData.items` and routes them through the existing `handleFiles` → `/upload` flow.
- Pasted blobs arrive with a generic/empty name, so each is renamed `pasted-<timestamp>-<n>.<ext>` (extension from the MIME subtype, which maps cleanly to the allowlisted types). This keeps the upload endpoint's extension check happy and prevents repeated pastes from colliding on the content-hashed server filename.
- Non-image pastes fall through untouched, so the existing paste-link behaviour still works.
- Docs: `docs/post-types.md` now documents both drag-drop and paste.

## Testing

- `composer lint` clean; `vendor/bin/codecept run Unit` green (635 tests).
- The `/upload` server side is unchanged and already covered by `UploadCest` / `UploadTest`. The paste logic is browser-only; this repo has no JS test harness (acceptance uses PhpBrowser without JS execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)