### PR TITLE
Convert JPEG/PNG uploads to WebP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,7 @@ When the user is logged in, it also loads:
 
 User-uploaded files live under `src/assets/`, not under theme directories.
 
-`respond_upload()` stores files in `src/assets/YYYY/MM/` and returns Markdown image links pointing at those uploaded files. Deployment setups that support uploads must ensure `src/assets/` is writable by the web server or PHP-FPM user.
+`respond_upload()` stores files in `src/assets/YYYY/MM/` and returns Markdown image links pointing at those uploaded files. JPEG/PNG uploads are re-encoded to WebP via GD (`Response\convert_to_webp()`, gated by `Response\should_convert_to_webp()`); GIF/WebP/AVIF are stored unchanged, and any conversion failure falls back to storing the original bytes. The same conversion is applied to Micropub uploads (inline `photo` files and the media endpoint) in `micropub.php`. Deployment setups that support uploads must ensure `src/assets/` is writable by the web server or PHP-FPM user.
 
 ### `.gitignore` exemption
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ Devtools / local environments / sandbox:
 * [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %})
 * [Drafts]({{ site.baseurl }}{% link drafts.md %})
 * [Feeds]({{ site.baseurl }}{% link feeds.md %})
+* [Media]({{ site.baseurl }}{% link media.md %})
 * [Menu Items]({{ site.baseurl }}{% link menu-items.md %})
 * [Micropub]({{ site.baseurl }}{% link micropub.md %})
 * [Post Types]({{ site.baseurl }}{% link post-types.md %})

--- a/docs/media.md
+++ b/docs/media.md
@@ -1,0 +1,49 @@
+---
+title: Media
+---
+
+# Media
+
+Lamb lets you add images to posts without leaving the editor. Uploaded files are stored under `src/assets/YYYY/MM/` and served from your own site — there is no external image host.
+
+## Adding images
+
+When logged in, there are two ways to add an image to the post editor:
+
+- **Drag and drop** one or more image files onto the editor textarea.
+- **Paste** an image straight from the clipboard, for example a screenshot.
+
+Either way the file is uploaded and a markdown image link (`![name](url)`) is inserted at the cursor. Pasted screenshots arrive without a real filename, so each is given a unique name before upload.
+
+## Supported formats
+
+These image types are accepted:
+
+`jpg`, `jpeg`, `png`, `gif`, `webp`, `avif`
+
+SVG is **not** accepted, because SVG files can carry scripts.
+
+## WebP conversion
+
+To keep stored files small, **JPEG and PNG uploads are automatically re-encoded to WebP**. The markdown link inserted into your post points at the converted `.webp` file. Transparency in PNGs is preserved.
+
+`gif`, `webp`, and `avif` uploads are stored as-is:
+
+- **GIF** may be animated, and converting would flatten it to a single frame.
+- **WebP** and **AVIF** are already efficient formats.
+
+If conversion ever fails (for example on a server whose PHP GD extension lacks WebP support), Lamb falls back to storing the original file unchanged, so uploads never break.
+
+## Micropub uploads
+
+Images sent via Micropub — both inline `photo` files on a post and files sent to the media endpoint — go through the same storage and WebP conversion as editor uploads.
+
+## Server requirements
+
+Uploads require the directory `src/assets/` to be writable by the web server or PHP-FPM user. WebP conversion requires PHP's GD extension built with WebP support (the common default); without it, files are stored in their original format.
+
+## Related
+
+* [Post Types]({{ site.baseurl }}{% link post-types.md %}): Add images to status and page posts.
+* [Micropub]({{ site.baseurl }}{% link micropub.md %}): Publish posts and upload photos from external apps.
+* [Themes]({{ site.baseurl }}{% link themes.md %}): Uploaded files live in `src/assets/`, not in theme directories.

--- a/docs/media.md
+++ b/docs/media.md
@@ -40,7 +40,29 @@ Images sent via Micropub — both inline `photo` files on a post and files sent 
 
 ## Server requirements
 
-Uploads require the directory `src/assets/` to be writable by the web server or PHP-FPM user. WebP conversion requires PHP's GD extension built with WebP support (the common default); without it, files are stored in their original format.
+Uploads require the directory `src/assets/` to be writable by the web server or PHP-FPM user.
+
+WebP conversion relies on PHP's [GD extension](https://www.php.net/manual/en/book.image.php) being built **with WebP support**. This is the common default, but it isn't guaranteed on every host. WebP support is the only thing the conversion needs — if it's missing, nothing breaks: Lamb stores each upload in its original format instead, so JPEG and PNG files are saved as-is rather than being converted. You simply don't get the smaller WebP files.
+
+### Checking for WebP support
+
+Run this on the server (the same PHP binary your site uses):
+
+```bash
+php -r 'echo function_exists("imagewebp") ? "WebP: yes\n" : "WebP: no\n";'
+```
+
+For more detail, inspect GD's reported capabilities:
+
+```bash
+php -r 'print_r(gd_info());'
+```
+
+Look for `[WebP Support] => 1` in the output. `1` means uploads will be converted; `0` (or a missing line) means they'll be stored in their original format.
+
+If you can't run the CLI — for example on shared hosting where only the web server's PHP is configured — drop a one-line script such as `phpinfo();` into a temporary file in `src/`, load it in your browser, and search the page for "WebP" under the **gd** section. Delete the file afterwards.
+
+If WebP support is missing and you want it, install or enable the WebP-capable GD build for your platform (for example `apt install php-gd` on Debian/Ubuntu, which bundles WebP support in current releases) and restart PHP-FPM or your web server.
 
 ## Related
 

--- a/docs/micropub.md
+++ b/docs/micropub.md
@@ -55,6 +55,7 @@ Visit [MicroPub Rocks](https://micropub.rocks/) and enter your site. Lamb's impl
 
 ## Related
 
+* [Media]({{ site.baseurl }}{% link media.md %}): Uploaded photos are stored under `src/assets/` and JPEG/PNG are converted to WebP.
 * [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}): The `[me]`, `authorization_endpoint`, and `token_endpoint` settings.
 * [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Send a future `published` date or `post-status: scheduled` to schedule a post.
 * [Webmentions]({{ site.baseurl }}{% link webmentions.md %}): Receive notifications when other sites link to your posts.

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -12,7 +12,7 @@ Any tags are automatically linked to tag archives.
 
 Select some text and paste a link over it to turn the selection into a markdown link, e.g. selecting `Lamb` and pasting `https://example.com` produces `[Lamb](https://example.com)`.
 
-Add images by dragging files onto the editor, or by pasting an image straight from the clipboard (for example a screenshot). Either way the image is uploaded and a markdown image link is inserted at the cursor.
+Add images by dragging files onto the editor, or by pasting an image straight from the clipboard (for example a screenshot). Either way the image is uploaded and a markdown image link is inserted at the cursor. JPEG and PNG uploads are automatically converted to WebP to keep files small; GIF, WebP, and AVIF are stored as-is.
 
 Permalinks for statuses are in the form of `/status/<integer>`.
 

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -49,6 +49,7 @@ The following sections of the site are special:
 
 ## Related
 
+* [Media]({{ site.baseurl }}{% link media.md %}): Add images by drag-and-drop or paste; JPEG/PNG are converted to WebP.
 * [Drafts]({{ site.baseurl }}{% link drafts.md %}): Add `draft: true` to front-matter to save a post as a draft.
 * [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Add a future `created:` date to publish a post later.
 * [Menu Items]({{ site.baseurl }}{% link menu-items.md %}): Page posts with slugs can be pinned as menu items.

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -474,8 +474,25 @@ class LambMicropubAdapter extends MicropubAdapter
                 continue;
             }
             $uploadDir = \Lamb\Response\get_upload_dir();
-            $filename  = sha1($file->getClientFilename() ?? uniqid('', true)) . ".$ext";
-            $file->moveTo($uploadDir . '/' . $filename);
+            $seed      = sha1($file->getClientFilename() ?? uniqid('', true));
+
+            // Re-encode JPEG/PNG to WebP via a temp copy of the stream; fall back to
+            // storing the original bytes when conversion isn't possible.
+            $filename = null;
+            if (\Lamb\Response\should_convert_to_webp($ext)) {
+                $tmp = tempnam(sys_get_temp_dir(), 'lamb_up_');
+                if ($tmp !== false) {
+                    file_put_contents($tmp, (string) $file->getStream());
+                    if (\Lamb\Response\convert_to_webp($tmp, $uploadDir . '/' . $seed . '.webp')) {
+                        $filename = $seed . '.webp';
+                    }
+                    unlink($tmp);
+                }
+            }
+            if ($filename === null) {
+                $filename = $seed . ".$ext";
+                $file->moveTo($uploadDir . '/' . $filename);
+            }
 
             $urls[] = str_replace(ROOT_DIR, ROOT_URL, $uploadDir) . '/' . $filename;
         }
@@ -744,8 +761,17 @@ function respond_micropub_media(): void
     }
 
     $uploadDir = \Lamb\Response\get_upload_dir();
-    $filename  = sha1(($file['name'] ?? '') . uniqid('', true)) . ".$ext";
-    move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $filename);
+    $seed      = sha1(($file['name'] ?? '') . uniqid('', true));
+
+    // Re-encode JPEG/PNG to WebP, falling back to the original bytes on failure.
+    $converted = \Lamb\Response\should_convert_to_webp($ext)
+        && \Lamb\Response\convert_to_webp($file['tmp_name'], $uploadDir . '/' . $seed . '.webp');
+    if ($converted) {
+        $filename = $seed . '.webp';
+    } else {
+        $filename = $seed . ".$ext";
+        move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $filename);
+    }
 
     $url = str_replace(ROOT_DIR, ROOT_URL . '/', $uploadDir) . '/' . $filename;
 

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -51,6 +51,19 @@ function respond_upload(array $_args): void
             die();
         }
         $temp_fp = $f['tmp_name'];
+
+        // Re-encode JPEG/PNG to WebP for smaller files; fall back to the original
+        // bytes if conversion fails (assume success, communicate failure).
+        if (should_convert_to_webp($ext)) {
+            $webp_fn = sha1($f['name']) . '.webp';
+            $webp_fp = sprintf("%s/%s", get_upload_dir(), $webp_fn);
+            if (convert_to_webp($temp_fp, $webp_fp)) {
+                $upload_url = str_replace(ROOT_DIR, ROOT_URL, get_upload_dir());
+                $out .= sprintf("![%s](%s)", $f['name'], "$upload_url/$webp_fn");
+                continue;
+            }
+        }
+
         $new_fn = sha1($f['name']) . ".$ext";
         $new_fp = sprintf("%s/%s", get_upload_dir(), $new_fn);
         if (!move_uploaded_file($temp_fp, $new_fp)) {
@@ -84,6 +97,57 @@ function safe_upload_extension(string $filename): ?string
     }
 
     return $ext;
+}
+
+/**
+ * Whether an uploaded image of the given extension should be re-encoded to WebP.
+ *
+ * Only JPEG and PNG are converted: they are common, lossy/lossless raster formats
+ * that GD round-trips cleanly and that shrink noticeably as WebP. Already-efficient
+ * formats (webp, avif) are left untouched, and gif is passed through because it may
+ * be animated — GD would flatten it to a single frame.
+ *
+ * @param string|null $ext A lower-case extension as returned by safe_upload_extension().
+ * @return bool
+ */
+function should_convert_to_webp(?string $ext): bool
+{
+    return in_array($ext, ['jpg', 'jpeg', 'png'], true);
+}
+
+/**
+ * Re-encodes an image file as WebP, writing the result to $dest_path.
+ *
+ * Reads $src_path with GD, preserves alpha transparency, and writes a WebP. Returns
+ * false (writing nothing) when the source cannot be decoded, so callers can fall back
+ * to storing the original bytes.
+ *
+ * @param string $src_path  Path to the source image (e.g. an uploaded temp file).
+ * @param string $dest_path Path the WebP should be written to.
+ * @param int $quality      WebP quality (0-100).
+ * @return bool True when a WebP was written, false on failure.
+ */
+function convert_to_webp(string $src_path, string $dest_path, int $quality = 82): bool
+{
+    $data = @file_get_contents($src_path);
+    if ($data === false) {
+        return false;
+    }
+
+    $image = @imagecreatefromstring($data);
+    if ($image === false) {
+        return false;
+    }
+
+    // Preserve transparency from PNG sources.
+    imagepalettetotruecolor($image);
+    imagealphablending($image, false);
+    imagesavealpha($image, true);
+
+    $ok = imagewebp($image, $dest_path, $quality);
+    imagedestroy($image);
+
+    return $ok;
 }
 
 /**

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -4,8 +4,10 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+use function Lamb\Response\convert_to_webp;
 use function Lamb\Response\get_upload_dir;
 use function Lamb\Response\safe_upload_extension;
+use function Lamb\Response\should_convert_to_webp;
 
 class UploadTest extends TestCase
 {
@@ -136,5 +138,114 @@ class UploadTest extends TestCase
     {
         // "evil.php.png" should be treated as a png (the stored name is hashed anyway)
         $this->assertSame('png', safe_upload_extension('evil.php.png'));
+    }
+
+    // should_convert_to_webp — only re-encode raster formats that benefit and that
+    // GD can losslessly round-trip (jpeg/png). webp/avif are already efficient; gif
+    // may be animated (GD flattens to one frame), so it is passed through untouched.
+
+    public function testShouldConvertJpg(): void
+    {
+        $this->assertTrue(should_convert_to_webp('jpg'));
+    }
+
+    public function testShouldConvertJpeg(): void
+    {
+        $this->assertTrue(should_convert_to_webp('jpeg'));
+    }
+
+    public function testShouldConvertPng(): void
+    {
+        $this->assertTrue(should_convert_to_webp('png'));
+    }
+
+    public function testShouldNotConvertGif(): void
+    {
+        $this->assertFalse(should_convert_to_webp('gif'));
+    }
+
+    public function testShouldNotConvertWebp(): void
+    {
+        $this->assertFalse(should_convert_to_webp('webp'));
+    }
+
+    public function testShouldNotConvertAvif(): void
+    {
+        $this->assertFalse(should_convert_to_webp('avif'));
+    }
+
+    public function testShouldNotConvertNull(): void
+    {
+        $this->assertFalse(should_convert_to_webp(null));
+    }
+
+    // convert_to_webp — GD-backed re-encode of an uploaded image into WebP
+
+    public function testConvertWritesWebpFile(): void
+    {
+        $src = $this->makePng(40, 30);
+        $dest = $this->tempRootDir . '/out.webp';
+
+        $this->assertTrue(convert_to_webp($src, $dest));
+        $this->assertFileExists($dest);
+        $this->assertSame('image/webp', mime_content_type($dest));
+    }
+
+    public function testConvertPreservesDimensions(): void
+    {
+        $src = $this->makePng(40, 30);
+        $dest = $this->tempRootDir . '/out.webp';
+
+        convert_to_webp($src, $dest);
+
+        [$width, $height] = getimagesize($dest);
+        $this->assertSame(40, $width);
+        $this->assertSame(30, $height);
+    }
+
+    public function testConvertPreservesTransparency(): void
+    {
+        $src = $this->makeTransparentPng(20, 20);
+        $dest = $this->tempRootDir . '/out.webp';
+
+        convert_to_webp($src, $dest);
+
+        // Re-open the WebP and confirm the centre pixel kept a non-opaque alpha.
+        $im = imagecreatefromwebp($dest);
+        $alpha = (imagecolorat($im, 10, 10) >> 24) & 0x7F;
+        imagedestroy($im);
+        $this->assertGreaterThan(0, $alpha);
+    }
+
+    public function testConvertReturnsFalseForNonImage(): void
+    {
+        $src = $this->tempRootDir . '/notimage.png';
+        file_put_contents($src, 'this is not an image');
+        $dest = $this->tempRootDir . '/out.webp';
+
+        $this->assertFalse(convert_to_webp($src, $dest));
+        $this->assertFileDoesNotExist($dest);
+    }
+
+    private function makePng(int $w, int $h): string
+    {
+        $im = imagecreatetruecolor($w, $h);
+        imagefill($im, 0, 0, imagecolorallocate($im, 10, 120, 200));
+        $path = $this->tempRootDir . '/src_' . uniqid() . '.png';
+        imagepng($im, $path);
+        imagedestroy($im);
+        return $path;
+    }
+
+    private function makeTransparentPng(int $w, int $h): string
+    {
+        $im = imagecreatetruecolor($w, $h);
+        imagealphablending($im, false);
+        imagesavealpha($im, true);
+        imagefill($im, 0, 0, imagecolorallocatealpha($im, 0, 0, 0, 127));
+        $path = $this->tempRootDir . '/srcalpha_' . uniqid() . '.png';
+        imagepng($im, $path);
+        imagedestroy($im);
+        return $path;
     }
 }


### PR DESCRIPTION
## What

JPEG and PNG image uploads are now automatically re-encoded to **WebP** to keep stored files small. The conversion is applied to all three upload paths:

- the editor `/upload` endpoint (drag-and-drop and clipboard paste),
- Micropub inline `photo` files, and
- the Micropub media endpoint.

`gif`, `webp`, and `avif` uploads are stored unchanged — GIF may be animated (GD would flatten it to one frame), and WebP/AVIF are already efficient. If conversion ever fails (e.g. a host whose GD build lacks WebP support), Lamb falls back to storing the original bytes, so uploads never break.

## How

- New `Lamb\Response\should_convert_to_webp(?string $ext)` — predicate gating conversion to `jpg`/`jpeg`/`png`.
- New `Lamb\Response\convert_to_webp(string $src, string $dest, int $quality = 82)` — GD-backed re-encode that preserves PNG alpha and returns `false` (writing nothing) on a decode failure.
- Wired into `src/response/upload.php` and both Micropub upload paths in `src/micropub.php`. The stored filename becomes `<hash>.webp` and the emitted markdown link points at it.

## Docs

- New `docs/media.md` covering uploads, supported formats, WebP conversion, the GD-with-WebP requirement, and how to test for it. Linked from the docs index and cross-linked with Post Types and Micropub.
- Updated `docs/post-types.md` and the codebase guide (`CLAUDE.md`).

## Testing (TDD)

Red-first unit tests in `tests/Unit/UploadTest.php` (fixtures generated in-test via GD — no binaries committed): WebP output format, preserved dimensions, preserved transparency, and graceful failure on non-image input.

- `vendor/bin/codecept run Unit` → 684 tests, 1023 assertions, OK
- `composer lint` → clean
- `composer analyse` (PHPStan) → no errors

There is no associated issue for this work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjgCvXqKSfixoD9NFkgLY1)_