### PR TITLE
Remove leftover debug console.log from growing-input.js

### DIFF
--- a/src/scripts/logged_in/growing-input.js
+++ b/src/scripts/logged_in/growing-input.js
@@ -9,7 +9,6 @@ onLoaded(() => {
 
 function growing_input(ev)
 {
-    console.log('recalculating input')
     const target = ev.target
     target.style.height = 'auto'
     target.style.height = (20 + target.scrollHeight) + 'px'


### PR DESCRIPTION
## Summary
`growing-input.js` logged `recalculating input` to the console on every keystroke in the editor textarea — leftover debug output. Removed; no behaviour change.

## Test plan
- [x] `vendor/bin/codecept run Unit` — 853 tests OK
- [x] No other `console.log` left under `src/scripts/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)