### PR TITLE
Add Dependabot github-actions ecosystem for automatic Action upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions" # Keep GitHub Actions up to date
+    directory: "/" # Workflow files live under .github/workflows
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Configures Dependabot to automatically upgrade GitHub Actions to their latest versions.

The existing `.github/dependabot.yml` only covered the `composer` ecosystem, so Action versions pinned in workflows were never kept up to date. This adds a `github-actions` ecosystem entry (weekly schedule), which will open PRs to bump pinned Action versions in `.github/workflows/`.

The repo already has a `dependabot-auto-merge.yml` workflow that enables auto-merge for Dependabot PRs, so these upgrades will flow through automatically once CI passes.

## Notes

There's currently version drift Dependabot will catch on its first run — e.g. `actions/checkout@v4` in `release-artifacts.yml` vs `@v6` in `ci.yml`.

## Test plan

- [ ] Dependabot picks up the `github-actions` ecosystem and opens upgrade PRs on the weekly schedule
- [ ] Auto-merge workflow merges them once CI is green

https://claude.ai/code/session_01G1a82UZZzNSSCsbmX2jCTr

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1a82UZZzNSSCsbmX2jCTr)_