### PR TITLE
docs: refer to settings page instead of config.ini

### DIFF
--- a/docs/menu-items.md
+++ b/docs/menu-items.md
@@ -19,4 +19,4 @@ Links can also point to external resources.
 
 ## Related
 
-* [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}): More information on `config.ini`.
+* [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}): More information on the settings page.

--- a/docs/preconnect.md
+++ b/docs/preconnect.md
@@ -27,4 +27,4 @@ The above configuration emits the following in the HTML `<head>`:
 
 ## Related
 
-* [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}): More information on `config.ini`.
+* [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}): More information on the settings page.


### PR DESCRIPTION
The "Related" links in `menu-items.md` and `preconnect.md` pointed users to "More information on `config.ini`." Configuration is stored in the DB and edited via the web settings page — there is no `config.ini` for end users — so both now refer to "the settings page".

🤖 Generated with [Claude Code](https://claude.com/claude-code)