### PR TITLE
ci: enforce passing checks before merge

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,59 @@
+# Branch protection rulesets
+
+GitHub branch protection lives in **repository settings**, not in the repo
+tree — so it cannot be enabled by a commit. These JSON files are the
+exportable form of the rules we want, kept under version control so the
+intended configuration is reviewable and reproducible.
+
+## `require-ci.json`
+
+Blocks merging any pull request into `main` (the default branch) or
+`release` until the **`ci`** status check is green. `ci` is the single
+aggregate gate job in `.github/workflows/ci.yml`; it only succeeds when both
+`quality` and every `test` matrix entry succeed.
+
+Why this matters: without a required status check, a PR can be merged the
+instant it opens — before CI has finished, or even when it has failed.
+That is exactly how red PRs reached `main` (e.g. #309 merged with a failing
+`test (8.2)`). The `ci` job is also written with `if: always()` so a failed
+dependency makes it report **failure**, not *skipped* — GitHub counts a
+skipped required check as passing, so a plain aggregate job would not block
+anything.
+
+The ruleset uses `required_approving_review_count: 0`, so the solo
+maintainer can still self-merge — but only once CI passes. `bypass_actors`
+is empty, so the rule applies to everyone, including admins ("this must not
+be possible" — including by accident).
+
+### Apply it (one time, ~1 minute)
+
+UI:
+
+1. Repo → **Settings → Rules → Rulesets → New ruleset → Import a ruleset**.
+2. Choose `require-ci.json`.
+3. Confirm enforcement is **Active** and click **Create**.
+
+Or via the GitHub CLI / API:
+
+```bash
+gh api -X POST repos/svandragt/lamb/rulesets \
+  --input .github/rulesets/require-ci.json
+```
+
+### Verify
+
+Open a throwaway PR that deliberately fails a test. The **Merge** button
+should be disabled with "Required statuses must pass before merging", and
+`ci` should show a red ✗ (not a grey "skipped").
+
+### Adjust later
+
+- Require code review too: raise `required_approving_review_count`.
+- Require branches to be up to date before merging: set
+  `strict_required_status_checks_policy` to `true`.
+- Allow a specific automation/admin to bypass: add entries to
+  `bypass_actors`.
+
+> Note: the `playwright` workflow is intentionally **not** required — it is
+> path-filtered (`src/**` etc.), so it does not run on every PR and cannot
+> serve as a universal gate. It remains an advisory check.

--- a/.github/rulesets/require-ci.json
+++ b/.github/rulesets/require-ci.json
@@ -1,0 +1,50 @@
+{
+  "name": "Require CI on protected branches",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/release"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "ci"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,23 @@ jobs:
         if: matrix.php-version == '8.2'
         run: composer coverage
 
+  # Single aggregate gate. Mark THIS job ("ci") as the required status check
+  # in branch protection / the ruleset — not the individual matrix jobs.
+  # `if: always()` ensures the job runs (and reports a definite success/failure)
+  # even when a dependency fails. Without it the job would be *skipped* when
+  # `quality`/`test` fail, and GitHub treats a skipped required check as
+  # passing — which would let a red PR merge.
   ci:
     runs-on: ubuntu-latest
     needs: [quality, test]
+    if: always()
     steps:
-      - run: echo "All checks passed"
+      - name: Verify required jobs succeeded
+        run: |
+          echo "quality: ${{ needs.quality.result }}"
+          echo "test:    ${{ needs.test.result }}"
+          if [ "${{ needs.quality.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ]; then
+            echo "::error::One or more required jobs did not succeed"
+            exit 1
+          fi
+          echo "All checks passed"

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -19,6 +19,14 @@ I wouldn't want you to spend a lot of effort building a feature that I'm unwilli
 
 Have fun!
 
+MERGE PROTECTION (MAINTAINERS)
+
+Pull requests into main and release must not be merged until the `ci` status
+check passes. This is enforced by a GitHub ruleset, which lives in repository
+settings rather than the repo tree. The intended configuration is checked in
+at .github/rulesets/require-ci.json — see .github/rulesets/README.md for how
+to import and verify it.
+
 DEVELOPMENT ENVIRONMENTS
 
 Set up your environment using the README. Alternatives are documented for end users in docs/ (Devbox, DDev, Docker, local PHP). For a sandboxed, reproducible environment using Canonical Workshop, see .workshop/README.md.

--- a/src/themes/2026/html.php
+++ b/src/themes/2026/html.php
@@ -31,6 +31,7 @@ global $template;
     <link rel="authorization_endpoint" href="<?= escape($config['authorization_endpoint']) ?>">
     <link rel="token_endpoint" href="<?= escape($config['token_endpoint']) ?>">
     <link rel="micropub" href="<?= ROOT_URL ?>/micropub">
+    <link rel="webmention" href="<?= ROOT_URL ?>/webmention">
     <?php if (!empty($data['feed_url']) && $data['feed_url'] !== ROOT_URL . '/feed') : ?>
     <link rel="alternate" type="application/atom+xml" href="<?= escape($data['feed_url']) ?>"
           title="<?= escape($data['title'] ?? $config['site_title']) ?>">


### PR DESCRIPTION
Red PRs were reaching main because main had no *required* status check.
A PR could be merged the instant it opened, before CI finished or even
when it failed (e.g. #309 merged with a failing test (8.2)).

Two fixes:

1. Harden the aggregate 'ci' gate job (if: always() + explicit result
   check). Previously a failed dependency left 'ci' *skipped*, and GitHub
   counts a skipped required check as passing — so requiring it would not
   have blocked anything. It now reports a definite success/failure.

2. Check in the intended branch-protection ruleset
   (.github/rulesets/require-ci.json) plus import/verify instructions.
   Branch protection lives in repo settings, so it cannot be turned on by
   a commit — this makes the desired config reviewable and one-click to
   apply. Pointer added to CONTRIBUTING.