### PR TITLE
Fix TagFeedCest feed-root assertion after thr namespace (#249 follow-up)

### DIFF
--- a/tests/Acceptance/TagFeedCest.php
+++ b/tests/Acceptance/TagFeedCest.php
@@ -10,27 +10,27 @@ class TagFeedCest
     {
         $I->amOnPage('/tag/lamb/feed');
         $I->seeResponseCodeIs(200);
-        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom">');
+        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom"');
     }
 
     public function tryTagFeedContainsTagTitle(AcceptanceTester $I)
     {
         $I->amOnPage('/tag/lamb/feed');
-        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom">');
+        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom"');
         $I->seeInSource('lamb');
     }
 
     public function tryTagFeedContainsValidAtomStructure(AcceptanceTester $I)
     {
         $I->amOnPage('/tag/lamb/feed');
-        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom">');
+        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom"');
         $I->seeInSource('<generator>Lamb</generator>');
     }
 
     public function tryTagFeedUrlPointsToTagFeed(AcceptanceTester $I)
     {
         $I->amOnPage('/tag/lamb/feed');
-        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom">');
+        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom"');
         $I->seeInSource('/tag/lamb/feed');
     }
 
@@ -53,7 +53,7 @@ class TagFeedCest
     {
         $I->amOnPage('/home/feed');
         $I->seeResponseCodeIs(200);
-        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom">');
+        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom"');
         $I->seeInSource('<generator>Lamb</generator>');
     }
 
@@ -61,7 +61,7 @@ class TagFeedCest
     {
         $I->amOnPage('/tag/%F0%9F%90%91/feed');
         $I->seeResponseCodeIs(200);
-        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom">');
+        $I->seeInSource('<feed xmlns="http://www.w3.org/2005/Atom"');
         // SimpleXMLElement encodes emoji as XML character entities
         $I->seeInSource('&#x1F411;');
     }


### PR DESCRIPTION
Follow-up to #249.

## Problem

#249 added `xmlns:thr="http://purl.org/syndication/thread/1.0"` to the Atom `<feed>` root (for `<thr:in-reply-to>`). `TagFeedCest` asserts the **exact** string `<feed xmlns="http://www.w3.org/2005/Atom">`, so the added namespace broke 6 tests:

- tryTagFeedReturnsAtomXml, tryTagFeedContainsTagTitle, tryTagFeedContainsValidAtomStructure, tryTagFeedUrlPointsToTagFeed, tryHomeFeedReturnsAtomXml, tryEncodedTagFeedWorks

The unit `FeedTemplateTest` didn't catch it because it parses the XML via `SimpleXMLElement` (namespace-agnostic); the acceptance test does literal string matching. The feed output itself is valid Atom — only the assertion was brittle.

## Fix

Match the opening `<feed xmlns="http://www.w3.org/2005/Atom"` by prefix (drop the trailing `>`), so the assertions tolerate additional namespace declarations.

## Testing

`vendor/bin/codecept run Acceptance` — **54 tests green** (run with the dev-server env exported and port 8747 free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)