### PR TITLE
Give web-editor drafts the same preview links as Micropub drafts

### DIFF
--- a/docs/drafts.md
+++ b/docs/drafts.md
@@ -8,6 +8,8 @@ Posts can be saved as drafts by adding `draft: true` to the front-matter.
 
 When logged in, all drafts are available from `/drafts`.
 
+Each draft (and scheduled post) shows a **Preview** link next to its Edit button. The link carries an expiring token valid for 24 hours, so you can share it with someone who isn't logged in. A fresh token is issued whenever you save the post after the old one expires.
+
 Feed ingested posts are saved as drafts by default to prioritize authorship over syndication. Should you prefer, add `feeds_draft = false` to the site settings and they will be published instead. Place it in the top-level section, above any `[section]` headers — inside `[feeds]` it would be read as a feed entry, not a setting.
 
 ## Related
@@ -15,5 +17,5 @@ Feed ingested posts are saved as drafts by default to prioritize authorship over
 - [Post Types]({{ site.baseurl }}{% link post-types.md %}): Front-matter is used to set `draft: true`.
 - [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Hide a post until a future `created` date.
 - [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %}): Feed ingestion that produces drafts.
-- [Micropub]({{ site.baseurl }}{% link micropub.md %}): Drafts created via Micropub get a 24-hour preview link.
+- [Micropub]({{ site.baseurl }}{% link micropub.md %}): Drafts created via Micropub get the same 24-hour preview link.
 - [Cron Scheduled Tasks]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}): The cron endpoint triggers feed ingestion.

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -50,7 +50,7 @@ Use a name from the [list of supported timezones](https://www.php.net/manual/en/
 
 ## Viewing scheduled posts
 
-When logged in and one or more posts are scheduled, a **Scheduled** link appears in the admin toolbar, listing future-dated posts soonest-first at `/scheduled`. You can still open a scheduled post directly via its `/status/<id>` URL to preview it before it goes live.
+When logged in and one or more posts are scheduled, a **Scheduled** link appears in the admin toolbar, listing future-dated posts soonest-first at `/scheduled`. You can still open a scheduled post directly via its `/status/<id>` URL to preview it before it goes live. Each scheduled post also shows a **Preview** link next to its Edit button — a shareable URL with an expiring 24-hour token that works without being logged in.
 
 ## Via Micropub
 

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -436,6 +436,30 @@ function preview_token_valid(OODBBean $post, ?string $token): bool
 }
 
 /**
+ * Issues a preview token on a draft or scheduled post when it has none, or
+ * when the existing one has expired. Published posts are left untouched.
+ *
+ * Shared by every way a draft can be made — Micropub createCallback and the
+ * web editor's create/edit handlers — so all unpublished posts get a working
+ * ?preview= link (see issues #285 and #373). The caller stores the bean.
+ *
+ * @param OODBBean $post The post to (maybe) stamp with a token.
+ * @return void
+ */
+function ensure_preview_token(OODBBean $post): void
+{
+    if ($post->draft != 1 && !is_scheduled($post)) {
+        return;
+    }
+    $expires = $post->preview_token_expires ?? '';
+    if (!empty($post->preview_token) && !empty($expires) && strtotime($expires) >= time()) {
+        return;
+    }
+    $post->preview_token         = bin2hex(random_bytes(16));
+    $post->preview_token_expires = date('Y-m-d H:i:s', time() + 86400);
+}
+
+/**
  * Checks if a post with the given slug exists in the database and may be
  * routed for the current request: published posts for everyone, drafts and
  * scheduled posts for the logged-in author (matching is_viewable()) or via a

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -240,10 +240,7 @@ class LambMicropubAdapter extends MicropubAdapter
         // URL we return to show the just-created post. Attach a short-lived
         // preview token so that URL works without a Lamb session (#285).
         $needs_preview = $bean->draft == 1 || is_scheduled($bean);
-        if ($needs_preview) {
-            $bean->preview_token = bin2hex(random_bytes(16));
-            $bean->preview_token_expires = date('Y-m-d H:i:s', time() + 86400);
-        }
+        \Lamb\ensure_preview_token($bean);
 
         R::store($bean);
         // Reserved-route and duplicate slugs get an id suffix; the final slug

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -39,6 +39,7 @@ function redirect_created(): void
     }
 
     $bean = populate_bean($contents);
+    \Lamb\ensure_preview_token($bean);
 
     try {
         R::store($bean);
@@ -179,6 +180,7 @@ function redirect_edited(): void
     $bean->body = $contents;
 
     parse_bean($bean);
+    \Lamb\ensure_preview_token($bean);
     $bean->version = 1;
     $bean->updated = date("Y-m-d H:i:s");
 

--- a/src/theme.php
+++ b/src/theme.php
@@ -86,6 +86,30 @@ function action_edit(OODBBean $bean): string
 }
 
 /**
+ * Returns a shareable preview link for an unpublished post, or '' when the
+ * user is not logged in or the post has no valid preview token.
+ *
+ * @param OODBBean $bean The post bean to preview.
+ * @return string HTML anchor element, or '' when not applicable.
+ */
+function action_preview(OODBBean $bean): string
+{
+    if (!can_act_on($bean)) {
+        return '';
+    }
+    if (!\Lamb\preview_token_valid($bean, (string) $bean->preview_token)) {
+        return '';
+    }
+    if ($bean->draft != 1 && !\Lamb\is_scheduled($bean)) {
+        return '';
+    }
+
+    $url = permalink($bean) . '?preview=' . $bean->preview_token;
+
+    return sprintf('<a class="link-preview" href="%s">Preview</a>', escape($url));
+}
+
+/**
  * Returns the current session CSRF token, creating one if it does not exist yet.
  *
  * @return string 64-character hex CSRF token (32 random bytes) stored in the session.

--- a/src/themes/2024/parts/_items.php
+++ b/src/themes/2024/parts/_items.php
@@ -6,6 +6,7 @@ global $template;
 
 use function Lamb\Theme\action_delete;
 use function Lamb\Theme\action_edit;
+use function Lamb\Theme\action_preview;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\date_created;
 use function Lamb\Theme\escape;
@@ -49,7 +50,7 @@ else :
             <?= $bean->transformed ?>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
-                <small><?= link_source($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
+                <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
             <?php endif; ?>
         </article>
         <?php

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -6,6 +6,7 @@ global $template;
 
 use function Lamb\Theme\action_delete;
 use function Lamb\Theme\action_edit;
+use function Lamb\Theme\action_preview;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\date_created;
 use function Lamb\Theme\escape;
@@ -49,7 +50,7 @@ else :
             <?= $bean->transformed ?>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
-                <small><?= link_source($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
+                <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
             <?php endif; ?>
         </article>
         <?php

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -5,6 +5,7 @@ global $template;
 
 use function Lamb\Theme\action_delete;
 use function Lamb\Theme\action_edit;
+use function Lamb\Theme\action_preview;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\date_created;
 use function Lamb\Config\is_menu_item;
@@ -32,7 +33,7 @@ else :
             <?= the_reply_context($bean) ?>
             <?= $bean->transformed ?>
             <footer>
-                <small><?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
+                <small><?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
             </footer>
         </article>
         <?php

--- a/tests/Acceptance/DraftPreviewLinkCest.php
+++ b/tests/Acceptance/DraftPreviewLinkCest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Acceptance;
+
+use Tests\Support\AcceptanceTester;
+
+class DraftPreviewLinkCest
+{
+    private string $uniqueContent = '';
+
+    private function login(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', $_ENV['LAMB_TEST_PASSWORD']);
+        $I->click('Log in');
+    }
+
+    private function createDraft(AcceptanceTester $I): void
+    {
+        $this->uniqueContent = 'draft-preview-test-' . uniqid();
+        $I->amOnPage('/');
+        $I->fillField('contents', "---\ndraft: true\n---\n" . $this->uniqueContent);
+        $I->click('Create post');
+    }
+
+    public function testWebUiDraftGetsPreviewLinkOnDraftsPage(AcceptanceTester $I): void
+    {
+        $this->login($I);
+        $this->createDraft($I);
+
+        $I->amOnPage('/drafts');
+        $I->see($this->uniqueContent);
+        $I->seeElement('//article[contains(., "' . $this->uniqueContent . '")]//a[contains(@href, "?preview=")]');
+    }
+
+    public function testPreviewLinkWorksLoggedOut(AcceptanceTester $I): void
+    {
+        $this->login($I);
+        $this->createDraft($I);
+
+        $I->amOnPage('/drafts');
+        $href = $I->grabAttributeFrom('//article[contains(., "' . $this->uniqueContent . '")]//a[contains(@href, "?preview=")]', 'href');
+
+        $I->amOnPage('/logout');
+        $I->amOnUrl($href);
+        $I->see($this->uniqueContent);
+    }
+}

--- a/tests/Unit/PreviewTokenParityTest.php
+++ b/tests/Unit/PreviewTokenParityTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\ensure_preview_token;
+use function Lamb\Theme\action_preview;
+
+class PreviewTokenParityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    private function makeBean(array $fields): \RedBeanPHP\OODBBean
+    {
+        $bean = R::dispense('post');
+        $bean->body                  = 'Body';
+        $bean->draft                 = $fields['draft'] ?? 0;
+        $bean->deleted               = 0;
+        $bean->slug                  = $fields['slug'] ?? '';
+        $bean->created               = $fields['created'] ?? date('Y-m-d H:i:s');
+        $bean->preview_token         = $fields['preview_token'] ?? '';
+        $bean->preview_token_expires = $fields['preview_token_expires'] ?? '';
+
+        return $bean;
+    }
+
+    // ---- ensure_preview_token() ---------------------------------------------
+
+    public function testIssuesTokenForDraft(): void
+    {
+        $bean = $this->makeBean(['draft' => 1]);
+        ensure_preview_token($bean);
+
+        $this->assertNotEmpty($bean->preview_token);
+        $this->assertGreaterThan(time(), strtotime($bean->preview_token_expires));
+    }
+
+    public function testIssuesTokenForScheduledPost(): void
+    {
+        $bean = $this->makeBean(['created' => date('Y-m-d H:i:s', time() + 86400)]);
+        ensure_preview_token($bean);
+
+        $this->assertNotEmpty($bean->preview_token);
+    }
+
+    public function testDoesNotIssueTokenForPublishedPost(): void
+    {
+        $bean = $this->makeBean([]);
+        ensure_preview_token($bean);
+
+        $this->assertEmpty($bean->preview_token);
+    }
+
+    public function testKeepsExistingUnexpiredToken(): void
+    {
+        $bean = $this->makeBean([
+            'draft'                 => 1,
+            'preview_token'         => 'existing-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        ensure_preview_token($bean);
+
+        $this->assertSame('existing-token', $bean->preview_token);
+    }
+
+    public function testReplacesExpiredToken(): void
+    {
+        $bean = $this->makeBean([
+            'draft'                 => 1,
+            'preview_token'         => 'expired-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() - 3600),
+        ]);
+        ensure_preview_token($bean);
+
+        $this->assertNotSame('expired-token', $bean->preview_token);
+        $this->assertGreaterThan(time(), strtotime($bean->preview_token_expires));
+    }
+
+    // ---- Theme\action_preview() ----------------------------------------------
+
+    public function testActionPreviewRendersLinkForLoggedInAuthor(): void
+    {
+        $bean = $this->makeBean([
+            'draft'                 => 1,
+            'slug'                  => 'my-draft',
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        R::store($bean);
+
+        $_SESSION[SESSION_LOGIN] = true;
+        $html = action_preview($bean);
+
+        $this->assertStringContainsString('http://localhost/my-draft?preview=secret-token', $html);
+        $this->assertStringContainsString('Preview', $html);
+    }
+
+    public function testActionPreviewEmptyWhenLoggedOut(): void
+    {
+        $bean = $this->makeBean([
+            'draft'                 => 1,
+            'preview_token'         => 'secret-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        R::store($bean);
+
+        $this->assertSame('', action_preview($bean));
+    }
+
+    public function testActionPreviewEmptyForPublishedPost(): void
+    {
+        $bean = $this->makeBean([]);
+        R::store($bean);
+
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertSame('', action_preview($bean));
+    }
+
+    public function testActionPreviewEmptyWithoutValidToken(): void
+    {
+        $bean = $this->makeBean([
+            'draft'                 => 1,
+            'preview_token'         => 'expired-token',
+            'preview_token_expires' => date('Y-m-d H:i:s', time() - 3600),
+        ]);
+        R::store($bean);
+
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertSame('', action_preview($bean));
+    }
+}


### PR DESCRIPTION
Stacked on #372 (retarget to main once that merges).

## What

Closes #373 — preview-link parity across all ways to make drafts:

- New `Lamb\ensure_preview_token()`: issues an expiring token on draft/scheduled posts (keeps an unexpired one, replaces expired). Shared by Micropub `createCallback` (refactored to use it) and the web editor's create/edit handlers.
- New `Theme\action_preview()`: renders a "Preview" link (`?preview=<token>`) next to Edit for logged-in users on unpublished posts with a valid token. Added to `_items.php` in base, 2024, and 2026 themes.

## Tests (red-green)

- 9 new unit tests (`PreviewTokenParityTest`): token issuance rules + `action_preview` markup/visibility.
- 2 new acceptance tests (`DraftPreviewLinkCest`): web-UI draft shows a preview link on /drafts, and that link works logged-out.
- Full suite green (853 unit, 56 acceptance), lint + analyse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)