### PR TITLE
Refactor: consolidate WebP upload conversion into one helper

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -504,9 +504,7 @@ class LambMicropubAdapter extends MicropubAdapter
                 $tmp = tempnam(sys_get_temp_dir(), 'lamb_up_');
                 if ($tmp !== false) {
                     file_put_contents($tmp, (string) $file->getStream());
-                    if (\Lamb\Response\convert_to_webp($tmp, $uploadDir . '/' . $seed . '.webp')) {
-                        $filename = $seed . '.webp';
-                    }
+                    $filename = \Lamb\Response\store_webp_copy($tmp, $ext, $uploadDir, $seed);
                     unlink($tmp);
                 }
             }
@@ -785,11 +783,8 @@ function respond_micropub_media(): void
     $seed      = sha1(($file['name'] ?? '') . uniqid('', true));
 
     // Re-encode JPEG/PNG to WebP, falling back to the original bytes on failure.
-    $converted = \Lamb\Response\should_convert_to_webp($ext)
-        && \Lamb\Response\convert_to_webp($file['tmp_name'], $uploadDir . '/' . $seed . '.webp');
-    if ($converted) {
-        $filename = $seed . '.webp';
-    } else {
+    $filename = \Lamb\Response\store_webp_copy($file['tmp_name'], $ext, $uploadDir, $seed);
+    if ($filename === null) {
         $filename = $seed . ".$ext";
         move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $filename);
     }

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -51,24 +51,18 @@ function respond_upload(array $_args): void
             die();
         }
         $temp_fp = $f['tmp_name'];
+        $seed    = sha1($f['name']);
 
         // Re-encode JPEG/PNG to WebP for smaller files; fall back to the original
         // bytes if conversion fails (assume success, communicate failure).
-        if (should_convert_to_webp($ext)) {
-            $webp_fn = sha1($f['name']) . '.webp';
-            $webp_fp = sprintf("%s/%s", get_upload_dir(), $webp_fn);
-            if (convert_to_webp($temp_fp, $webp_fp)) {
-                $upload_url = str_replace(ROOT_DIR, ROOT_URL, get_upload_dir());
-                $out .= sprintf("![%s](%s)", $f['name'], "$upload_url/$webp_fn");
-                continue;
+        $new_fn = store_webp_copy($temp_fp, $ext, get_upload_dir(), $seed);
+        if ($new_fn === null) {
+            $new_fn = "$seed.$ext";
+            $new_fp = sprintf("%s/%s", get_upload_dir(), $new_fn);
+            if (!move_uploaded_file($temp_fp, $new_fp)) {
+                echo json_encode('Move upload error: ' . $temp_fp, JSON_THROW_ON_ERROR);
+                die();
             }
-        }
-
-        $new_fn = sha1($f['name']) . ".$ext";
-        $new_fp = sprintf("%s/%s", get_upload_dir(), $new_fn);
-        if (!move_uploaded_file($temp_fp, $new_fp)) {
-            echo json_encode('Move upload error: ' . $temp_fp, JSON_THROW_ON_ERROR);
-            die();
         }
         $upload_url = str_replace(ROOT_DIR, ROOT_URL, get_upload_dir());
         $out .= sprintf("![%s](%s)", $f['name'], "$upload_url/$new_fn");
@@ -113,6 +107,38 @@ function safe_upload_extension(string $filename): ?string
 function should_convert_to_webp(?string $ext): bool
 {
     return in_array($ext, ['jpg', 'jpeg', 'png'], true);
+}
+
+/**
+ * Re-encodes an upload to WebP under $dest_dir, or returns null to fall back.
+ *
+ * Owns the shared "convert to WebP or fall back to the original bytes" decision used
+ * by every upload path (web upload, Micropub inline photos, Micropub media endpoint):
+ * the destination filename is the $seed plus the chosen extension. When the extension
+ * is a convertible raster format (should_convert_to_webp()) and convert_to_webp()
+ * succeeds, the WebP is written at "$dest_dir/$seed.webp" and that filename is
+ * returned. Otherwise nothing is written and null is returned, leaving each caller to
+ * store the original bytes under "$seed.$ext" via its own move semantics
+ * (move_uploaded_file() vs UploadedFileInterface::moveTo()) and build its own URL.
+ *
+ * @param string $src_path A readable path to the source image bytes.
+ * @param string $ext      The lower-case extension from safe_upload_extension().
+ * @param string $dest_dir The upload directory from get_upload_dir() (no trailing slash).
+ * @param string $seed     The hashed base filename (without extension).
+ * @return string|null The "$seed.webp" filename on success, or null to fall back.
+ */
+function store_webp_copy(string $src_path, string $ext, string $dest_dir, string $seed): ?string
+{
+    if (!should_convert_to_webp($ext)) {
+        return null;
+    }
+
+    $webp_fn = $seed . '.webp';
+    if (convert_to_webp($src_path, sprintf('%s/%s', $dest_dir, $webp_fn))) {
+        return $webp_fn;
+    }
+
+    return null;
 }
 
 /**

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -9,6 +9,7 @@ use function Lamb\Response\get_upload_dir;
 use function Lamb\Response\safe_upload_extension;
 use function Lamb\Response\scaled_dimensions;
 use function Lamb\Response\should_convert_to_webp;
+use function Lamb\Response\store_webp_copy;
 
 class UploadTest extends TestCase
 {
@@ -274,6 +275,43 @@ class UploadTest extends TestCase
         [$width, $height] = getimagesize($dest);
         $this->assertSame(40, $width);
         $this->assertSame(30, $height);
+    }
+
+    // store_webp_copy — shared decision: convert a JPEG/PNG source to a .webp file
+    // under the destination dir, returning the .webp filename, or null when the
+    // source should not be (or cannot be) converted so callers fall back to the
+    // original extension.
+
+    public function testStoreWebpCopyReturnsWebpFilenameForPng(): void
+    {
+        $src = $this->makePng(40, 30);
+
+        $result = store_webp_copy($src, 'png', $this->tempRootDir, 'seedhash');
+
+        $this->assertSame('seedhash.webp', $result);
+        $this->assertFileExists($this->tempRootDir . '/seedhash.webp');
+        $this->assertSame('image/webp', mime_content_type($this->tempRootDir . '/seedhash.webp'));
+    }
+
+    public function testStoreWebpCopyReturnsNullForNonConvertibleExtension(): void
+    {
+        $src = $this->makePng(40, 30);
+
+        $result = store_webp_copy($src, 'gif', $this->tempRootDir, 'seedhash');
+
+        $this->assertNull($result);
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.webp');
+    }
+
+    public function testStoreWebpCopyReturnsNullForGarbageSource(): void
+    {
+        $src = $this->tempRootDir . '/notimage.png';
+        file_put_contents($src, 'this is not an image');
+
+        $result = store_webp_copy($src, 'png', $this->tempRootDir, 'seedhash');
+
+        $this->assertNull($result);
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.webp');
     }
 
     private function makePng(int $w, int $h): string


### PR DESCRIPTION
Part of a refactoring series (see #337–#342). Pure refactor — no behaviour change.

## What

The "convert an upload to WebP, fall back to the original bytes on failure" decision was duplicated in three places. Extracted into a single helper `Lamb\Response\store_webp_copy($src_path, $ext, $dest_dir, $seed): ?string` (in `src/response/upload.php`) that owns the `$seed.webp` naming and the `should_convert_to_webp()` + `convert_to_webp()` decision, returning the `.webp` filename on success or `null` so each caller does its own fallback move and URL build.

Call sites now delegate while keeping their own semantics **exactly**:
- `respond_upload()` — `$_FILES` temp path, `move_uploaded_file()` fallback, `str_replace(ROOT_DIR, ROOT_URL, …)` URL.
- `LambMicropubAdapter::saveUploadedPhotos()` — PSR-7 stream → tempfile, `$file->moveTo()` fallback.
- `respond_micropub_media()` — `$_FILES` temp path, `move_uploaded_file()` fallback, `ROOT_URL . '/'` URL preserved.

No `move_uploaded_file` vs `moveTo` choice changed; no URL string changed.

## Verification

- `vendor/bin/phpcs` clean
- `vendor/bin/phpstan analyse` → No errors
- `vendor/bin/codecept run Unit` → 790 tests, 1206 assertions, OK (787 existing + 3 new in `tests/Unit/UploadTest.php`: PNG → `.webp`, non-convertible gif → null, garbage source → null)

Closes #337

https://claude.ai/code/session_01Ma9G1KZWfxNTso76d8pHX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ma9G1KZWfxNTso76d8pHX8)_