### PR TITLE
docs: explain what gets imported when a feed is first added

### DIFF
--- a/docs/cross-posting.md
+++ b/docs/cross-posting.md
@@ -30,6 +30,12 @@ to avoid spamming the endpoint.
 
 It is your responsibility to [call the `_cron` endpoint]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}), unlike other CMSes you might be used to.
 
+## What gets imported when you add a feed
+
+The first cron run after adding a feed imports every item currently present in the feed itself — typically the publisher's most recent 10–20 entries, depending on how many they include. It does not reach back through the publisher's full archive.
+
+After that first run, only items published or updated since the previous run are imported.
+
 ## Related
 
 * [Cron Scheduled Tasks]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}): How to call the `/_cron` endpoint periodically.


### PR DESCRIPTION
The cross-posting docs page didn't say whether adding a feed pulls in existing items or only items published afterwards.

Adds a short section: the first cron run imports every item currently present in the feed document (typically the publisher's most recent 10–20 entries, not the full archive); subsequent runs only import items published or updated since the previous run. Matches the behaviour in `src/network.php` (per-feed `last_processed_date` starts at 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)