### PR TITLE
Refactor: centralise YAML front-matter manipulation

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -16,6 +16,7 @@ use RedBeanPHP\R;
 use RedBeanPHP\RedException\SQL;
 
 use function Lamb\Post\parse_matter;
+use function Lamb\Post\set_matter;
 
 /**
  * Retrieves the tags from the given HTML.
@@ -240,30 +241,7 @@ function visible_clause(): array
  */
 function persist_resolved_created(string $body, string $resolved): string
 {
-    // Only touch a front-matter block at the very start of the body.
-    if (!preg_match('/\A(\s*---\s*\n)(.*?\n)(---\s*\n?)/s', $body, $m)) {
-        return $body;
-    }
-
-    $new_yaml = preg_replace_callback(
-        '/^([ \t]*created[ \t]*:)[ \t]*(.*?)[ \t]*$/mi',
-        function (array $line) use ($resolved): string {
-            $current = trim($line[2], " \t'\"");
-            if ($current === $resolved) {
-                return $line[0];
-            }
-            return $line[1] . " '" . $resolved . "'";
-        },
-        $m[2],
-        1,
-        $count
-    );
-
-    if ($count === 0) {
-        return $body;
-    }
-
-    return $m[1] . $new_yaml . $m[3] . substr($body, strlen($m[0]));
+    return set_matter($body, 'created', $resolved, quote: true, append: false);
 }
 
 /**

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -14,6 +14,7 @@ use function Lamb\get_tags;
 use function Lamb\is_scheduled;
 use function Lamb\parse_bean;
 use function Lamb\permalink;
+use function Lamb\Post\build_matter;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\populate_bean;
@@ -456,19 +457,15 @@ class LambMicropubAdapter extends MicropubAdapter
 
         $content = $newContent . $hashtagStr;
 
-        $front = [];
+        $matter = [];
         if ($title !== null) {
-            $front[] = "title: $title";
+            $matter['title'] = (string) $title;
         }
         if (is_string($replyTo) && $replyTo !== '') {
-            $front[] = "in-reply-to: $replyTo";
+            $matter['in-reply-to'] = $replyTo;
         }
 
-        if ($front === []) {
-            return $content;
-        }
-
-        return "---\n" . implode("\n", $front) . "\n---\n$content";
+        return build_matter($matter, $content);
     }
 
     /**
@@ -575,17 +572,13 @@ class LambMicropubAdapter extends MicropubAdapter
 
         $matter = [];
         if ($title !== null) {
-            $matter[] = "title: $title";
+            $matter['title'] = (string) $title;
         }
         if (is_string($replyTo) && $replyTo !== '') {
-            $matter[] = "in-reply-to: $replyTo";
+            $matter['in-reply-to'] = $replyTo;
         }
 
-        if ($matter === []) {
-            return $content;
-        }
-
-        return "---\n" . implode("\n", $matter) . "\n---\n$content";
+        return build_matter($matter, $content);
     }
 
     /**

--- a/src/post.php
+++ b/src/post.php
@@ -151,6 +151,84 @@ function slugify(string $text): string
 }
 
 /**
+ * Renders a body from a `key => value` front-matter map plus content.
+ *
+ * Each pair becomes a `key: value` line inside a leading `---` fence; an empty
+ * map returns the content verbatim (no fence). Key order is preserved. This is
+ * the single place that assembles a fresh front-matter block from scratch
+ * (used by Micropub create/update).
+ *
+ * @param array<string, string> $matter Ordered front-matter key/value pairs.
+ * @param string $content The post content to place after the fence.
+ * @return string The assembled body.
+ */
+function build_matter(array $matter, string $content): string
+{
+    if ($matter === []) {
+        return $content;
+    }
+
+    $lines = [];
+    foreach ($matter as $key => $value) {
+        $lines[] = "$key: $value";
+    }
+
+    return "---\n" . implode("\n", $lines) . "\n---\n$content";
+}
+
+/**
+ * Sets a single key in a body's leading YAML front-matter block, leaving all
+ * other front matter intact.
+ *
+ * An existing `key:` line is updated in place (preserving the original key text
+ * and indentation, rewriting only the value with a single separating space).
+ * When the block has no such line and $append is true, an explicit line is
+ * appended to the block. Bodies without a leading front-matter block, or whose
+ * key already holds the target value, are returned unchanged (no cosmetic
+ * churn).
+ *
+ * @param string $body The raw post body.
+ * @param string $key The front-matter key to set.
+ * @param string $value The value to write.
+ * @param bool $quote When true, the value is wrapped in single quotes.
+ * @param bool $append When true, the key is appended if absent (otherwise the
+ *                     body is returned unchanged when the key is missing).
+ * @return string The body with the front-matter key set.
+ */
+function set_matter(string $body, string $key, string $value, bool $quote = false, bool $append = true): string
+{
+    // Only touch a front-matter block at the very start of the body.
+    if (!preg_match('/\A(\s*---\s*\n)(.*?\n)(---\s*\n?)/s', $body, $m)) {
+        return $body;
+    }
+
+    $rendered = $quote ? "'" . $value . "'" : $value;
+
+    $new_yaml = preg_replace_callback(
+        '/^([ \t]*' . preg_quote($key, '/') . '[ \t]*:)[ \t]*(.*?)[ \t]*$/mi',
+        function (array $line) use ($value, $rendered): string {
+            $current = trim($line[2], " \t'\"");
+            if ($current === $value) {
+                return $line[0];
+            }
+            return $line[1] . ' ' . $rendered;
+        },
+        $m[2],
+        1,
+        $count
+    );
+
+    if ($count === 0) {
+        if (!$append) {
+            return $body;
+        }
+        $new_yaml = $m[2] . "$key: $rendered\n";
+    }
+
+    return $m[1] . $new_yaml . $m[3] . substr($body, strlen($m[0]));
+}
+
+/**
  * Rewrites the `slug` value inside a body's leading YAML front-matter block to
  * the given actual slug, leaving all other front matter intact.
  *
@@ -168,30 +246,7 @@ function slugify(string $text): string
  */
 function persist_slug(string $body, string $slug): string
 {
-    // Only touch a front-matter block at the very start of the body.
-    if (!preg_match('/\A(\s*---\s*\n)(.*?\n)(---\s*\n?)/s', $body, $m)) {
-        return $body;
-    }
-
-    $new_yaml = preg_replace_callback(
-        '/^([ \t]*slug[ \t]*:)[ \t]*(.*?)[ \t]*$/mi',
-        function (array $line) use ($slug): string {
-            $current = trim($line[2], " \t'\"");
-            if ($current === $slug) {
-                return $line[0];
-            }
-            return $line[1] . ' ' . $slug;
-        },
-        $m[2],
-        1,
-        $count
-    );
-
-    if ($count === 0) {
-        $new_yaml = $m[2] . "slug: $slug\n";
-    }
-
-    return $m[1] . $new_yaml . $m[3] . substr($body, strlen($m[0]));
+    return set_matter($body, 'slug', $slug);
 }
 
 /**

--- a/tests/Unit/FrontMatterTest.php
+++ b/tests/Unit/FrontMatterTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Post\build_matter;
+use function Lamb\Post\set_matter;
+
+class FrontMatterTest extends TestCase
+{
+    // build_matter
+
+    public function testBuildMatterReturnsContentOnlyWhenMatterEmpty(): void
+    {
+        $this->assertSame('Just content', build_matter([], 'Just content'));
+    }
+
+    public function testBuildMatterRendersSingleKey(): void
+    {
+        $this->assertSame(
+            "---\ntitle: Hello\n---\nContent",
+            build_matter(['title' => 'Hello'], 'Content')
+        );
+    }
+
+    public function testBuildMatterRendersMultipleKeysInOrder(): void
+    {
+        $this->assertSame(
+            "---\ntitle: Hello\nin-reply-to: https://example.com\n---\nBody",
+            build_matter(
+                ['title' => 'Hello', 'in-reply-to' => 'https://example.com'],
+                'Body'
+            )
+        );
+    }
+
+    // set_matter — insert into existing fence
+
+    public function testSetMatterReplacesExistingKeyInPlace(): void
+    {
+        $body = "---\ntitle: Hi\nslug: old\n---\nContent.";
+        $this->assertSame(
+            "---\ntitle: Hi\nslug: new\n---\nContent.",
+            set_matter($body, 'slug', 'new')
+        );
+    }
+
+    public function testSetMatterAppendsKeyWhenAbsent(): void
+    {
+        $body = "---\ntitle: Hi\n---\nContent.";
+        $this->assertSame(
+            "---\ntitle: Hi\nslug: new\n---\nContent.",
+            set_matter($body, 'slug', 'new')
+        );
+    }
+
+    public function testSetMatterPreservesUnrelatedKeys(): void
+    {
+        $body = "---\ntitle: Hi\ndescription: keep me\nslug: old\n---\nBody.";
+        $this->assertSame(
+            "---\ntitle: Hi\ndescription: keep me\nslug: new\n---\nBody.",
+            set_matter($body, 'slug', 'new')
+        );
+    }
+
+    public function testSetMatterIsIdempotentWhenValueUnchanged(): void
+    {
+        $body = "---\ntitle: Hi\nslug: same\n---\nContent.";
+        $this->assertSame($body, set_matter($body, 'slug', 'same'));
+    }
+
+    public function testSetMatterReturnsBodyUnchangedWhenNoFence(): void
+    {
+        $body = "Just plain text, no front matter.";
+        $this->assertSame($body, set_matter($body, 'slug', 'new'));
+    }
+
+    public function testSetMatterPreservesKeyWhitespacePrefixOnReplace(): void
+    {
+        $body = "---\n  slug:   old\n---\nContent.";
+        // The matched key prefix is preserved; value rewritten with single space.
+        $this->assertSame(
+            "---\n  slug: new\n---\nContent.",
+            set_matter($body, 'slug', 'new')
+        );
+    }
+
+    // set_matter — quoted variant (created date)
+
+    public function testSetMatterQuotedReplacesExistingKey(): void
+    {
+        $body = "---\ncreated: 2020-01-01 00:00:00\n---\nContent.";
+        $this->assertSame(
+            "---\ncreated: '2024-06-05 12:00:00'\n---\nContent.",
+            set_matter($body, 'created', '2024-06-05 12:00:00', quote: true, append: false)
+        );
+    }
+
+    public function testSetMatterQuotedDoesNotAppendWhenAbsent(): void
+    {
+        $body = "---\ntitle: Hi\n---\nContent.";
+        $this->assertSame(
+            $body,
+            set_matter($body, 'created', '2024-06-05 12:00:00', quote: true, append: false)
+        );
+    }
+
+    public function testSetMatterQuotedIdempotentWhenValueUnchanged(): void
+    {
+        $body = "---\ncreated: '2024-06-05 12:00:00'\n---\nContent.";
+        $this->assertSame(
+            $body,
+            set_matter($body, 'created', '2024-06-05 12:00:00', quote: true, append: false)
+        );
+    }
+}


### PR DESCRIPTION
Part of a refactoring series (see #337–#342). Pure refactor — front-matter output is byte-identical for existing posts.

## What

Centralises the duplicated regex/string-based YAML front-matter manipulation into two helpers in `Lamb\Post` (`src/post.php`):

- `build_matter(array $matter, string $content): string` — assembles a fresh `---`-fenced block from an ordered `key => value` map; returns content verbatim when empty. Replaces the by-hand block assembly in Micropub.
- `set_matter(string $body, string $key, string $value, bool $quote = false, bool $append = true): string` — replaces or appends a single key inside a leading front-matter block. `quote` wraps the value in single quotes; `append` controls whether a missing key is appended or the body returned unchanged.

## Call sites converted (all byte-identical output)

- `persist_slug()` (`post.php`) → `set_matter($body, 'slug', $slug)` (unquoted, append-if-absent)
- `persist_resolved_created()` (`lamb.php`) → `set_matter($body, 'created', $resolved, quote: true, append: false)` (quoted, replace-only)
- `LambMicropubAdapter::buildBody()` / `::rebuildBody()` (`micropub.php`) → `build_matter($matter, $content)` with an ordered `['title' => …, 'in-reply-to' => …]` map preserving original key order.

`normalize_frontmatter_fence()` and `parse_matter()` are kept as the single pre-parse normalisation / read path (unchanged). No call site needed to be left alone.

## Verification

- `vendor/bin/phpcs` clean
- `vendor/bin/phpstan analyse` → No errors
- `vendor/bin/codecept run Unit` → 799 tests, 1211 assertions, OK (787 baseline + 12 new in `tests/Unit/FrontMatterTest.php`, written red-first with exact byte assertions)
- `vendor/bin/codecept run Functional` → OK
- (Acceptance tests need a running dev server, unavailable in the sandbox — unrelated to this change.)

Closes #341

https://claude.ai/code/session_01Ma9G1KZWfxNTso76d8pHX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ma9G1KZWfxNTso76d8pHX8)_