### PR TITLE
Dependabot: add npm, docker, and devcontainer ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,19 @@ updates:
     directory: "/" # Workflow files live under .github/workflows
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm" # JS dev dependencies (Playwright, jsdom, etc.)
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker" # Base images in .docker/
+    directories:
+      - "/.docker"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "devcontainers" # .devcontainer/devcontainer.json image
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Expands Dependabot coverage to the three dependency manifests that were previously unmanaged:

- **npm** — root `package.json` / `pnpm-lock.yaml` (Playwright, jsdom, `@types/*`)
- **docker** — `.docker/Dockerfile` + `.docker/Dockerfile.release` base images (targets `/.docker`)
- **devcontainers** — `.devcontainer/devcontainer.json` image reference

Closes #348.

## Stack

Bottom of the stack — based on `main` (now that the github-actions ecosystem from #347 is merged). Two PRs are stacked on top of this one:
- grouping (#349)
- auto-merge hardening (#350)

## Test plan

- [x] `yaml.safe_load` parses the config locally
- [ ] Dependabot picks up the new ecosystems on the next run

https://claude.ai/code/session_01G1a82UZZzNSSCsbmX2jCTr

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1a82UZZzNSSCsbmX2jCTr)_