### PR TITLE
Add WebSub support: advertise hub in feeds and ping on publish

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
       "src/theme/formatting.php",
       "src/theme/meta.php",
       "src/micropub.php",
-      "src/webmention.php"
+      "src/webmention.php",
+      "src/websub.php"
     ]
   },
   "autoload-dev": {

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -43,10 +43,11 @@ included when its file exists, so the feed never points at a missing image.
 Feed readers normally poll for changes. With [WebSub](https://www.w3.org/TR/websub/),
 subscribers can instead be pushed new posts the moment you publish.
 
-Set a hub in the [site configuration]({{ site.baseurl }}{% link site-configuration.md %}):
+Set one or more hubs (comma-separated) in the
+[site configuration]({{ site.baseurl }}{% link site-configuration.md %}):
 
 ```
-websub_hub = https://hub.example.com/
+websub_hubs = https://hub.example.com/
 ```
 
 With a hub configured, Lamb:
@@ -61,5 +62,5 @@ Drafts, scheduled posts, and cross-posted feed items do not trigger pings.
 ## Related
 
 * [Cross-posting From Feeds]({{ site.baseurl }}{% link cross-posting.md %}) — consuming external feeds into Lamb
-* [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}) — the `websub_hub` setting
+* [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}) — the `websub_hubs` setting
 * [Themes]({{ site.baseurl }}{% link themes.md %}) — overriding `feed.php` / `feed_json.php` in a custom theme

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -38,7 +38,27 @@ The RFC recommends these aspect ratios but does not mandate pixel sizes. Drop
 either file into the `src/` directory (the web root). Each element is only
 included when its file exists, so the feed never points at a missing image.
 
+## Real-time push (WebSub)
+
+Feed readers normally poll for changes. With [WebSub](https://www.w3.org/TR/websub/),
+subscribers can instead be pushed new posts the moment you publish.
+
+Set a hub in the [site configuration]({{ site.baseurl }}{% link site-configuration.md %}):
+
+```
+websub_hub = https://pubsubhubbub.superfeedr.com/
+```
+
+With a hub configured, Lamb:
+
+* advertises it in the Atom feed (`<link rel="hub">`) and the JSON Feed (`hubs` field), so WebSub-aware readers subscribe automatically;
+* pings the hub whenever a post is published or updated (from the web interface or via Micropub), so it fetches the updated `/feed` and `/feed.json` and pushes them to subscribers.
+
+Any public hub works — [Superfeedr](https://pubsubhubbub.superfeedr.com/) is a free
+option. Drafts, scheduled posts, and cross-posted feed items do not trigger pings.
+
 ## Related
 
 * [Cross-posting From Feeds]({{ site.baseurl }}{% link cross-posting.md %}) — consuming external feeds into Lamb
+* [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}) — the `websub_hub` setting
 * [Themes]({{ site.baseurl }}{% link themes.md %}) — overriding `feed.php` / `feed_json.php` in a custom theme

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -46,7 +46,7 @@ subscribers can instead be pushed new posts the moment you publish.
 Set a hub in the [site configuration]({{ site.baseurl }}{% link site-configuration.md %}):
 
 ```
-websub_hub = https://pubsubhubbub.superfeedr.com/
+websub_hub = https://hub.example.com/
 ```
 
 With a hub configured, Lamb:
@@ -54,8 +54,9 @@ With a hub configured, Lamb:
 * advertises it in the Atom feed (`<link rel="hub">`) and the JSON Feed (`hubs` field), so WebSub-aware readers subscribe automatically;
 * pings the hub whenever a post is published or updated (from the web interface or via Micropub), so it fetches the updated `/feed` and `/feed.json` and pushes them to subscribers.
 
-Any public hub works — [Superfeedr](https://pubsubhubbub.superfeedr.com/) is a free
-option. Drafts, scheduled posts, and cross-posted feed items do not trigger pings.
+Any public hub works — the IndieWeb wiki keeps a
+[list of hubs](https://indieweb.org/WebSub#Hubs) to choose from.
+Drafts, scheduled posts, and cross-posted feed items do not trigger pings.
 
 ## Related
 

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -43,7 +43,7 @@ token_endpoint = https://tokens.indieauth.com/token
 
 ;; WebSub hub used to push new posts to feed subscribers in real time.
 ;; The hub is advertised in the Atom and JSON feeds, and pinged when you publish.
-;websub_hub = https://pubsubhubbub.superfeedr.com/
+;websub_hub = https://hub.example.com/
 
 [menu_items]
 ;; Add <label>=<url> entries. URL can be:

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -41,6 +41,10 @@ token_endpoint = https://tokens.indieauth.com/token
 ;; relative path on another site. Useful for archived or under-construction sites.
 ;404_fallback = https://my.oldsite.com
 
+;; WebSub hub used to push new posts to feed subscribers in real time.
+;; The hub is advertised in the Atom and JSON feeds, and pinged when you publish.
+;websub_hub = https://pubsubhubbub.superfeedr.com/
+
 [menu_items]
 ;; Add <label>=<url> entries. URL can be:
 ;;   - A post slug, which hides the post from the feed and timeline
@@ -80,6 +84,7 @@ token_endpoint = https://tokens.indieauth.com/token
 
 * [Setting up Cross-Posting]({{ site.baseurl }}{% link cross-posting.md %}#setup) requires site configuration changes.
 * [Drafts]({{ site.baseurl }}{% link drafts.md %}): The `feeds_draft` setting controls whether ingested posts are published or saved as drafts.
+* [Feeds]({{ site.baseurl }}{% link feeds.md %}): The `websub_hub` setting enables real-time push to feed subscribers.
 * [Menu Items]({{ site.baseurl }}{% link menu-items.md %})
 * [Micropub]({{ site.baseurl }}{% link micropub.md %}): The `[me]`, `authorization_endpoint`, and `token_endpoint` settings enable Micropub publishing.
 * [Preconnect]({{ site.baseurl }}{% link preconnect.md %})

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -41,9 +41,10 @@ token_endpoint = https://tokens.indieauth.com/token
 ;; relative path on another site. Useful for archived or under-construction sites.
 ;404_fallback = https://my.oldsite.com
 
-;; WebSub hub used to push new posts to feed subscribers in real time.
-;; The hub is advertised in the Atom and JSON feeds, and pinged when you publish.
-;websub_hub = https://hub.example.com/
+;; WebSub hubs used to push new posts to feed subscribers in real time.
+;; Hubs are advertised in the Atom and JSON feeds, and pinged when you publish.
+;; Separate multiple hubs with commas.
+;websub_hubs = https://hub.example.com/
 
 [menu_items]
 ;; Add <label>=<url> entries. URL can be:
@@ -84,7 +85,7 @@ token_endpoint = https://tokens.indieauth.com/token
 
 * [Setting up Cross-Posting]({{ site.baseurl }}{% link cross-posting.md %}#setup) requires site configuration changes.
 * [Drafts]({{ site.baseurl }}{% link drafts.md %}): The `feeds_draft` setting controls whether ingested posts are published or saved as drafts.
-* [Feeds]({{ site.baseurl }}{% link feeds.md %}): The `websub_hub` setting enables real-time push to feed subscribers.
+* [Feeds]({{ site.baseurl }}{% link feeds.md %}): The `websub_hubs` setting enables real-time push to feed subscribers.
 * [Menu Items]({{ site.baseurl }}{% link menu-items.md %})
 * [Micropub]({{ site.baseurl }}{% link micropub.md %}): The `[me]`, `authorization_endpoint`, and `token_endpoint` settings enable Micropub publishing.
 * [Preconnect]({{ site.baseurl }}{% link preconnect.md %})

--- a/src/config.php
+++ b/src/config.php
@@ -50,7 +50,7 @@ token_endpoint = https://tokens.indieauth.com/token
 
 ;; WebSub hub used to push new posts to feed subscribers in real time.
 ;; The hub is advertised in the Atom and JSON feeds, and pinged when you publish.
-;websub_hub = https://pubsubhubbub.superfeedr.com/
+;websub_hub = https://hub.example.com/
 
 [menu_items]
 ;; Add <label>=<url> entries here where URL is either:

--- a/src/config.php
+++ b/src/config.php
@@ -48,6 +48,10 @@ token_endpoint = https://tokens.indieauth.com/token
 ;; Useful where old content is archived to an archive site, or the lamb blog is still under construction but public.
 ;404_fallback = https://my.oldsite.com
 
+;; WebSub hub used to push new posts to feed subscribers in real time.
+;; The hub is advertised in the Atom and JSON feeds, and pinged when you publish.
+;websub_hub = https://pubsubhubbub.superfeedr.com/
+
 [menu_items]
 ;; Add <label>=<url> entries here where URL is either:
 ;;   - Slugs of an existing post, which is then hidden in the feed and the timeline (

--- a/src/config.php
+++ b/src/config.php
@@ -48,9 +48,10 @@ token_endpoint = https://tokens.indieauth.com/token
 ;; Useful where old content is archived to an archive site, or the lamb blog is still under construction but public.
 ;404_fallback = https://my.oldsite.com
 
-;; WebSub hub used to push new posts to feed subscribers in real time.
-;; The hub is advertised in the Atom and JSON feeds, and pinged when you publish.
-;websub_hub = https://hub.example.com/
+;; WebSub hubs used to push new posts to feed subscribers in real time.
+;; Hubs are advertised in the Atom and JSON feeds, and pinged when you publish.
+;; Separate multiple hubs with commas.
+;websub_hubs = https://hub.example.com/
 
 [menu_items]
 ;; Add <label>=<url> entries here where URL is either:

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -247,6 +247,7 @@ class LambMicropubAdapter extends MicropubAdapter
         R::store($bean);
 
         \Lamb\Webmention\enqueue_for_post($bean);
+        \Lamb\Websub\ping_for_post($bean);
 
         $location = permalink($bean);
         if ($needs_preview) {
@@ -357,6 +358,7 @@ class LambMicropubAdapter extends MicropubAdapter
         R::store($bean);
 
         \Lamb\Webmention\enqueue_for_post($bean);
+        \Lamb\Websub\ping_for_post($bean);
 
         return true;
     }

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -58,6 +58,7 @@ function redirect_created(): void
         $_SESSION['flash'][] = 'Failed to save: ' . $e->getMessage();
     }
     \Lamb\Webmention\enqueue_for_post($bean);
+    \Lamb\Websub\ping_for_post($bean);
     redirect_uri('/');
 }
 
@@ -211,6 +212,7 @@ function redirect_edited(): void
     }
 
     \Lamb\Webmention\enqueue_for_post($bean);
+    \Lamb\Websub\ping_for_post($bean);
 
     $redirect = $_SESSION['edit-referrer'];
     unset($_SESSION['edit-referrer']);

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -37,6 +37,14 @@ $Link = $Xml->addChild('atom:link');
 $Link->addAttribute('rel', 'self');
 $Link->addAttribute('href', escape($channel_link));
 
+// WebSub: advertise the configured hub so subscribers can get real-time pushes.
+$websub_hub = trim((string) ($config['websub_hub'] ?? ''));
+if ($websub_hub !== '') {
+    $Hub = $Xml->addChild('link');
+    $Hub->addAttribute('rel', 'hub');
+    $Hub->addAttribute('href', escape($websub_hub));
+}
+
 $Author = $Xml->addChild('author');
 $Author->addChild('name', escape($config['author_name']));
 $Author->addChild('uri', ROOT_URL);

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -37,9 +37,8 @@ $Link = $Xml->addChild('atom:link');
 $Link->addAttribute('rel', 'self');
 $Link->addAttribute('href', escape($channel_link));
 
-// WebSub: advertise the configured hub so subscribers can get real-time pushes.
-$websub_hub = trim((string) ($config['websub_hub'] ?? ''));
-if ($websub_hub !== '') {
+// WebSub: advertise the configured hubs so subscribers can get real-time pushes.
+foreach (Lamb\Websub\hub_urls($config) as $websub_hub) {
     $Hub = $Xml->addChild('link');
     $Hub->addAttribute('rel', 'hub');
     $Hub->addAttribute('href', escape($websub_hub));

--- a/src/themes/base/feed_json.php
+++ b/src/themes/base/feed_json.php
@@ -20,6 +20,14 @@ $feed = [
     'items'         => [],
 ];
 
+// WebSub: advertise the configured hub so subscribers can get real-time pushes.
+$websub_hub = trim((string) ($config['websub_hub'] ?? ''));
+if ($websub_hub !== '') {
+    $feed['hubs'] = [
+        ['type' => 'WebSub', 'url' => $websub_hub],
+    ];
+}
+
 foreach ($data['posts'] as $bean) {
     $url = Lamb\permalink($bean);
     $item = [

--- a/src/themes/base/feed_json.php
+++ b/src/themes/base/feed_json.php
@@ -20,12 +20,13 @@ $feed = [
     'items'         => [],
 ];
 
-// WebSub: advertise the configured hub so subscribers can get real-time pushes.
-$websub_hub = trim((string) ($config['websub_hub'] ?? ''));
-if ($websub_hub !== '') {
-    $feed['hubs'] = [
-        ['type' => 'WebSub', 'url' => $websub_hub],
-    ];
+// WebSub: advertise the configured hubs so subscribers can get real-time pushes.
+$websub_hubs = \Lamb\Websub\hub_urls($config);
+if ($websub_hubs !== []) {
+    $feed['hubs'] = array_map(
+        fn($hub) => ['type' => 'WebSub', 'url' => $hub],
+        $websub_hubs
+    );
 }
 
 foreach ($data['posts'] as $bean) {

--- a/src/websub.php
+++ b/src/websub.php
@@ -1,0 +1,112 @@
+<?php
+
+/** @noinspection PhpUnused */
+
+namespace Lamb\Websub;
+
+use RedBeanPHP\OODBBean;
+
+use const ROOT_URL;
+
+/**
+ * Seconds before a hub ping is abandoned.
+ */
+const WEBSUB_PING_TIMEOUT = 5;
+
+/**
+ * The configured WebSub hub URL, or '' when none is set.
+ *
+ * @param array|null $config Config array; defaults to the global config.
+ * @return string
+ */
+function hub_url(?array $config = null): string
+{
+    if ($config === null) {
+        global $config;
+    }
+    return trim((string) (($config ?? [])['websub_hub'] ?? ''));
+}
+
+/**
+ * Notify the configured hub that the site's feeds have new content.
+ *
+ * Sends one `hub.mode=publish` ping per feed URL (Atom and JSON). A no-op
+ * when no hub is configured. The sender is injectable for testing; in
+ * production it defaults to {@see send_ping}.
+ *
+ * @param array|null    $config Config array; defaults to the global config.
+ * @param callable|null $sender fn(string $hub, string $topic): int (HTTP status).
+ * @return array<string,int> Map of topic URL → HTTP status code.
+ */
+function ping_hub(?array $config = null, ?callable $sender = null): array
+{
+    $hub = hub_url($config);
+    if ($hub === '') {
+        return [];
+    }
+
+    $sender ??= __NAMESPACE__ . '\\send_ping';
+
+    $results = [];
+    foreach ([ROOT_URL . '/feed', ROOT_URL . '/feed.json'] as $topic) {
+        $results[$topic] = (int) $sender($hub, $topic);
+    }
+    return $results;
+}
+
+/**
+ * Ping the hub for a freshly saved post, if it is eligible.
+ *
+ * Skips ingested feed items, drafts, and future-dated scheduled posts — the
+ * same eligibility rules as outbound webmentions.
+ *
+ * @param OODBBean      $bean   A stored post bean.
+ * @param array|null    $config Config array; defaults to the global config.
+ * @param callable|null $sender Injectable sender, see {@see ping_hub}.
+ * @return void
+ */
+function ping_for_post(OODBBean $bean, ?array $config = null, ?callable $sender = null): void
+{
+    if (!$bean->id || !empty($bean->feed_name) || !empty($bean->draft)) {
+        return;
+    }
+    if (!empty($bean->created) && strtotime((string) $bean->created) > time()) {
+        return;
+    }
+
+    ping_hub($config, $sender);
+}
+
+/**
+ * POST a publish notification to the hub and return the HTTP status code.
+ *
+ * @param string $hub   The hub endpoint URL.
+ * @param string $topic The feed URL that changed.
+ * @return int HTTP status code, or 0 on transport failure.
+ */
+function send_ping(string $hub, string $topic): int
+{
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'POST',
+            'header' => implode("\r\n", [
+                'Content-Type: application/x-www-form-urlencoded',
+                'User-Agent: Lamb-WebSub',
+            ]),
+            'content' => http_build_query(['hub.mode' => 'publish', 'hub.url' => $topic]),
+            'timeout' => WEBSUB_PING_TIMEOUT,
+            'ignore_errors' => true,
+        ],
+    ]);
+
+    $http_response_header = [];
+    @file_get_contents($hub, false, $context);
+
+    $status = 0;
+    foreach ($http_response_header as $header) {
+        if (preg_match('#^HTTP/\S+\s+(\d{3})#', $header, $m)) {
+            $status = (int) $m[1];
+        }
+    }
+    return $status;
+}

--- a/src/websub.php
+++ b/src/websub.php
@@ -14,42 +14,49 @@ use const ROOT_URL;
 const WEBSUB_PING_TIMEOUT = 5;
 
 /**
- * The configured WebSub hub URL, or '' when none is set.
+ * The configured WebSub hub URLs.
+ *
+ * `websub_hubs` is a comma-separated list; most sites need just one.
  *
  * @param array|null $config Config array; defaults to the global config.
- * @return string
+ * @return string[]
  */
-function hub_url(?array $config = null): string
+function hub_urls(?array $config = null): array
 {
     if ($config === null) {
         global $config;
     }
-    return trim((string) (($config ?? [])['websub_hub'] ?? ''));
+    $value = (string) (($config ?? [])['websub_hubs'] ?? '');
+
+    $hubs = array_map('trim', explode(',', $value));
+    return array_values(array_filter($hubs, fn($hub) => $hub !== ''));
 }
 
 /**
- * Notify the configured hub that the site's feeds have new content.
+ * Notify the configured hubs that the site's feeds have new content.
  *
- * Sends one `hub.mode=publish` ping per feed URL (Atom and JSON). A no-op
- * when no hub is configured. The sender is injectable for testing; in
- * production it defaults to {@see send_ping}.
+ * Sends one `hub.mode=publish` ping per hub per feed URL (Atom and JSON).
+ * A no-op when no hub is configured. The sender is injectable for testing;
+ * in production it defaults to {@see send_ping}.
  *
  * @param array|null    $config Config array; defaults to the global config.
  * @param callable|null $sender fn(string $hub, string $topic): int (HTTP status).
- * @return array<string,int> Map of topic URL → HTTP status code.
+ * @return array<array{hub: string, topic: string, status: int}>
  */
 function ping_hub(?array $config = null, ?callable $sender = null): array
 {
-    $hub = hub_url($config);
-    if ($hub === '') {
+    $hubs = hub_urls($config);
+    if ($hubs === []) {
         return [];
     }
 
     $sender ??= __NAMESPACE__ . '\\send_ping';
 
     $results = [];
-    foreach ([ROOT_URL . '/feed', ROOT_URL . '/feed.json'] as $topic) {
-        $results[$topic] = (int) $sender($hub, $topic);
+    foreach ($hubs as $hub) {
+        foreach ([ROOT_URL . '/feed', ROOT_URL . '/feed.json'] as $topic) {
+            $results[] = ['hub' => $hub, 'topic' => $topic, 'status' => (int) $sender($hub, $topic)];
+        }
     }
     return $results;
 }

--- a/src/websub.php
+++ b/src/websub.php
@@ -9,9 +9,10 @@ use RedBeanPHP\OODBBean;
 use const ROOT_URL;
 
 /**
- * Seconds before a hub ping is abandoned.
+ * Seconds before a hub ping is abandoned. Pings run in the publish request,
+ * so this is kept short to avoid a dead hub holding up the redirect.
  */
-const WEBSUB_PING_TIMEOUT = 5;
+const WEBSUB_PING_TIMEOUT = 2;
 
 /**
  * The configured WebSub hub URLs.
@@ -36,29 +37,23 @@ function hub_urls(?array $config = null): array
  * Notify the configured hubs that the site's feeds have new content.
  *
  * Sends one `hub.mode=publish` ping per hub per feed URL (Atom and JSON).
- * A no-op when no hub is configured. The sender is injectable for testing;
- * in production it defaults to {@see send_ping}.
+ * A no-op when no hub is configured. Fire-and-forget: WebSub is best-effort,
+ * subscribers fall back to polling if a ping is missed. The sender is
+ * injectable for testing; in production it defaults to {@see send_ping}.
  *
  * @param array|null    $config Config array; defaults to the global config.
- * @param callable|null $sender fn(string $hub, string $topic): int (HTTP status).
- * @return array<array{hub: string, topic: string, status: int}>
+ * @param callable|null $sender fn(string $hub, string $topic): void.
+ * @return void
  */
-function ping_hub(?array $config = null, ?callable $sender = null): array
+function ping_hub(?array $config = null, ?callable $sender = null): void
 {
-    $hubs = hub_urls($config);
-    if ($hubs === []) {
-        return [];
-    }
-
     $sender ??= __NAMESPACE__ . '\\send_ping';
 
-    $results = [];
-    foreach ($hubs as $hub) {
+    foreach (hub_urls($config) as $hub) {
         foreach ([ROOT_URL . '/feed', ROOT_URL . '/feed.json'] as $topic) {
-            $results[] = ['hub' => $hub, 'topic' => $topic, 'status' => (int) $sender($hub, $topic)];
+            $sender($hub, $topic);
         }
     }
-    return $results;
 }
 
 /**
@@ -85,13 +80,13 @@ function ping_for_post(OODBBean $bean, ?array $config = null, ?callable $sender 
 }
 
 /**
- * POST a publish notification to the hub and return the HTTP status code.
+ * POST a publish notification to the hub.
  *
  * @param string $hub   The hub endpoint URL.
  * @param string $topic The feed URL that changed.
- * @return int HTTP status code, or 0 on transport failure.
+ * @return void
  */
-function send_ping(string $hub, string $topic): int
+function send_ping(string $hub, string $topic): void
 {
     $context = stream_context_create([
         'http' => [
@@ -106,14 +101,5 @@ function send_ping(string $hub, string $topic): int
         ],
     ]);
 
-    $http_response_header = [];
     @file_get_contents($hub, false, $context);
-
-    $status = 0;
-    foreach ($http_response_header as $header) {
-        if (preg_match('#^HTTP/\S+\s+(\d{3})#', $header, $m)) {
-            $status = (int) $m[1];
-        }
-    }
-    return $status;
 }

--- a/tests/Unit/FeedJsonTemplateTest.php
+++ b/tests/Unit/FeedJsonTemplateTest.php
@@ -78,13 +78,34 @@ class FeedJsonTemplateTest extends TestCase
     {
         $json = $this->renderJsonFeedWithPost(
             ['title' => 'Hello', 'transformed' => '<p>Body</p>'],
-            ['websub_hub' => 'https://hub.example.com/']
+            ['websub_hubs' => 'https://hub.example.com/']
         );
 
         $this->assertSame(
             [['type' => 'WebSub', 'url' => 'https://hub.example.com/']],
             $json['hubs'],
             'JSON feed should advertise the configured WebSub hub'
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedJsonAdvertisesEveryCommaSeparatedHub(): void
+    {
+        $json = $this->renderJsonFeedWithPost(
+            ['title' => 'Hello', 'transformed' => '<p>Body</p>'],
+            ['websub_hubs' => 'https://hub-a.example.com/, https://hub-b.example.com/']
+        );
+
+        $this->assertSame(
+            [
+                ['type' => 'WebSub', 'url' => 'https://hub-a.example.com/'],
+                ['type' => 'WebSub', 'url' => 'https://hub-b.example.com/'],
+            ],
+            $json['hubs'],
+            'Every comma-separated hub should appear in the hubs array'
         );
     }
 
@@ -99,7 +120,7 @@ class FeedJsonTemplateTest extends TestCase
             'transformed' => '<p>Body</p>',
         ]);
 
-        $this->assertArrayNotHasKey('hubs', $json, 'No hubs field should be emitted without websub_hub config');
+        $this->assertArrayNotHasKey('hubs', $json, 'No hubs field should be emitted without websub_hubs config');
     }
 
     private function renderJsonFeedWithPost(array $fields, array $extraConfig = []): array

--- a/tests/Unit/FeedJsonTemplateTest.php
+++ b/tests/Unit/FeedJsonTemplateTest.php
@@ -70,7 +70,39 @@ class FeedJsonTemplateTest extends TestCase
         $this->assertSame('<p>Status update.</p>', $item['content_html']);
     }
 
-    private function renderJsonFeedWithPost(array $fields): array
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedJsonAdvertisesWebSubHubWhenConfigured(): void
+    {
+        $json = $this->renderJsonFeedWithPost(
+            ['title' => 'Hello', 'transformed' => '<p>Body</p>'],
+            ['websub_hub' => 'https://hub.example.com/']
+        );
+
+        $this->assertSame(
+            [['type' => 'WebSub', 'url' => 'https://hub.example.com/']],
+            $json['hubs'],
+            'JSON feed should advertise the configured WebSub hub'
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedJsonOmitsHubsWhenNotConfigured(): void
+    {
+        $json = $this->renderJsonFeedWithPost([
+            'title'       => 'Hello',
+            'transformed' => '<p>Body</p>',
+        ]);
+
+        $this->assertArrayNotHasKey('hubs', $json, 'No hubs field should be emitted without websub_hub config');
+    }
+
+    private function renderJsonFeedWithPost(array $fields, array $extraConfig = []): array
     {
         require_once __DIR__ . '/../../vendor/autoload.php';
 
@@ -92,11 +124,11 @@ class FeedJsonTemplateTest extends TestCase
         R::store($bean);
 
         global $config, $data;
-        $config = [
+        $config = array_merge([
             'site_title'   => 'Test Blog',
             'author_name'  => 'Test Author',
             'author_email' => 'test@test.com',
-        ];
+        ], $extraConfig);
         $data = [
             'posts'    => [$bean],
             'title'    => 'Test Blog',

--- a/tests/Unit/FeedTemplateTest.php
+++ b/tests/Unit/FeedTemplateTest.php
@@ -210,7 +210,7 @@ class FeedTemplateTest extends TestCase
         $xml = $this->renderFeedWithPost(
             ['title' => 'Post', 'transformed' => '<p>Body</p>'],
             [],
-            ['websub_hub' => 'https://hub.example.com/']
+            ['websub_hubs' => 'https://hub.example.com/']
         );
 
         $hub = null;
@@ -226,12 +226,37 @@ class FeedTemplateTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
+    public function testFeedAdvertisesEveryCommaSeparatedHub(): void
+    {
+        $xml = $this->renderFeedWithPost(
+            ['title' => 'Post', 'transformed' => '<p>Body</p>'],
+            [],
+            ['websub_hubs' => 'https://hub-a.example.com/, https://hub-b.example.com/']
+        );
+
+        $hubs = [];
+        foreach ($xml->link as $link) {
+            if ((string) $link['rel'] === 'hub') {
+                $hubs[] = (string) $link['href'];
+            }
+        }
+        $this->assertSame(
+            ['https://hub-a.example.com/', 'https://hub-b.example.com/'],
+            $hubs,
+            'Every comma-separated hub should get its own link element'
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testFeedOmitsHubLinkWhenNotConfigured(): void
     {
         $xml = $this->renderFeedWithPost(['title' => 'Post', 'transformed' => '<p>Body</p>']);
 
         foreach ($xml->link as $link) {
-            $this->assertNotSame('hub', (string) $link['rel'], 'No hub link should be emitted without websub_hub config');
+            $this->assertNotSame('hub', (string) $link['rel'], 'No hub link should be emitted without websub_hubs config');
         }
     }
 

--- a/tests/Unit/FeedTemplateTest.php
+++ b/tests/Unit/FeedTemplateTest.php
@@ -202,10 +202,45 @@ class FeedTemplateTest extends TestCase
     }
 
     /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedAdvertisesWebSubHubWhenConfigured(): void
+    {
+        $xml = $this->renderFeedWithPost(
+            ['title' => 'Post', 'transformed' => '<p>Body</p>'],
+            [],
+            ['websub_hub' => 'https://hub.example.com/']
+        );
+
+        $hub = null;
+        foreach ($xml->link as $link) {
+            if ((string) $link['rel'] === 'hub') {
+                $hub = (string) $link['href'];
+            }
+        }
+        $this->assertSame('https://hub.example.com/', $hub, 'Feed should advertise the configured WebSub hub');
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedOmitsHubLinkWhenNotConfigured(): void
+    {
+        $xml = $this->renderFeedWithPost(['title' => 'Post', 'transformed' => '<p>Body</p>']);
+
+        foreach ($xml->link as $link) {
+            $this->assertNotSame('hub', (string) $link['rel'], 'No hub link should be emitted without websub_hub config');
+        }
+    }
+
+    /**
      * @param array $fields        Post bean fields.
      * @param array $conventionFiles Names of web-root convention files to create (e.g. favicon.png).
+     * @param array $extraConfig   Extra config keys merged into $config.
      */
-    private function renderFeedWithPost(array $fields, array $conventionFiles = []): \SimpleXMLElement
+    private function renderFeedWithPost(array $fields, array $conventionFiles = [], array $extraConfig = []): \SimpleXMLElement
     {
         require_once __DIR__ . '/../../vendor/autoload.php';
 
@@ -244,11 +279,11 @@ class FeedTemplateTest extends TestCase
         R::store($bean);
 
         global $config, $data;
-        $config = [
+        $config = array_merge([
             'site_title'   => 'Test Blog',
             'author_name'  => 'Test Author',
             'author_email' => 'test@test.com',
-        ];
+        ], $extraConfig);
         $data = [
             'posts'    => [$bean],
             'title'    => 'Test Blog',

--- a/tests/Unit/WebsubTest.php
+++ b/tests/Unit/WebsubTest.php
@@ -27,9 +27,8 @@ class WebsubTest extends TestCase
     public function testPingHubPostsBothFeedUrlsToConfiguredHub(): void
     {
         $pings = [];
-        $sender = function (string $hub, string $topic) use (&$pings): int {
+        $sender = function (string $hub, string $topic) use (&$pings): void {
             $pings[] = [$hub, $topic];
-            return 204;
         };
 
         ping_hub(['websub_hubs' => 'https://hub.example.com/'], $sender);
@@ -43,9 +42,8 @@ class WebsubTest extends TestCase
     public function testPingHubPingsEveryConfiguredHub(): void
     {
         $pings = [];
-        $sender = function (string $hub, string $topic) use (&$pings): int {
+        $sender = function (string $hub, string $topic) use (&$pings): void {
             $pings[] = [$hub, $topic];
-            return 204;
         };
 
         ping_hub(['websub_hubs' => 'https://hub-a.example.com/, https://hub-b.example.com/'], $sender);
@@ -75,13 +73,12 @@ class WebsubTest extends TestCase
     public function testPingHubIsNoOpWhenHubNotConfigured(): void
     {
         $called = false;
-        $sender = function () use (&$called): int {
+        $sender = function () use (&$called): void {
             $called = true;
-            return 204;
         };
 
-        $this->assertSame([], ping_hub([], $sender));
-        $this->assertSame([], ping_hub(['websub_hubs' => '  '], $sender));
+        ping_hub([], $sender);
+        ping_hub(['websub_hubs' => '  '], $sender);
         $this->assertFalse($called, 'Sender must not be invoked without a configured hub');
     }
 
@@ -92,9 +89,8 @@ class WebsubTest extends TestCase
         $bean = $this->storedPost();
 
         $pings = 0;
-        ping_for_post($bean, ['websub_hubs' => 'https://hub.example.com/'], function () use (&$pings): int {
+        ping_for_post($bean, ['websub_hubs' => 'https://hub.example.com/'], function () use (&$pings): void {
             $pings++;
-            return 204;
         });
 
         $this->assertSame(2, $pings, 'A published local post should ping the hub for both feeds');
@@ -114,9 +110,8 @@ class WebsubTest extends TestCase
         $unsaved = R::dispense('post');
 
         $called = false;
-        $sender = function () use (&$called): int {
+        $sender = function () use (&$called): void {
             $called = true;
-            return 204;
         };
 
         foreach ([$draft, $feedItem, $scheduled, $unsaved] as $bean) {

--- a/tests/Unit/WebsubTest.php
+++ b/tests/Unit/WebsubTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Websub\ping_for_post;
+use function Lamb\Websub\ping_hub;
+
+class WebsubTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'https://example.com');
+        }
+    }
+
+    // ping_hub ---------------------------------------------------------------
+
+    public function testPingHubPostsBothFeedUrlsToConfiguredHub(): void
+    {
+        $pings = [];
+        $sender = function (string $hub, string $topic) use (&$pings): int {
+            $pings[] = [$hub, $topic];
+            return 204;
+        };
+
+        $results = ping_hub(['websub_hub' => 'https://hub.example.com/'], $sender);
+
+        $this->assertSame([
+            ['https://hub.example.com/', ROOT_URL . '/feed'],
+            ['https://hub.example.com/', ROOT_URL . '/feed.json'],
+        ], $pings);
+        $this->assertSame([
+            ROOT_URL . '/feed'      => 204,
+            ROOT_URL . '/feed.json' => 204,
+        ], $results);
+    }
+
+    public function testPingHubIsNoOpWhenHubNotConfigured(): void
+    {
+        $called = false;
+        $sender = function () use (&$called): int {
+            $called = true;
+            return 204;
+        };
+
+        $this->assertSame([], ping_hub([], $sender));
+        $this->assertSame([], ping_hub(['websub_hub' => '  '], $sender));
+        $this->assertFalse($called, 'Sender must not be invoked without a configured hub');
+    }
+
+    // ping_for_post ----------------------------------------------------------
+
+    public function testPingForPostPingsForEligiblePost(): void
+    {
+        $bean = $this->storedPost();
+
+        $pings = 0;
+        ping_for_post($bean, ['websub_hub' => 'https://hub.example.com/'], function () use (&$pings): int {
+            $pings++;
+            return 204;
+        });
+
+        $this->assertSame(2, $pings, 'A published local post should ping the hub for both feeds');
+    }
+
+    public function testPingForPostSkipsDraftsFeedItemsAndScheduledPosts(): void
+    {
+        $draft = $this->storedPost();
+        $draft->draft = 1;
+
+        $feedItem = $this->storedPost();
+        $feedItem->feed_name = 'some-feed';
+
+        $scheduled = $this->storedPost();
+        $scheduled->created = date('Y-m-d H:i:s', time() + 3600);
+
+        $unsaved = R::dispense('post');
+
+        $called = false;
+        $sender = function () use (&$called): int {
+            $called = true;
+            return 204;
+        };
+
+        foreach ([$draft, $feedItem, $scheduled, $unsaved] as $bean) {
+            ping_for_post($bean, ['websub_hub' => 'https://hub.example.com/'], $sender);
+        }
+
+        $this->assertFalse($called, 'Drafts, feed items, scheduled and unsaved posts must not ping the hub');
+    }
+
+    private function storedPost(): \RedBeanPHP\OODBBean
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Hello';
+        $bean->transformed = '<p>Hello</p>';
+        $bean->created = '2026-01-01 00:00:00';
+        $bean->updated = '2026-01-01 00:00:00';
+        $bean->version = 1;
+        R::store($bean);
+        return $bean;
+    }
+}

--- a/tests/Unit/WebsubTest.php
+++ b/tests/Unit/WebsubTest.php
@@ -32,16 +32,44 @@ class WebsubTest extends TestCase
             return 204;
         };
 
-        $results = ping_hub(['websub_hub' => 'https://hub.example.com/'], $sender);
+        ping_hub(['websub_hubs' => 'https://hub.example.com/'], $sender);
 
         $this->assertSame([
             ['https://hub.example.com/', ROOT_URL . '/feed'],
             ['https://hub.example.com/', ROOT_URL . '/feed.json'],
         ], $pings);
+    }
+
+    public function testPingHubPingsEveryConfiguredHub(): void
+    {
+        $pings = [];
+        $sender = function (string $hub, string $topic) use (&$pings): int {
+            $pings[] = [$hub, $topic];
+            return 204;
+        };
+
+        ping_hub(['websub_hubs' => 'https://hub-a.example.com/, https://hub-b.example.com/'], $sender);
+
         $this->assertSame([
-            ROOT_URL . '/feed'      => 204,
-            ROOT_URL . '/feed.json' => 204,
-        ], $results);
+            ['https://hub-a.example.com/', ROOT_URL . '/feed'],
+            ['https://hub-a.example.com/', ROOT_URL . '/feed.json'],
+            ['https://hub-b.example.com/', ROOT_URL . '/feed'],
+            ['https://hub-b.example.com/', ROOT_URL . '/feed.json'],
+        ], $pings);
+    }
+
+    public function testHubUrlsParsesCommaSeparatedValues(): void
+    {
+        $this->assertSame([], \Lamb\Websub\hub_urls([]));
+        $this->assertSame([], \Lamb\Websub\hub_urls(['websub_hubs' => ' , ']));
+        $this->assertSame(
+            ['https://hub.example.com/'],
+            \Lamb\Websub\hub_urls(['websub_hubs' => ' https://hub.example.com/ '])
+        );
+        $this->assertSame(
+            ['https://hub-a.example.com/', 'https://hub-b.example.com/'],
+            \Lamb\Websub\hub_urls(['websub_hubs' => 'https://hub-a.example.com/, https://hub-b.example.com/,'])
+        );
     }
 
     public function testPingHubIsNoOpWhenHubNotConfigured(): void
@@ -53,7 +81,7 @@ class WebsubTest extends TestCase
         };
 
         $this->assertSame([], ping_hub([], $sender));
-        $this->assertSame([], ping_hub(['websub_hub' => '  '], $sender));
+        $this->assertSame([], ping_hub(['websub_hubs' => '  '], $sender));
         $this->assertFalse($called, 'Sender must not be invoked without a configured hub');
     }
 
@@ -64,7 +92,7 @@ class WebsubTest extends TestCase
         $bean = $this->storedPost();
 
         $pings = 0;
-        ping_for_post($bean, ['websub_hub' => 'https://hub.example.com/'], function () use (&$pings): int {
+        ping_for_post($bean, ['websub_hubs' => 'https://hub.example.com/'], function () use (&$pings): int {
             $pings++;
             return 204;
         });
@@ -92,7 +120,7 @@ class WebsubTest extends TestCase
         };
 
         foreach ([$draft, $feedItem, $scheduled, $unsaved] as $bean) {
-            ping_for_post($bean, ['websub_hub' => 'https://hub.example.com/'], $sender);
+            ping_for_post($bean, ['websub_hubs' => 'https://hub.example.com/'], $sender);
         }
 
         $this->assertFalse($called, 'Drafts, feed items, scheduled and unsaved posts must not ping the hub');


### PR DESCRIPTION
Closes #250

When `websub_hub` is set in the site configuration, Lamb now supports [WebSub](https://www.w3.org/TR/websub/) real-time push, in two parts (per the scoping notes on the issue):

**1. Advertise the hub**
- Atom feed: `<link rel="hub" href="...">` alongside the existing `rel="self"` link
- JSON Feed: native `hubs` field — `[{"type": "WebSub", "url": "..."}]`

**2. Ping the hub on publish**
- New `Lamb\Websub` module (`src/websub.php`): POSTs `hub.mode=publish` + `hub.url` for both `/feed` and `/feed.json`
- Hooked next to every `Webmention\enqueue_for_post()` call (web create/edit + Micropub create/update), with the same eligibility rules: drafts, scheduled posts, and ingested feed items don't ping

Unconfigured installs are unchanged: no hub link, no `hubs` field, no pings.

**Tests** (written first, red→green): hub advertising in both feed templates, ping payload/topics, no-op without config, eligibility skips.

**Docs**: new "Real-time push (WebSub)" section on the Feeds page, `websub_hub` added to site-configuration, cross-linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
