### PR TITLE
Enqueue in-reply-to target for outbound webmentions

### DIFF
--- a/src/webmention.php
+++ b/src/webmention.php
@@ -271,23 +271,34 @@ function response(int $status, string $body): array
  */
 function extract_outbound_links(string $html): array
 {
-    $own_host = strtolower((string) parse_url(ROOT_URL, PHP_URL_HOST));
     $targets = [];
 
     if (preg_match_all('/<a\b[^>]*\bhref\s*=\s*["\']([^"\']+)["\']/i', $html, $matches)) {
         foreach ($matches[1] as $href) {
             $href = html_entity_decode(trim($href), ENT_QUOTES | ENT_HTML5);
-            if (!is_valid_http_url($href)) {
-                continue;
-            }
-            $host = strtolower((string) parse_url($href, PHP_URL_HOST));
-            if ($host !== '' && $host !== $own_host && !in_array($href, $targets, true)) {
+            if (is_external_http_url($href) && !in_array($href, $targets, true)) {
                 $targets[] = $href;
             }
         }
     }
 
     return $targets;
+}
+
+/**
+ * Whether a URL is an absolute http(s) URL pointing at a host other than ours.
+ *
+ * @param string $url
+ * @return bool
+ */
+function is_external_http_url(string $url): bool
+{
+    if (!is_valid_http_url($url)) {
+        return false;
+    }
+    $own_host = strtolower((string) parse_url(ROOT_URL, PHP_URL_HOST));
+    $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+    return $host !== '' && $host !== $own_host;
 }
 
 /**
@@ -396,7 +407,12 @@ function enqueue_for_post(OODBBean $bean): void
         return;
     }
 
-    enqueue_outbound((int) $bean->id, permalink($bean), (string) ($bean->transformed ?? ''));
+    enqueue_outbound(
+        (int) $bean->id,
+        permalink($bean),
+        (string) ($bean->transformed ?? ''),
+        (string) ($bean->in_reply_to ?? '')
+    );
 }
 
 /**
@@ -406,15 +422,27 @@ function enqueue_for_post(OODBBean $bean): void
  * source+target is left untouched (so receivers are not spammed), while a
  * previously failed row is reset to pending for another attempt.
  *
+ * The reply target (from a post's `in-reply-to` front matter) is treated as an
+ * outbound link even when it does not appear in the body, so replies notify the
+ * parent. It is subject to the same external-host filter as body links.
+ *
  * @param int    $post_id
- * @param string $source  This post's permalink.
- * @param string $html    The post's rendered HTML.
+ * @param string $source   This post's permalink.
+ * @param string $html     The post's rendered HTML.
+ * @param string $reply_to Optional `in-reply-to` target URL.
  * @return int Number of newly created queue rows.
  */
-function enqueue_outbound(int $post_id, string $source, string $html): int
+function enqueue_outbound(int $post_id, string $source, string $html, string $reply_to = ''): int
 {
+    $targets = extract_outbound_links($html);
+
+    $reply_to = trim($reply_to);
+    if ($reply_to !== '' && is_external_http_url($reply_to) && !in_array($reply_to, $targets, true)) {
+        $targets[] = $reply_to;
+    }
+
     $created = 0;
-    foreach (extract_outbound_links($html) as $target) {
+    foreach ($targets as $target) {
         $row = R::findOne('webmentionoutbox', ' source = ? AND target = ? ', [$source, $target]);
         if ($row) {
             if ($row->status === 'failed') {

--- a/tests/Unit/WebmentionSendTest.php
+++ b/tests/Unit/WebmentionSendTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
 use function Lamb\Webmention\discover_endpoint;
+use function Lamb\Webmention\enqueue_for_post;
 use function Lamb\Webmention\enqueue_outbound;
 use function Lamb\Webmention\extract_outbound_links;
 use function Lamb\Webmention\process_outbound;
@@ -143,6 +144,54 @@ class WebmentionSendTest extends TestCase
         enqueue_outbound($this->postId, $source, $html);
         $row = R::findOne('webmentionoutbox');
         $this->assertSame('sent', $row->status);
+    }
+
+    // enqueue_for_post (reply targets) --------------------------------------
+
+    private function dispenseReply(string $transformed, string $replyTo): \RedBeanPHP\OODBBean
+    {
+        $post = R::dispense('post');
+        $post->body = 'A reply';
+        $post->transformed = $transformed;
+        $post->in_reply_to = $replyTo;
+        $post->created = '2026-01-01 00:00:00';
+        $post->updated = '2026-01-01 00:00:00';
+        $post->version = 1;
+        R::store($post);
+
+        return $post;
+    }
+
+    public function testEnqueueForPostQueuesExternalReplyTarget(): void
+    {
+        $target = 'https://other.example/their-post';
+        $post = $this->dispenseReply('<p>A reply with no links</p>', $target);
+
+        enqueue_for_post($post);
+
+        $row = R::findOne('webmentionoutbox', ' target = ? ', [$target]);
+        $this->assertNotNull($row);
+        $this->assertSame('pending', $row->status);
+        $this->assertSame(ROOT_URL . '/status/' . $post->id, $row->source);
+    }
+
+    public function testEnqueueForPostSkipsSameSiteReplyTarget(): void
+    {
+        $post = $this->dispenseReply('<p>No links</p>', ROOT_URL . '/status/1');
+
+        enqueue_for_post($post);
+
+        $this->assertSame(0, R::count('webmentionoutbox'));
+    }
+
+    public function testEnqueueForPostDeduplicatesReplyTargetAlsoInBody(): void
+    {
+        $target = 'https://other.example/their-post';
+        $post = $this->dispenseReply('<p><a href="' . $target . '">link</a></p>', $target);
+
+        enqueue_for_post($post);
+
+        $this->assertSame(1, R::count('webmentionoutbox', ' target = ? ', [$target]));
     }
 
     // process_outbound ------------------------------------------------------


### PR DESCRIPTION
## Problem

A reply post marked with `in-reply-to` front matter never notified its parent. The reply target is stored in the `in_reply_to` column and rendered separately by the theme (`the_reply_context()`), so it never appeared in the `transformed` HTML that `enqueue_for_post()` scanned for outbound links. Nothing was queued in `webmentionoutbox`, so `/_cron` had nothing to send.

## Fix

`enqueue_for_post()` now passes the post's `in_reply_to` value into `enqueue_outbound()`, which treats it as an outbound link even when it does not appear in the body — subject to the **same external-host filter** as body links. Same-site reply targets are still skipped, since received webmentions are author-only today; revisiting that is a one-line change if reader-facing display is added later.

The external-host check is factored into `is_external_http_url()` and reused by `extract_outbound_links()` (behavior unchanged).

## Tests

Added three `enqueue_for_post()` unit tests under red-green TDD:

- `testEnqueueForPostQueuesExternalReplyTarget` — external reply target with no body links is queued.
- `testEnqueueForPostSkipsSameSiteReplyTarget` — same-host reply target is not queued.
- `testEnqueueForPostDeduplicatesReplyTargetAlsoInBody` — reply URL also in body produces one row.

Full unit suite green (696 tests, 1051 assertions); `phpcs` and `phpstan` clean.

https://claude.ai/code/session_01E8tcQR4hHFdaYqbGp9gEhX

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8tcQR4hHFdaYqbGp9gEhX)_