### PR TITLE
Refactor: break up parse_bean() into named transformation steps

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -85,37 +85,122 @@ function permalink(OODBBean $bean): string
  */
 function parse_bean(OODBBean $bean): void
 {
-    $parts = explode('---', $bean->body);
+    $markdown = render_body($bean->body);
+
+    $front_matter = parse_matter($bean->body);
+    $front_matter['description'] = extract_description($markdown);
+    $front_matter['transformed'] = highlight_and_link($markdown);
+
+    // Capture the existing created date before apply_frontmatter() blind-copies the
+    // raw front-matter `created` value over it, so apply_scheduling() can fall back
+    // to the prior date when the front-matter value is unparseable.
+    $previous_created = $bean->created;
+    apply_frontmatter($bean, $front_matter);
+    apply_scheduling($bean, $front_matter, $previous_created);
+}
+
+/**
+ * Renders the Markdown body (everything after the front-matter block) to HTML
+ * via LambDown with safe mode enabled.
+ *
+ * @param string $body The raw post body, optionally prefixed by front matter.
+ * @return string The rendered HTML.
+ *
+ * @internal Decomposed step of parse_bean(); not part of the public API.
+ */
+function render_body(string $body): string
+{
+    $parts = explode('---', $body);
     $md_text = trim($parts[count($parts) - 1]);
     $parser = new LambDown();
     $parser->setSafeMode(true);
-    $markdown = $parser->text($md_text);
 
-    $front_matter = parse_matter($bean->body);
+    return $parser->text($md_text);
+}
+
+/**
+ * Extracts a plain-text, single-line description from rendered post HTML.
+ *
+ * @param string $markdown The rendered post HTML.
+ * @return string The first line of stripped, entity-decoded text.
+ *
+ * @internal Decomposed step of parse_bean(); not part of the public API.
+ */
+function extract_description(string $markdown): string
+{
     $description = strtok(strip_tags($markdown), "\n");
     // Decode twice: feed-ingested bodies already contain HTML entities (e.g. `&#039;`),
     // which Parsedown then re-encodes (`&amp;#039;`). A single decode only undoes one layer.
     $description = html_entity_decode($description, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-    $description = html_entity_decode($description, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-    $front_matter['description'] = $description;
 
-    // Protect code blocks from hashtag linking (a `#comment` or a highlighter
-    // colour like `style="color: #005cc5"` must never become a /tag/ link),
-    // then highlight them server-side so visitors get pre-rendered markup.
+    return html_entity_decode($description, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+}
+
+/**
+ * Hashtag-links the rendered HTML while server-side highlighting fenced code.
+ *
+ * Code blocks are pulled out before hashtag linking so a `#comment` or a
+ * highlighter colour like `style="color: #005cc5"` can never become a /tag/
+ * link, then highlighted and restored so visitors get pre-rendered markup.
+ * The extract/restore order is load-bearing: linking must run on the
+ * code-free HTML, and the highlighted blocks are spliced back afterwards.
+ *
+ * @param string $markdown The rendered post HTML.
+ * @return string The HTML with hashtag links and highlighted code blocks.
+ *
+ * @internal Decomposed step of parse_bean(); not part of the public API.
+ */
+function highlight_and_link(string $markdown): string
+{
     [$markdown_without_code, $code_blocks] = Highlight\extract_code_blocks($markdown);
     $code_blocks = array_map('Lamb\Highlight\highlight_code_blocks', $code_blocks);
-    $front_matter['transformed'] = Highlight\restore_code_blocks(parse_tags($markdown_without_code), $code_blocks);
 
-    // Normalise the reply target. Accept either `in-reply-to` (IndieWeb/Micropub
-    // spelling) or `in_reply_to`, and remove both from the blind copy below so the
-    // hyphenated key is never written as an invalid column. Empty when absent, so
-    // removing it from front matter on edit clears the stored value.
+    return Highlight\restore_code_blocks(parse_tags($markdown_without_code), $code_blocks);
+}
+
+/**
+ * Normalises the reply target from front matter into a single string.
+ *
+ * Accepts either `in-reply-to` (IndieWeb/Micropub spelling) or `in_reply_to`,
+ * collapsing a YAML list to its first entry. Both keys are removed from the
+ * passed-by-reference front matter so the hyphenated key is never written as an
+ * invalid column by the blind copy in apply_frontmatter().
+ *
+ * @param array $front_matter The parsed front matter, modified in place.
+ * @return string The normalised reply target, or '' when absent.
+ *
+ * @internal Decomposed step of parse_bean(); not part of the public API.
+ */
+function normalize_in_reply_to(array &$front_matter): string
+{
     $in_reply_to = $front_matter['in-reply-to'] ?? $front_matter['in_reply_to'] ?? null;
     unset($front_matter['in-reply-to'], $front_matter['in_reply_to']);
     if (is_array($in_reply_to)) {
         $in_reply_to = $in_reply_to[0] ?? null;
     }
-    $bean->in_reply_to = is_string($in_reply_to) ? trim($in_reply_to) : '';
+
+    return is_string($in_reply_to) ? trim($in_reply_to) : '';
+}
+
+/**
+ * Applies non-date front-matter fields onto the bean.
+ *
+ * Resets `in_reply_to`, `title`, and `draft` to their defaults when absent so
+ * removing a line on edit clears the stored value, then blind-copies the
+ * remaining front-matter keys. Date normalisation is handled separately by
+ * apply_scheduling().
+ *
+ * @param OODBBean $bean         The bean to mutate.
+ * @param array    $front_matter The parsed front matter (including derived keys).
+ * @return void
+ *
+ * @internal Decomposed step of parse_bean(); not part of the public API.
+ */
+function apply_frontmatter(OODBBean $bean, array $front_matter): void
+{
+    // Normalise the reply target. Empty when absent, so removing it from front
+    // matter on edit clears the stored value.
+    $bean->in_reply_to = normalize_in_reply_to($front_matter);
 
     // Reset the title to empty when it is absent from front matter, so removing
     // the `title:` line (or all front matter) on an edit clears a previously
@@ -123,31 +208,50 @@ function parse_bean(OODBBean $bean): void
     // present, so without this an old title would survive every save.
     $bean->title = isset($front_matter['title']) ? (string) $front_matter['title'] : '';
 
-    // Preserve the existing created date (now for new posts, the stored value for
-    // edits, the feed date for ingested items) so an unparseable front-matter date
-    // falls back to it rather than leaving a non-date string in the column.
-    $previous_created = $bean->created;
-
     foreach ($front_matter as $key => $value) {
         $bean->$key = $value;
-    }
-
-    // Normalise a front-matter `created` date into the canonical Y-m-d H:i:s string.
-    // Accepts absolute dates (kept as the typed wall-clock) and relative strings such
-    // as "next friday 3pm" (resolved in the server timezone). A future date schedules
-    // the post; an unparseable value falls back to the previous date so the post still
-    // publishes rather than staying hidden forever.
-    if (isset($front_matter['created'])) {
-        $bean->created = normalize_datetime($front_matter['created'])
-            ?? ($previous_created ?: date('Y-m-d H:i:s'));
-        // Pin the resolved date back into the body so relative phrases like
-        // "next friday" don't drift to a new date on the next edit.
-        $bean->body = persist_resolved_created($bean->body, $bean->created);
     }
 
     // Explicitly normalise draft: 1 if truthy in frontmatter, 0 otherwise.
     // This ensures removing "draft: true" from frontmatter publishes the post on next save.
     $bean->draft = !empty($front_matter['draft']) ? 1 : 0;
+}
+
+/**
+ * Normalises a front-matter `created` date onto the bean and schedules accordingly.
+ *
+ * Accepts absolute dates (kept as the typed wall-clock) and relative strings such
+ * as "next friday 3pm" (resolved in the server timezone). A future date schedules
+ * the post; an unparseable value falls back to the date already on the bean so the
+ * post still publishes rather than staying hidden forever. The resolved date is
+ * pinned back into the body so relative phrases don't drift on the next edit.
+ *
+ * Must run after apply_frontmatter(), which has already blind-copied the raw
+ * `created` value onto the bean. The previous (pre-blind-copy) created date is
+ * passed in by parse_bean() so the unparseable-date fallback uses the genuine
+ * prior value rather than the raw front-matter string now sitting on the bean.
+ *
+ * @param OODBBean $bean             The bean to mutate.
+ * @param array    $front_matter     The parsed front matter.
+ * @param mixed    $previous_created The created date held before apply_frontmatter().
+ * @return void
+ *
+ * @internal Decomposed step of parse_bean(); not part of the public API.
+ */
+function apply_scheduling(OODBBean $bean, array $front_matter, mixed $previous_created): void
+{
+    if (!isset($front_matter['created'])) {
+        return;
+    }
+
+    // Preserve the existing created date (now for new posts, the stored value for
+    // edits, the feed date for ingested items) so an unparseable front-matter date
+    // falls back to it rather than leaving a non-date string in the column.
+    $bean->created = normalize_datetime($front_matter['created'])
+        ?? ($previous_created ?: date('Y-m-d H:i:s'));
+    // Pin the resolved date back into the body so relative phrases like
+    // "next friday" don't drift to a new date on the next edit.
+    $bean->body = persist_resolved_created($bean->body, $bean->created);
 }
 
 /**

--- a/tests/Unit/DateParsingTest.php
+++ b/tests/Unit/DateParsingTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
 use function Lamb\is_scheduled;
+use function Lamb\parse_bean;
 use function Lamb\Post\populate_bean;
 
 class DateParsingTest extends TestCase
@@ -87,5 +88,21 @@ class DateParsingTest extends TestCase
             is_scheduled($bean),
             'An unparseable date must not leave the post scheduled forever'
         );
+    }
+
+    public function testUnparseableDateOnEditFallsBackToThePriorStoredDate(): void
+    {
+        date_default_timezone_set('UTC');
+
+        // Simulate editing an existing post that already has a stored created
+        // date, where the new front matter carries an unparseable value. The
+        // fallback must use the date that existed before front matter was
+        // applied (the prior stored value), not the raw front-matter string.
+        $bean = R::dispense('post');
+        $bean->created = '2020-01-01 00:00:00';
+        $bean->body = "---\ncreated: sometime soon\n---\n\nBody #tag";
+        parse_bean($bean);
+
+        $this->assertSame('2020-01-01 00:00:00', (string) $bean->created);
     }
 }

--- a/tests/Unit/ReplyContextTest.php
+++ b/tests/Unit/ReplyContextTest.php
@@ -51,6 +51,16 @@ class ReplyContextTest extends TestCase
         $this->assertNull($bean->{'in-reply-to'});
     }
 
+    public function testListInReplyToUsesFirstEntry(): void
+    {
+        // A YAML list (Micropub clients may send multiple reply targets) collapses
+        // to its first entry rather than being stored verbatim.
+        $bean = populate_bean(
+            "---\nin-reply-to:\n  - https://first.example/post\n  - https://second.example/post\n---\nHi"
+        );
+        $this->assertSame('https://first.example/post', $bean->in_reply_to);
+    }
+
     // the_reply_context helper ----------------------------------------------
 
     public function testReplyContextHelperRendersMarkup(): void


### PR DESCRIPTION
Part of a refactoring series (see #337–#342). Pure refactor — `parse_bean()`'s public signature and resulting bean state are unchanged.

## What

`Lamb\parse_bean()` (`src/lamb.php`) is decomposed into small, named, individually-testable steps that it now orchestrates:

- `render_body()` — Markdown → HTML via LambDown (safe mode)
- `extract_description()` — single-line plain-text description (preserves the deliberate **double** `html_entity_decode` for feed-ingested bodies)
- `highlight_and_link()` — fenced-code extract → highlight → hashtag-link → restore (load-bearing extract/restore ordering intact)
- `normalize_in_reply_to()` — collapses `in-reply-to` / `in_reply_to` (incl. YAML list → first entry)
- `apply_frontmatter()` — title/draft/reply-target defaulting + blind-copy of remaining keys
- `apply_scheduling()` — created-date normalisation + scheduling

## Behaviour regression caught & fixed

While finishing the decomposition, `apply_scheduling()` was recapturing `$previous_created` from the bean *after* `apply_frontmatter()` had already blind-copied the raw front-matter `created` string onto it — so an edit with an unparseable date would store the garbage string instead of the genuine prior date. Fixed by passing the pre-blind-copy `$previous_created` from `parse_bean()` (as the call site/docblock already intended), restoring `origin/main` behaviour. Covered by a new test.

## Verification

- `vendor/bin/phpcs` clean
- `vendor/bin/phpstan analyse` → No errors
- `vendor/bin/codecept run Unit` → 789 tests, 1201 assertions, OK
- New tests: `DateParsingTest::testUnparseableDateOnEditFallsBackToThePriorStoredDate` (red→green) and `ReplyContextTest::testListInReplyToUsesFirstEntry`

Closes #340

https://claude.ai/code/session_01Ma9G1KZWfxNTso76d8pHX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ma9G1KZWfxNTso76d8pHX8)_