### PR TITLE
Normalise iOS smart-punctuation front-matter fence

### DIFF
--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -38,6 +38,8 @@ A slug is preserved after creation. Changing the title later does not automatica
 
 You can also set a `created:` date in the front-matter. A future date schedules the post — see [Scheduling]({{ site.baseurl }}{% link scheduling.md %}).
 
+> **iOS note:** iOS "Smart Punctuation" rewrites a typed `---` into em/en dashes (for example `—-`). Lamb recognises a mangled opening and closing fence and restores it to `---` automatically, so front-matter still works from an iPhone or iPad. If you'd rather type plain dashes everywhere, turn the feature off under _Settings → General → Keyboard → Smart Punctuation_.
+
 # System types
 
 The following sections of the site are special:

--- a/src/post.php
+++ b/src/post.php
@@ -24,6 +24,7 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
 {
     global $config;
 
+    $text = normalize_frontmatter_fence($text);
     $matter = parse_matter($text);
 
     if ($bean === null) {
@@ -57,6 +58,28 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
     }
 
     return $bean;
+}
+
+/**
+ * Restores a front-matter fence that iOS "Smart Punctuation" has rewritten.
+ *
+ * Typing `---` on iOS produces em/en dashes (commonly `—-`), which stops the
+ * fence from being recognised as a front-matter delimiter. When the body opens
+ * with a dash-only fence line and has a matching closing fence line, both are
+ * normalised back to a literal `---`. Dashes anywhere else (post body, em-dash
+ * punctuation, signatures) are left untouched, and the surrounding whitespace
+ * and line endings are preserved.
+ *
+ * @param string $body The raw post body.
+ * @return string The body with a normalised opening/closing front-matter fence.
+ */
+function normalize_frontmatter_fence(string $body): string
+{
+    // Dash-like fence characters: hyphen-minus, en dash (U+2013), em dash (U+2014).
+    $pattern = '/\A([-\x{2013}\x{2014}]{2,})([ \t]*\R)(.*?)(\R)([-\x{2013}\x{2014}]{2,})([ \t]*)(\R|\z)/su';
+    return preg_replace_callback($pattern, static function (array $m): string {
+        return '---' . $m[2] . $m[3] . $m[4] . '---' . $m[6] . $m[7];
+    }, $body, 1) ?? $body;
 }
 
 /**

--- a/tests/Unit/PopulateBeanTest.php
+++ b/tests/Unit/PopulateBeanTest.php
@@ -188,6 +188,37 @@ class PopulateBeanTest extends TestCase
         $this->assertSame(1, $bean->version);
     }
 
+    public function testPopulateBeanNormalisesIosSmartDashFenceForSlug(): void
+    {
+        // iOS "Smart Punctuation" rewrites the typed `---` fence as `—-`.
+        $text = "\u{2014}-\ntitle: My Post Title\n\u{2014}-\nContent here.";
+        $bean = populate_bean($text);
+        $this->assertSame('my-post-title', $bean->slug);
+    }
+
+    public function testPopulateBeanRewritesMangledFenceInStoredBody(): void
+    {
+        $text = "\u{2014}-\ntitle: Hello World\n\u{2014}-\nContent.";
+        $bean = populate_bean($text);
+        $this->assertStringStartsWith("---\n", $bean->body);
+        $this->assertStringNotContainsString("\u{2014}", $bean->body);
+    }
+
+    public function testPopulateBeanNormalisesDoubleEmDashFence(): void
+    {
+        $text = "\u{2014}\u{2014}\ntitle: Double Dash\n\u{2014}\u{2014}\nBody.";
+        $bean = populate_bean($text);
+        $this->assertSame('double-dash', $bean->slug);
+    }
+
+    public function testPopulateBeanLeavesEmDashesInContentUntouched(): void
+    {
+        $text = "A plain status \u{2014} with an em dash in it.";
+        $bean = populate_bean($text);
+        $this->assertSame($text, $bean->body);
+        $this->assertSame('', $bean->slug);
+    }
+
     public function testPopulateBeanSetsSourceUrlFromFeedItem(): void
     {
         $item = $this->createMock(SimplePieItem::class);


### PR DESCRIPTION
iOS "Smart Punctuation" rewrites a typed --- fence into em/en dashes
(e.g. the em-dash variant), which stopped Lamb from recognising the
front-matter delimiter so titles, slugs and other metadata were lost.

normalize_frontmatter_fence() restores a dash-only opening fence and
its matching closing fence to a literal --- before the body is stored,
fixing both YAML parsing and the rendered output. Dashes elsewhere in
the body are left untouched.

https://claude.ai/code/session_01LzGR7vg5NCroPdJLnLxUFR