### PR TITLE
Fix cron output: create SimplePie cache dir, skip non-URL feed entries

### DIFF
--- a/docs/drafts.md
+++ b/docs/drafts.md
@@ -8,7 +8,7 @@ Posts can be saved as drafts by adding `draft: true` to the front-matter.
 
 When logged in, all drafts are available from `/drafts`.
 
-Feed ingested posts are saved as drafts by default to prioritize authorship over syndication. Should you prefer, add `feeds_draft = false` to the site settings and they will be published instead.
+Feed ingested posts are saved as drafts by default to prioritize authorship over syndication. Should you prefer, add `feeds_draft = false` to the site settings and they will be published instead. Place it in the top-level section, above any `[section]` headers — inside `[feeds]` it would be read as a feed entry, not a setting.
 
 ## Related
 

--- a/src/network.php
+++ b/src/network.php
@@ -23,7 +23,30 @@ function get_feeds(): array
 {
     global $config;
 
-    return $config['feeds'] ?? [];
+    // A setting accidentally placed under [feeds] (e.g. `feeds_draft = false`)
+    // would otherwise be fetched as a feed URL. Only keep http(s) URLs.
+    return array_filter($config['feeds'] ?? [], function ($url) {
+        return filter_var($url, FILTER_VALIDATE_URL)
+            && in_array(parse_url($url, PHP_URL_SCHEME), ['http', 'https'], true);
+    });
+}
+
+/**
+ * Ensures the SimplePie cache directory exists, creating it when missing.
+ *
+ * SimplePie warns loudly (HTML in the text/plain cron output) when the cache
+ * location is not writable, so create it up front and disable caching when
+ * that fails.
+ *
+ * @param string $dir The cache directory path.
+ * @return string|false The directory when usable, false otherwise.
+ */
+function ensure_feed_cache(string $dir): string|false
+{
+    if (!is_dir($dir) && !mkdir($dir, 0775, true)) {
+        return false;
+    }
+    return is_writable($dir) ? $dir : false;
 }
 
 /** @noinspection PhpUnused */
@@ -67,8 +90,13 @@ function purge_deleted_posts(): int
         }
 
         $feed = new SimplePie();
-        /** @noinspection PhpDeprecationInspection */
-        $feed->set_cache_location('../data/cache/simplepie');
+        $cache_dir = ensure_feed_cache('../data/cache/simplepie');
+        if ($cache_dir === false) {
+            $feed->enable_cache(false);
+        } else {
+            /** @noinspection PhpDeprecationInspection */
+            $feed->set_cache_location($cache_dir);
+        }
         $feed->set_feed_url($url);
         // Cap each fetch so a slow or hostile feed URL cannot stall the cron run.
         $feed->set_timeout(FEED_FETCH_TIMEOUT);

--- a/tests/Unit/NetworkFeedTest.php
+++ b/tests/Unit/NetworkFeedTest.php
@@ -95,6 +95,62 @@ class NetworkFeedTest extends TestCase
         $config = $original;
     }
 
+    public function testGetFeedsSkipsEntriesWithoutValidUrl(): void
+    {
+        global $config;
+        $original = $config;
+        // A misplaced setting under [feeds] (e.g. `feeds_draft = false`) must
+        // not be treated as a feed URL (#cron tried to fetch host "false").
+        $config['feeds']['feeds_draft'] = 'false';
+
+        $result = get_feeds();
+        $this->assertArrayNotHasKey('feeds_draft', $result);
+        $this->assertCount(2, $result);
+
+        $config = $original;
+    }
+
+    public function testGetFeedsSkipsNonHttpSchemes(): void
+    {
+        global $config;
+        $original = $config;
+        $config['feeds']['weird'] = 'file:///etc/passwd';
+
+        $result = get_feeds();
+        $this->assertArrayNotHasKey('weird', $result);
+
+        $config = $original;
+    }
+
+    // ensure_feed_cache
+
+    public function testEnsureFeedCacheCreatesMissingDirectory(): void
+    {
+        $dir = sys_get_temp_dir() . '/lamb-test-cache-' . uniqid() . '/simplepie';
+        $this->assertDirectoryDoesNotExist($dir);
+
+        $result = \Lamb\Network\ensure_feed_cache($dir);
+
+        $this->assertSame($dir, $result);
+        $this->assertDirectoryExists($dir);
+
+        rmdir($dir);
+        rmdir(dirname($dir));
+    }
+
+    public function testEnsureFeedCacheReturnsFalseWhenNotCreatable(): void
+    {
+        // Parent is a file, so the directory cannot be created.
+        $file = tempnam(sys_get_temp_dir(), 'lamb-test-');
+        $dir = $file . '/simplepie';
+
+        $result = @\Lamb\Network\ensure_feed_cache($dir);
+
+        $this->assertFalse($result);
+
+        unlink($file);
+    }
+
     // prepare_item
 
     public function testPrepareItemReturnsBean(): void


### PR DESCRIPTION
## Problem

`/_cron` output showed two bugs:

```
<b>Warning</b>: ../data/cache/simplepie is not writable. ...
FAILED: feeds_draft - cURL error 6: Could not resolve host: false
```

1. SimplePie's cache directory `../data/cache/simplepie` was never created, so every cron run emitted an HTML warning into the text/plain output.
2. A setting accidentally placed under the `[feeds]` INI section (e.g. `feeds_draft = false` added below the section header) was treated as a feed named `feeds_draft` with URL `false`, which cron then tried to fetch.

## Fix

- New `Network\ensure_feed_cache()` creates the cache directory when missing and disables SimplePie caching when it cannot be created/written, so the warning can never fire.
- `Network\get_feeds()` now filters the `[feeds]` config to entries whose value is a valid `http(s)` URL, so misplaced settings (or junk values) are silently skipped instead of fetched.

## Tests

Red-green TDD: four new unit tests in `NetworkFeedTest` (feeds filtering for non-URLs and non-http schemes; cache dir creation and uncreatable-path fallback). Full Unit suite: 830 tests passing. `composer lint` and `composer analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)