### PR TITLE
Webmentions: frame author-only display as intended, not a stopgap

### DIFF
--- a/docs/webmentions.md
+++ b/docs/webmentions.md
@@ -25,7 +25,7 @@ Senders that don't follow the rules are rejected: a missing or non-`http(s)` `so
 
 ## Seeing your mentions
 
-Received webmentions appear at the bottom of the relevant post page. For now they are shown to the **logged-in author only** — public display and moderation are planned follow-ups. Each entry links to the source page, with the author and a short snippet where they can be detected.
+Received webmentions appear at the bottom of the relevant post page, visible to the **logged-in author only**. Lamb treats them as a private notification for you rather than public comments, so they are not displayed to visitors. Each entry links to the source page, with the author and a short snippet where they can be detected.
 
 ## Sending
 

--- a/src/themes/base/parts/_webmentions.php
+++ b/src/themes/base/parts/_webmentions.php
@@ -7,8 +7,8 @@ use function Lamb\Theme\escape;
 use function Lamb\Theme\human_time;
 use function Lamb\Webmention\webmentions_for_post;
 
-// Received webmentions are shown to the logged-in author only for now; public
-// display / moderation is a follow-up (see #244).
+// Received webmentions are a private notification for the author, not public
+// comments: they are shown to the logged-in author only, by design.
 if ($template !== 'status' || !isset($_SESSION[SESSION_LOGIN])) {
     return;
 }


### PR DESCRIPTION
The webmentions docs and the `_webmentions.php` comment described author-only display as temporary, "pending public display and moderation follow-ups." That work is **not planned** — author-only visibility is the intended design (received mentions are a private notification for the author, not public comments).

- `docs/webmentions.md`: reworded to present author-only as deliberate.
- `parts/_webmentions.php`: same, and dropped the stale `(see #244)` follow-up reference (#244 is closed).

Closes the loop on #300 (closed as not-planned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)