### PR TITLE
Fix phpcs hidden-dir exclude silently skipping dotted checkout paths

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,10 +14,11 @@
     <!-- Check PHP files only. -->
     <arg name="extensions" value="php"/>
 
-    <!-- leave only src -->
-    <exclude-pattern>\.*/</exclude-pattern>
+    <!-- Exclude hidden directories (relative, so a checkout under a dotted
+         path such as a .claude/worktrees/ worktree doesn't exclude everything) -->
+    <exclude-pattern type="relative">^\.</exclude-pattern>
     <exclude-pattern>vendor/</exclude-pattern>
-    <exclude-pattern>vendor/</exclude-pattern>
+    <exclude-pattern>node_modules/</exclude-pattern>
 
     <!-- Check for PHP cross-version compatibility. -->
     <rule ref="PHPCompatibility"/>


### PR DESCRIPTION
Follow-up to #325 — this commit missed the auto-merge window there.

The `\.*/` exclude pattern (with `*` expanded to `.*` by phpcs) matched any path containing a dot before a slash, so a checkout under a dotted path (e.g. a `.claude/worktrees/` worktree) excluded **every file** and `composer lint` passed without checking anything. That's how snake_case test names reached CI in #325.

- Anchor the hidden-dir exclusion with `type="relative"` so it only skips actual dot-directories at the repo root
- Replace the duplicated `vendor/` entry with `node_modules/`

Verified: a canary file with violations now fails phpcs from inside a worktree; the full repo still lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)