### PR TITLE
Add bin/upgrade script and no-Composer install routes

### DIFF
--- a/.docker/Caddyfile.release
+++ b/.docker/Caddyfile.release
@@ -1,0 +1,9 @@
+{
+	frankenphp
+}
+
+:80 {
+	root * /app/src
+	encode zstd gzip
+	php_server
+}

--- a/.docker/Dockerfile.release
+++ b/.docker/Dockerfile.release
@@ -1,0 +1,32 @@
+# Production image published to ghcr.io/svandragt/lamb on each release.
+# Self-contained: app + vendor baked in, FrankenPHP (Caddy + PHP) serves it.
+# Build from the repository root: docker build -f .docker/Dockerfile.release .
+
+FROM composer:2 AS vendor
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --no-interaction --prefer-dist --no-scripts --no-autoloader --ignore-platform-reqs
+COPY src/ src/
+RUN composer dump-autoload --no-dev --optimize --ignore-platform-reqs
+
+FROM dunglas/frankenphp:php8.2
+LABEL maintainer="Sander van Dragt <sander@vandragt.com>"
+LABEL org.opencontainers.image.source="https://github.com/svandragt/lamb"
+
+RUN install-php-extensions gettext pdo_mysql
+
+RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+COPY .docker/Caddyfile.release /etc/frankenphp/Caddyfile
+
+WORKDIR /app
+COPY composer.json make-password.php ./
+COPY src/ src/
+COPY --from=vendor /app/vendor/ vendor/
+
+# SQLite database and uploads live outside the image.
+RUN mkdir -p data src/assets
+VOLUME ["/app/data", "/app/src/assets"]
+
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s CMD curl -fsS -o /dev/null http://localhost/ || exit 1

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,84 @@
+name: Release artifacts
+
+# Builds the no-Composer install artifacts for each published release:
+# - lamb-<version>.tar.gz with vendor/ bundled, attached to the GitHub Release
+# - ghcr.io/svandragt/lamb:<version> Docker image (and :latest for final releases)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to (re)build artifacts for'
+        required: true
+
+env:
+  TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+
+jobs:
+  tarball:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: sqlite3, gettext, simplexml
+
+      - name: Install production dependencies
+        run: composer install --no-dev --no-interaction --prefer-dist --no-scripts --optimize-autoloader
+
+      - name: Build tarball
+        run: |
+          mkdir -p build/lamb
+          cp -r src vendor composer.json composer.lock make-password.php README.md LICENSE build/lamb/
+          # Runtime dirs (data/, src/assets/) are deliberately not shipped:
+          # extracting them over a live install would reset their ownership.
+          rm -rf build/lamb/src/assets
+          tar -czf "lamb-${TAG}.tar.gz" -C build lamb
+
+      - name: Attach tarball to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$TAG" "lamb-${TAG}.tar.gz" --clobber
+
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Determine whether this is a pre-release
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          prerelease=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq .isPrerelease)
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .docker/Dockerfile.release
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.TAG }}
+            ${{ steps.meta.outputs.prerelease == 'false' && format('ghcr.io/{0}:latest', github.repository) || '' }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,6 +84,10 @@ gh release create <version> \
 
 ## 6. Post-release
 
+- [ ] Publishing the release triggers the `Release artifacts` workflow. Verify it
+      attached `lamb-<version>.tar.gz` to the release (`gh release view <version>`)
+      and pushed `ghcr.io/svandragt/lamb:<version>` (plus `:latest` for finals).
+      Re-run via `gh workflow run release-artifacts.yml -f tag=<version>` if needed.
 - [ ] Announce / update any demo site if applicable.
 - [ ] Note that the Docker/Devbox/DDev users pull from `release`; confirm a
       clean checkout of `release` installs and runs.

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Upgrade Lamb in place: reset to the upstream of the checked-out branch,
+# reinstall production dependencies, and verify the site still responds.
+# Safe to run from cron, e.g.: 15 3 * * * /path/to/lamb/bin/upgrade
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+prev=$(git rev-parse HEAD)
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+git fetch origin
+git reset --hard '@{u}'
+composer install --no-dev --no-interaction --prefer-dist --no-scripts
+
+echo "Upgraded ${branch}: ${prev:0:7} -> $(git rev-parse --short HEAD)"
+
+# Health check: only when SITE_URL is configured (written by make-password.php).
+site_url=$(grep -E '^SITE_URL=' .env 2>/dev/null | head -n1 | cut -d= -f2- | tr -d "'\"") || true
+if [ -n "${site_url:-}" ] && command -v curl > /dev/null; then
+    if ! curl -fsS -o /dev/null --max-time 15 "$site_url"; then
+        echo "Health check failed for ${site_url}" >&2
+        echo "Roll back with: git reset --hard ${prev} && composer install --no-dev --no-interaction --prefer-dist --no-scripts" >&2
+        exit 1
+    fi
+fi

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -6,7 +6,31 @@ title: Docker
 
 The only requirement in this case is a working Docker setup!
 
-## Setup
+## Prebuilt image (recommended)
+
+Every release publishes a ready-to-run image to GitHub Container Registry. It bundles PHP, the webserver (FrankenPHP/Caddy), and all dependencies in a single container:
+
+```shell
+# Generate a password hash on any machine with PHP, or inside a throwaway container:
+$ docker run --rm php:8.2-cli php -r "echo base64_encode(password_hash('hackme', PASSWORD_DEFAULT));"
+
+# Run Lamb
+$ docker run -d --name lamb -p 80:80 \
+    -e LAMB_LOGIN_PASSWORD='<the-hash>' \
+    -v lamb-data:/app/data \
+    -v lamb-assets:/app/src/assets \
+    ghcr.io/svandragt/lamb:latest
+```
+
+Your site is now ready at http://localhost
+
+The SQLite database lives in the `lamb-data` volume and uploads in `lamb-assets`, so they survive container upgrades. To upgrade, see [Upgrading]({{ site.baseurl }}{% link upgrading.md %}).
+
+Specific versions are available as tags, e.g. `ghcr.io/svandragt/lamb:0.9.0`.
+
+## Build from source
+
+This is the development setup: the project directory is live-mounted into the containers, so code changes apply immediately.
 
 ```shell
 $ cd .docker
@@ -24,7 +48,7 @@ Uploaded images are stored under `src/assets/` inside the app container.
 
 Errors can be inspected with `docker composer logs -f php`.
 
-## Update Lamb
+### Update
 
 To refresh Docker Compose containers, you can follow these steps:
 
@@ -40,11 +64,11 @@ The `-d` flag is used to start the containers in the background (detached mode).
 
 ## Running tests
 
-Codeception runs inside the `lamb-app` container. The whole project is mounted
+Codeception runs inside the `lamb-app` container of the build-from-source setup. The whole project is mounted
 at `/srv/app`, so the test suites and configuration are available there.
 
 The test runner reads `.env` for its parameters, so make sure you have generated
-one with the `make-password.php` step from [Setup](#setup) before running the
+one with the `make-password.php` step from [Build from source](#build-from-source) before running the
 tests.
 
 ```shell
@@ -58,3 +82,8 @@ $ docker exec -it lamb-app vendor/bin/codecept run
 Acceptance tests use `SITE_URL`, which `make-password.php` automatically sets to
 `http://lamb-web` (the Caddy container) when run inside the container, so they
 exercise the live Docker stack.
+
+## Related
+
+- [Installation options]({{ site.baseurl }}{% link index.md %})
+- [Upgrading]({{ site.baseurl }}{% link upgrading.md %})

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,11 +15,47 @@ Barrier free super simple blogging, self-hosted. [Read about the features](https
 
 ## Getting started
 
+There are three ways to install Lamb. All of them track the stable release channel.
+
+### 1. Docker image (easiest)
+
+No PHP, git, or Composer needed on the host — just Docker:
+
+```
+# Generate a password hash first (any machine with PHP), or copy one from make-password.php output
+docker run -d --name lamb -p 80:80 \
+  -e LAMB_LOGIN_PASSWORD='<your-hash>' \
+  -v lamb-data:/app/data -v lamb-assets:/app/src/assets \
+  ghcr.io/svandragt/lamb:latest
+```
+
+See [Docker]({{ site.baseurl }}{% link docker.md %}) for details.
+
+### 2. Release tarball
+
+For shared hosting or servers without git/Composer. Download `lamb-<version>.tar.gz` from the [releases page](https://github.com/svandragt/lamb/releases) — it includes all dependencies:
+
+```
+mkdir lamb && tar -xzf lamb-<version>.tar.gz --strip-components=1 -C lamb
+cd lamb
+php make-password.php <your-password>
+```
+
+Point your webserver at the `src/` directory ([Caddy]({{ site.baseurl }}{% link caddy.md %}) or [Nginx]({{ site.baseurl }}{% link nginx.md %})). Those pages also cover making `data/` and `src/assets/` writable by the webserver user.
+
+### 3. Git checkout
+
+Requires git and [Composer](https://getcomposer.org):
+
 ```
 # Checkout project - release branch is stable
 git clone --branch release https://github.com/svandragt/lamb.git
 cd lamb
+composer install --no-dev
+php make-password.php <your-password>
 ```
+
+This route gets you the `bin/upgrade` script for one-command (or cron-driven) upgrades — see [Upgrading]({{ site.baseurl }}{% link upgrading.md %}).
 
 Lamb can be run locally with the builtin PHP webserver, or with other tooling.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -4,34 +4,55 @@ title: Upgrading
 
 # Upgrading
 
-Full instructions for upgrading lamb to a newer version.
+How you upgrade depends on how you installed Lamb. There is [more information about branches](https://github.com/svandragt/lamb/blob/main/BRANCHES) to be on — `release` is the stable branch.
 
-This is what I do every night:
+## Git install
+
+Run the bundled upgrade script:
 
 ```
-git pull
-git reset --hard $(git rev-parse --abbrev-ref --symbolic-full-name @{u})
-composer install
+bin/upgrade
 ```
 
-This is all you need to upgrade. There is [more information about branches](https://github.com/svandragt/lamb/blob/main/BRANCHES) to be on.
+It resets your checkout to the latest version of the branch you are on, installs production dependencies, and — when `SITE_URL` is set in `.env` — checks that the site still responds. If the health check fails, it prints the exact command to roll back to the previous version.
 
-## Explanation
+Note: the reset discards any local changes to tracked files. Your database (`data/`), uploads (`src/assets/`), and `.env` are not tracked, so they are unaffected.
 
-The commands are a series of Git and Composer commands typically used in a development environment. Here's a breakdown of what each command does:
+To upgrade automatically every night, add it to cron:
 
-1. **`git pull`**:
-   - This command fetches changes from the remote repository and merges them into the current branch. It is a combination of `git fetch` (which retrieves the latest changes from the remote) and `git merge` (which integrates those changes into your current branch).
+```
+15 3 * * * /path/to/lamb/bin/upgrade
+```
 
-2. **`git reset --hard $(git rev-parse --abbrev-ref --symbolic-full-name @{u})`**:
-   - This command resets the current branch to the state of its upstream branch (the branch it is tracking on the remote).
-   - `git rev-parse --abbrev-ref --symbolic-full-name @{u}` retrieves the name of the upstream branch for the current branch. The `@{u}` syntax refers to the upstream branch.
-   - The `git reset --hard` command then resets the current branch to match the upstream branch exactly, discarding any local changes (both staged and unstaged). This means any uncommitted changes in your working directory will be lost.
+Cron will email you the output if the health check fails (when your system is set up to deliver mail).
 
-3. **`composer install`**:
-   - This command is used in PHP projects that use Composer as a dependency manager. It installs the dependencies listed in the `composer.json` file.
-   - If the `composer.lock` file exists, it will install the exact versions of the dependencies specified in that file. If it doesn't exist, it will create one based on the versions of the dependencies that are installed.
+## Tarball install
 
-### Summary
+Download the latest `lamb-<version>.tar.gz` from the [releases page](https://github.com/svandragt/lamb/releases) and extract it over your existing installation:
 
-In summary, these commands are used to update a local Git repository to match the remote repository (discarding any local changes) and then install the necessary PHP dependencies for the project. This sequence is often used to ensure that the local development environment is in sync with the latest code and dependencies from the remote repository.
+```
+tar -xzf lamb-<version>.tar.gz --strip-components=1 -C /path/to/lamb
+```
+
+Your database (`data/`), uploads (`src/assets/`), and `.env` are preserved — the tarball does not contain them.
+
+## Docker install
+
+Pull the new image and recreate the container:
+
+```
+docker pull ghcr.io/svandragt/lamb:latest
+docker stop lamb && docker rm lamb
+docker run -d --name lamb -p 80:80 \
+  -e LAMB_LOGIN_PASSWORD='<your-hash>' \
+  -v lamb-data:/app/data -v lamb-assets:/app/src/assets \
+  ghcr.io/svandragt/lamb:latest
+```
+
+The database and uploads live in the named volumes and survive the recreate.
+
+## Related
+
+- [Installation options]({{ site.baseurl }}{% link index.md %})
+- [Docker]({{ site.baseurl }}{% link docker.md %})
+- [Cron Scheduled Tasks]({{ site.baseurl }}{% link cron-scheduled-tasks.md %})

--- a/tests/Unit/UpgradeScriptTest.php
+++ b/tests/Unit/UpgradeScriptTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * Exercises bin/upgrade against a temporary origin + clone pair, with
+ * composer and curl replaced by PATH stubs that log their invocations.
+ */
+class UpgradeScriptTest extends TestCase
+{
+    private string $workspace;
+    private string $origin;
+    private string $seed;
+    private string $site;
+    private string $stubs;
+    private string $composerLog;
+    private string $curlLog;
+
+    protected function setUp(): void
+    {
+        $this->workspace = sys_get_temp_dir() . '/lamb-upgrade-test-' . uniqid();
+        $this->origin = $this->workspace . '/origin.git';
+        $this->seed = $this->workspace . '/seed';
+        $this->site = $this->workspace . '/site';
+        $this->stubs = $this->workspace . '/stubs';
+        $this->composerLog = $this->workspace . '/composer.log';
+        $this->curlLog = $this->workspace . '/curl.log';
+
+        mkdir($this->workspace, 0777, true);
+        mkdir($this->stubs, 0777, true);
+        $this->writeStub('composer', $this->composerLog);
+        $this->writeStub('curl', $this->curlLog);
+
+        $this->git(['git', 'init', '--bare', '--initial-branch=main', $this->origin], $this->workspace);
+        $this->git(['git', 'clone', $this->origin, $this->seed], $this->workspace);
+
+        // Seed the repo with the working tree's upgrade script and a content file.
+        mkdir($this->seed . '/bin');
+        copy(codecept_root_dir('bin/upgrade'), $this->seed . '/bin/upgrade');
+        chmod($this->seed . '/bin/upgrade', 0755);
+        file_put_contents($this->seed . '/file.txt', "v1\n");
+        $this->git(['git', 'add', '.'], $this->seed);
+        $this->git(['git', 'commit', '-m', 'v1'], $this->seed);
+        $this->git(['git', 'push', 'origin', 'main'], $this->seed);
+
+        $this->git(['git', 'clone', $this->origin, $this->site], $this->workspace);
+
+        // Advance origin past the site clone.
+        file_put_contents($this->seed . '/file.txt', "v2\n");
+        $this->git(['git', 'commit', '-am', 'v2'], $this->seed);
+        $this->git(['git', 'push', 'origin', 'main'], $this->seed);
+    }
+
+    protected function tearDown(): void
+    {
+        (new Process(['rm', '-rf', $this->workspace]))->run();
+    }
+
+    public function testUpgradeResetsToUpstreamAndInstallsWithoutDevDependencies(): void
+    {
+        // Local drift that a hard reset must discard.
+        file_put_contents($this->site . '/file.txt', "local edit\n");
+
+        $process = $this->runUpgrade();
+
+        $this->assertSame(0, $process->getExitCode(), $process->getErrorOutput() . $process->getOutput());
+        $this->assertSame($this->revParse($this->seed), $this->revParse($this->site), 'site should be at origin HEAD');
+        $this->assertSame("v2\n", file_get_contents($this->site . '/file.txt'), 'local edits should be discarded');
+
+        $this->assertFileExists($this->composerLog);
+        $composerArgs = file_get_contents($this->composerLog);
+        $this->assertStringContainsString('install', $composerArgs);
+        $this->assertStringContainsString('--no-dev', $composerArgs);
+        $this->assertStringContainsString('--no-interaction', $composerArgs);
+    }
+
+    public function testUpgradeReportsOldAndNewRevisions(): void
+    {
+        $before = $this->revParse($this->site);
+        $process = $this->runUpgrade();
+
+        $this->assertSame(0, $process->getExitCode(), $process->getErrorOutput() . $process->getOutput());
+        $this->assertStringContainsString(substr($before, 0, 7), $process->getOutput());
+        $this->assertStringContainsString(substr($this->revParse($this->seed), 0, 7), $process->getOutput());
+    }
+
+    public function testUpgradeChecksSiteHealthWhenSiteUrlIsConfigured(): void
+    {
+        file_put_contents($this->site . '/.env', "SITE_URL='http://example.test:8747'\n");
+
+        $process = $this->runUpgrade();
+
+        $this->assertSame(0, $process->getExitCode(), $process->getErrorOutput() . $process->getOutput());
+        $this->assertFileExists($this->curlLog);
+        $this->assertStringContainsString('http://example.test:8747', file_get_contents($this->curlLog));
+    }
+
+    public function testUpgradeSkipsHealthCheckWithoutSiteUrl(): void
+    {
+        $process = $this->runUpgrade();
+
+        $this->assertSame(0, $process->getExitCode(), $process->getErrorOutput() . $process->getOutput());
+        $this->assertFileDoesNotExist($this->curlLog);
+    }
+
+    public function testFailedHealthCheckPrintsRollbackCommandAndExitsNonZero(): void
+    {
+        $before = $this->revParse($this->site);
+        file_put_contents($this->site . '/.env', "SITE_URL='http://example.test:8747'\n");
+        $this->writeStub('curl', $this->curlLog, 22);
+
+        $process = $this->runUpgrade();
+
+        $this->assertNotSame(0, $process->getExitCode(), 'health check failure should be visible to cron');
+        $output = $process->getOutput() . $process->getErrorOutput();
+        $this->assertStringContainsString('git reset --hard ' . $before, $output, 'should print a rollback command');
+    }
+
+    private function runUpgrade(): Process
+    {
+        $process = new Process(
+            [$this->site . '/bin/upgrade'],
+            $this->site,
+            ['PATH' => $this->stubs . ':' . getenv('PATH')]
+        );
+        $process->run();
+
+        return $process;
+    }
+
+    private function writeStub(string $name, string $log, int $exitCode = 0): void
+    {
+        $script = "#!/bin/sh\necho \"$*\" >> " . escapeshellarg($log) . "\nexit {$exitCode}\n";
+        file_put_contents($this->stubs . '/' . $name, $script);
+        chmod($this->stubs . '/' . $name, 0755);
+    }
+
+    private function git(array $command, string $cwd): void
+    {
+        $process = new Process($command, $cwd, [
+            'GIT_AUTHOR_NAME' => 'Test',
+            'GIT_AUTHOR_EMAIL' => 'test@example.test',
+            'GIT_COMMITTER_NAME' => 'Test',
+            'GIT_COMMITTER_EMAIL' => 'test@example.test',
+            'HOME' => $this->workspace,
+        ]);
+        $process->mustRun();
+    }
+
+    private function revParse(string $repo): string
+    {
+        $process = new Process(['git', 'rev-parse', 'HEAD'], $repo);
+        $process->mustRun();
+
+        return trim($process->getOutput());
+    }
+}


### PR DESCRIPTION
## Summary

Makes it easy for others to run Lamb instances on the `release` channel.

- **`bin/upgrade`** — shipped upgrade script: `git fetch` + `reset --hard @{u}` (follows whatever branch is checked out), `composer install --no-dev`, prints old→new revision, health-checks `SITE_URL` from `.env` and prints an exact rollback command on failure (non-zero exit so cron notices). Covered by `tests/Unit/UpgradeScriptTest.php` (temp git repos, PATH-stubbed composer/curl).
- **Release tarball** — `release-artifacts.yml` runs on release publish and attaches `lamb-<version>.tar.gz` with `vendor/` bundled; install = extract + point webserver at `src/`. Runtime dirs are excluded so extract-over upgrades can't clobber `data/` or assets ownership.
- **GHCR image** — same workflow pushes `ghcr.io/svandragt/lamb:<version>` (+`:latest` for finals, skipped for `-rc` prereleases). New single-container `.docker/Dockerfile.release` on FrankenPHP (Caddy+PHP), volumes for `/app/data` and `/app/src/assets`, config via `LAMB_LOGIN_PASSWORD` env. The dev compose setup is untouched.
- **Docs** — `index.md` now lists three install routes; `upgrading.md` covers all three upgrade paths (incl. cron example); `docker.md` gains a prebuilt-image section; RELEASING.md gains an artifact-verification step.

## Test plan

- [x] `vendor/bin/codecept run Unit` — 689 tests green (5 new)
- [x] `composer lint` / `composer analyse` clean
- [x] Docker image built locally and smoke-tested: `/`, `/feed`, `/login` 200, 404 route, login 302 + entry form rendered with env-passed password
- [x] Workflow checked with actionlint
- [x] After merge: cut an `-rcN` pre-release to exercise tarball upload + GHCR push end-to-end (won't touch `:latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)