### PR TITLE
Send webmentions for scheduled posts at publication time

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -62,3 +62,4 @@ Micropub clients can schedule a post by sending a future `published` date. Sendi
 * [Post Types]({{ site.baseurl }}{% link post-types.md %}): Front-matter is used to set the `created` date.
 * [Drafts]({{ site.baseurl }}{% link drafts.md %}): Drafts are hidden until published; scheduled posts are hidden until their date.
 * [Micropub]({{ site.baseurl }}{% link micropub.md %}): Scheduling posts from a Micropub client.
+* [Webmentions]({{ site.baseurl }}{% link webmentions.md %}): Outbound webmentions for a scheduled post are sent when it goes live, not when you save it.

--- a/docs/webmentions.md
+++ b/docs/webmentions.md
@@ -34,11 +34,14 @@ When you publish or edit a post, Lamb scans its rendered HTML for links to **oth
 1. Fetches the target page and discovers its webmention endpoint (HTTP `Link` header → `<link rel="webmention">` → `<a rel="webmention">`).
 2. POSTs your post URL (`source`) and the linked URL (`target`) to that endpoint.
 
-Each source/target pair is sent once — re-editing a post does not re-notify targets it already reached, so receivers are not spammed. Drafts, future-scheduled posts, and posts ingested from other feeds do not send webmentions.
+Each source/target pair is sent once — re-editing a post does not re-notify targets it already reached, so receivers are not spammed. Drafts and posts ingested from other feeds do not send webmentions.
+
+[Scheduled posts]({{ site.baseurl }}{% link scheduling.md %}) are queued when you save them, but nothing is sent until the publication time has passed — the first `/_cron` run after the post goes live delivers its webmentions, once the post is publicly reachable for receivers to verify. Editing a scheduled post before it publishes updates the queue (removed links are dropped), and deleting it cancels the queued mentions entirely.
 
 ## Related
 
 * [Reply posts]({{ site.baseurl }}{% link replies.md %}): Mark a post as `in-reply-to` another URL — the most common webmention type.
 * [Micropub]({{ site.baseurl }}{% link micropub.md %}): Publish posts from any Micropub client; uses the same IndieWeb discovery pattern.
 * [Cron / scheduled tasks]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}): How `/_cron` drives feed ingestion and outbound webmentions.
+* [Scheduling posts]({{ site.baseurl }}{% link scheduling.md %}): Scheduled posts send their webmentions when they go live.
 * [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %}): Pull posts in from other feeds.

--- a/src/network.php
+++ b/src/network.php
@@ -97,12 +97,13 @@ function purge_deleted_posts(): int
     }
 
     $sent = \Lamb\Webmention\process_outbound();
-    if ($sent['sent'] || $sent['failed'] || $sent['skipped']) {
+    if ($sent['sent'] || $sent['failed'] || $sent['skipped'] || $sent['cancelled']) {
         printf(
-            "Webmentions sent: %d, failed: %d, skipped: %d" . PHP_EOL,
+            "Webmentions sent: %d, failed: %d, skipped: %d, cancelled: %d" . PHP_EOL,
             $sent['sent'],
             $sent['failed'],
-            $sent['skipped']
+            $sent['skipped'],
+            $sent['cancelled']
         );
     }
 

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -8,6 +8,7 @@ use JetBrains\PhpStorm\NoReturn;
 use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
 
+use function Lamb\is_scheduled;
 use function Lamb\permalink;
 
 use const ROOT_URL;
@@ -392,8 +393,10 @@ function resolve_url(string $base, string $rel): string
 /**
  * Queue outbound webmentions for a freshly saved post, if it is eligible.
  *
- * Skips ingested feed items (third-party content), drafts, and future-dated
- * scheduled posts — none of which should notify external targets (yet).
+ * Skips ingested feed items (third-party content) and drafts — neither should
+ * notify external targets. Future-dated scheduled posts ARE queued: their rows
+ * wait in the outbox until publication, because process_outbound() only sends
+ * once the source post is publicly visible (#302).
  *
  * @param OODBBean $bean A stored post bean.
  * @return void
@@ -401,9 +404,6 @@ function resolve_url(string $base, string $rel): string
 function enqueue_for_post(OODBBean $bean): void
 {
     if (!$bean->id || !empty($bean->feed_name) || !empty($bean->draft)) {
-        return;
-    }
-    if (!empty($bean->created) && strtotime((string) $bean->created) > time()) {
         return;
     }
 
@@ -420,7 +420,9 @@ function enqueue_for_post(OODBBean $bean): void
  *
  * Idempotent across edits: an existing pending/sent row for the same
  * source+target is left untouched (so receivers are not spammed), while a
- * previously failed row is reset to pending for another attempt.
+ * previously failed or cancelled row is reset to pending for another attempt.
+ * Pending rows whose target no longer appears in the post are cancelled, so a
+ * scheduled post edited to remove a link before publication does not notify it.
  *
  * The reply target (from a post's `in-reply-to` front matter) is treated as an
  * outbound link even when it does not appear in the body, so replies notify the
@@ -441,11 +443,20 @@ function enqueue_outbound(int $post_id, string $source, string $html, string $re
         $targets[] = $reply_to;
     }
 
+    // Cancel pending rows for links the post no longer contains.
+    $stale = R::find('webmentionoutbox', ' source = ? AND status = ? ', [$source, 'pending']);
+    foreach ($stale as $row) {
+        if (!in_array((string) $row->target, $targets, true)) {
+            $row->status = 'cancelled';
+            R::store($row);
+        }
+    }
+
     $created = 0;
     foreach ($targets as $target) {
         $row = R::findOne('webmentionoutbox', ' source = ? AND target = ? ', [$source, $target]);
         if ($row) {
-            if ($row->status === 'failed') {
+            if ($row->status === 'failed' || $row->status === 'cancelled') {
                 $row->status = 'pending';
                 R::store($row);
             }
@@ -471,6 +482,14 @@ function enqueue_outbound(int $post_id, string $source, string $html, string $re
  * Process queued outbound webmentions: discover each target's endpoint and
  * POST the mention. Intended to be driven by the `/_cron` route.
  *
+ * Each row's source post is re-checked before sending: rows for deleted,
+ * draft, or missing posts are cancelled, and rows for still-scheduled posts
+ * are left pending (untouched, no attempt counted) until publication. This
+ * deliberately does not use is_visible(), which trusts logged-in sessions —
+ * a logged-in author hitting /_cron must not leak drafts. Deferred scheduled
+ * rows still occupy part of the LIMIT window; with the default of 20 that is
+ * harmless.
+ *
  * Both network operations are injectable for testing:
  *  - $fetcher fn(string $url): ?array{headers: string[], body: string}
  *  - $sender  fn(string $endpoint, string $source, string $target): int (HTTP status)
@@ -478,17 +497,29 @@ function enqueue_outbound(int $post_id, string $source, string $html, string $re
  * @param callable|null $fetcher
  * @param callable|null $sender
  * @param int           $limit Maximum rows to process per run.
- * @return array{sent:int, failed:int, skipped:int}
+ * @return array{sent:int, failed:int, skipped:int, cancelled:int}
  */
 function process_outbound(?callable $fetcher = null, ?callable $sender = null, int $limit = 20): array
 {
     $fetcher ??= __NAMESPACE__ . '\\fetch_target';
     $sender ??= __NAMESPACE__ . '\\send_webmention';
 
-    $stats = ['sent' => 0, 'failed' => 0, 'skipped' => 0];
+    $stats = ['sent' => 0, 'failed' => 0, 'skipped' => 0, 'cancelled' => 0];
     $rows = R::find('webmentionoutbox', ' status = ? ORDER BY created ASC LIMIT ? ', ['pending', $limit]);
 
     foreach ($rows as $row) {
+        $post = R::load('post', (int) $row->post_id);
+        if (!$post->id || $post->deleted == 1 || $post->draft == 1) {
+            $row->status = 'cancelled';
+            $row->processed_at = date('Y-m-d H:i:s');
+            $stats['cancelled']++;
+            R::store($row);
+            continue;
+        }
+        if (is_scheduled($post)) {
+            continue;
+        }
+
         $row->attempts = (int) $row->attempts + 1;
         $row->processed_at = date('Y-m-d H:i:s');
 

--- a/tests/Unit/WebmentionSendTest.php
+++ b/tests/Unit/WebmentionSendTest.php
@@ -194,11 +194,100 @@ class WebmentionSendTest extends TestCase
         $this->assertSame(1, R::count('webmentionoutbox', ' target = ? ', [$target]));
     }
 
+    public function testEnqueueForPostQueuesScheduledPost(): void
+    {
+        $post = R::dispense('post');
+        $post->body = 'Scheduled';
+        $post->transformed = '<p><a href="https://other.example/a">a</a></p>';
+        $post->created = date('Y-m-d H:i:s', time() + 3600);
+        $post->updated = date('Y-m-d H:i:s');
+        $post->version = 1;
+        R::store($post);
+
+        enqueue_for_post($post);
+
+        $this->assertSame(1, R::count('webmentionoutbox', ' status = ? ', ['pending']));
+    }
+
+    public function testEnqueueForPostSkipsFeedItems(): void
+    {
+        $post = R::dispense('post');
+        $post->body = 'Ingested';
+        $post->transformed = '<p><a href="https://other.example/a">a</a></p>';
+        $post->feed_name = 'somefeed';
+        $post->created = '2026-01-01 00:00:00';
+        $post->updated = '2026-01-01 00:00:00';
+        $post->version = 1;
+        R::store($post);
+
+        enqueue_for_post($post);
+
+        $this->assertSame(0, R::count('webmentionoutbox'));
+    }
+
+    // enqueue_outbound (stale rows) ------------------------------------------
+
+    public function testEnqueueCancelsStalePendingRowsForRemovedLinks(): void
+    {
+        $source = ROOT_URL . '/status/1';
+        enqueue_outbound($this->postId, $source, '<a href="https://other.example/a">a</a><a href="https://third.example/b">b</a>');
+
+        enqueue_outbound($this->postId, $source, '<a href="https://third.example/b">b</a>');
+
+        $removed = R::findOne('webmentionoutbox', ' target = ? ', ['https://other.example/a']);
+        $kept = R::findOne('webmentionoutbox', ' target = ? ', ['https://third.example/b']);
+        $this->assertSame('cancelled', $removed->status);
+        $this->assertSame('pending', $kept->status);
+    }
+
+    public function testEnqueueLeavesSentRowsForRemovedLinks(): void
+    {
+        $source = ROOT_URL . '/status/1';
+        enqueue_outbound($this->postId, $source, '<a href="https://other.example/a">a</a>');
+        $row = R::findOne('webmentionoutbox');
+        $row->status = 'sent';
+        R::store($row);
+
+        enqueue_outbound($this->postId, $source, '<p>no links</p>');
+
+        $this->assertSame('sent', R::findOne('webmentionoutbox')->status);
+    }
+
+    public function testEnqueueRequeuesCancelledRowWhenLinkRestored(): void
+    {
+        $source = ROOT_URL . '/status/1';
+        enqueue_outbound($this->postId, $source, '<a href="https://other.example/a">a</a>');
+        $row = R::findOne('webmentionoutbox');
+        $row->status = 'cancelled';
+        R::store($row);
+
+        enqueue_outbound($this->postId, $source, '<a href="https://other.example/a">a</a>');
+
+        $this->assertSame('pending', R::findOne('webmentionoutbox')->status);
+    }
+
     // process_outbound ------------------------------------------------------
 
     private function seedPending(string $target): void
     {
         enqueue_outbound($this->postId, ROOT_URL . '/status/1', '<a href="' . $target . '">x</a>');
+    }
+
+    /**
+     * A fetcher/sender pair that fails the test if either is invoked.
+     *
+     * @return array{0: callable, 1: callable}
+     */
+    private function unreachableNetwork(): array
+    {
+        $fetcher = function (string $url): ?array {
+            $this->fail('fetcher must not be called');
+        };
+        $sender = function (string $e, string $s, string $t): int {
+            $this->fail('sender must not be called');
+        };
+
+        return [$fetcher, $sender];
     }
 
     public function testProcessMarksSentOnSuccess(): void
@@ -238,5 +327,77 @@ class WebmentionSendTest extends TestCase
         $result = process_outbound($fetcher, $sender);
         $this->assertSame(1, $result['failed']);
         $this->assertSame('failed', R::findOne('webmentionoutbox')->status);
+    }
+
+    // process_outbound (source-post guard) -----------------------------------
+
+    public function testProcessLeavesRowsPendingWhileSourcePostIsScheduled(): void
+    {
+        $post = R::load('post', $this->postId);
+        $post->created = date('Y-m-d H:i:s', time() + 3600);
+        R::store($post);
+        $this->seedPending('https://other.example/a');
+
+        [$fetcher, $sender] = $this->unreachableNetwork();
+        process_outbound($fetcher, $sender);
+
+        $row = R::findOne('webmentionoutbox');
+        $this->assertSame('pending', $row->status);
+        $this->assertSame(0, (int) $row->attempts);
+    }
+
+    public function testProcessCancelsRowsForDeletedSourcePost(): void
+    {
+        $this->seedPending('https://other.example/a');
+        $post = R::load('post', $this->postId);
+        $post->deleted = 1;
+        R::store($post);
+
+        [$fetcher, $sender] = $this->unreachableNetwork();
+        $result = process_outbound($fetcher, $sender);
+
+        $this->assertSame(1, $result['cancelled']);
+        $this->assertSame('cancelled', R::findOne('webmentionoutbox')->status);
+    }
+
+    public function testProcessCancelsRowsForDraftSourcePost(): void
+    {
+        $this->seedPending('https://other.example/a');
+        $post = R::load('post', $this->postId);
+        $post->draft = 1;
+        R::store($post);
+
+        [$fetcher, $sender] = $this->unreachableNetwork();
+        $result = process_outbound($fetcher, $sender);
+
+        $this->assertSame(1, $result['cancelled']);
+        $this->assertSame('cancelled', R::findOne('webmentionoutbox')->status);
+    }
+
+    public function testProcessCancelsRowsForMissingSourcePost(): void
+    {
+        $this->seedPending('https://other.example/a');
+        R::trash(R::load('post', $this->postId));
+
+        [$fetcher, $sender] = $this->unreachableNetwork();
+        $result = process_outbound($fetcher, $sender);
+
+        $this->assertSame(1, $result['cancelled']);
+        $this->assertSame('cancelled', R::findOne('webmentionoutbox')->status);
+    }
+
+    public function testProcessSendsOnceScheduledPostBecomesPublic(): void
+    {
+        $post = R::load('post', $this->postId);
+        $post->created = date('Y-m-d H:i:s', time() - 60);
+        R::store($post);
+        $this->seedPending('https://other.example/a');
+
+        $fetcher = fn (string $url) => ['headers' => ['<https://other.example/wm>; rel="webmention"'], 'body' => ''];
+        $sender = fn (string $e, string $s, string $t): int => 202;
+
+        $result = process_outbound($fetcher, $sender);
+        $this->assertSame(1, $result['sent']);
+        $this->assertSame('sent', R::findOne('webmentionoutbox')->status);
     }
 }


### PR DESCRIPTION
Fixes #302.

## Approach

Instead of the issue's Option B (per-post flag + cron scan, which needs a carefully one-time backfill), this gates **sending** rather than enqueueing — discussed in [this comment](https://github.com/svandragt/lamb/issues/302#issuecomment-4626092978):

- `enqueue_for_post()` now queues scheduled posts at save time (drafts and feed items still never enqueue; `network.php` never calls it, so aggregator use creates no queue build-up).
- `process_outbound()` loads each row's source post before sending:
  - missing / `deleted = 1` / `draft = 1` → row `cancelled` (new status + stat, reported by `/_cron`)
  - still scheduled → row stays `pending`, untouched, no attempt counted
  - public → sent as before
- `enqueue_outbound()` cancels pending rows whose target no longer appears in the post (a scheduled post edited to remove a link before publication won't notify it) and requeues cancelled rows if the link is restored.

`is_visible()` is deliberately not used for the guard: it trusts logged-in sessions, so an author manually hitting `/_cron` while logged in would have sent webmentions for drafts.

Rows persist in the outbox until sendable, so missed cron runs lose nothing, and no schema change or migration is needed.

## Accepted edge

Scheduled posts already in flight when this upgrade lands have no outbox rows (the old code skipped them at save); editing such a post re-enqueues it.

## Tests

10 new unit tests (red-green): scheduled posts enqueue, feed items don't, guard cancels deleted/draft/missing, defers scheduled, sends once public, stale-row cancellation/requeue. Full suite: 750 tests green; lint + analyse clean.

Docs: `docs/webmentions.md` Sending section rewritten for the new behaviour; cross-links added between webmentions and scheduling pages.

## Follow-ups (separate issues)

- WebSub has the identical gap (`ping_for_post()` skips scheduled posts; a no-links post has no outbox rows to piggyback on).
- Per the Webmention spec, deleting a post that already sent mentions should re-send so receivers can remove them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
