### PR TITLE
chore: raise PHPStan to level 5 and fix flagged issues

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 3
+    level: 5
     parallel:
         maximumNumberOfProcesses: 1
     paths:
@@ -14,3 +14,7 @@ parameters:
         - phpstan-bootstrap.php
     universalObjectCratesClasses:
         - RedBeanPHP\OODBBean
+    # ROOT_URL is derived from site config at runtime; don't constant-fold the
+    # placeholder value defined in phpstan-bootstrap.php.
+    dynamicConstantNames:
+        - ROOT_URL

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -108,9 +108,6 @@ class LambMicropubAdapter extends MicropubAdapter
         if (strtolower($request->getMethod()) === 'get' && ($request->getQueryParams()['q'] ?? '') === 'config') {
             $this->request = $request;
             $configResult = $this->configurationQueryCallback($request->getQueryParams());
-            if ($configResult instanceof \Psr\Http\Message\ResponseInterface) {
-                return $configResult;
-            }
             return new Response(200, ['content-type' => 'application/json'], json_encode($configResult));
         }
 

--- a/src/network.php
+++ b/src/network.php
@@ -119,10 +119,6 @@ function update_item(SimplePieItem $item, string $name): void
         return;
     }
     $bean = prepare_item($item, $name, $bean);
-    if (!$bean) {
-        // Record not found, should not happen as we already checked for existence.
-        return;
-    }
     $bean->updated = $item->get_updated_date("Y-m-d H:i:s");
 
     try {
@@ -132,28 +128,17 @@ function update_item(SimplePieItem $item, string $name): void
     }
 }
 
-function prepare_item(SimplePieItem $item, string $name, ?OODBBean $bean = null): ?OODBBean
+function prepare_item(SimplePieItem $item, string $name, ?OODBBean $bean = null): OODBBean
 {
     $contents = get_structured_content($item, $name);
-    $bean = populate_bean($contents, $item, $name, $bean);
-    if ($bean === null) {
-        $_SESSION['flash'][] = 'Failed to save post';
 
-        return null;
-    }
-
-    return $bean;
+    return populate_bean($contents, $item, $name, $bean);
 }
 
 function create_item(SimplePieItem $item, string $name)
 {
     $contents = get_structured_content($item, $name);
     $bean = populate_bean($contents, $item, $name);
-    if ($bean === null) {
-        $_SESSION['flash'][] = 'Failed to save post';
-
-        return;
-    }
 
     try {
         $id = R::store($bean);

--- a/src/post.php
+++ b/src/post.php
@@ -17,10 +17,10 @@ use function Lamb\parse_bean;
  * @param Item|null $feed_item An optional feed item to extract creation date and ID from.
  * @param string|null $feed_name An optional feed name to prefix the slug and associate with the bean.
  * @param OODBBean|null $bean An optional existing bean to populate. If null, a new 'post' bean is dispensed.
- * @return OODBBean|null The populated bean instance, or null if input is insufficient.
+ * @return OODBBean The populated bean instance.
  * @noinspection CallableParameterUseCaseInTypeContextInspection
  */
-function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name = null, ?OODBBean $bean = null): ?OODBBean
+function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name = null, ?OODBBean $bean = null): OODBBean
 {
     global $config;
 

--- a/src/response.php
+++ b/src/response.php
@@ -10,7 +10,7 @@ use RedBeanPHP\RedException\SQL;
 
 use function Lamb\parse_bean;
 
-define('LOGIN_PASSWORD', getenv("LAMB_LOGIN_PASSWORD"));
+define('LOGIN_PASSWORD', getenv("LAMB_LOGIN_PASSWORD") ?: '');
 
 // IMAGE_FILES is defined in constants.php
 

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -17,10 +17,10 @@ use Random\RandomException;
  * If the submitted password is incorrect, it sets a flash message and redirects to the root URL.
  * If the login is successful, it sets the SESSION_LOGIN session variable to true, regenerates the session ID, and redirects to the specified URL.
  *
- * @return array|null
+ * @return array
  * @throws RandomException
  */
-function redirect_login(): ?array
+function redirect_login(): array
 {
     // The login page needs a session for the CSRF token and any flash messages,
     // even for an otherwise-anonymous visitor who carries no session cookie yet.

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -38,10 +38,6 @@ function redirect_created(): void
     }
 
     $bean = populate_bean($contents);
-    if ($bean === null) {
-        $_SESSION['flash'][] = 'Failed to create status: Invalid content.';
-        return;
-    }
 
     try {
         $id = R::store($bean);

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -120,7 +120,7 @@ function target_post_id(string $target): ?int
 {
     $root_host = parse_url(ROOT_URL, PHP_URL_HOST);
     $target_host = parse_url($target, PHP_URL_HOST);
-    if ($target_host === null || $root_host === null || strcasecmp($target_host, $root_host) !== 0) {
+    if (!is_string($target_host) || !is_string($root_host) || strcasecmp($target_host, $root_host) !== 0) {
         return null;
     }
 


### PR DESCRIPTION
Bumps PHPStan from level 3 to 5. The codebase was only a handful of errors away, and some were real signal.

- `phpstan.neon`: level 5; `dynamicConstantNames: ROOT_URL` so the runtime-config-derived constant isn't constant-folded from the analysis bootstrap placeholder
- `src/response.php`: `LOGIN_PASSWORD` falls back to `''` when the env var is unset (was `false`, silently coerced)
- `src/response/auth.php`: `redirect_login(): array` — never returned null
- `src/post.php`: `populate_bean(): OODBBean` — never returned null
- `src/network.php`, `src/response/posts.php`: removed the now-dead null checks on `populate_bean`/`prepare_item`
- `src/micropub.php`: removed dead `instanceof ResponseInterface` branch (our override always returns array)
- `src/webmention.php`: host checks use `is_string()`, also covering `parse_url()` returning `false` on malformed URLs

No behaviour change. `composer analyse` clean, `composer lint` clean, 712 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)