### PR TITLE
docs: webmention sending is automatic, not configured

### DIFF
--- a/docs/replies.md
+++ b/docs/replies.md
@@ -28,7 +28,7 @@ Remove the value from the front matter and re-save to turn the post back into a 
 - **Atom feed**: emits `<thr:in-reply-to ref="…" href="…" />` (the `http://purl.org/syndication/thread/1.0` thread extension).
 - **JSON feed**: emits `_microblog.in_reply_to_url` (the micro.blog reply convention).
 
-If you also have [webmention sending]({{ site.baseurl }}{% link webmentions.md %}) configured, replying to a page that links back is the most common kind of webmention — the link in your reply is picked up and the parent is notified on the next `/_cron` run.
+Replying to a page is the most common kind of [webmention]({{ site.baseurl }}{% link webmentions.md %}), and Lamb sends them automatically — there is nothing to configure. The link in your reply is picked up and the parent is notified on the next `/_cron` run.
 
 ## Related
 


### PR DESCRIPTION
`docs/replies.md` said "If you also have webmention sending configured…", implying it's optional. It isn't — `enqueue_for_post()` runs on every post save (web + Micropub) and `process_outbound()` runs on every `/_cron`. There's no config key. Reworded to state sending is automatic, with the only prerequisite being that `/_cron` runs (as with feeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)