### PR TITLE
Add 3-day dependency cooldown (.npmrc + Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown: # Covers PHP until Composer ships its own minimum-release-age policy
+      default-days: 3
     groups:
       minor-and-patch:
         update-types:
@@ -29,6 +31,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown: # Matches min-release-age in .npmrc so Dependabot doesn't propose versions npm/pnpm refuse to install
+      default-days: 3
     groups:
       minor-and-patch:
         update-types:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Refuse to install package versions younger than 3 days (supply-chain cooldown).
+# npm (11.10.0+) reads min-release-age in days; pnpm reads minimum-release-age in minutes.
+min-release-age=3
+minimum-release-age=4320


### PR DESCRIPTION
Implements a supply-chain cooldown so freshly published package versions aren't installed before the ecosystem has had a few days to catch malicious releases.

## Changes

- **`.npmrc`** — `min-release-age=3` (npm 11.10+, days) and `minimum-release-age=4320` (pnpm, minutes). Both keys are set because this repo installs with pnpm 10.x, which uses its own key/unit, while the npm key covers anyone installing with npm.
- **`dependabot.yml`** — `cooldown: default-days: 3` on the **npm** ecosystem (so Dependabot doesn't open PRs for versions the package manager then refuses to install) and on the **composer** ecosystem (covers PHP until Composer ships its own minimum-release-age dependency policy — 2.10 added the policy framework; release-age is the planned follow-up).

Dependabot's cooldown only applies to version updates — security updates still flow through immediately.

## Verification

- `pnpm install --frozen-lockfile` passes locally with the new `.npmrc` in place.
- CI will exercise the same install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)