### PR TITLE
Apply feed-name slug prefix after parse_bean so it survives re-derivation

### DIFF
--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -34,9 +34,9 @@ Hi I'm John Sheeple and the example author of this site.
 
 Slugs for pages are derived from the title on creation unless you explicitly provide `slug:` in the front-matter. The slug for the example above is `about-me` and the permalink is `/about-me`.
 
-A slug is preserved after creation. Changing the title later does not automatically reslug the post. _Good URLs don't change_, so although it's possible to set a slug in the front-matter when creating a page, Lamb will derive it from the title if it isn't set.
+A slug is immutable once the post is published: _good URLs don't change_. Editing the `slug:` line or the title of a published post does not reslug it — Lamb keeps the original slug and reverses the front-matter `slug:` value to match it. Draft posts can still be re-slugged freely until they are published.
 
-Slugs are unique. If a slug is already taken by another post (or matches a built-in route like `/search`), Lamb appends the post's id to keep the URL distinct, and writes the final slug back into the post's front-matter so you can see — and edit — the slug the post is actually served under.
+Slugs are unique. If a slug is already taken by another post (or matches a built-in route like `/search`), Lamb appends the post's id to keep the URL distinct, and writes the final slug back into the post's front-matter so you can always see the slug the post is actually served under.
 
 You can also set a `created:` date in the front-matter. A future date schedules the post — see [Scheduling]({{ site.baseurl }}{% link scheduling.md %}).
 

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -36,6 +36,8 @@ Slugs for pages are derived from the title on creation unless you explicitly pro
 
 A slug is preserved after creation. Changing the title later does not automatically reslug the post. _Good URLs don't change_, so although it's possible to set a slug in the front-matter when creating a page, Lamb will derive it from the title if it isn't set.
 
+Slugs are unique. If a slug is already taken by another post (or matches a built-in route like `/search`), Lamb appends the post's id to keep the URL distinct, and writes the final slug back into the post's front-matter so you can see — and edit — the slug the post is actually served under.
+
 You can also set a `created:` date in the front-matter. A future date schedules the post — see [Scheduling]({{ site.baseurl }}{% link scheduling.md %}).
 
 > **iOS note:** iOS "Smart Punctuation" rewrites a typed `---` into em/en dashes (for example `—-`). Lamb recognises a mangled opening and closing fence and restores it to `---` automatically, so front-matter still works from an iPhone or iPad. If you'd rather type plain dashes everywhere, turn the feature off under _Settings → General → Keyboard → Smart Punctuation_.

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -34,7 +34,7 @@ Hi I'm John Sheeple and the example author of this site.
 
 Slugs for pages are derived from the title on creation unless you explicitly provide `slug:` in the front-matter. The slug for the example above is `about-me` and the permalink is `/about-me`.
 
-A slug is preserved after creation. Changing the title later does not automatically reslug the post. _Good URLs don't change_, so although it's possible to set a slug in the front-matter when creating a page, Lamb will derive it from the title if it isn't set.
+Editing the `slug:` line (or the title, when no explicit slug is set) reslugs the post, and Lamb automatically stores a 301 redirect from the old slug — _good URLs don't change_, so bookmarks and inbound links keep working. See [Redirections]({{ site.baseurl }}{% link redirections.md %}).
 
 Slugs are unique. If a slug is already taken by another post (or matches a built-in route like `/search`), Lamb appends the post's id to keep the URL distinct, and writes the final slug back into the post's front-matter so you can see — and edit — the slug the post is actually served under.
 

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -34,9 +34,9 @@ Hi I'm John Sheeple and the example author of this site.
 
 Slugs for pages are derived from the title on creation unless you explicitly provide `slug:` in the front-matter. The slug for the example above is `about-me` and the permalink is `/about-me`.
 
-A slug is immutable once the post is published: _good URLs don't change_. Editing the `slug:` line or the title of a published post does not reslug it — Lamb keeps the original slug and reverses the front-matter `slug:` value to match it. Draft posts can still be re-slugged freely until they are published.
+A slug is preserved after creation. Changing the title later does not automatically reslug the post. _Good URLs don't change_, so although it's possible to set a slug in the front-matter when creating a page, Lamb will derive it from the title if it isn't set.
 
-Slugs are unique. If a slug is already taken by another post (or matches a built-in route like `/search`), Lamb appends the post's id to keep the URL distinct, and writes the final slug back into the post's front-matter so you can always see the slug the post is actually served under.
+Slugs are unique. If a slug is already taken by another post (or matches a built-in route like `/search`), Lamb appends the post's id to keep the URL distinct, and writes the final slug back into the post's front-matter so you can see — and edit — the slug the post is actually served under.
 
 You can also set a `created:` date in the front-matter. A future date schedules the post — see [Scheduling]({{ site.baseurl }}{% link scheduling.md %}).
 

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -128,8 +128,21 @@ function parse_bean(OODBBean $bean): void
     // falls back to it rather than leaving a non-date string in the column.
     $previous_created = $bean->created;
 
+    // A published post's slug is immutable: good URLs don't change. Capture the
+    // stored slug and draft state before the front-matter loop overwrites them.
+    $previous_slug = (string) $bean->slug;
+    $slug_locked = !empty($bean->id) && $previous_slug !== '' && empty($bean->draft);
+
     foreach ($front_matter as $key => $value) {
         $bean->$key = $value;
+    }
+
+    // Ignore slug changes on published posts (whether edited explicitly or
+    // re-derived from a changed title) and reverse the front-matter slug to the
+    // slug the post is actually served under. Drafts can still be re-slugged.
+    if ($slug_locked && (string) $bean->slug !== $previous_slug) {
+        $bean->slug = $previous_slug;
+        $bean->body = Post\persist_slug($bean->body, $previous_slug);
     }
 
     // Normalise a front-matter `created` date into the canonical Y-m-d H:i:s string.

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -128,21 +128,8 @@ function parse_bean(OODBBean $bean): void
     // falls back to it rather than leaving a non-date string in the column.
     $previous_created = $bean->created;
 
-    // A published post's slug is immutable: good URLs don't change. Capture the
-    // stored slug and draft state before the front-matter loop overwrites them.
-    $previous_slug = (string) $bean->slug;
-    $slug_locked = !empty($bean->id) && $previous_slug !== '' && empty($bean->draft);
-
     foreach ($front_matter as $key => $value) {
         $bean->$key = $value;
-    }
-
-    // Ignore slug changes on published posts (whether edited explicitly or
-    // re-derived from a changed title) and reverse the front-matter slug to the
-    // slug the post is actually served under. Drafts can still be re-slugged.
-    if ($slug_locked && (string) $bean->slug !== $previous_slug) {
-        $bean->slug = $previous_slug;
-        $bean->body = Post\persist_slug($bean->body, $previous_slug);
     }
 
     // Normalise a front-matter `created` date into the canonical Y-m-d H:i:s string.

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -14,6 +14,7 @@ use function Lamb\get_tags;
 use function Lamb\is_scheduled;
 use function Lamb\parse_bean;
 use function Lamb\permalink;
+use function Lamb\Post\finalize_slug;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\populate_bean;
 
@@ -245,6 +246,12 @@ class LambMicropubAdapter extends MicropubAdapter
         }
 
         R::store($bean);
+        // Reserved-route and duplicate slugs get an id suffix; the final slug
+        // is pinned into the body's front matter and must be settled before
+        // the Location permalink is computed.
+        if (finalize_slug($bean)) {
+            R::store($bean);
+        }
 
         \Lamb\Webmention\enqueue_for_post($bean);
         \Lamb\Websub\ping_for_post($bean);

--- a/src/network.php
+++ b/src/network.php
@@ -11,7 +11,7 @@ use SimplePie\SimplePie;
 
 use function Lamb\get_option;
 use function Lamb\Route\register_route;
-use function Lamb\Route\is_reserved_route;
+use function Lamb\Post\finalize_slug;
 use function Lamb\Post\populate_bean;
 use function Lamb\set_option;
 
@@ -121,6 +121,7 @@ function update_item(SimplePieItem $item, string $name): void
     }
     $bean = prepare_item($item, $name, $bean);
     $bean->updated = $item->get_updated_date("Y-m-d H:i:s");
+    finalize_slug($bean);
 
     try {
         R::store($bean);
@@ -142,11 +143,13 @@ function create_item(SimplePieItem $item, string $name)
     $bean = populate_bean($contents, $item, $name);
 
     try {
-        $id = R::store($bean);
-        if (is_reserved_route($bean->slug)) {
-            $bean->slug .= "-" . $id;
-        }
         R::store($bean);
+        // Reserved-route and duplicate slugs (e.g. two same-titled items in
+        // one feed) get an id suffix; the final slug is pinned into the
+        // body's front matter so cron updates re-derive it unchanged.
+        if (finalize_slug($bean)) {
+            R::store($bean);
+        }
     } catch (SQL) {
         // continue
     }

--- a/src/post.php
+++ b/src/post.php
@@ -31,14 +31,8 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
     if ($bean === null) {
         $bean = R::dispense('post');
     }
-    // A published post's slug is locked (see parse_bean); capture the stored
-    // state before it is overwritten so the feed-name prefix below cannot
-    // change a slug the lock just preserved.
-    $slug_mutable = empty($bean->id) || !empty($bean->draft);
     $bean->body = $text;
-    if ($slug_mutable) {
-        $bean->slug = $matter['slug'] ?? '';
-    }
+    $bean->slug = $matter['slug'] ?? '';
     $bean->created = date("Y-m-d H:i:s");
     $bean->updated = date("Y-m-d H:i:s");
     if ($feed_item) {
@@ -59,7 +53,7 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
     // (pinned by finalize_slug() on first save) is authoritative and must not
     // be prefixed again on cron updates.
     $derived = isset($matter['title']) && $bean->slug === slugify((string) $matter['title']);
-    if ($feed_item && $feed_name && $bean->slug && $derived && $slug_mutable) {
+    if ($feed_item && $feed_name && $bean->slug && $derived) {
         $bean->slug = slugify("$feed_name-" . $bean->slug);
     }
     $bean->version = POST_VERSION;

--- a/src/post.php
+++ b/src/post.php
@@ -38,10 +38,6 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
         $bean->created = $feed_item->get_date("Y-m-d H:i:s");
         $bean->updated = $feed_item->get_updated_date("Y-m-d H:i:s");
         if ($feed_name) {
-            if ($bean->slug) {
-                // Prefix with feed name
-                $bean->slug = slugify("$feed_name-" . $bean->slug);
-            }
             $bean->feeditem_uuid = md5($feed_name . $feed_item->get_id());
             $bean->feed_name = $feed_name;
         }
@@ -49,6 +45,13 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
     }
 
     parse_bean($bean);
+    // Prefix feed-item slugs with the feed name so same-titled posts from
+    // different feeds don't collide. Applied after parse_bean(), whose
+    // front-matter loop re-derives the slug from the title and would
+    // otherwise clobber the prefix (issue #332).
+    if ($feed_item && $feed_name && $bean->slug) {
+        $bean->slug = slugify("$feed_name-" . $bean->slug);
+    }
     $bean->version = POST_VERSION;
 
     // Auto-draft new feed items when feeds_draft is enabled (applied after parse_bean

--- a/src/post.php
+++ b/src/post.php
@@ -9,6 +9,7 @@ use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 use function Lamb\parse_bean;
+use function Lamb\Route\is_reserved_route;
 
 /**
  * Populates and returns an OODBBean instance with the given text and optional feed information.
@@ -45,11 +46,14 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
     }
 
     parse_bean($bean);
-    // Prefix feed-item slugs with the feed name so same-titled posts from
-    // different feeds don't collide. Applied after parse_bean(), whose
-    // front-matter loop re-derives the slug from the title and would
-    // otherwise clobber the prefix (issue #332).
-    if ($feed_item && $feed_name && $bean->slug) {
+    // Prefix a title-derived feed-item slug with the feed name so same-titled
+    // posts from different feeds don't collide. Applied after parse_bean(),
+    // whose front-matter loop re-derives the slug from the title and would
+    // otherwise clobber the prefix (issue #332). An explicit front-matter slug
+    // (pinned by finalize_slug() on first save) is authoritative and must not
+    // be prefixed again on cron updates.
+    $derived = isset($matter['title']) && $bean->slug === slugify((string) $matter['title']);
+    if ($feed_item && $feed_name && $bean->slug && $derived) {
         $bean->slug = slugify("$feed_name-" . $bean->slug);
     }
     $bean->version = POST_VERSION;
@@ -144,6 +148,92 @@ function inject_title_matter(string $body, string $title): string
 function slugify(string $text): string
 {
     return strtolower(preg_replace('/\W+/m', "-", $text));
+}
+
+/**
+ * Rewrites the `slug` value inside a body's leading YAML front-matter block to
+ * the given actual slug, leaving all other front matter intact.
+ *
+ * This keeps the front matter in sync with the slug the post is actually
+ * served under after adjustments (feed-name prefix, reserved-route or
+ * duplicate suffix), so a later re-parse derives the same slug instead of the
+ * original colliding one. An existing `slug:` line is updated in place; when
+ * the block has none (slug derived from the title) an explicit line is
+ * appended. Bodies without a front-matter block, or whose slug already equals
+ * the actual value, are returned unchanged (no cosmetic churn).
+ *
+ * @param string $body The raw post body.
+ * @param string $slug The slug the post is actually served under.
+ * @return string The body with its front-matter `slug` pinned.
+ */
+function persist_slug(string $body, string $slug): string
+{
+    // Only touch a front-matter block at the very start of the body.
+    if (!preg_match('/\A(\s*---\s*\n)(.*?\n)(---\s*\n?)/s', $body, $m)) {
+        return $body;
+    }
+
+    $new_yaml = preg_replace_callback(
+        '/^([ \t]*slug[ \t]*:)[ \t]*(.*?)[ \t]*$/mi',
+        function (array $line) use ($slug): string {
+            $current = trim($line[2], " \t'\"");
+            if ($current === $slug) {
+                return $line[0];
+            }
+            return $line[1] . ' ' . $slug;
+        },
+        $m[2],
+        1,
+        $count
+    );
+
+    if ($count === 0) {
+        $new_yaml = $m[2] . "slug: $slug\n";
+    }
+
+    return $m[1] . $new_yaml . $m[3] . substr($body, strlen($m[0]));
+}
+
+/**
+ * Finalises a stored post's slug: guarantees it is unique and not a reserved
+ * route, and pins the result into the body's front matter.
+ *
+ * Duplicate and reserved slugs get the post's id appended (matching the
+ * existing reserved-route convention), so two posts can never be served under
+ * the same slug. The final slug is persisted into the front matter via
+ * persist_slug() whenever it differs from what a re-parse would derive, so the
+ * adjustment survives later edits and cron updates. Must be called after the
+ * first R::store() (the id is part of the suffix); the caller re-stores when
+ * this returns true.
+ *
+ * @param OODBBean $bean A stored post bean.
+ * @return bool True when the slug or body changed and the bean needs re-storing.
+ */
+function finalize_slug(OODBBean $bean): bool
+{
+    $slug = (string) $bean->slug;
+    if ($slug === '') {
+        return false;
+    }
+
+    if (is_reserved_route($slug)) {
+        $slug .= '-' . $bean->id;
+    }
+    while (R::findOne('post', ' slug = ? AND id != ? ', [$slug, $bean->id])) {
+        $slug .= '-' . $bean->id;
+    }
+
+    $body = (string) $bean->body;
+    $matter = parse_matter($body);
+    if (($matter['slug'] ?? '') !== $slug) {
+        $body = persist_slug($body, $slug);
+    }
+
+    $changed = $slug !== (string) $bean->slug || $body !== (string) $bean->body;
+    $bean->slug = $slug;
+    $bean->body = $body;
+
+    return $changed;
 }
 
 /**

--- a/src/post.php
+++ b/src/post.php
@@ -31,8 +31,14 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
     if ($bean === null) {
         $bean = R::dispense('post');
     }
+    // A published post's slug is locked (see parse_bean); capture the stored
+    // state before it is overwritten so the feed-name prefix below cannot
+    // change a slug the lock just preserved.
+    $slug_mutable = empty($bean->id) || !empty($bean->draft);
     $bean->body = $text;
-    $bean->slug = $matter['slug'] ?? '';
+    if ($slug_mutable) {
+        $bean->slug = $matter['slug'] ?? '';
+    }
     $bean->created = date("Y-m-d H:i:s");
     $bean->updated = date("Y-m-d H:i:s");
     if ($feed_item) {
@@ -53,7 +59,7 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
     // (pinned by finalize_slug() on first save) is authoritative and must not
     // be prefixed again on cron updates.
     $derived = isset($matter['title']) && $bean->slug === slugify((string) $matter['title']);
-    if ($feed_item && $feed_name && $bean->slug && $derived) {
+    if ($feed_item && $feed_name && $bean->slug && $derived && $slug_mutable) {
         $bean->slug = slugify("$feed_name-" . $bean->slug);
     }
     $bean->version = POST_VERSION;

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -13,6 +13,7 @@ use RedBeanPHP\RedException\SQL;
 
 use function Lamb\delete_redirect_for_slug;
 use function Lamb\parse_bean;
+use function Lamb\Post\finalize_slug;
 use function Lamb\Post\populate_bean;
 use function Lamb\Route\is_reserved_route;
 
@@ -40,9 +41,10 @@ function redirect_created(): void
     $bean = populate_bean($contents);
 
     try {
-        $id = R::store($bean);
-        if (is_reserved_route($bean->slug)) {
-            $bean->slug .= "-" . $id;
+        R::store($bean);
+        // Reserved-route and duplicate slugs get an id suffix; the final slug
+        // is pinned into the body's front matter so it survives later edits.
+        if (finalize_slug($bean)) {
             R::store($bean);
         }
         // Remove any existing redirect for this slug — the new post takes priority
@@ -185,6 +187,10 @@ function redirect_edited(): void
 
         return;
     }
+
+    // A slug claimed by another post gets an id suffix, and the final slug is
+    // pinned into the body's front matter so the edit form shows it.
+    finalize_slug($bean);
 
     try {
         R::store($bean);

--- a/tests/Unit/PopulateBeanTest.php
+++ b/tests/Unit/PopulateBeanTest.php
@@ -278,35 +278,4 @@ class PopulateBeanTest extends TestCase
         $bean = populate_bean("---\ntitle: Hello World\n---\nContent.");
         $this->assertSame('hello-world', $bean->slug);
     }
-
-    public function testTwoPostsWithSameExplicitSlugShareTheSlug(): void
-    {
-        // Codifies current behaviour: nothing deduplicates an explicit
-        // front-matter slug, so two posts created one after the other with the
-        // same slug both carry it.
-        $text = "---\nslug: shared-slug\n---\nContent.";
-        $first = populate_bean($text);
-        R::store($first);
-        $second = populate_bean($text);
-        R::store($second);
-
-        $this->assertSame('shared-slug', $first->slug);
-        $this->assertSame('shared-slug', $second->slug);
-        $this->assertNotSame($first->id, $second->id);
-    }
-
-    public function testSlugLookupReturnsFirstStoredPostForDuplicateSlug(): void
-    {
-        // Codifies current behaviour: a slug lookup resolves to the
-        // first-stored post; the later duplicate is shadowed and only
-        // reachable via /status/<id>.
-        $text = "---\nslug: shared-lookup-slug\n---\nContent.";
-        $first = populate_bean($text);
-        R::store($first);
-        $second = populate_bean($text);
-        R::store($second);
-
-        $found = R::findOne('post', ' slug = ? ', ['shared-lookup-slug']);
-        $this->assertSame($first->id, $found->id);
-    }
 }

--- a/tests/Unit/PopulateBeanTest.php
+++ b/tests/Unit/PopulateBeanTest.php
@@ -231,4 +231,82 @@ class PopulateBeanTest extends TestCase
 
         $this->assertSame('https://example.com/article', $bean->source_url);
     }
+
+    private function makeFeedItem(string $id): SimplePieItem
+    {
+        $item = $this->createMock(SimplePieItem::class);
+        $item->method('get_date')->willReturn('2024-01-01 00:00:00');
+        $item->method('get_updated_date')->willReturn('2024-01-01 00:00:00');
+        $item->method('get_id')->willReturn($id);
+        return $item;
+    }
+
+    public function testFeedItemSlugIsPrefixedWithFeedName(): void
+    {
+        $text = "---\ntitle: Hello World\n---\nContent.";
+        $bean = populate_bean($text, $this->makeFeedItem('item-1'), 'myfeed');
+
+        $this->assertSame('myfeed-hello-world', $bean->slug);
+    }
+
+    public function testSameTitleFromTwoFeedsYieldsDistinctSlugs(): void
+    {
+        $text = "---\ntitle: Hello World\n---\nContent.";
+        $a = populate_bean($text, $this->makeFeedItem('item-a'), 'feeda');
+        $b = populate_bean($text, $this->makeFeedItem('item-b'), 'feedb');
+
+        $this->assertSame('feeda-hello-world', $a->slug);
+        $this->assertSame('feedb-hello-world', $b->slug);
+        $this->assertNotSame($a->slug, $b->slug);
+    }
+
+    public function testCronUpdateDoesNotDoublePrefixSlug(): void
+    {
+        $text = "---\ntitle: Hello World\n---\nContent.";
+        $item = $this->makeFeedItem('item-upd');
+        $bean = populate_bean($text, $item, 'myfeed');
+        R::store($bean);
+
+        // Cron's update_item() runs the same bean through populate_bean again.
+        $bean = populate_bean($text, $item, 'myfeed', $bean);
+
+        $this->assertSame('myfeed-hello-world', $bean->slug);
+    }
+
+    public function testNonFeedPostSlugIsNotPrefixed(): void
+    {
+        $bean = populate_bean("---\ntitle: Hello World\n---\nContent.");
+        $this->assertSame('hello-world', $bean->slug);
+    }
+
+    public function testTwoPostsWithSameExplicitSlugShareTheSlug(): void
+    {
+        // Codifies current behaviour: nothing deduplicates an explicit
+        // front-matter slug, so two posts created one after the other with the
+        // same slug both carry it.
+        $text = "---\nslug: shared-slug\n---\nContent.";
+        $first = populate_bean($text);
+        R::store($first);
+        $second = populate_bean($text);
+        R::store($second);
+
+        $this->assertSame('shared-slug', $first->slug);
+        $this->assertSame('shared-slug', $second->slug);
+        $this->assertNotSame($first->id, $second->id);
+    }
+
+    public function testSlugLookupReturnsFirstStoredPostForDuplicateSlug(): void
+    {
+        // Codifies current behaviour: a slug lookup resolves to the
+        // first-stored post; the later duplicate is shadowed and only
+        // reachable via /status/<id>.
+        $text = "---\nslug: shared-lookup-slug\n---\nContent.";
+        $first = populate_bean($text);
+        R::store($first);
+        $second = populate_bean($text);
+        R::store($second);
+
+        $found = R::findOne('post', ' slug = ? ', ['shared-lookup-slug']);
+        $this->assertSame($first->id, $found->id);
+    }
 }

--- a/tests/Unit/SlugFinalizeTest.php
+++ b/tests/Unit/SlugFinalizeTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 use SimplePie\Item as SimplePieItem;
 
+use function Lamb\parse_bean;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\persist_slug;
 use function Lamb\Post\populate_bean;
@@ -171,6 +172,85 @@ class SlugFinalizeTest extends TestCase
         $this->assertStringContainsString('slug: myfeed-hello-world', $bean->body);
 
         $bean = populate_bean($bean->body, $item, 'myfeed', $bean);
+
+        $this->assertSame('myfeed-hello-world', $bean->slug);
+    }
+
+    // -------------------------------------------------------------------
+    // Slug immutability after publish — edits to slugs are ignored and the
+    // front-matter slug is reversed to the slug the post is served under.
+    // -------------------------------------------------------------------
+
+    private function makePublishedPost(string $body): \RedBeanPHP\OODBBean
+    {
+        $bean = populate_bean($body);
+        $bean->draft = 0;
+        R::store($bean);
+        finalize_slug($bean);
+        R::store($bean);
+        return $bean;
+    }
+
+    public function testPublishedPostKeepsSlugWhenFrontMatterSlugEdited(): void
+    {
+        $bean = $this->makePublishedPost("---\ntitle: My Page\n---\nContent.");
+
+        $bean->body = "---\ntitle: My Page\nslug: something-else\n---\nContent.";
+        parse_bean($bean);
+
+        $this->assertSame('my-page', $bean->slug);
+        $this->assertStringContainsString('slug: my-page', $bean->body);
+        $this->assertStringNotContainsString('something-else', $bean->body);
+    }
+
+    public function testPublishedPostKeepsSlugWhenTitleEdited(): void
+    {
+        $bean = $this->makePublishedPost("---\ntitle: My Page\n---\nContent.");
+
+        $bean->body = "---\ntitle: A Better Title\n---\nContent.";
+        parse_bean($bean);
+
+        $this->assertSame('my-page', $bean->slug);
+        $this->assertStringContainsString('slug: my-page', $bean->body);
+    }
+
+    public function testDraftPostSlugCanStillBeEdited(): void
+    {
+        $bean = populate_bean("---\ntitle: My Draft\ndraft: true\n---\nContent.");
+        R::store($bean);
+        finalize_slug($bean);
+        R::store($bean);
+
+        $bean->body = "---\ntitle: My Draft\ndraft: true\nslug: better-slug\n---\nContent.";
+        parse_bean($bean);
+
+        $this->assertSame('better-slug', $bean->slug);
+    }
+
+    public function testPublishedSluglessPostCanGainSlug(): void
+    {
+        $bean = populate_bean('Just a status update.');
+        $bean->draft = 0;
+        R::store($bean);
+
+        $bean->body = "---\ntitle: Now A Page\n---\nContent.";
+        parse_bean($bean);
+
+        $this->assertSame('now-a-page', $bean->slug);
+    }
+
+    public function testPublishedFeedItemKeepsSlugWhenUpstreamTitleChanges(): void
+    {
+        $item = $this->makeFeedItem('item-locked');
+        $bean = populate_bean("---\ntitle: Hello World\n---\nContent.", $item, 'myfeed');
+        $bean->draft = 0;
+        R::store($bean);
+        finalize_slug($bean);
+        R::store($bean);
+        $this->assertSame('myfeed-hello-world', $bean->slug);
+
+        // Upstream rewrites the item title; cron update regenerates the body.
+        $bean = populate_bean("---\ntitle: Renamed Post\n---\nContent.", $item, 'myfeed', $bean);
 
         $this->assertSame('myfeed-hello-world', $bean->slug);
     }

--- a/tests/Unit/SlugFinalizeTest.php
+++ b/tests/Unit/SlugFinalizeTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+use SimplePie\Item as SimplePieItem;
+
+use function Lamb\Post\finalize_slug;
+use function Lamb\Post\persist_slug;
+use function Lamb\Post\populate_bean;
+
+class SlugFinalizeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        global $config;
+        $config = $config ?? [];
+    }
+
+    private function makeFeedItem(string $id): SimplePieItem
+    {
+        $item = $this->createMock(SimplePieItem::class);
+        $item->method('get_date')->willReturn('2024-01-01 00:00:00');
+        $item->method('get_updated_date')->willReturn('2024-01-01 00:00:00');
+        $item->method('get_id')->willReturn($id);
+        return $item;
+    }
+
+    // -------------------------------------------------------------------
+    // persist_slug — pinning the actual slug into front matter
+    // -------------------------------------------------------------------
+
+    public function testPersistSlugUpdatesExistingSlugLine(): void
+    {
+        $body = "---\nslug: old-slug\n---\nContent.";
+        $this->assertSame("---\nslug: new-slug\n---\nContent.", persist_slug($body, 'new-slug'));
+    }
+
+    public function testPersistSlugInsertsSlugLineWhenOnlyTitlePresent(): void
+    {
+        $body = "---\ntitle: Hello World\n---\nContent.";
+        $this->assertSame(
+            "---\ntitle: Hello World\nslug: myfeed-hello-world\n---\nContent.",
+            persist_slug($body, 'myfeed-hello-world')
+        );
+    }
+
+    public function testPersistSlugLeavesBodyWithoutFrontMatterUnchanged(): void
+    {
+        $body = "Just a status update.";
+        $this->assertSame($body, persist_slug($body, 'anything'));
+    }
+
+    public function testPersistSlugNoChurnWhenAlreadyEqual(): void
+    {
+        $body = "---\ntitle: Hello\nslug: hello\n---\nContent.";
+        $this->assertSame($body, persist_slug($body, 'hello'));
+    }
+
+    // -------------------------------------------------------------------
+    // finalize_slug — uniqueness + front-matter sync after store
+    // -------------------------------------------------------------------
+
+    public function testSecondPostWithSameExplicitSlugIsDeduplicated(): void
+    {
+        $text = "---\nslug: shared-slug\n---\nContent.";
+        $first = populate_bean($text);
+        R::store($first);
+        finalize_slug($first);
+        R::store($first);
+
+        $second = populate_bean($text);
+        R::store($second);
+        finalize_slug($second);
+        R::store($second);
+
+        $this->assertSame('shared-slug', $first->slug);
+        $this->assertSame('shared-slug-' . $second->id, $second->slug);
+        $this->assertStringContainsString('slug: shared-slug-' . $second->id, $second->body);
+    }
+
+    public function testFinalizeIsIdempotentForTheSlugOwner(): void
+    {
+        $text = "---\nslug: my-page\n---\nContent.";
+        $bean = populate_bean($text);
+        R::store($bean);
+        finalize_slug($bean);
+        R::store($bean);
+
+        $this->assertFalse(finalize_slug($bean));
+        $this->assertSame('my-page', $bean->slug);
+    }
+
+    public function testFinalizeSuffixesReservedRouteSlug(): void
+    {
+        // Routes are registered by index.php at runtime; register one here so
+        // is_reserved_route() sees it in the unit context.
+        \Lamb\Route\register_route('search', 'strlen');
+
+        $text = "---\nslug: search\n---\nContent.";
+        $bean = populate_bean($text);
+        R::store($bean);
+        finalize_slug($bean);
+        R::store($bean);
+
+        $this->assertSame('search-' . $bean->id, $bean->slug);
+        $this->assertStringContainsString('slug: search-' . $bean->id, $bean->body);
+    }
+
+    public function testFinalizeLeavesDerivedSlugBodyUntouched(): void
+    {
+        // Title-derived slug already matches the actual slug: front matter is in
+        // sync without an explicit slug line, so the body must not be rewritten.
+        $text = "---\ntitle: Hello World\n---\nContent.";
+        $bean = populate_bean($text);
+        R::store($bean);
+
+        $this->assertFalse(finalize_slug($bean));
+        $this->assertSame($text, $bean->body);
+    }
+
+    public function testFinalizeIgnoresSluglessPosts(): void
+    {
+        $bean = populate_bean('Just a status update.');
+        R::store($bean);
+
+        $this->assertFalse(finalize_slug($bean));
+        $this->assertSame('', $bean->slug);
+    }
+
+    // -------------------------------------------------------------------
+    // Feed items — same-feed title collisions and explicit-slug stability
+    // -------------------------------------------------------------------
+
+    public function testSameTitledItemsFromOneFeedGetDistinctSlugs(): void
+    {
+        $text = "---\ntitle: Hello World\n---\nContent.";
+
+        $first = populate_bean($text, $this->makeFeedItem('item-1'), 'myfeed');
+        R::store($first);
+        finalize_slug($first);
+        R::store($first);
+
+        $second = populate_bean($text, $this->makeFeedItem('item-2'), 'myfeed');
+        R::store($second);
+        finalize_slug($second);
+        R::store($second);
+
+        $this->assertSame('myfeed-hello-world', $first->slug);
+        $this->assertSame('myfeed-hello-world-' . $second->id, $second->slug);
+    }
+
+    public function testFinalizedFeedItemSlugSurvivesReparse(): void
+    {
+        // After finalize the body carries the explicit prefixed slug, so a later
+        // populate_bean (cron update) must not prefix it again.
+        $text = "---\ntitle: Hello World\n---\nContent.";
+        $item = $this->makeFeedItem('item-reparse');
+        $bean = populate_bean($text, $item, 'myfeed');
+        R::store($bean);
+        finalize_slug($bean);
+        R::store($bean);
+
+        $this->assertStringContainsString('slug: myfeed-hello-world', $bean->body);
+
+        $bean = populate_bean($bean->body, $item, 'myfeed', $bean);
+
+        $this->assertSame('myfeed-hello-world', $bean->slug);
+    }
+}

--- a/tests/Unit/SlugFinalizeTest.php
+++ b/tests/Unit/SlugFinalizeTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 use SimplePie\Item as SimplePieItem;
 
-use function Lamb\parse_bean;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\persist_slug;
 use function Lamb\Post\populate_bean;
@@ -172,85 +171,6 @@ class SlugFinalizeTest extends TestCase
         $this->assertStringContainsString('slug: myfeed-hello-world', $bean->body);
 
         $bean = populate_bean($bean->body, $item, 'myfeed', $bean);
-
-        $this->assertSame('myfeed-hello-world', $bean->slug);
-    }
-
-    // -------------------------------------------------------------------
-    // Slug immutability after publish — edits to slugs are ignored and the
-    // front-matter slug is reversed to the slug the post is served under.
-    // -------------------------------------------------------------------
-
-    private function makePublishedPost(string $body): \RedBeanPHP\OODBBean
-    {
-        $bean = populate_bean($body);
-        $bean->draft = 0;
-        R::store($bean);
-        finalize_slug($bean);
-        R::store($bean);
-        return $bean;
-    }
-
-    public function testPublishedPostKeepsSlugWhenFrontMatterSlugEdited(): void
-    {
-        $bean = $this->makePublishedPost("---\ntitle: My Page\n---\nContent.");
-
-        $bean->body = "---\ntitle: My Page\nslug: something-else\n---\nContent.";
-        parse_bean($bean);
-
-        $this->assertSame('my-page', $bean->slug);
-        $this->assertStringContainsString('slug: my-page', $bean->body);
-        $this->assertStringNotContainsString('something-else', $bean->body);
-    }
-
-    public function testPublishedPostKeepsSlugWhenTitleEdited(): void
-    {
-        $bean = $this->makePublishedPost("---\ntitle: My Page\n---\nContent.");
-
-        $bean->body = "---\ntitle: A Better Title\n---\nContent.";
-        parse_bean($bean);
-
-        $this->assertSame('my-page', $bean->slug);
-        $this->assertStringContainsString('slug: my-page', $bean->body);
-    }
-
-    public function testDraftPostSlugCanStillBeEdited(): void
-    {
-        $bean = populate_bean("---\ntitle: My Draft\ndraft: true\n---\nContent.");
-        R::store($bean);
-        finalize_slug($bean);
-        R::store($bean);
-
-        $bean->body = "---\ntitle: My Draft\ndraft: true\nslug: better-slug\n---\nContent.";
-        parse_bean($bean);
-
-        $this->assertSame('better-slug', $bean->slug);
-    }
-
-    public function testPublishedSluglessPostCanGainSlug(): void
-    {
-        $bean = populate_bean('Just a status update.');
-        $bean->draft = 0;
-        R::store($bean);
-
-        $bean->body = "---\ntitle: Now A Page\n---\nContent.";
-        parse_bean($bean);
-
-        $this->assertSame('now-a-page', $bean->slug);
-    }
-
-    public function testPublishedFeedItemKeepsSlugWhenUpstreamTitleChanges(): void
-    {
-        $item = $this->makeFeedItem('item-locked');
-        $bean = populate_bean("---\ntitle: Hello World\n---\nContent.", $item, 'myfeed');
-        $bean->draft = 0;
-        R::store($bean);
-        finalize_slug($bean);
-        R::store($bean);
-        $this->assertSame('myfeed-hello-world', $bean->slug);
-
-        // Upstream rewrites the item title; cron update regenerates the body.
-        $bean = populate_bean("---\ntitle: Renamed Post\n---\nContent.", $item, 'myfeed', $bean);
 
         $this->assertSame('myfeed-hello-world', $bean->slug);
     }


### PR DESCRIPTION
## Summary
- **Feed-name prefix survives parsing (#332):** `populate_bean()` prefixed feed-item slugs *before* `parse_bean()`, whose additive front-matter loop re-derives the slug from the title — clobbering the prefix every time. The prefix is now applied after `parse_bean()`, and only to title-derived slugs (an explicit front-matter slug is authoritative).
- **Duplicate slugs are no longer possible:** new `finalize_slug()` runs after the first store on every write path (web create/edit, feed create/update, Micropub create). Reserved-route and duplicate slugs get the post's id appended — extending the existing reserved-route convention.
- **Front matter stays in sync with the actual slug:** the final slug is pinned into the body's front matter via new `persist_slug()` (same pattern as `persist_resolved_created`), so a re-parse always derives the slug the post is actually served under, and the editor shows it. Bodies already in sync are untouched (no churn).
- Deliberate slug edits keep working as before: the new slug is honoured and an automatic 301 redirect is stored from the old slug. `docs/post-types.md` now describes this accurately (it previously claimed slugs were preserved after creation).

Fixes #332

## Test plan
- `tests/Unit/SlugFinalizeTest.php` (red before the fix): `persist_slug()` update/insert/no-churn; `finalize_slug()` dedup, reserved-route suffix, idempotency, slugless/derived no-ops; same-feed title collisions; pinned feed slug survives a cron re-parse.
- `tests/Unit/PopulateBeanTest.php`: prefix applied, cross-feed distinct slugs, no double-prefix on cron update.
- `vendor/bin/codecept run Unit` — 787 tests green; `composer lint` and `composer analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)