### PR TITLE
Fix 500 on image upload in the release Docker image (missing gd)

### DIFF
--- a/.docker/Dockerfile.release
+++ b/.docker/Dockerfile.release
@@ -13,7 +13,8 @@ FROM dunglas/frankenphp:php8.2
 LABEL maintainer="Sander van Dragt <sander@vandragt.com>"
 LABEL org.opencontainers.image.source="https://github.com/svandragt/lamb"
 
-RUN install-php-extensions gettext pdo_mysql
+# gd powers WebP upload conversion
+RUN install-php-extensions gettext pdo_mysql gd
 
 RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Barrier free super simple blogging, self-hosted. [Read about the features](https
 
 - PHP 8.2 – 8.5
 - SQLite3, gettext, simplexml, mbstring, pdo_mysql extensions (pdo_mysql is required by the database library even though Lamb uses SQLite)
+- gd extension, recommended: converts image uploads to WebP (without it originals are stored as-is)
 
 ## Getting started
 

--- a/docs/local-php-setup.md
+++ b/docs/local-php-setup.md
@@ -11,9 +11,10 @@ Make sure everything is installed:
 ```bash
 # Install required system packages, for example on Debian Linux derivatives like Ubuntu
 sudo apt update
-sudo apt install php8.4 php8.4-gettext php8.4-mbstring php8.4-sqlite3 php8.4-xml php8.4-mysql composer
+sudo apt install php8.4 php8.4-gettext php8.4-mbstring php8.4-sqlite3 php8.4-xml php8.4-mysql php8.4-gd composer
 # PHP 8.2–8.5 are supported; replace 8.4 with your preferred version
 # php8.4-mysql (pdo_mysql) is required by the database library even though Lamb uses SQLite
+# php8.4-gd converts image uploads to WebP; without it originals are stored as-is
 
 # install project packages
 composer install

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -101,12 +101,18 @@ function safe_upload_extension(string $filename): ?string
  * formats (webp, avif) are left untouched, and gif is passed through because it may
  * be animated — GD would flatten it to a single frame.
  *
- * @param string|null $ext A lower-case extension as returned by safe_upload_extension().
+ * Conversion also requires the gd extension: without it the original bytes are
+ * stored as-is instead of fataling on undefined GD functions.
+ *
+ * @param string|null $ext          A lower-case extension as returned by safe_upload_extension().
+ * @param bool|null   $gd_available Overrides the gd extension check (for tests); null = detect.
  * @return bool
  */
-function should_convert_to_webp(?string $ext): bool
+function should_convert_to_webp(?string $ext, ?bool $gd_available = null): bool
 {
-    return in_array($ext, ['jpg', 'jpeg', 'png'], true);
+    $gd_available ??= extension_loaded('gd');
+
+    return $gd_available && in_array($ext, ['jpg', 'jpeg', 'png'], true);
 }
 
 /**

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -181,6 +181,13 @@ class UploadTest extends TestCase
         $this->assertFalse(should_convert_to_webp(null));
     }
 
+    public function testShouldNotConvertWithoutGd(): void
+    {
+        // Installs without the gd extension must store the original bytes
+        // instead of fataling on undefined GD functions.
+        $this->assertFalse(should_convert_to_webp('jpg', gd_available: false));
+    }
+
     // convert_to_webp — GD-backed re-encode of an uploaded image into WebP
 
     public function testConvertWritesWebpFile(): void


### PR DESCRIPTION
## Summary
- Dragging a JPEG into the editor on a release-image install returned an empty `500` from `/upload` (`SyntaxError: JSON.parse: unexpected end of data` in the browser): the WebP conversion path fataled on `imagecreatefromstring()` because `Dockerfile.release` never installed the `gd` extension (the dev `Dockerfile` already had it).
- Install `gd` in `Dockerfile.release`.
- Defence in depth: `should_convert_to_webp()` now requires `gd` to be loaded, so a GD-less install stores the original upload bytes instead of crashing (covers web uploads and both Micropub upload paths).

## Test plan
- [x] New unit test `testShouldNotConvertWithoutGd` (red before, green after)
- [x] `vendor/bin/codecept run Unit` — 854 tests OK
- [x] `composer lint` / `composer analyse` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)