### PR TITLE
Verify release setups: acceptance tests against Docker image and nginx+fpm

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,153 @@
+# Pre-release verification: runs the Codeception Acceptance suite against the
+# server-distinct documented ways of running Lamb that ci.yml does not cover.
+#
+# ci.yml already exercises the built-in PHP server (composer serve) on every PR
+# across PHP 8.2-8.5, so that path is intentionally not duplicated here. This
+# workflow adds:
+#   - the Docker/FrankenPHP release image (.docker/Dockerfile.release, what
+#     release-artifacts.yml publishes to GHCR)
+#   - an nginx + php-fpm install using the shipped .nginx/ configuration
+#
+# Both jobs run codecept on the runner with `--env external` (see
+# tests/Acceptance.suite.yml), pointing SITE_URL at the externally started
+# server. The served instance shares tests/Support/Data with the test runner so
+# the per-test database reset in Tests\Support\Helper\Acceptance keeps working.
+name: Release verification
+
+on:
+  pull_request:
+    branches: [ "release" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-frankenphp:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP (test runner)
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: sqlite3, gettext, simplexml, mbstring, curl
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Generate credentials
+        run: |
+          php make-password.php ci-verify-password
+          sed -i "s|^SITE_URL=.*|SITE_URL='http://localhost:8080'|" .env
+
+      - name: Build release image
+        run: docker build -f .docker/Dockerfile.release -t lamb:verify .
+
+      - name: Run container
+        run: |
+          mkdir -p tests/Support/Data
+          chmod 0777 tests/Support/Data
+          HASH=$(grep LAMB_LOGIN_PASSWORD .env | cut -d"'" -f2)
+          docker run -d --name lamb-verify -p 8080:80 \
+            -e LAMB_LOGIN_PASSWORD="$HASH" \
+            -v "$PWD/tests/Support/Data:/app/data" \
+            lamb:verify
+
+      - name: Wait for server
+        run: |
+          for i in $(seq 1 30); do
+            curl -fsS -o /dev/null http://localhost:8080/ && exit 0
+            sleep 2
+          done
+          docker logs lamb-verify
+          exit 1
+
+      - name: Run acceptance tests against the release image
+        run: vendor/bin/codecept run Acceptance --env external --steps
+
+      - name: Container logs on failure
+        if: failure()
+        run: docker logs lamb-verify
+
+  nginx-fpm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP (test runner)
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: sqlite3, gettext, simplexml, mbstring, curl
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Generate credentials
+        run: |
+          php make-password.php ci-verify-password
+          sed -i "s|^SITE_URL=.*|SITE_URL='http://127.0.0.1:8080'|" .env
+
+      - name: Install nginx and php-fpm
+        # setup-php adds the ondrej/php PPA, so php8.2-fpm is installable on any runner image.
+        run: sudo apt-get update && sudo apt-get install -y nginx php8.2-fpm php8.2-sqlite3 php8.2-mbstring php8.2-xml
+
+      - name: Configure php-fpm pool
+        run: |
+          mkdir -p tests/Support/Data
+          chmod 0777 tests/Support/Data
+          chmod o+x "$HOME" "$GITHUB_WORKSPACE"
+          HASH=$(grep LAMB_LOGIN_PASSWORD .env | cut -d"'" -f2)
+          POOL=/etc/php/8.2/fpm/pool.d/www.conf
+          sudo tee -a "$POOL" > /dev/null <<EOF
+          clear_env = no
+          env[LAMB_LOGIN_PASSWORD] = $HASH
+          env[LAMB_DATA_DIR] = $GITHUB_WORKSPACE/tests/Support/Data
+          EOF
+          sudo systemctl restart php8.2-fpm
+
+      - name: Configure nginx from the shipped .nginx/ files
+        run: |
+          sudo cp .nginx/snippets/*.conf /etc/nginx/snippets/
+          # Use the documented vhost, adjusted only for the CI environment:
+          # docroot in the workspace, port 8080, catch-all server name.
+          sed -e "s|root .*;|root $GITHUB_WORKSPACE/src;|" \
+              -e "s|listen 80;|listen 8080;|" \
+              -e "s|server_name lamb.test;|server_name _;|" \
+              .nginx/sites-available/lamb.test | sudo tee /etc/nginx/sites-available/lamb-verify > /dev/null
+          sudo ln -s /etc/nginx/sites-available/lamb-verify /etc/nginx/sites-enabled/
+          sudo rm -f /etc/nginx/sites-enabled/default
+          sudo nginx -t
+          sudo systemctl restart nginx
+
+      - name: Wait for server
+        run: |
+          for i in $(seq 1 30); do
+            curl -fsS -o /dev/null http://127.0.0.1:8080/ && exit 0
+            sleep 1
+          done
+          sudo tail -50 /var/log/nginx/lamb.test-error.log || true
+          exit 1
+
+      - name: Run acceptance tests against nginx + php-fpm
+        run: vendor/bin/codecept run Acceptance --env external --steps
+
+      - name: Server logs on failure
+        if: failure()
+        run: sudo tail -100 /var/log/nginx/lamb.test-error.log /var/log/nginx/lamb.test-access.log || true
+
+  # Aggregate gate: require this single check on PRs targeting release
+  # (mirrors the `ci` gate job in ci.yml).
+  release-verify:
+    runs-on: ubuntu-latest
+    needs: [ docker-frankenphp, nginx-fpm ]
+    if: always()
+    steps:
+      - name: Check matrix results
+        run: |
+          [ "${{ needs.docker-frankenphp.result }}" = "success" ] || { echo "::error::docker-frankenphp failed"; exit 1; }
+          [ "${{ needs.nginx-fpm.result }}" = "success" ] || { echo "::error::nginx-fpm failed"; exit 1; }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -63,6 +63,10 @@ gh pr create --base release --head main \
 gh pr merge --merge --subject "Release <version>"
 ```
 
+- [ ] Confirm the **release-verify** check is green on the PR before merging.
+      It runs the Acceptance suite against the Docker/FrankenPHP release image
+      and an nginx + php-fpm install — the well-travelled production paths —
+      in addition to `ci`'s built-in-server run.
 - [ ] If the PR reports `BEHIND`, `release` has commits not on `main` (e.g.
       old release merges). Sync first: branch from `main`, `git merge
       origin/release` (a merge commit, no content changes expected), PR that

--- a/docs/ddev.md
+++ b/docs/ddev.md
@@ -2,6 +2,8 @@
 title: DDev
 ---
 
+> DDev is a convenience wrapper that runs Lamb under nginx + php-fpm in Docker. The underlying server setups are release-verified (see [Nginx]({{ site.baseurl }}{% link nginx.md %}) and [Docker]({{ site.baseurl }}{% link docker.md %})), but the DDev wrapper itself is not separately tested.
+
 ## Setup
 
 * [Install ddev](https://ddev.com/get-started/), if you haven't.

--- a/docs/devbox.md
+++ b/docs/devbox.md
@@ -2,7 +2,7 @@
 title: Devbox
 ---
 
-> Devbox is a convenience wrapper around the [local PHP setup]({{ site.baseurl }}{% link local-php-setup.md %}) — it runs the same built-in PHP webserver that the test suite verifies, but the wrapper itself is not separately tested.
+> **Well-travelled path.** Devbox is the maintainer's daily development environment. It wraps the [local PHP setup]({{ site.baseurl }}{% link local-php-setup.md %}), running the same built-in PHP webserver that the test suite verifies on every change.
 
 ```shell
 devbox shell

--- a/docs/devbox.md
+++ b/docs/devbox.md
@@ -2,6 +2,8 @@
 title: Devbox
 ---
 
+> Devbox is a convenience wrapper around the [local PHP setup]({{ site.baseurl }}{% link local-php-setup.md %}) — it runs the same built-in PHP webserver that the test suite verifies, but the wrapper itself is not separately tested.
+
 ```shell
 devbox shell
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,6 +4,8 @@ title: Docker
 
 # Docker
 
+> **Well-travelled path.** The release image is verified by the automated acceptance suite before every release (the `release-verify` workflow), so this is a supported, regularly-tested way to run Lamb.
+
 The only requirement in this case is a working Docker setup!
 
 ## Prebuilt image (recommended)

--- a/docs/frankenphp.md
+++ b/docs/frankenphp.md
@@ -4,6 +4,8 @@ title: FrankenPHP
 
 # FrankenPHP
 
+> **Well-travelled path.** The FrankenPHP runtime is the same one inside the release Docker image, which is verified by the automated acceptance suite before every release (the `release-verify` workflow).
+
 [FrankenPHP](https://frankenphp.dev) is the Caddy webserver with a PHP runtime built in: a single binary serves Lamb with no separate php-fpm service to configure. It is the recommended way to host Lamb on a server you control.
 
 A working `Caddyfile` is provided in the project root. From the project directory:

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Lamb can be run locally with the builtin PHP webserver, or with other tooling.
 
 ## Verified setups
 
-The well-travelled paths — verified automatically by the acceptance test suite — are the [Docker image]({{ site.baseurl }}{% link docker.md %}) and [Nginx]({{ site.baseurl }}{% link nginx.md %}) (checked before every release by the `release-verify` workflow), [FrankenPHP]({{ site.baseurl }}{% link frankenphp.md %}) (same runtime as the Docker image), and the [built-in PHP webserver]({{ site.baseurl }}{% link local-php-setup.md %}) (checked on every change). [DDev]({{ site.baseurl }}{% link ddev.md %}) and [Devbox]({{ site.baseurl }}{% link devbox.md %}) are convenience wrappers around these and are not separately tested.
+The well-travelled paths — verified automatically by the acceptance test suite — are the [Docker image]({{ site.baseurl }}{% link docker.md %}) and [Nginx]({{ site.baseurl }}{% link nginx.md %}) (checked before every release by the `release-verify` workflow), [FrankenPHP]({{ site.baseurl }}{% link frankenphp.md %}) (same runtime as the Docker image), and the [built-in PHP webserver]({{ site.baseurl }}{% link local-php-setup.md %}) (checked on every change). [Devbox]({{ site.baseurl }}{% link devbox.md %}) wraps the built-in webserver and is the maintainer's daily development environment, so it is well-travelled too. [DDev]({{ site.baseurl }}{% link ddev.md %}) is a convenience wrapper and is not separately tested.
 
 ## Deployment options
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,10 @@ This route gets you the `bin/upgrade` script for one-command (or cron-driven) up
 
 Lamb can be run locally with the builtin PHP webserver, or with other tooling.
 
+## Verified setups
+
+The well-travelled paths — verified automatically by the acceptance test suite — are the [Docker image]({{ site.baseurl }}{% link docker.md %}) and [Nginx]({{ site.baseurl }}{% link nginx.md %}) (checked before every release by the `release-verify` workflow), [FrankenPHP]({{ site.baseurl }}{% link frankenphp.md %}) (same runtime as the Docker image), and the [built-in PHP webserver]({{ site.baseurl }}{% link local-php-setup.md %}) (checked on every change). [DDev]({{ site.baseurl }}{% link ddev.md %}) and [Devbox]({{ site.baseurl }}{% link devbox.md %}) are convenience wrappers around these and are not separately tested.
+
 ## Deployment options
 
 Webservers:

--- a/docs/local-php-setup.md
+++ b/docs/local-php-setup.md
@@ -4,6 +4,8 @@ title: Local PHP setup
 
 # Local PHP setup
 
+> **Well-travelled path.** The built-in PHP webserver is exercised by the full test suite on every change, across PHP 8.2–8.5 (the `ci` workflow).
+
 Make sure everything is installed:
 
 ```bash

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -4,6 +4,8 @@ title: NGINX configuration
 
 # NGINX configuration
 
+> **Well-travelled path.** The shipped `.nginx/` configuration is deployed and verified by the automated acceptance suite before every release (the `release-verify` workflow), so this is a supported, regularly-tested way to run Lamb.
+
 Copy the files in the `site-available` and `snippets` into the respective directories. The `fastcgi`  and `php`
 configuration files might already exist on the system, in which case you can use these as known-good reference.
 

--- a/tests/Acceptance.suite.yml
+++ b/tests/Acceptance.suite.yml
@@ -23,3 +23,16 @@ step_decorators:
   - Codeception\Step\ConditionalAssertion
   - Codeception\Step\TryTo
   - Codeception\Step\Retry
+env:
+  # Run against an already-running external server (Docker/FrankenPHP, nginx+fpm):
+  # %SITE_URL% in .env must point at it, and the server must use
+  # tests/Support/Data as its data dir so the per-test DB reset in
+  # Tests\Support\Helper\Acceptance::_before() takes effect.
+  # Usage: vendor/bin/codecept run Acceptance --env external
+  external:
+    extensions:
+      enabled:
+        - Codeception\Extension\RunProcess:
+            # Neutralise the self-started dev server; the external server is already up.
+            0: sleep 86400
+            sleep: 0


### PR DESCRIPTION
## Summary
- New `release-verify` workflow runs the Codeception Acceptance suite against the server-distinct documented ways of running Lamb, on PRs targeting `release`:
  - the **Docker/FrankenPHP release image** (built from `.docker/Dockerfile.release`, the artifact `release-artifacts.yml` publishes)
  - an **nginx + php-fpm** install deployed from the shipped `.nginx/` configs
- The built-in PHP server is already exercised by `ci.yml` on every PR (PHP 8.2–8.5), so it is not duplicated.
- Adds an `external` Codeception env to `tests/Acceptance.suite.yml` that neutralises the suite's self-started dev server and points PhpBrowser at the running external instance. The served instance shares `tests/Support/Data`, so the per-test DB reset in the Acceptance helper keeps working.
- Docs: Docker, FrankenPHP, nginx and local PHP setup are marked as well-travelled (verified) paths; ddev/devbox noted as convenience wrappers; new "Verified setups" section in `docs/index.md`; `RELEASING.md` gains a release-verify checklist item.

## Verification
- `vendor/bin/codecept run Acceptance --env external` passed locally (54 tests) against:
  - the built Docker release image with `tests/Support/Data` bind-mounted at `/app/data`
  - a manually started external `php -S` server
- Default `vendor/bin/codecept run Acceptance` (self-started server) still passes — `ci.yml` unaffected.
- `vendor/bin/codecept run Unit`: 826 tests green.
- The nginx job runs first in CI on a PR into `release`; it can also be exercised via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)