### PR TITLE
Reply posts with in-reply-to context (#249)

### DIFF
--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -52,3 +52,4 @@ The following sections of the site are special:
 * [Drafts]({{ site.baseurl }}{% link drafts.md %}): Add `draft: true` to front-matter to save a post as a draft.
 * [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Add a future `created:` date to publish a post later.
 * [Menu Items]({{ site.baseurl }}{% link menu-items.md %}): Page posts with slugs can be pinned as menu items.
+* [Reply posts]({{ site.baseurl }}{% link replies.md %}): Add `in-reply-to:` to front-matter to mark a post as a reply to another URL.

--- a/docs/replies.md
+++ b/docs/replies.md
@@ -1,0 +1,37 @@
+---
+title: Reply posts
+---
+
+# Reply posts
+
+A reply post links back to another page as its conversational parent. On [micro.blog](https://micro.blog) and across the IndieWeb this `in-reply-to` relationship lets your post be shown as a reply, and lets [webmentions]({{ site.baseurl }}{% link webmentions.md %}) be categorised correctly by the site you are replying to.
+
+## Marking a post as a reply
+
+Add an `in-reply-to` value to the post's YAML front matter:
+
+```markdown
+---
+in-reply-to: https://example.com/their-post
+---
+
+Great point — here's my reply.
+```
+
+`in_reply_to` (underscore) is accepted as well. [Micropub]({{ site.baseurl }}{% link micropub.md %}) clients can send the standard `in-reply-to` property, which Lamb stores the same way.
+
+Remove the value from the front matter and re-save to turn the post back into a normal post.
+
+## What it does
+
+- **On the post page** a small "In reply to …" line is shown above the content, linked to the parent and marked up with `u-in-reply-to` so Webmention receivers treat it as a reply.
+- **Atom feed**: emits `<thr:in-reply-to ref="…" href="…" />` (the `http://purl.org/syndication/thread/1.0` thread extension).
+- **JSON feed**: emits `_microblog.in_reply_to_url` (the micro.blog reply convention).
+
+If you also have [webmention sending]({{ site.baseurl }}{% link webmentions.md %}) configured, replying to a page that links back is the most common kind of webmention — the link in your reply is picked up and the parent is notified on the next `/_cron` run.
+
+## Related
+
+* [Webmentions]({{ site.baseurl }}{% link webmentions.md %}): Send and receive mentions; replies are the most common webmention type.
+* [Micropub]({{ site.baseurl }}{% link micropub.md %}): Publish replies from a Micropub client with the `in-reply-to` property.
+* [Post types]({{ site.baseurl }}{% link post-types.md %}): Statuses, pages, and other post formats.

--- a/docs/webmentions.md
+++ b/docs/webmentions.md
@@ -38,6 +38,7 @@ Each source/target pair is sent once — re-editing a post does not re-notify ta
 
 ## Related
 
+* [Reply posts]({{ site.baseurl }}{% link replies.md %}): Mark a post as `in-reply-to` another URL — the most common webmention type.
 * [Micropub]({{ site.baseurl }}{% link micropub.md %}): Publish posts from any Micropub client; uses the same IndieWeb discovery pattern.
 * [Cron / scheduled tasks]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}): How `/_cron` drives feed ingestion and outbound webmentions.
 * [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %}): Pull posts in from other feeds.

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -101,6 +101,17 @@ function parse_bean(OODBBean $bean): void
 
     $front_matter['transformed'] = (parse_tags($markdown));
 
+    // Normalise the reply target. Accept either `in-reply-to` (IndieWeb/Micropub
+    // spelling) or `in_reply_to`, and remove both from the blind copy below so the
+    // hyphenated key is never written as an invalid column. Empty when absent, so
+    // removing it from front matter on edit clears the stored value.
+    $in_reply_to = $front_matter['in-reply-to'] ?? $front_matter['in_reply_to'] ?? null;
+    unset($front_matter['in-reply-to'], $front_matter['in_reply_to']);
+    if (is_array($in_reply_to)) {
+        $in_reply_to = $in_reply_to[0] ?? null;
+    }
+    $bean->in_reply_to = is_string($in_reply_to) ? trim($in_reply_to) : '';
+
     // Preserve the existing created date (now for new posts, the stored value for
     // edits, the feed date for ingested items) so an unparseable front-matter date
     // falls back to it rather than leaving a non-date string in the column.

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -428,17 +428,26 @@ class LambMicropubAdapter extends MicropubAdapter
         $currentBody = $bean->body ?? '';
         $matter      = parse_matter($currentBody);
         $title       = $matter['title'] ?? null;
+        $replyTo     = $matter['in-reply-to'] ?? $matter['in_reply_to'] ?? null;
 
         $tags      = get_tags($currentBody);
         $hashtagStr = empty($tags) ? '' : ' ' . implode(' ', array_map(fn($t) => '#' . $t, $tags));
 
         $content = $newContent . $hashtagStr;
 
-        if ($title === null) {
+        $front = [];
+        if ($title !== null) {
+            $front[] = "title: $title";
+        }
+        if (is_string($replyTo) && $replyTo !== '') {
+            $front[] = "in-reply-to: $replyTo";
+        }
+
+        if ($front === []) {
             return $content;
         }
 
-        return "---\ntitle: $title\n---\n$content";
+        return "---\n" . implode("\n", $front) . "\n---\n$content";
     }
 
     /**
@@ -509,6 +518,7 @@ class LambMicropubAdapter extends MicropubAdapter
     private function buildBody(array $props, string $content): string
     {
         $title = $props['name'][0] ?? null;
+        $replyTo = $props['in-reply-to'][0] ?? null;
 
         $photos = $this->buildPhotos($props['photo'] ?? []);
         if ($photos !== '') {
@@ -525,11 +535,19 @@ class LambMicropubAdapter extends MicropubAdapter
             $content = $content . "\n\n" . $extra;
         }
 
-        if ($title === null) {
+        $matter = [];
+        if ($title !== null) {
+            $matter[] = "title: $title";
+        }
+        if (is_string($replyTo) && $replyTo !== '') {
+            $matter[] = "in-reply-to: $replyTo";
+        }
+
+        if ($matter === []) {
             return $content;
         }
 
-        return "---\ntitle: $title\n---\n$content";
+        return "---\n" . implode("\n", $matter) . "\n---\n$content";
     }
 
     /**

--- a/src/theme/formatting.php
+++ b/src/theme/formatting.php
@@ -15,6 +15,30 @@ function escape(string $html): string
     return htmlspecialchars($html, ENT_HTML5 | ENT_QUOTES | ENT_SUBSTITUTE);
 }
 
+
+/**
+ * Render the reply-context line for a post that is a reply to another URL.
+ *
+ * Returns an empty string when the post has no `in_reply_to` target. The link
+ * carries the `u-in-reply-to` microformats2 class so Webmention receivers
+ * categorise the mention as a reply.
+ *
+ * @param \RedBeanPHP\OODBBean $bean
+ * @return string
+ */
+function the_reply_context(\RedBeanPHP\OODBBean $bean): string
+{
+    $url = trim((string) ($bean->in_reply_to ?? ''));
+    if ($url === '') {
+        return '';
+    }
+
+    $label = parse_url($url, PHP_URL_HOST) ?: $url;
+
+    return '<p class="reply-context">In reply to <a class="u-in-reply-to" rel="in-reply-to" href="'
+        . escape($url) . '">' . escape($label) . '</a></p>';
+}
+
 /**
  * Escapes a string for use in OpenGraph meta attribute values.
  * Decodes any existing HTML entities first to avoid double-encoding.

--- a/src/themes/2024/parts/_items.php
+++ b/src/themes/2024/parts/_items.php
@@ -11,6 +11,7 @@ use function Lamb\Theme\date_created;
 use function Lamb\Theme\escape;
 use function Lamb\Config\is_menu_item;
 use function Lamb\Theme\link_source;
+use function Lamb\Theme\the_reply_context;
 use function Lamb\Theme\title_link;
 
 if (empty($data['posts'])) :
@@ -44,6 +45,7 @@ else :
                     <?= date_created($bean) ?>
                 </div>
             </header>
+            <?= the_reply_context($bean) ?>
             <?= $bean->transformed ?>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -11,6 +11,7 @@ use function Lamb\Theme\date_created;
 use function Lamb\Theme\escape;
 use function Lamb\Config\is_menu_item;
 use function Lamb\Theme\link_source;
+use function Lamb\Theme\the_reply_context;
 use function Lamb\Theme\title_link;
 
 if (empty($data['posts'])) :
@@ -44,6 +45,7 @@ else :
                     <?= date_created($bean) ?>
                 </div>
             </header>
+            <?= the_reply_context($bean) ?>
             <?= $bean->transformed ?>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -13,7 +13,9 @@ if (!function_exists('escape')) {
 header('Content-type: application/atom+xml');
 $channel_link = $data['feed_url'] ?? ROOT_URL . '/feed';
 
-$Xml = new SimpleXMLElement('<feed xmlns="http://www.w3.org/2005/Atom"></feed>');
+$Xml = new SimpleXMLElement(
+    '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0"></feed>'
+);
 $Xml->addChild('title', escape($data['title'] ?? $config['site_title']));
 $Xml->addChild('id', escape($channel_link));
 $Xml->addChild('updated', date(DATE_ATOM, strtotime($data['updated'])));
@@ -47,6 +49,13 @@ foreach ($data['posts'] as $bean) {
     $Entry->addChild('updated', date(DATE_ATOM, strtotime($bean->updated)));
     $Content = $Entry->addChild('content', $bean->transformed);
     $Content->addAttribute('type', 'html');
+    if (!empty($bean->in_reply_to)) {
+        // Raw URL: SimpleXML escapes attribute values itself, so pre-escaping
+        // would double-encode any query-string ampersands.
+        $Thread = $Entry->addChild('in-reply-to', null, 'http://purl.org/syndication/thread/1.0');
+        $Thread->addAttribute('ref', $bean->in_reply_to);
+        $Thread->addAttribute('href', $bean->in_reply_to);
+    }
     $Link = $Entry->addChild('link');
     $Link->addAttribute('rel', 'alternate');
     $Link->addAttribute('type', 'text/html');

--- a/src/themes/base/feed_json.php
+++ b/src/themes/base/feed_json.php
@@ -32,6 +32,10 @@ foreach ($data['posts'] as $bean) {
     if (!empty($bean->title)) {
         $item['title'] = $bean->title;
     }
+    if (!empty($bean->in_reply_to)) {
+        // micro.blog reply convention.
+        $item['_microblog'] = ['in_reply_to_url' => $bean->in_reply_to];
+    }
     $feed['items'][] = $item;
 }
 

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -10,6 +10,7 @@ use function Lamb\Theme\date_created;
 use function Lamb\Config\is_menu_item;
 use function Lamb\Theme\escape;
 use function Lamb\Theme\link_source;
+use function Lamb\Theme\the_reply_context;
 use function Lamb\Theme\title_link;
 
 if (empty($data['posts'])) :
@@ -28,6 +29,7 @@ else :
                 <?php endif; ?>
                 <small><?= date_created($bean) ?><?= link_source($bean) ?></small>
             </header>
+            <?= the_reply_context($bean) ?>
             <?= $bean->transformed ?>
             <footer>
                 <small><?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>

--- a/tests/Unit/ReplyContextTest.php
+++ b/tests/Unit/ReplyContextTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Post\populate_bean;
+use function Lamb\Theme\the_reply_context;
+
+class ReplyContextTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        R::exec('DELETE FROM post WHERE 1');
+    }
+
+    // Front-matter parsing --------------------------------------------------
+
+    public function testFrontMatterHyphenSetsInReplyTo(): void
+    {
+        $bean = populate_bean("---\nin-reply-to: https://other.example/post\n---\nHi there");
+        $this->assertSame('https://other.example/post', $bean->in_reply_to);
+    }
+
+    public function testFrontMatterUnderscoreSetsInReplyTo(): void
+    {
+        $bean = populate_bean("---\nin_reply_to: https://other.example/post\n---\nHi there");
+        $this->assertSame('https://other.example/post', $bean->in_reply_to);
+    }
+
+    public function testAbsentInReplyToIsEmpty(): void
+    {
+        $bean = populate_bean('Just a normal post');
+        $this->assertSame('', (string) $bean->in_reply_to);
+    }
+
+    public function testHyphenKeyDoesNotLeakAsProperty(): void
+    {
+        $bean = populate_bean("---\nin-reply-to: https://other.example/post\n---\nHi");
+        // The hyphenated key must be normalised, not copied verbatim onto the bean.
+        $this->assertNull($bean->{'in-reply-to'});
+    }
+
+    // the_reply_context helper ----------------------------------------------
+
+    public function testReplyContextHelperRendersMarkup(): void
+    {
+        $bean = R::dispense('post');
+        $bean->in_reply_to = 'https://other.example/post';
+
+        $html = the_reply_context($bean);
+        $this->assertStringContainsString('u-in-reply-to', $html);
+        $this->assertStringContainsString('https://other.example/post', $html);
+        $this->assertStringContainsString('other.example', $html);
+    }
+
+    public function testReplyContextHelperEmptyWhenUnset(): void
+    {
+        $bean = R::dispense('post');
+        $this->assertSame('', the_reply_context($bean));
+    }
+
+    // Atom feed -------------------------------------------------------------
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testAtomFeedIncludesThrInReplyTo(): void
+    {
+        require_once __DIR__ . '/../../vendor/autoload.php';
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        $bean = R::dispense('post');
+        $bean->title = '';
+        $bean->transformed = '<p>A reply</p>';
+        $bean->in_reply_to = 'https://other.example/post';
+        $bean->created = '2024-01-01 12:00:00';
+        $bean->updated = '2024-01-01 12:00:00';
+
+        global $config, $data;
+        $config = ['site_title' => 'Blog', 'author_name' => 'Author', 'author_email' => 'a@b.c'];
+        $data = ['posts' => [$bean], 'title' => 'Blog', 'feed_url' => 'http://localhost/feed', 'updated' => '2024-01-01 12:00:00'];
+
+        ob_start();
+        require __DIR__ . '/../../src/themes/base/feed.php';
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('xmlns:thr', $output);
+        $this->assertStringContainsString('thr:in-reply-to', $output);
+        $this->assertStringContainsString('https://other.example/post', $output);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testJsonFeedIncludesMicroblogInReplyTo(): void
+    {
+        require_once __DIR__ . '/../../vendor/autoload.php';
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        $bean = R::dispense('post');
+        $bean->title = '';
+        $bean->transformed = '<p>A reply</p>';
+        $bean->in_reply_to = 'https://other.example/post';
+        $bean->created = '2024-01-01 12:00:00';
+        $bean->updated = '2024-01-01 12:00:00';
+
+        global $config, $data;
+        $config = ['site_title' => 'Blog', 'author_name' => 'Author'];
+        $data = ['posts' => [$bean], 'title' => 'Blog', 'feed_url' => 'http://localhost/feed.json', 'updated' => '2024-01-01 12:00:00'];
+
+        ob_start();
+        require __DIR__ . '/../../src/themes/base/feed_json.php';
+        $output = ob_get_clean();
+
+        $json = json_decode($output, true);
+        $this->assertSame('https://other.example/post', $json['items'][0]['_microblog']['in_reply_to_url']);
+    }
+}


### PR DESCRIPTION
Closes #249

Completes the IndieWeb reply loop alongside #244 (receive) and #248 (send).

## What

Posts can now declare an `in-reply-to` target, turning them into conversational replies that render reply context, expose the relationship in feeds, and carry `u-in-reply-to` markup so receivers categorise webmentions correctly.

## How

- **Input**: `parse_bean()` reads `in-reply-to` (or `in_reply_to`) from front matter into `$bean->in_reply_to`, normalising it (string, cleared when removed) and removing the hyphenated key from the blind front-matter copy so it never becomes an invalid column. This covers the web editor (front matter in the textarea). Micropub's `in-reply-to` property is round-tripped through the post's front matter in `buildBody`/`rebuildBody`, so create **and** content-edits preserve it.
- **Render**: new `Theme\the_reply_context()` helper emits `In reply to <a class="u-in-reply-to" rel="in-reply-to" href="…">host</a>`, wired into the **base, 2026, and 2024** `_items.php`.
- **Atom feed**: root declares `xmlns:thr`; reply entries emit `<thr:in-reply-to ref="…" href="…" />` (RFC 4685 thread extension).
- **JSON feed**: reply items emit `_microblog.in_reply_to_url` (micro.blog convention).

## Testing

- `composer lint` clean, `composer analyse` (phpstan) clean.
- `vendor/bin/codecept run Unit` green — **672 tests**, incl. 8 new `ReplyContextTest` cases (front-matter hyphen/underscore parsing, no-leak of the hyphen key, helper markup, Atom `thr:in-reply-to`, JSON `_microblog`).
- Same 20 login-gated acceptance tests fail locally only (unset `LAMB_TEST_PASSWORD`); unrelated.

## Scope notes / follow-ups

- A dedicated editor form field is deferred (the issue marks it optional) — front matter in the post textarea already sets `in-reply-to`.
- Fetching/caching the target page's title for a richer "In reply to <title>" line is a follow-up; the link currently shows the target host.
- Full h-entry mf2 annotation of the themes (these use schema.org microdata) is broader; the `u-in-reply-to` link is still parsed by receivers via the implied h-entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)