### PR TITLE
Clear post title when removed from front matter on edit

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -112,6 +112,12 @@ function parse_bean(OODBBean $bean): void
     }
     $bean->in_reply_to = is_string($in_reply_to) ? trim($in_reply_to) : '';
 
+    // Reset the title to empty when it is absent from front matter, so removing
+    // the `title:` line (or all front matter) on an edit clears a previously
+    // stored title. The additive loop below only ever sets keys that are
+    // present, so without this an old title would survive every save.
+    $bean->title = isset($front_matter['title']) ? (string) $front_matter['title'] : '';
+
     // Preserve the existing created date (now for new posts, the stored value for
     // edits, the feed date for ingested items) so an unparseable front-matter date
     // falls back to it rather than leaving a non-date string in the column.

--- a/tests/Unit/ParseBeanTitleTest.php
+++ b/tests/Unit/ParseBeanTitleTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\parse_bean;
+
+class ParseBeanTitleTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+    }
+
+    public function testParseBeanSetsTitleFromFrontmatter()
+    {
+        $bean = R::dispense('post');
+        $bean->body = "---\ntitle: My Title\n---\nContent.";
+
+        parse_bean($bean);
+
+        $this->assertSame('My Title', $bean->title);
+    }
+
+    public function testParseBeanClearsTitleWhenRemovedFromFrontmatter()
+    {
+        $bean = R::dispense('post');
+        // Simulate a post that previously had a title (title set in DB).
+        $bean->title = 'Old Title';
+        // User edited to remove the front matter entirely.
+        $bean->body = 'Just a plain status update with no front matter.';
+
+        parse_bean($bean);
+
+        $this->assertSame('', $bean->title);
+    }
+
+    public function testParseBeanLeavesTitleEmptyForPlainMarkdownPost()
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Just a plain status update with no front matter.';
+
+        parse_bean($bean);
+
+        $this->assertSame('', $bean->title);
+    }
+}


### PR DESCRIPTION
parse_bean() applied front matter additively: the loop only set keys
present in the parsed front matter, so a previously stored title
survived every save. Removing the `title:` line (or all front matter)
in the editor could never clear the title — the same blind spot that
`draft` and `in_reply_to` already work around with explicit resets.

Reset `title` to empty when it is absent from front matter, matching
the existing handling for `draft` and `in_reply_to`. `slug` is left
untouched (immutable by design on main/release) and `description` is
already recomputed every parse.

This also fixes titled Micropub posts (clients that send a `name`
property) becoming impossible to convert to titleless notes by editing.

https://claude.ai/code/session_011G81naUZf5HyHmeTAVK1uz