### PR TITLE
docs: refresh cron task list and trash purge behaviour

### DIFF
--- a/docs/cron-scheduled-tasks.md
+++ b/docs/cron-scheduled-tasks.md
@@ -10,7 +10,9 @@ Lamb has an scheduled task endpoint that can be called periodically to run tasks
 
 The following tasks run periodically:
 
-1. [Crossposting]({{ site.baseurl }}{% link cross-posting.md %}) new content from feeds.
+1. **Purging trash.** Posts in the [trash]({{ site.baseurl }}{% link trash.md %}) are permanently deleted once they have been there for 30 days.
+2. **Crossposting.** New content from your configured [feeds]({{ site.baseurl }}{% link feeds.md %}) is [ingested]({{ site.baseurl }}{% link cross-posting.md %}) as posts.
+3. **Sending webmentions.** Any pending outbound [webmentions]({{ site.baseurl }}{% link webmentions.md %}) for your posts are delivered.
 
 Note that the feed system has its own rate limiting system to prevent sending too many requests to the feed provider, so checking more often than every 30 minutes or so is not typically useful.
 
@@ -28,5 +30,7 @@ For example the linux cron system can be setup as follows:
 ## Related
 
 * [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %}): Feed syndication that runs via the cron endpoint.
+* [Trash]({{ site.baseurl }}{% link trash.md %}): Trashed posts are purged after 30 days by the cron.
+* [Webmentions]({{ site.baseurl }}{% link webmentions.md %}): Outbound webmentions are sent during the cron run.
 * [Drafts]({{ site.baseurl }}{% link drafts.md %}): Feed-ingested posts are saved as drafts by default.
 * [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Publishing a post at a future date (a different feature, despite the similar name).

--- a/docs/trash.md
+++ b/docs/trash.md
@@ -16,9 +16,10 @@ From the `/trash` page, use the restore button on any post to move it back to pu
 
 ## Permanent deletion
 
-Posts in the trash are not currently purged automatically. To permanently remove a post you would need to delete it directly from the database.
+Posts in the trash are permanently deleted once they have been there for 30 days. This happens automatically during the [cron run]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}), so the trash purges itself as long as the cron endpoint is being called.
 
 ## Related
 
 * [Post Types]({{ site.baseurl }}{% link post-types.md %}): The types of posts that can be deleted.
 * [Drafts]({{ site.baseurl }}{% link drafts.md %}): Drafts are separate from the trash.
+* [Cron / Scheduled Tasks]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}): Runs the 30-day trash purge.


### PR DESCRIPTION
The `/_cron` endpoint had grown beyond feed crossposting, but the docs were stale.

`process_feeds()` (`src/network.php`) now runs three tasks in order:
1. `purge_deleted_posts()` — permanently deletes trashed posts older than 30 days
2. feed ingestion (crossposting)
3. `process_outbound()` — sends pending outbound webmentions

Changes:
- **Cron / Scheduled Tasks** page now lists all three tasks, and links to Trash and Webmentions.
- **Trash** page's "Permanent deletion" section previously said purging *never* happens — corrected to describe the automatic 30-day purge, with a link to the cron page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)