### PR TITLE
Send webmentions on publish (#248)

### DIFF
--- a/docs/webmentions.md
+++ b/docs/webmentions.md
@@ -6,7 +6,7 @@ title: Webmentions
 
 [Webmention](https://www.w3.org/TR/webmention/) is an open standard that lets one site notify another when it links to it. When someone replies to, likes, or links one of your posts from their own Webmention-enabled site, they can send your blog a notification so you know about the mention.
 
-Lamb can **receive** webmentions out of the box.
+Lamb can **receive** webmentions, and **send** them when you publish a post that links to other sites.
 
 ## How it works
 
@@ -27,7 +27,17 @@ Senders that don't follow the rules are rejected: a missing or non-`http(s)` `so
 
 Received webmentions appear at the bottom of the relevant post page. For now they are shown to the **logged-in author only** — public display and moderation are planned follow-ups. Each entry links to the source page, with the author and a short snippet where they can be detected.
 
+## Sending
+
+When you publish or edit a post, Lamb scans its rendered HTML for links to **other** sites and queues a webmention for each. The queue is worked through on the next [`/_cron`]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}) run rather than during the publish request, so saving a post stays fast. For each queued target Lamb:
+
+1. Fetches the target page and discovers its webmention endpoint (HTTP `Link` header → `<link rel="webmention">` → `<a rel="webmention">`).
+2. POSTs your post URL (`source`) and the linked URL (`target`) to that endpoint.
+
+Each source/target pair is sent once — re-editing a post does not re-notify targets it already reached, so receivers are not spammed. Drafts, future-scheduled posts, and posts ingested from other feeds do not send webmentions.
+
 ## Related
 
 * [Micropub]({{ site.baseurl }}{% link micropub.md %}): Publish posts from any Micropub client; uses the same IndieWeb discovery pattern.
+* [Cron / scheduled tasks]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}): How `/_cron` drives feed ingestion and outbound webmentions.
 * [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %}): Pull posts in from other feeds.

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -239,6 +239,8 @@ class LambMicropubAdapter extends MicropubAdapter
 
         R::store($bean);
 
+        \Lamb\Webmention\enqueue_for_post($bean);
+
         return permalink($bean);
     }
 
@@ -341,6 +343,8 @@ class LambMicropubAdapter extends MicropubAdapter
         parse_bean($bean);
         $bean->updated = date('Y-m-d H:i:s');
         R::store($bean);
+
+        \Lamb\Webmention\enqueue_for_post($bean);
 
         return true;
     }

--- a/src/network.php
+++ b/src/network.php
@@ -96,6 +96,16 @@ function purge_deleted_posts(): int
         set_option($last_updated, (int)date('U'));
     }
 
+    $sent = \Lamb\Webmention\process_outbound();
+    if ($sent['sent'] || $sent['failed'] || $sent['skipped']) {
+        printf(
+            "Webmentions sent: %d, failed: %d, skipped: %d" . PHP_EOL,
+            $sent['sent'],
+            $sent['failed'],
+            $sent['skipped']
+        );
+    }
+
     set_option($cron_last_updated, (int)date('U'));
     exit('Done');
 }

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -61,6 +61,7 @@ function redirect_created(): void
     } catch (SQL $e) {
         $_SESSION['flash'][] = 'Failed to save: ' . $e->getMessage();
     }
+    \Lamb\Webmention\enqueue_for_post($bean);
     redirect_uri('/');
 }
 
@@ -212,6 +213,8 @@ function redirect_edited(): void
                 . '</code> still exists in Settings → [redirections]. You may want to remove it.';
         }
     }
+
+    \Lamb\Webmention\enqueue_for_post($bean);
 
     $redirect = $_SESSION['edit-referrer'];
     unset($_SESSION['edit-referrer']);

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -8,6 +8,8 @@ use JetBrains\PhpStorm\NoReturn;
 use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
 
+use function Lamb\permalink;
+
 use const ROOT_URL;
 
 /**
@@ -252,4 +254,306 @@ function is_valid_http_url(string $url): bool
 function response(int $status, string $body): array
 {
     return ['status' => $status, 'body' => $body];
+}
+
+// ---------------------------------------------------------------------------
+// Sending webmentions on publish (#248)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract distinct external http(s) link targets from rendered post HTML.
+ *
+ * Only absolute links to other hosts are returned — links back to this site,
+ * relative links, and non-http(s) schemes (mailto:, etc.) are ignored.
+ *
+ * @param string $html
+ * @return string[]
+ */
+function extract_outbound_links(string $html): array
+{
+    $own_host = strtolower((string) parse_url(ROOT_URL, PHP_URL_HOST));
+    $targets = [];
+
+    if (preg_match_all('/<a\b[^>]*\bhref\s*=\s*["\']([^"\']+)["\']/i', $html, $matches)) {
+        foreach ($matches[1] as $href) {
+            $href = html_entity_decode(trim($href), ENT_QUOTES | ENT_HTML5);
+            if (!is_valid_http_url($href)) {
+                continue;
+            }
+            $host = strtolower((string) parse_url($href, PHP_URL_HOST));
+            if ($host !== '' && $host !== $own_host && !in_array($href, $targets, true)) {
+                $targets[] = $href;
+            }
+        }
+    }
+
+    return $targets;
+}
+
+/**
+ * Discover a target's webmention endpoint.
+ *
+ * Resolution order follows the spec: HTTP `Link` headers first, then the first
+ * `<link>`/`<a>` with `rel="webmention"` in document order. Relative endpoints
+ * are resolved against the target URL. Returns null when none is found.
+ *
+ * @param string   $html         The fetched target HTML.
+ * @param string[] $link_headers Raw `Link` header values (without the "Link:" prefix).
+ * @param string   $target_url   The URL the headers/HTML were fetched from.
+ * @return string|null
+ */
+function discover_endpoint(string $html, array $link_headers, string $target_url): ?string
+{
+    foreach ($link_headers as $header) {
+        foreach (explode(',', $header) as $part) {
+            if (!preg_match('/<([^>]+)>\s*;\s*(.*)/s', trim($part), $m)) {
+                continue;
+            }
+            if (preg_match('/\brel\s*=\s*"?([^";]+)"?/i', $m[2], $rel) && rel_has_webmention($rel[1])) {
+                return resolve_url($target_url, trim($m[1]));
+            }
+        }
+    }
+
+    if (preg_match_all('/<(?:link|a)\b[^>]*>/i', $html, $tags)) {
+        foreach ($tags[0] as $tag) {
+            if (!preg_match('/\brel\s*=\s*["\']([^"\']*)["\']/i', $tag, $rel) || !rel_has_webmention($rel[1])) {
+                continue;
+            }
+            if (preg_match('/\bhref\s*=\s*["\']([^"\']+)["\']/i', $tag, $href)) {
+                return resolve_url($target_url, html_entity_decode(trim($href[1]), ENT_QUOTES | ENT_HTML5));
+            }
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Whether a rel attribute's space-separated token list contains "webmention".
+ *
+ * @param string $rel
+ * @return bool
+ */
+function rel_has_webmention(string $rel): bool
+{
+    foreach (preg_split('/\s+/', strtolower($rel)) as $token) {
+        if (trim($token, " \t\"'") === 'webmention') {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Resolve a possibly-relative URL against a base URL.
+ *
+ * @param string $base
+ * @param string $rel
+ * @return string
+ */
+function resolve_url(string $base, string $rel): string
+{
+    if ($rel === '') {
+        return $base;
+    }
+    if (parse_url($rel, PHP_URL_SCHEME) !== null) {
+        return $rel;
+    }
+
+    $scheme = parse_url($base, PHP_URL_SCHEME) ?: 'https';
+    $host = parse_url($base, PHP_URL_HOST) ?: '';
+    $port = parse_url($base, PHP_URL_PORT);
+    $authority = $scheme . '://' . $host . ($port ? ':' . $port : '');
+
+    if (str_starts_with($rel, '//')) {
+        return $scheme . ':' . $rel;
+    }
+    if (str_starts_with($rel, '/')) {
+        return $authority . $rel;
+    }
+
+    $path = parse_url($base, PHP_URL_PATH) ?: '/';
+    $dir = rtrim(substr($path, 0, strrpos($path, '/') + 1), '/');
+    return $authority . $dir . '/' . $rel;
+}
+
+/**
+ * Queue outbound webmentions for a freshly saved post, if it is eligible.
+ *
+ * Skips ingested feed items (third-party content), drafts, and future-dated
+ * scheduled posts — none of which should notify external targets (yet).
+ *
+ * @param OODBBean $bean A stored post bean.
+ * @return void
+ */
+function enqueue_for_post(OODBBean $bean): void
+{
+    if (!$bean->id || !empty($bean->feed_name) || !empty($bean->draft)) {
+        return;
+    }
+    if (!empty($bean->created) && strtotime((string) $bean->created) > time()) {
+        return;
+    }
+
+    enqueue_outbound((int) $bean->id, permalink($bean), (string) ($bean->transformed ?? ''));
+}
+
+/**
+ * Queue outbound webmentions for every external link in a post.
+ *
+ * Idempotent across edits: an existing pending/sent row for the same
+ * source+target is left untouched (so receivers are not spammed), while a
+ * previously failed row is reset to pending for another attempt.
+ *
+ * @param int    $post_id
+ * @param string $source  This post's permalink.
+ * @param string $html    The post's rendered HTML.
+ * @return int Number of newly created queue rows.
+ */
+function enqueue_outbound(int $post_id, string $source, string $html): int
+{
+    $created = 0;
+    foreach (extract_outbound_links($html) as $target) {
+        $row = R::findOne('webmentionoutbox', ' source = ? AND target = ? ', [$source, $target]);
+        if ($row) {
+            if ($row->status === 'failed') {
+                $row->status = 'pending';
+                R::store($row);
+            }
+            continue;
+        }
+
+        $row = R::dispense('webmentionoutbox');
+        $row->post_id = $post_id;
+        $row->source = $source;
+        $row->target = $target;
+        $row->status = 'pending';
+        $row->attempts = 0;
+        $row->created = date('Y-m-d H:i:s');
+        $row->processed_at = null;
+        R::store($row);
+        $created++;
+    }
+
+    return $created;
+}
+
+/**
+ * Process queued outbound webmentions: discover each target's endpoint and
+ * POST the mention. Intended to be driven by the `/_cron` route.
+ *
+ * Both network operations are injectable for testing:
+ *  - $fetcher fn(string $url): ?array{headers: string[], body: string}
+ *  - $sender  fn(string $endpoint, string $source, string $target): int (HTTP status)
+ *
+ * @param callable|null $fetcher
+ * @param callable|null $sender
+ * @param int           $limit Maximum rows to process per run.
+ * @return array{sent:int, failed:int, skipped:int}
+ */
+function process_outbound(?callable $fetcher = null, ?callable $sender = null, int $limit = 20): array
+{
+    $fetcher ??= __NAMESPACE__ . '\\fetch_target';
+    $sender ??= __NAMESPACE__ . '\\send_webmention';
+
+    $stats = ['sent' => 0, 'failed' => 0, 'skipped' => 0];
+    $rows = R::find('webmentionoutbox', ' status = ? ORDER BY created ASC LIMIT ? ', ['pending', $limit]);
+
+    foreach ($rows as $row) {
+        $row->attempts = (int) $row->attempts + 1;
+        $row->processed_at = date('Y-m-d H:i:s');
+
+        $fetched = $fetcher($row->target);
+        $endpoint = is_array($fetched)
+            ? discover_endpoint($fetched['body'] ?? '', $fetched['headers'] ?? [], $row->target)
+            : null;
+
+        if ($endpoint === null) {
+            $row->status = 'skipped';
+            $stats['skipped']++;
+            R::store($row);
+            continue;
+        }
+
+        $row->endpoint = $endpoint;
+        $code = (int) $sender($endpoint, $row->source, $row->target);
+        if ($code >= 200 && $code < 300) {
+            $row->status = 'sent';
+            $stats['sent']++;
+        } else {
+            $row->status = 'failed';
+            $stats['failed']++;
+        }
+        R::store($row);
+    }
+
+    return $stats;
+}
+
+/**
+ * Fetch a target page, returning its `Link` headers and body.
+ *
+ * @param string $url
+ * @return array{headers: string[], body: string}|null
+ */
+function fetch_target(string $url): ?array
+{
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'GET',
+            'header' => implode("\r\n", ['Accept: text/html, */*', 'User-Agent: Lamb-Webmention']),
+            'timeout' => WEBMENTION_FETCH_TIMEOUT,
+            'follow_location' => 1,
+            'max_redirects' => 5,
+            'ignore_errors' => true,
+        ],
+    ]);
+
+    $http_response_header = [];
+    $body = @file_get_contents($url, false, $context);
+    if ($body === false) {
+        return null;
+    }
+
+    $link_headers = [];
+    foreach ($http_response_header as $header) {
+        if (preg_match('/^link:\s*(.*)$/i', $header, $m)) {
+            $link_headers[] = trim($m[1]);
+        }
+    }
+
+    return ['headers' => $link_headers, 'body' => $body];
+}
+
+/**
+ * POST a webmention to a discovered endpoint and return the HTTP status code.
+ *
+ * @param string $endpoint
+ * @param string $source
+ * @param string $target
+ * @return int HTTP status code, or 0 on transport failure.
+ */
+function send_webmention(string $endpoint, string $source, string $target): int
+{
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'POST',
+            'header' => implode("\r\n", [
+                'Content-Type: application/x-www-form-urlencoded',
+                'User-Agent: Lamb-Webmention',
+            ]),
+            'content' => http_build_query(['source' => $source, 'target' => $target]),
+            'timeout' => WEBMENTION_FETCH_TIMEOUT,
+            'ignore_errors' => true,
+        ],
+    ]);
+
+    $response = @file_get_contents($endpoint, false, $context);
+    if ($response === false && empty($http_response_header)) {
+        return 0;
+    }
+
+    $status_line = $http_response_header[0] ?? '';
+    return preg_match('#\s(\d{3})\s#', $status_line, $m) ? (int) $m[1] : 0;
 }

--- a/tests/Unit/WebmentionSendTest.php
+++ b/tests/Unit/WebmentionSendTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Webmention\discover_endpoint;
+use function Lamb\Webmention\enqueue_outbound;
+use function Lamb\Webmention\extract_outbound_links;
+use function Lamb\Webmention\process_outbound;
+
+class WebmentionSendTest extends TestCase
+{
+    private int $postId;
+
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'https://example.com');
+        }
+
+        R::exec('DELETE FROM webmentionoutbox WHERE 1');
+
+        $post = R::dispense('post');
+        $post->body = 'Hello';
+        $post->transformed = '<p>Hello</p>';
+        $post->created = '2026-01-01 00:00:00';
+        $post->updated = '2026-01-01 00:00:00';
+        $post->version = 1;
+        $this->postId = (int) R::store($post);
+    }
+
+    // extract_outbound_links ------------------------------------------------
+
+    public function testExtractReturnsOnlyExternalLinks(): void
+    {
+        $html = '<p><a href="https://other.example/a">x</a> '
+            . '<a href="' . ROOT_URL . '/status/1">self</a> '
+            . '<a href="/relative">rel</a> '
+            . '<a href="mailto:a@b.c">mail</a></p>';
+
+        $links = extract_outbound_links($html);
+        $this->assertSame(['https://other.example/a'], $links);
+    }
+
+    public function testExtractDeduplicates(): void
+    {
+        $html = '<a href="https://other.example/a">1</a><a href="https://other.example/a">2</a>';
+        $this->assertSame(['https://other.example/a'], extract_outbound_links($html));
+    }
+
+    // discover_endpoint -----------------------------------------------------
+
+    public function testDiscoverFromLinkHeader(): void
+    {
+        $endpoint = discover_endpoint('', ['<https://other.example/wm>; rel="webmention"'], 'https://other.example/post');
+        $this->assertSame('https://other.example/wm', $endpoint);
+    }
+
+    public function testDiscoverFromRelativeLinkHeader(): void
+    {
+        $endpoint = discover_endpoint('', ['</wm>; rel="webmention"'], 'https://other.example/post');
+        $this->assertSame('https://other.example/wm', $endpoint);
+    }
+
+    public function testDiscoverFromHtmlLinkTag(): void
+    {
+        $html = '<html><head><link rel="webmention" href="/wm"></head></html>';
+        $this->assertSame('https://other.example/wm', discover_endpoint($html, [], 'https://other.example/post'));
+    }
+
+    public function testDiscoverFromHtmlAnchor(): void
+    {
+        $html = '<a href="https://other.example/wm" rel="webmention">wm</a>';
+        $this->assertSame('https://other.example/wm', discover_endpoint($html, [], 'https://other.example/post'));
+    }
+
+    public function testDiscoverHeaderTakesPrecedenceOverHtml(): void
+    {
+        $html = '<link rel="webmention" href="/html-wm">';
+        $endpoint = discover_endpoint($html, ['<https://other.example/header-wm>; rel="webmention"'], 'https://other.example/post');
+        $this->assertSame('https://other.example/header-wm', $endpoint);
+    }
+
+    public function testDiscoverReturnsNullWhenAbsent(): void
+    {
+        $this->assertNull(discover_endpoint('<p>no endpoint here</p>', [], 'https://other.example/post'));
+    }
+
+    // enqueue_outbound ------------------------------------------------------
+
+    public function testEnqueueCreatesPendingRowsForExternalLinks(): void
+    {
+        $source = ROOT_URL . '/status/1';
+        $html = '<a href="https://other.example/a">a</a><a href="https://third.example/b">b</a>';
+
+        $count = enqueue_outbound($this->postId, $source, $html);
+        $this->assertSame(2, $count);
+        $this->assertSame(2, R::count('webmentionoutbox', ' status = ? ', ['pending']));
+    }
+
+    public function testEnqueueDeduplicatesAcrossEdits(): void
+    {
+        $source = ROOT_URL . '/status/1';
+        $html = '<a href="https://other.example/a">a</a>';
+
+        enqueue_outbound($this->postId, $source, $html);
+        enqueue_outbound($this->postId, $source, $html);
+        $this->assertSame(1, R::count('webmentionoutbox'));
+    }
+
+    public function testEnqueueRetriesFailedRow(): void
+    {
+        $source = ROOT_URL . '/status/1';
+        $html = '<a href="https://other.example/a">a</a>';
+        enqueue_outbound($this->postId, $source, $html);
+
+        $row = R::findOne('webmentionoutbox');
+        $row->status = 'failed';
+        R::store($row);
+
+        enqueue_outbound($this->postId, $source, $html);
+        $row = R::findOne('webmentionoutbox');
+        $this->assertSame('pending', $row->status);
+    }
+
+    public function testEnqueueDoesNotResendAlreadySent(): void
+    {
+        $source = ROOT_URL . '/status/1';
+        $html = '<a href="https://other.example/a">a</a>';
+        enqueue_outbound($this->postId, $source, $html);
+
+        $row = R::findOne('webmentionoutbox');
+        $row->status = 'sent';
+        R::store($row);
+
+        enqueue_outbound($this->postId, $source, $html);
+        $row = R::findOne('webmentionoutbox');
+        $this->assertSame('sent', $row->status);
+    }
+
+    // process_outbound ------------------------------------------------------
+
+    private function seedPending(string $target): void
+    {
+        enqueue_outbound($this->postId, ROOT_URL . '/status/1', '<a href="' . $target . '">x</a>');
+    }
+
+    public function testProcessMarksSentOnSuccess(): void
+    {
+        $target = 'https://other.example/a';
+        $this->seedPending($target);
+
+        $fetcher = fn (string $url) => ['headers' => ['<https://other.example/wm>; rel="webmention"'], 'body' => ''];
+        $sender = function (string $endpoint, string $source, string $tgt): int {
+            return 202;
+        };
+
+        $result = process_outbound($fetcher, $sender);
+        $this->assertSame(1, $result['sent']);
+        $this->assertSame('sent', R::findOne('webmentionoutbox')->status);
+    }
+
+    public function testProcessMarksSkippedWhenNoEndpoint(): void
+    {
+        $this->seedPending('https://other.example/a');
+
+        $fetcher = fn (string $url) => ['headers' => [], 'body' => '<p>no endpoint</p>'];
+        $sender = fn (string $e, string $s, string $t): int => 200;
+
+        $result = process_outbound($fetcher, $sender);
+        $this->assertSame(1, $result['skipped']);
+        $this->assertSame('skipped', R::findOne('webmentionoutbox')->status);
+    }
+
+    public function testProcessMarksFailedOnBadStatus(): void
+    {
+        $this->seedPending('https://other.example/a');
+
+        $fetcher = fn (string $url) => ['headers' => ['<https://other.example/wm>; rel="webmention"'], 'body' => ''];
+        $sender = fn (string $e, string $s, string $t): int => 400;
+
+        $result = process_outbound($fetcher, $sender);
+        $this->assertSame(1, $result['failed']);
+        $this->assertSame('failed', R::findOne('webmentionoutbox')->status);
+    }
+}


### PR DESCRIPTION
Closes #248

Builds on #244 (receive webmentions).

## What

When you publish or edit a post that links to other sites, Lamb now notifies those sites via Webmention — the outbound half of the IndieWeb conversation loop.

## How

- **Enqueue on save**: `Webmention\enqueue_for_post()` runs after every author save — web editor (`redirect_created`/`redirect_edited`) and Micropub (`createCallback`/`updateCallback`). It extracts external `http(s)` links from the post's rendered HTML and queues one row per target in a new `webmentionoutbox` bean. Drafts, future-scheduled posts, and ingested feed items are skipped.
- **Process via cron**: `process_feeds` (`/_cron`) now also calls `Webmention\process_outbound()`, so sending happens out-of-band, not during the publish request.
- **Endpoint discovery** follows the spec order: HTTP `Link` header → `<link rel="webmention">` → `<a rel="webmention">`, with relative endpoints resolved against the target.
- **Dedup**: a source/target pair is sent once. Re-edits leave already-sent rows alone (no spam); previously failed rows are retried.
- Both network operations (`fetch_target`, `send_webmention`) are injectable, so discovery / queue / processing are fully unit-testable without network.

## Testing

- `composer lint` clean, `composer analyse` (phpstan) clean.
- `vendor/bin/codecept run Unit` green — **664 tests**, incl. 15 new `WebmentionSendTest` cases (link extraction, endpoint discovery incl. header precedence + relative resolution, enqueue dedup/retry, and process sent/failed/skipped outcomes).
- Same 20 login-gated acceptance tests fail **locally only** (unset `LAMB_TEST_PASSWORD`); unrelated to this change.

## Follow-ups (out of scope)

- Notifying targets that were *removed* from a post on edit (so receivers can drop the mention).
- Reply posts with `in-reply-to` context (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)