### PR TITLE
Dependabot: group minor and patch updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,24 +9,49 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions" # Keep GitHub Actions up to date
     directory: "/" # Workflow files live under .github/workflows
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm" # JS dev dependencies (Playwright, jsdom, etc.)
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker" # Base images in .docker/
     directories:
       - "/.docker"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "devcontainers" # .devcontainer/devcontainer.json image
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds a `groups:` block to every ecosystem in `.github/dependabot.yml` so that **minor and patch** updates are batched into a single PR per ecosystem. Major updates remain individual PRs for separate review — which dovetails with the auto-merge hardening in #350 (majors are not auto-merged).

Closes #349.

## Stack

Stacked on #348 (coverage) — it groups all five ecosystems including the npm one added there. Review/merge #348 first; GitHub will retarget this PR to `main` once the base merges.

## Test plan

- [x] `yaml.safe_load` parses, and `groups` is present on all 5 ecosystems
- [ ] Next Dependabot run opens a single grouped PR per ecosystem for minor/patch bumps

https://claude.ai/code/session_01G1a82UZZzNSSCsbmX2jCTr

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1a82UZZzNSSCsbmX2jCTr)_