### PR TITLE
Receive webmentions (#244)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
       "src/theme/assets.php",
       "src/theme/formatting.php",
       "src/theme/meta.php",
-      "src/micropub.php"
+      "src/micropub.php",
+      "src/webmention.php"
     ]
   },
   "autoload-dev": {

--- a/docs/micropub.md
+++ b/docs/micropub.md
@@ -57,3 +57,4 @@ Visit [MicroPub Rocks](https://micropub.rocks/) and enter your site. Lamb's impl
 
 * [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}): The `[me]`, `authorization_endpoint`, and `token_endpoint` settings.
 * [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Send a future `published` date or `post-status: scheduled` to schedule a post.
+* [Webmentions]({{ site.baseurl }}{% link webmentions.md %}): Receive notifications when other sites link to your posts.

--- a/docs/webmentions.md
+++ b/docs/webmentions.md
@@ -1,0 +1,33 @@
+---
+title: Webmentions
+---
+
+# Webmentions
+
+[Webmention](https://www.w3.org/TR/webmention/) is an open standard that lets one site notify another when it links to it. When someone replies to, likes, or links one of your posts from their own Webmention-enabled site, they can send your blog a notification so you know about the mention.
+
+Lamb can **receive** webmentions out of the box.
+
+## How it works
+
+Lamb exposes a `/webmention` endpoint. Other sites discover it two ways:
+
+- An HTTP `Link: <…/webmention>; rel="webmention"` header on every page.
+- A `<link rel="webmention" href="…/webmention">` tag in your page `<head>`.
+
+When a sender POSTs a `source` (their page) and `target` (your post URL) to the endpoint, Lamb:
+
+1. Checks that `target` is a real post on your site.
+2. Fetches the `source` page and verifies it actually links to `target`.
+3. Stores the verified mention against the post.
+
+Senders that don't follow the rules are rejected: a missing or non-`http(s)` `source`/`target`, a `target` that isn't one of your posts, or a `source` that doesn't link back all return `400`. If a previously received `source` is re-checked and no longer links to the `target`, the stored mention is removed.
+
+## Seeing your mentions
+
+Received webmentions appear at the bottom of the relevant post page. For now they are shown to the **logged-in author only** — public display and moderation are planned follow-ups. Each entry links to the source page, with the author and a short snippet where they can be detected.
+
+## Related
+
+* [Micropub]({{ site.baseurl }}{% link micropub.md %}): Publish posts from any Micropub client; uses the same IndieWeb discovery pattern.
+* [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %}): Pull posts in from other feeds.

--- a/src/index.php
+++ b/src/index.php
@@ -25,6 +25,7 @@ foreach (Bootstrap\cache_headers(isset($_SESSION[SESSION_LOGIN])) as $cache_head
     header($cache_header);
 }
 header('Link: <' . ROOT_URL . '/micropub>; rel="micropub"', false);
+header('Link: <' . ROOT_URL . '/webmention>; rel="webmention"', false);
 header('Link: <' . $config['authorization_endpoint'] . '>; rel="authorization_endpoint"', false);
 header('Link: <' . $config['token_endpoint'] . '>; rel="token_endpoint"', false);
 
@@ -65,6 +66,7 @@ if ($action === 'tag' && $sublookup === 'feed') {
 } else {
     Route\register_route('tag', __NAMESPACE__ . '\\Response\respond_tag', $lookup);
 }
+Route\register_route('webmention', __NAMESPACE__ . '\\Webmention\respond_webmention');
 Route\register_route('micropub', __NAMESPACE__ . '\\Micropub\respond_micropub');
 Route\register_route('micropub-media', __NAMESPACE__ . '\\Micropub\respond_micropub_media');
 Route\register_route('upload', __NAMESPACE__ . '\\Response\respond_upload', $lookup);

--- a/src/themes/base/html.php
+++ b/src/themes/base/html.php
@@ -31,6 +31,7 @@ global $template;
     <link rel="authorization_endpoint" href="<?= escape($config['authorization_endpoint']) ?>">
     <link rel="token_endpoint" href="<?= escape($config['token_endpoint']) ?>">
     <link rel="micropub" href="<?= ROOT_URL ?>/micropub">
+    <link rel="webmention" href="<?= ROOT_URL ?>/webmention">
     <?php if (!empty($data['feed_url']) && $data['feed_url'] !== ROOT_URL . '/feed') : ?>
     <link rel="alternate" type="application/atom+xml" href="<?= escape($data['feed_url']) ?>"
           title="<?= escape($data['title'] ?? $config['site_title']) ?>">
@@ -77,6 +78,8 @@ global $template;
         part($template);
 
         part("_related");
+
+        part("_webmentions");
         ?>
     </main>
 </div>

--- a/src/themes/base/parts/_webmentions.php
+++ b/src/themes/base/parts/_webmentions.php
@@ -1,0 +1,40 @@
+<?php
+
+global $data;
+global $template;
+
+use function Lamb\Theme\escape;
+use function Lamb\Theme\human_time;
+use function Lamb\Webmention\webmentions_for_post;
+
+// Received webmentions are shown to the logged-in author only for now; public
+// display / moderation is a follow-up (see #244).
+if ($template !== 'status' || !isset($_SESSION[SESSION_LOGIN])) {
+    return;
+}
+
+$current_id = (int) $data['posts'][0]->id;
+$mentions = webmentions_for_post($current_id);
+
+if (empty($mentions)) {
+    return;
+}
+?>
+<article class="webmentions">
+    <h6>Webmentions</h6>
+    <ul>
+        <?php foreach ($mentions as $mention) : ?>
+            <li>
+                <?php if (!empty($mention->author)) : ?>
+                    <span class="webmention-author"><?= escape($mention->author) ?></span>
+                <?php endif; ?>
+                <a href="<?= escape($mention->source) ?>" rel="nofollow ugc">
+                    <?= escape($mention->content ?: $mention->source) ?>
+                </a>
+                <?php if (!empty($mention->verified_at)) : ?>
+                    <time datetime="<?= escape($mention->verified_at) ?>"><?= escape(human_time(strtotime($mention->verified_at))) ?></time>
+                <?php endif; ?>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+</article>

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -1,0 +1,255 @@
+<?php
+
+/** @noinspection PhpUnused */
+
+namespace Lamb\Webmention;
+
+use JetBrains\PhpStorm\NoReturn;
+use RedBeanPHP\OODBBean;
+use RedBeanPHP\R;
+
+use const ROOT_URL;
+
+/**
+ * Seconds before fetching a webmention source page is abandoned.
+ */
+const WEBMENTION_FETCH_TIMEOUT = 10;
+
+/**
+ * Route handler for POST /webmention.
+ *
+ * Accepts `source` and `target` form parameters per the Webmention spec,
+ * verifies them, and persists a verified mention. Always terminates the
+ * request with a plain-text response.
+ *
+ * @param array $_args Unused route arguments.
+ * @return void
+ */
+#[NoReturn]
+function respond_webmention(array $_args): void
+{
+    $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+    if ($method !== 'POST') {
+        http_response_code(405);
+        header('Allow: POST');
+        header('Content-Type: text/plain; charset=utf-8');
+        echo 'Method Not Allowed';
+        die();
+    }
+
+    $result = verify_and_store((string) ($_POST['source'] ?? ''), (string) ($_POST['target'] ?? ''));
+
+    http_response_code($result['status']);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo $result['body'];
+    die();
+}
+
+/**
+ * Verify a source→target webmention and persist (or remove) it.
+ *
+ * The fetcher is injectable so the verification flow can be tested without
+ * network access; in production it defaults to {@see fetch_source}.
+ *
+ * @param string        $source  The page that supposedly links to us.
+ * @param string        $target  The Lamb post URL being mentioned.
+ * @param callable|null $fetcher fn(string $url): ?string — returns source HTML or null.
+ * @return array{status:int, body:string}
+ */
+function verify_and_store(string $source, string $target, ?callable $fetcher = null): array
+{
+    $source = trim($source);
+    $target = trim($target);
+
+    if (!is_valid_http_url($source) || !is_valid_http_url($target)) {
+        return response(400, 'source and target are required and must be http(s) URLs');
+    }
+    if (rtrim($source, '/') === rtrim($target, '/')) {
+        return response(400, 'source and target must differ');
+    }
+
+    $post_id = target_post_id($target);
+    if ($post_id === null) {
+        return response(400, 'target is not a valid post on this site');
+    }
+
+    $fetcher ??= __NAMESPACE__ . '\\fetch_source';
+    $html = $fetcher($source);
+
+    $existing = R::findOne('webmention', ' source = ? AND target = ? ', [$source, $target]);
+
+    if (!is_string($html) || !source_mentions_target($html, $target)) {
+        // The source no longer links to us: drop any mention we already held.
+        if ($existing) {
+            R::trash($existing);
+            return response(200, 'mention removed: source no longer links to target');
+        }
+        return response(400, 'source does not link to target');
+    }
+
+    $meta = extract_meta($html);
+    $now = date('Y-m-d H:i:s');
+
+    $mention = $existing ?: R::dispense('webmention');
+    $mention->source = $source;
+    $mention->target = $target;
+    $mention->post_id = $post_id;
+    $mention->type = 'mention';
+    $mention->author = $meta['author'];
+    $mention->content = $meta['content'];
+    $mention->status = $mention->status ?: 'pending';
+    $mention->created = $mention->created ?: $now;
+    $mention->verified_at = $now;
+    R::store($mention);
+
+    return response(202, 'accepted');
+}
+
+/**
+ * Resolve a target URL to the id of the Lamb post it points at.
+ *
+ * Returns null when the host is not ours, the path is not a recognised post
+ * URL, or no matching post exists.
+ *
+ * @param string $target
+ * @return int|null
+ */
+function target_post_id(string $target): ?int
+{
+    $root_host = parse_url(ROOT_URL, PHP_URL_HOST);
+    $target_host = parse_url($target, PHP_URL_HOST);
+    if ($target_host === null || $root_host === null || strcasecmp($target_host, $root_host) !== 0) {
+        return null;
+    }
+
+    $path = parse_url($target, PHP_URL_PATH) ?: '';
+
+    if (preg_match('#^/status/(\d+)$#', $path, $matches)) {
+        $bean = R::load('post', (int) $matches[1]);
+        return $bean->id ? (int) $bean->id : null;
+    }
+
+    $slug = trim($path, '/');
+    if ($slug !== '') {
+        $bean = R::findOne('post', ' slug = ? ', [$slug]);
+        return $bean ? (int) $bean->id : null;
+    }
+
+    return null;
+}
+
+/**
+ * Determine whether the fetched source HTML links to the target URL.
+ *
+ * Checks href/src attributes (the spec's primary requirement) and falls back
+ * to a raw substring match so plain-text or unusual markup still counts.
+ *
+ * @param string $html
+ * @param string $target
+ * @return bool
+ */
+function source_mentions_target(string $html, string $target): bool
+{
+    if ($target === '' || $html === '') {
+        return false;
+    }
+
+    $needle = rtrim($target, '/');
+    if (preg_match_all('/(?:href|src)\s*=\s*["\']([^"\']+)["\']/i', $html, $matches)) {
+        foreach ($matches[1] as $url) {
+            if (rtrim(html_entity_decode($url), '/') === $needle) {
+                return true;
+            }
+        }
+    }
+
+    return str_contains($html, $target);
+}
+
+/**
+ * Return verified webmentions for a post, oldest first.
+ *
+ * @param int $post_id
+ * @return OODBBean[]
+ */
+function webmentions_for_post(int $post_id): array
+{
+    return array_values(
+        R::find('webmention', ' post_id = ? AND verified_at IS NOT NULL ORDER BY created ASC ', [$post_id])
+    );
+}
+
+/**
+ * Best-effort extraction of author name and a short content snippet from a
+ * source page, without pulling in a full microformats2 parser.
+ *
+ * @param string $html
+ * @return array{author:?string, content:?string}
+ */
+function extract_meta(string $html): array
+{
+    $author = null;
+    if (preg_match('/<meta\s+name=["\']author["\']\s+content=["\']([^"\']*)["\']/i', $html, $m)) {
+        $author = trim($m[1]) ?: null;
+    }
+    if ($author === null && preg_match('/rel=["\']author["\'][^>]*>([^<]+)</i', $html, $m)) {
+        $author = trim(strip_tags($m[1])) ?: null;
+    }
+
+    $content = null;
+    if (preg_match('/<title[^>]*>(.*?)<\/title>/is', $html, $m)) {
+        $content = trim(html_entity_decode(strip_tags($m[1]), ENT_QUOTES | ENT_HTML5)) ?: null;
+    }
+
+    return ['author' => $author, 'content' => $content];
+}
+
+/**
+ * Fetch the raw HTML of a webmention source page.
+ *
+ * @param string $url
+ * @return string|null
+ */
+function fetch_source(string $url): ?string
+{
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'GET',
+            'header' => implode("\r\n", [
+                'Accept: text/html, */*',
+                'User-Agent: Lamb-Webmention',
+            ]),
+            'timeout' => WEBMENTION_FETCH_TIMEOUT,
+            'follow_location' => 1,
+            'max_redirects' => 5,
+            'ignore_errors' => true,
+        ],
+    ]);
+
+    $body = @file_get_contents($url, false, $context);
+    return $body === false ? null : $body;
+}
+
+/**
+ * Whether a string is an absolute http(s) URL with a host.
+ *
+ * @param string $url
+ * @return bool
+ */
+function is_valid_http_url(string $url): bool
+{
+    $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+    return in_array($scheme, ['http', 'https'], true) && parse_url($url, PHP_URL_HOST) !== null;
+}
+
+/**
+ * Build a {status, body} response array.
+ *
+ * @param int    $status
+ * @param string $body
+ * @return array{status:int, body:string}
+ */
+function response(int $status, string $body): array
+{
+    return ['status' => $status, 'body' => $body];
+}

--- a/tests/Acceptance/WebmentionCest.php
+++ b/tests/Acceptance/WebmentionCest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Acceptance;
+
+use Tests\Support\AcceptanceTester;
+
+class WebmentionCest
+{
+    public function homepageHtmlContainsWebmentionLink(AcceptanceTester $I)
+    {
+        $I->amOnPage('/');
+        $I->seeElement('link[rel="webmention"]');
+    }
+
+    public function endpointRejectsGet(AcceptanceTester $I)
+    {
+        $I->amOnPage('/webmention');
+        $I->seeResponseCodeIs(405);
+    }
+
+    public function endpointRejectsMissingParams(AcceptanceTester $I)
+    {
+        $I->sendAjaxPostRequest('/webmention', []);
+        $I->seeResponseCodeIs(400);
+    }
+
+    public function endpointRejectsForeignTarget(AcceptanceTester $I)
+    {
+        $I->sendAjaxPostRequest('/webmention', [
+            'source' => 'https://other.example/reply',
+            'target' => 'https://not-this-site.example/status/1',
+        ]);
+        $I->seeResponseCodeIs(400);
+    }
+}

--- a/tests/Unit/WebmentionTest.php
+++ b/tests/Unit/WebmentionTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Webmention\source_mentions_target;
+use function Lamb\Webmention\target_post_id;
+use function Lamb\Webmention\verify_and_store;
+use function Lamb\Webmention\webmentions_for_post;
+
+class WebmentionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'https://example.com');
+        }
+
+        R::exec('DELETE FROM post WHERE 1');
+        R::exec('DELETE FROM webmention WHERE 1');
+    }
+
+    private function makePost(?string $slug = null): int
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Hello world';
+        $bean->transformed = '<p>Hello world</p>';
+        $bean->created = '2026-01-01 00:00:00';
+        $bean->updated = '2026-01-01 00:00:00';
+        $bean->version = 1;
+        if ($slug !== null) {
+            $bean->slug = $slug;
+        }
+        return (int) R::store($bean);
+    }
+
+    // target_post_id --------------------------------------------------------
+
+    public function testTargetPostIdResolvesStatusUrl(): void
+    {
+        $id = $this->makePost();
+        $this->assertSame($id, target_post_id(ROOT_URL . '/status/' . $id));
+    }
+
+    public function testTargetPostIdResolvesSlugUrl(): void
+    {
+        $id = $this->makePost('my-page');
+        $this->assertSame($id, target_post_id(ROOT_URL . '/my-page'));
+    }
+
+    public function testTargetPostIdRejectsForeignHost(): void
+    {
+        $id = $this->makePost();
+        $this->assertNull(target_post_id('https://evil.example/status/' . $id));
+    }
+
+    public function testTargetPostIdRejectsUnknownPost(): void
+    {
+        $this->assertNull(target_post_id(ROOT_URL . '/status/999999'));
+    }
+
+    // source_mentions_target ------------------------------------------------
+
+    public function testSourceMentionsTargetMatchesHref(): void
+    {
+        $target = ROOT_URL . '/status/1';
+        $html = '<p>Great post <a href="' . $target . '">here</a></p>';
+        $this->assertTrue(source_mentions_target($html, $target));
+    }
+
+    public function testSourceMentionsTargetFalseWhenAbsent(): void
+    {
+        $html = '<p>Nothing relevant here</p>';
+        $this->assertFalse(source_mentions_target($html, ROOT_URL . '/status/1'));
+    }
+
+    // verify_and_store ------------------------------------------------------
+
+    public function testVerifyRejectsMissingParams(): void
+    {
+        $this->assertSame(400, verify_and_store('', '', fn () => '')['status']);
+    }
+
+    public function testVerifyRejectsForeignTarget(): void
+    {
+        $res = verify_and_store('https://other.example/a', 'https://evil.example/status/1', fn () => '');
+        $this->assertSame(400, $res['status']);
+    }
+
+    public function testVerifyRejectsSourceEqualToTarget(): void
+    {
+        $id = $this->makePost();
+        $url = ROOT_URL . '/status/' . $id;
+        $this->assertSame(400, verify_and_store($url, $url, fn () => '')['status']);
+    }
+
+    public function testVerifyRejectsWhenSourceDoesNotLinkTarget(): void
+    {
+        $id = $this->makePost();
+        $target = ROOT_URL . '/status/' . $id;
+        $res = verify_and_store('https://other.example/a', $target, fn () => '<p>unrelated</p>');
+        $this->assertSame(400, $res['status']);
+        $this->assertSame(0, R::count('webmention'));
+    }
+
+    public function testVerifyStoresVerifiedMention(): void
+    {
+        $id = $this->makePost();
+        $target = ROOT_URL . '/status/' . $id;
+        $source = 'https://other.example/reply';
+        $html = '<a href="' . $target . '">re</a>';
+
+        $res = verify_and_store($source, $target, fn () => $html);
+        $this->assertContains($res['status'], [201, 202]);
+        $this->assertSame(1, R::count('webmention'));
+
+        $wm = R::findOne('webmention');
+        $this->assertSame($source, $wm->source);
+        $this->assertSame($target, $wm->target);
+        $this->assertSame($id, (int) $wm->post_id);
+        $this->assertNotEmpty($wm->verified_at);
+    }
+
+    public function testVerifyDeduplicatesOnRepeat(): void
+    {
+        $id = $this->makePost();
+        $target = ROOT_URL . '/status/' . $id;
+        $source = 'https://other.example/reply';
+        $html = '<a href="' . $target . '">re</a>';
+
+        verify_and_store($source, $target, fn () => $html);
+        verify_and_store($source, $target, fn () => $html);
+        $this->assertSame(1, R::count('webmention'));
+    }
+
+    public function testVerifyDeletesStaleMentionWhenLinkRemoved(): void
+    {
+        $id = $this->makePost();
+        $target = ROOT_URL . '/status/' . $id;
+        $source = 'https://other.example/reply';
+
+        verify_and_store($source, $target, fn () => '<a href="' . $target . '">re</a>');
+        $this->assertSame(1, R::count('webmention'));
+
+        // Source page no longer links the target → mention is removed.
+        $res = verify_and_store($source, $target, fn () => '<p>removed</p>');
+        $this->assertSame(200, $res['status']);
+        $this->assertSame(0, R::count('webmention'));
+    }
+
+    // webmentions_for_post --------------------------------------------------
+
+    public function testWebmentionsForPostReturnsStored(): void
+    {
+        $id = $this->makePost();
+        $target = ROOT_URL . '/status/' . $id;
+        verify_and_store('https://other.example/reply', $target, fn () => '<a href="' . $target . '">re</a>');
+
+        $mentions = webmentions_for_post($id);
+        $this->assertCount(1, $mentions);
+        $this->assertSame('https://other.example/reply', $mentions[0]->source);
+    }
+}


### PR DESCRIPTION
Closes #244

## What

Adds the first IndieWeb building block for inbound mentions: a `/webmention` endpoint so other sites (micro.blog, etc.) can notify Lamb when they reply to, like, or link a post.

## How

- **Endpoint** `POST /webmention` (`src/webmention.php` → `respond_webmention`). GET returns `405`; bad/missing params return `400`.
- **Validation**: `target` must be an `http(s)` URL resolving to a real post on this site (`/status/<id>` or a slug); `source` must differ and be a valid URL.
- **Verification**: fetches the `source` page and confirms it links back to `target` (href/src match, with a raw-substring fallback). The fetcher is injectable so the whole flow is unit-testable without network.
- **Persistence**: a `webmention` bean (source, target, post_id, type, author, content, status, created, verified_at). Repeats dedupe onto the existing row; if a re-checked source no longer links back, the mention is removed.
- **Discovery**: HTTP `Link: …; rel="webmention"` header (`index.php`) **and** `<link rel="webmention">` in the base theme `<head>`.
- **Display**: `parts/_webmentions.php` lists verified mentions at the foot of a post page, **logged-in author only** for now (public display + moderation are deliberate follow-ups, per the issue).

## Testing

- `composer lint` clean, `composer analyse` (phpstan) clean.
- `vendor/bin/codecept run Unit` green — **649 tests** incl. 14 new `WebmentionTest` cases (target resolution, source verification, store/dedup/stale-removal).
- New `WebmentionCest` (discovery link + 405/400 paths) passes.
- Note: 20 unrelated acceptance tests fail **locally** because `LAMB_TEST_PASSWORD` is unset on this machine, so every login-gated test can't authenticate — pre-existing env gap, provisioned in CI. None touch webmention code.

## Follow-ups (out of scope)

- Public display + approval/moderation of received mentions.
- Sending webmentions on publish (#248).

🤖 Generated with [Claude Code](https://claude.com/claude-code)