### PR TITLE
Pass LAMB_LOGIN_PASSWORD to the acceptance test server

### DIFF
--- a/tests/Acceptance.suite.yml
+++ b/tests/Acceptance.suite.yml
@@ -14,7 +14,10 @@ modules:
 extensions:
   enabled:
     - Codeception\Extension\RunProcess:
-        0: env LAMB_DATA_DIR=../tests/Support/Data php -S 0.0.0.0:%LAMB_TEST_PORT% -t src
+        # Pass LAMB_LOGIN_PASSWORD through to the test web server: the app reads it
+        # via getenv(), but .env is only loaded into Codeception's %param% space, not
+        # exported to this child process. Without it, every login-gated test fails.
+        0: env LAMB_DATA_DIR=../tests/Support/Data LAMB_LOGIN_PASSWORD=%LAMB_LOGIN_PASSWORD% php -S 0.0.0.0:%LAMB_TEST_PORT% -t src
         sleep: 1
 step_decorators:
   - Codeception\Step\ConditionalAssertion


### PR DESCRIPTION
## Problem

The acceptance suite launches its own `php -S` server via the `RunProcess` extension. The app reads `LAMB_LOGIN_PASSWORD` via `getenv()`, but `.env` is only loaded into Codeception's `%param%` space — **not** exported to that child process. So `vendor/bin/codecept run Acceptance` left every login-gated test failing unless the runner had separately exported `.env` into their shell (`set -a; . ./.env; set +a`).

## Fix

Pass `LAMB_LOGIN_PASSWORD=%LAMB_LOGIN_PASSWORD%` on the `RunProcess` command line, so Codeception substitutes the `.env` value into the test server's environment.

## Testing

```
env -u LAMB_LOGIN_PASSWORD vendor/bin/codecept run Acceptance
```
→ **54 tests green** even with the variable explicitly unset in the shell, proving the suite now injects it itself. (Port 8747 must be free — don't run `composer serve` alongside the suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)