### PR TITLE
Add expiring preview tokens to Micropub draft/scheduled Location URLs

### DIFF
--- a/docs/drafts.md
+++ b/docs/drafts.md
@@ -15,4 +15,5 @@ Feed ingested posts are saved as drafts by default to prioritize authorship over
 - [Post Types]({{ site.baseurl }}{% link post-types.md %}): Front-matter is used to set `draft: true`.
 - [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Hide a post until a future `created` date.
 - [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %}): Feed ingestion that produces drafts.
+- [Micropub]({{ site.baseurl }}{% link micropub.md %}): Drafts created via Micropub get a 24-hour preview link.
 - [Cron Scheduled Tasks]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}): The cron endpoint triggers feed ingestion.

--- a/docs/micropub.md
+++ b/docs/micropub.md
@@ -49,6 +49,10 @@ token_endpoint = https://token.example.com/token
 
 A Micropub `h-entry` with a `content` property creates a status post (no title, no slug). If a `name` property is also present, it creates a titled post with a slug derived from the title.
 
+## Draft and scheduled post previews
+
+Posts created with `post-status: draft` or a future `published` date are not publicly visible, so their permalink returns a 404 to anyone who isn't logged in. Because Micropub clients open the post URL right after creating it, Lamb appends a secret preview token to the URL it returns (`?preview=…`). That link shows the unpublished post to anyone who has it — without logging in — and expires after 24 hours. The plain permalink (without the token) stays hidden until the post is published.
+
 ## How to test
 
 Visit [MicroPub Rocks](https://micropub.rocks/) and enter your site. Lamb's implementation report is available at [micropub.rocks/implementation-reports/servers/962](https://micropub.rocks/implementation-reports/servers/962/GYKIHp3O03m9vNil9Qcq).

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -315,6 +315,34 @@ function is_visible(OODBBean $post): bool
 }
 
 /**
+ * Returns true when the supplied preview token grants access to an
+ * unpublished post's permalink.
+ *
+ * Micropub createCallback appends ?preview=<token> to the Location header for
+ * draft/scheduled posts so the creating client can show the post it just made
+ * without a Lamb session (see issue #285). Tokens are random per-post secrets
+ * with an expiry; deleted posts never match.
+ *
+ * @param OODBBean    $post  The post to inspect.
+ * @param string|null $token The supplied preview token (e.g. $_GET['preview']).
+ * @return bool
+ */
+function preview_token_valid(OODBBean $post, ?string $token): bool
+{
+    if (empty($post->id) || $post->deleted == 1) {
+        return false;
+    }
+    if (empty($post->preview_token) || $token === null || $token === '') {
+        return false;
+    }
+    if (empty($post->preview_token_expires) || strtotime($post->preview_token_expires) < time()) {
+        return false;
+    }
+
+    return hash_equals((string) $post->preview_token, $token);
+}
+
+/**
  * Checks if a post with the given slug exists in the database.
  *
  * @param string $lookup The slug of the post to look up.
@@ -324,7 +352,11 @@ function is_visible(OODBBean $post): bool
 function post_has_slug(string $lookup): string|null
 {
     $post = R::findOne('post', ' slug = ? ', [$lookup]);
-    if ($post === null || $post->id === 0 || $post->draft == 1 || is_scheduled($post)) {
+    if ($post === null || $post->id === 0) {
+        return '';
+    }
+    $unpublished = $post->draft == 1 || is_scheduled($post);
+    if ($unpublished && !preview_token_valid($post, $_GET['preview'] ?? null)) {
         return '';
     }
 

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -11,6 +11,7 @@ use RedBeanPHP\R;
 use Taproot\Micropub\MicropubAdapter;
 
 use function Lamb\get_tags;
+use function Lamb\is_scheduled;
 use function Lamb\parse_bean;
 use function Lamb\permalink;
 use function Lamb\Post\parse_matter;
@@ -234,11 +235,25 @@ class LambMicropubAdapter extends MicropubAdapter
         // it is never a draft. Visibility is driven by the future `created` date set
         // above, so it stays hidden from public listings until that time arrives.
 
+        // Unpublished posts 404 anonymously (#284), but clients GET the Location
+        // URL we return to show the just-created post. Attach a short-lived
+        // preview token so that URL works without a Lamb session (#285).
+        $needs_preview = $bean->draft == 1 || is_scheduled($bean);
+        if ($needs_preview) {
+            $bean->preview_token = bin2hex(random_bytes(16));
+            $bean->preview_token_expires = date('Y-m-d H:i:s', time() + 86400);
+        }
+
         R::store($bean);
 
         \Lamb\Webmention\enqueue_for_post($bean);
 
-        return permalink($bean);
+        $location = permalink($bean);
+        if ($needs_preview) {
+            $location .= '?preview=' . $bean->preview_token;
+        }
+
+        return $location;
     }
 
     /**

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -227,7 +227,7 @@ function respond_status(array $args): array
 {
     [$id] = $args;
     $bean = R::load('post', (int)$id);
-    if (!\Lamb\is_visible($bean)) {
+    if (!\Lamb\is_visible($bean) && !\Lamb\preview_token_valid($bean, $_GET['preview'] ?? null)) {
         return respond_404([], true);
     }
 
@@ -271,7 +271,7 @@ function respond_post(array $args): array
 {
     [$slug] = $args;
     $post = R::findOne('post', ' slug = ? ', [$slug]);
-    if ($post === null || !\Lamb\is_visible($post)) {
+    if ($post === null || (!\Lamb\is_visible($post) && !\Lamb\preview_token_valid($post, $_GET['preview'] ?? null))) {
         return respond_404([]);
     }
     $data['posts'] = [$post];

--- a/tests/Unit/PreviewTokenTest.php
+++ b/tests/Unit/PreviewTokenTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+use Lamb\Micropub\LambMicropubAdapter;
+
+use function Lamb\preview_token_valid;
+use function Lamb\Response\respond_post;
+use function Lamb\Response\respond_status;
+
+class PreviewTokenTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+
+        // Seed schema columns so WHERE/visibility filters work regardless of test order.
+        $schema = R::dispense('post');
+        $schema->draft                 = 0;
+        $schema->deleted               = 0;
+        $schema->created               = date('Y-m-d H:i:s');
+        $schema->slug                  = '';
+        $schema->preview_token         = '';
+        $schema->preview_token_expires = '';
+        R::store($schema);
+        R::exec('DELETE FROM post');
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        global $config;
+        $config = ['site_title' => 'Test Blog', 'posts_per_page' => 10];
+
+        $_SESSION = [];
+        $_GET = [];
+    }
+
+    protected function tearDown(): void
+    {
+        R::exec('DELETE FROM post');
+        $_SESSION = [];
+        $_GET = [];
+    }
+
+    private function makePost(array $fields): \RedBeanPHP\OODBBean
+    {
+        $bean = R::dispense('post');
+        $bean->body                  = $fields['body'] ?? 'Body';
+        $bean->title                 = $fields['title'] ?? 'Title';
+        $bean->transformed           = '<p>Body</p>';
+        $bean->version               = 1;
+        $bean->draft                 = $fields['draft'] ?? 0;
+        $bean->deleted               = $fields['deleted'] ?? 0;
+        $bean->slug                  = $fields['slug'] ?? '';
+        $bean->created               = $fields['created'] ?? date('Y-m-d H:i:s');
+        $bean->preview_token         = $fields['preview_token'] ?? '';
+        $bean->preview_token_expires = $fields['preview_token_expires'] ?? '';
+        R::store($bean);
+        return $bean;
+    }
+
+    // ---- preview_token_valid() predicate -----------------------------------
+
+    public function testValidUnexpiredTokenOnDraftIsAccepted(): void
+    {
+        $bean = $this->makePost([
+            'draft'                 => 1,
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        $this->assertTrue(preview_token_valid($bean, 'secret-token'));
+    }
+
+    public function testWrongTokenIsRejected(): void
+    {
+        $bean = $this->makePost([
+            'draft'                 => 1,
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        $this->assertFalse(preview_token_valid($bean, 'wrong-token'));
+    }
+
+    public function testMissingTokenIsRejected(): void
+    {
+        $bean = $this->makePost([
+            'draft'                 => 1,
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        $this->assertFalse(preview_token_valid($bean, null));
+        $this->assertFalse(preview_token_valid($bean, ''));
+    }
+
+    public function testPostWithoutStoredTokenRejectsEmptyToken(): void
+    {
+        $bean = $this->makePost(['draft' => 1]);
+        $this->assertFalse(preview_token_valid($bean, ''), 'Empty stored token must not match empty supplied token');
+        $this->assertFalse(preview_token_valid($bean, null));
+    }
+
+    public function testExpiredTokenIsRejected(): void
+    {
+        $bean = $this->makePost([
+            'draft'                 => 1,
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() - 60),
+        ]);
+        $this->assertFalse(preview_token_valid($bean, 'secret-token'));
+    }
+
+    public function testDeletedPostRejectsValidToken(): void
+    {
+        $bean = $this->makePost([
+            'draft'                 => 1,
+            'deleted'               => 1,
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        $this->assertFalse(preview_token_valid($bean, 'secret-token'));
+    }
+
+    // ---- respond_status (/status/<id>?preview=…) ---------------------------
+
+    public function testRespondStatusShowsDraftWithValidToken(): void
+    {
+        $bean = $this->makePost([
+            'draft'                 => 1,
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        $_GET['preview'] = 'secret-token';
+        $data = respond_status([$bean->id]);
+        $this->assertArrayHasKey('posts', $data);
+        $this->assertCount(1, $data['posts']);
+    }
+
+    public function testRespondStatusHidesDraftWithWrongToken(): void
+    {
+        $bean = $this->makePost([
+            'draft'                 => 1,
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        $_GET['preview'] = 'wrong-token';
+        $data = respond_status([$bean->id]);
+        $this->assertSame('404', $data['action'] ?? null);
+    }
+
+    public function testRespondStatusHidesDraftWithExpiredToken(): void
+    {
+        $bean = $this->makePost([
+            'draft'                 => 1,
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() - 60),
+        ]);
+        $_GET['preview'] = 'secret-token';
+        $data = respond_status([$bean->id]);
+        $this->assertSame('404', $data['action'] ?? null);
+    }
+
+    // ---- respond_post (slug?preview=…) --------------------------------------
+
+    public function testRespondPostShowsDraftWithValidTokenBySlug(): void
+    {
+        $this->makePost([
+            'draft'                 => 1,
+            'slug'                  => 'my-preview-draft',
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        $_GET['preview'] = 'secret-token';
+        $data = respond_post(['my-preview-draft']);
+        $this->assertArrayHasKey('posts', $data);
+        $this->assertCount(1, $data['posts']);
+    }
+
+    public function testPostHasSlugResolvesDraftWithValidToken(): void
+    {
+        $this->makePost([
+            'draft'                 => 1,
+            'slug'                  => 'routed-preview-draft',
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+
+        $this->assertSame('', \Lamb\post_has_slug('routed-preview-draft'), 'Draft slug must not resolve without token');
+
+        $_GET['preview'] = 'secret-token';
+        $this->assertSame(
+            'routed-preview-draft',
+            \Lamb\post_has_slug('routed-preview-draft'),
+            'Draft slug resolves when a valid preview token is supplied'
+        );
+    }
+
+    // ---- Micropub createCallback Location URL --------------------------------
+
+    public function testCreateCallbackAppendsPreviewTokenForDraft(): void
+    {
+        $adapter = new LambMicropubAdapter();
+        $data = [
+            'type' => ['h-entry'],
+            'properties' => [
+                'content'     => ['A tokenised draft'],
+                'post-status' => ['draft'],
+            ],
+        ];
+        $location = $adapter->createCallback($data, []);
+        $this->assertIsString($location);
+
+        $post = R::findOne('post', ' body = ? ', ['A tokenised draft']);
+        $this->assertNotNull($post);
+        $this->assertNotEmpty($post->preview_token, 'Draft created via Micropub gets a preview token');
+        $this->assertStringContainsString('?preview=' . $post->preview_token, $location);
+
+        $expires = strtotime($post->preview_token_expires);
+        $this->assertGreaterThan(time(), $expires, 'Preview token expiry is in the future');
+        $this->assertLessThanOrEqual(time() + 86400, $expires, 'Preview token expires within 24 hours');
+    }
+
+    public function testCreateCallbackAppendsPreviewTokenForScheduledPost(): void
+    {
+        $adapter = new LambMicropubAdapter();
+        $data = [
+            'type' => ['h-entry'],
+            'properties' => [
+                'content'   => ['A tokenised scheduled post'],
+                'published' => [date('c', time() + 86400)],
+            ],
+        ];
+        $location = $adapter->createCallback($data, []);
+        $this->assertIsString($location);
+
+        $post = R::findOne('post', ' body LIKE ? ', ['%A tokenised scheduled post%']);
+        $this->assertNotNull($post);
+        $this->assertNotEmpty($post->preview_token, 'Scheduled post created via Micropub gets a preview token');
+        $this->assertStringContainsString('?preview=' . $post->preview_token, $location);
+    }
+
+    public function testCreateCallbackReturnsPlainPermalinkForPublishedPost(): void
+    {
+        $adapter = new LambMicropubAdapter();
+        $data = [
+            'type' => ['h-entry'],
+            'properties' => [
+                'content' => ['A plain published post'],
+            ],
+        ];
+        $location = $adapter->createCallback($data, []);
+        $this->assertIsString($location);
+        $this->assertStringNotContainsString('preview=', $location);
+
+        $post = R::findOne('post', ' body = ? ', ['A plain published post']);
+        $this->assertNotNull($post);
+        $this->assertEmpty($post->preview_token, 'Published posts get no preview token');
+    }
+}


### PR DESCRIPTION
Fixes #285.

## Problem

Micropub clients GET the `Location` URL returned after a create. Since #284, drafts and scheduled posts 404 anonymously, so clients (confirmed with iA Writer) get a dead link to the post they just created. `/status/<id>` is guessable, so simply relaxing the gate was not an option.

## Solution

- `createCallback` generates a per-post secret (`random_bytes(16)` → hex) for **draft and scheduled** posts and returns `Location: <permalink>?preview=<token>`.
- Tokens expire after **24 hours** (opinionated default, no config).
- `Lamb\preview_token_valid()` validates with `hash_equals`; deleted posts never match.
- `respond_status`, `respond_post`, and `post_has_slug` accept a valid token as an alternative to being logged in.
- Published posts ignore the param; anonymous visibility rules from #284 are otherwise unchanged.

## Testing

- Red-green TDD: 14 new unit tests in `tests/Unit/PreviewTokenTest.php` (token predicate, route handlers, slug routing, Location URL shape, expiry).
- Full suite green: 726 tests, 1105 assertions. `composer lint` + `composer analyse` clean.
- Docs: new "Draft and scheduled post previews" section in `docs/micropub.md`, cross-link from `docs/drafts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
