### PR TITLE
Seed new installs with an active site_title and Home/Feed menu items

### DIFF
--- a/docs/menu-items.md
+++ b/docs/menu-items.md
@@ -15,6 +15,8 @@ View Source = https://github.com/svandragt/lamb
 
 Menu labels are used as key, whilst the value are the links. When a slug (`/about-me`) is used then the matching post will not be loaded in the timeline (see [Page post-types]({{ site.baseurl }}{% link post-types.md %}#page)).
 
+New installs ship with two menu items by default: `Home = /` and `Feed = /feed`. Remove or change them on the settings page if you don't want them.
+
 Links can also point to external resources.
 
 ## Related

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -11,7 +11,7 @@ one value rather than write it from scratch; personal details stay commented:
 
 ```
 ;; Title of the site, shown in the HTML and feed views
-;site_title = My Microblog
+site_title = My Microblog
 
 ;; Author email in feed
 ;author_email = joe.sheeple@example.com
@@ -54,6 +54,8 @@ token_endpoint = https://tokens.indieauth.com/token
 ;Subscribe = /feed
 ;;   - A full URL to an external site
 ;Source = https://github.com/svandragt/lamb
+Home = /
+Feed = /feed
 
 [redirections]
 ;; Add 301 redirects for old URL path segments.

--- a/src/config.php
+++ b/src/config.php
@@ -26,7 +26,7 @@ theme = 2026
 ;author_name = Joe Sheeple
 
 ;; Title of the site, in html and feed views
-;site_title = My Microblog
+site_title = My Microblog
 
 ;; Your timezone, used for post dates and scheduling (the server is often UTC).
 ;; Use a name from https://www.php.net/manual/en/timezones.php.
@@ -61,6 +61,8 @@ token_endpoint = https://tokens.indieauth.com/token
 ;Subscribe = /feed
 ;;   - Full URLs to external sites
 ;Source = https://github.com/svandragt/lamb
+Home = /
+Feed = /feed
 
 [feeds]
 ;; Add feeds whose content gets published into the blog.
@@ -169,7 +171,6 @@ function compose_config(string $stored_ini, string $default_ini): array
     $fallback = [
         'author_email' => 'joe.sheeple@example.com',
         'author_name'  => 'Joe Sheeple',
-        'site_title'   => 'My Microblog',
     ];
 
     return array_merge($fallback, $defaults, $config);

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -165,6 +165,21 @@ class ConfigTest extends TestCase
         $this->assertSame('my-custom', resolve_theme('my-custom'));
     }
 
+    public function testDefaultIniSetsSiteTitleForNewInstalls(): void
+    {
+        $parsed = parse_ini_string(get_default_ini_text(), true, INI_SCANNER_RAW);
+
+        $this->assertSame('My Microblog', $parsed['site_title'] ?? null, 'site_title must be uncommented in the seeded INI');
+    }
+
+    public function testDefaultIniSetsHomeAndFeedMenuItemsForNewInstalls(): void
+    {
+        $parsed = parse_ini_string(get_default_ini_text(), true, INI_SCANNER_RAW);
+
+        $this->assertSame('/', $parsed['menu_items']['Home'] ?? null);
+        $this->assertSame('/feed', $parsed['menu_items']['Feed'] ?? null);
+    }
+
     public function testDefaultIniExposesRealDefaultsAtTopLevel(): void
     {
         $parsed = parse_ini_string(get_default_ini_text(), true, INI_SCANNER_RAW);


### PR DESCRIPTION
For the next version: new installs get usable defaults instead of an everything-commented config.

## Changes

- `site_title = My Microblog` ships uncommented in the seeded INI. The hardcoded `site_title` fallback in `compose_config()` is removed — the seeded INI is now the single source of truth for it.
- `[menu_items]` gains two active defaults: `Home = /` and `Feed = /feed`.
- Docs updated (`site-configuration.md`, `menu-items.md`).

## Notes

- Existing installs whose stored INI contains a `[menu_items]` section (even with all entries commented — i.e. anything bootstrapped from the seeded config) keep their own menu: the stored section overrides the default wholesale. Only a stored config with no `[menu_items]` section at all would inherit Home/Feed.
- TDD: tests added first (red), then implementation (green). `composer lint` and `composer analyse` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)