### PR TITLE
Raise upload size limits to 20M and document them

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -13,7 +13,10 @@ RUN touch /usr/local/etc/php/conf.d/app.ini && \
     echo "variables_order = \"EGPCS\"" >> /usr/local/etc/php/conf.d/app.ini && \
     echo "display_errors = off" >> /usr/local/etc/php/conf.d/app.ini && \
     echo "log_errors = On" >> /usr/local/etc/php/conf.d/app.ini && \
-    echo "error_log = /dev/stderr" >> /usr/local/etc/php/conf.d/app.ini
+    echo "error_log = /dev/stderr" >> /usr/local/etc/php/conf.d/app.ini && \
+    # Uploads are converted to WebP and resized server-side, so accept large originals.
+    echo "upload_max_filesize = 20M" >> /usr/local/etc/php/conf.d/app.ini && \
+    echo "post_max_size = 25M" >> /usr/local/etc/php/conf.d/app.ini
 
 # Allow FrankenPHP to bind :80 when running as the (remapped) www-data user.
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/frankenphp

--- a/.docker/Dockerfile.release
+++ b/.docker/Dockerfile.release
@@ -17,6 +17,10 @@ RUN install-php-extensions gettext pdo_mysql
 
 RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
+# Uploads are converted to WebP and resized server-side, so accept large
+# originals (phone photos easily exceed PHP's 2M default).
+RUN printf 'upload_max_filesize = 20M\npost_max_size = 25M\n' > "$PHP_INI_DIR/conf.d/uploads.ini"
+
 COPY .docker/Caddyfile.release /etc/frankenphp/Caddyfile
 
 WORKDIR /app

--- a/.nginx/snippets/lamb.conf
+++ b/.nginx/snippets/lamb.conf
@@ -1,3 +1,7 @@
+# Uploads are converted to WebP and resized server-side, so accept large
+# originals (nginx's default client_max_body_size is only 1m).
+client_max_body_size 25m;
+
 location / {
      try_files $uri $uri/ /index.php$is_args$args;
 }

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -48,6 +48,8 @@ Your site is now ready at http://localhost
 
 Uploaded images are stored under `src/assets/` inside the app container.
 
+Both images accept uploads up to 20&nbsp;MB (`upload_max_filesize = 20M`, `post_max_size = 25M`) — see [Media]({{ site.baseurl }}{% link media.md %}).
+
 Errors can be inspected with `docker compose logs -f app`.
 
 ### Update

--- a/docs/media.md
+++ b/docs/media.md
@@ -42,6 +42,15 @@ Images sent via Micropub — both inline `photo` files on a post and files sent 
 
 Uploads require the directory `src/assets/` to be writable by the web server or PHP-FPM user.
 
+### Upload size limits
+
+Because uploads are converted to WebP and resized server-side, the original file size mostly doesn't matter — large phone photos are fine. What limits the upload is the server configuration:
+
+- **PHP** caps uploads with `upload_max_filesize` (default **2M**) and `post_max_size` (default **8M**). The Lamb Docker images raise these to `20M` / `25M`; on other hosts raise them in `php.ini` or a `conf.d` file.
+- **NGINX** additionally caps the request body with `client_max_body_size` (default **1m**). The shipped `.nginx/snippets/lamb.conf` sets it to `25m`.
+
+If an upload over the limit fails, it fails silently from the editor's point of view — check the server limits first when a large image won't upload.
+
 WebP conversion relies on PHP's [GD extension](https://www.php.net/manual/en/book.image.php) being built **with WebP support**. This is the common default, but it isn't guaranteed on every host. WebP support is the only thing the conversion needs — if it's missing, nothing breaks: Lamb stores each upload in its original format instead, so JPEG and PNG files are saved as-is rather than being converted. You simply don't get the smaller WebP files.
 
 ### Checking for WebP support

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -17,6 +17,17 @@ The `data` and `src/assets` directory must be writable by the user php-fpm runs 
 
 `src/assets` is the runtime upload directory used for images dropped into posts. Theme CSS and application JavaScript live elsewhere and do not need to be writable at runtime.
 
+### Upload size limits
+
+PHP's defaults (`upload_max_filesize = 2M`, `post_max_size = 8M`) reject photos larger than 2&nbsp;MB. Raise them in your php.ini or FPM pool, for example:
+
+```text
+upload_max_filesize = 20M
+post_max_size = 25M
+```
+
+The shipped `snippets/lamb.conf` sets the matching NGINX limit (`client_max_body_size 25m;` — its default is only 1m). See [Media]({{ site.baseurl }}{% link media.md %}) for details.
+
 ```shell
 sudo chown $USER:www-data data -R
 sudo chmod g+w data -R


### PR DESCRIPTION
PHP's defaults (`upload_max_filesize = 2M`, `post_max_size = 8M`) silently reject typical phone photos — a 1.9 MB JPEG uploads but a 9 MB one doesn't. Since uploads are converted to WebP and resized server-side (#media), accepting large originals is cheap.

## Changes
- **Docker dev image** (`.docker/Dockerfile`): add `upload_max_filesize = 20M` / `post_max_size = 25M` to `app.ini`
- **Docker release image** (`.docker/Dockerfile.release`): same limits via `conf.d/uploads.ini`
- **Shipped nginx snippet** (`.nginx/snippets/lamb.conf`): `client_max_body_size 25m;` (nginx default is only 1m)
- **Docs**: new upload-size-limit sections in `media.md`, `nginx.md`, and a note in `docker.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)