### PR TITLE
Fix four surface-level bugs found in post-0.9.0 code

### DIFF
--- a/src/highlight.php
+++ b/src/highlight.php
@@ -21,13 +21,19 @@ const PLACEHOLDER_FORMAT = '<!--lamb-code-%d-->';
 function extract_code_blocks(string $html): array
 {
     $blocks = [];
-    $html = preg_replace_callback('/<pre><code[^>]*>.*?<\/code><\/pre>/s', function ($matches) use (&$blocks) {
+    $result = preg_replace_callback('/<pre><code[^>]*>.*?<\/code><\/pre>/s', function ($matches) use (&$blocks) {
         $blocks[] = $matches[0];
 
         return sprintf(PLACEHOLDER_FORMAT, count($blocks) - 1);
     }, $html);
 
-    return [$html, $blocks];
+    // PCRE failure (e.g. backtrack limit on a huge post) returns null — fall
+    // back to the untouched input rather than wiping the post.
+    if ($result === null) {
+        return [$html, []];
+    }
+
+    return [$result, $blocks];
 }
 
 /**
@@ -66,7 +72,7 @@ function highlight_code_blocks(string $html): string
         return $html;
     }
 
-    return preg_replace_callback(CODE_BLOCK_PATTERN, function ($matches) {
+    $result = preg_replace_callback(CODE_BLOCK_PATTERN, function ($matches) {
         $code = html_entity_decode($matches[2], ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
         try {
@@ -78,4 +84,8 @@ function highlight_code_blocks(string $html): string
             return $matches[0];
         }
     }, $html);
+
+    // PCRE failure (e.g. backtrack limit on a huge post) returns null — output
+    // is never worse than the unhighlighted original.
+    return $result ?? $html;
 }

--- a/src/http.php
+++ b/src/http.php
@@ -92,6 +92,20 @@ function build_http_context_options(array $opts): array
 }
 
 /**
+ * Extract the status code from an HTTP status line.
+ *
+ * Accepts status lines with or without a reason phrase ("HTTP/1.1 200 OK"
+ * and "HTTP/1.1 200" are both valid — the reason phrase may be empty).
+ *
+ * @param string $line The raw status line.
+ * @return int The status code, or 0 when none can be parsed.
+ */
+function parse_status_line(string $line): int
+{
+    return preg_match('#\s(\d{3})(?:\s|$)#', $line, $m) ? (int) $m[1] : 0;
+}
+
+/**
  * Perform a single HTTP request via the streams wrapper.
  *
  * This is the shared low-level fetch used by webmention discovery/verification
@@ -115,10 +129,6 @@ function fetch(string $url, array $opts = []): ?array
     }
 
     $headers = $http_response_header;
-    $status = 0;
-    if (isset($headers[0]) && preg_match('#\s(\d{3})\s#', $headers[0], $m)) {
-        $status = (int) $m[1];
-    }
 
-    return ['status' => $status, 'headers' => $headers, 'body' => $body];
+    return ['status' => parse_status_line($headers[0] ?? ''), 'headers' => $headers, 'body' => $body];
 }

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -473,10 +473,10 @@ function post_has_slug(string $lookup): string|null
 {
     $post = R::findOne('post', ' slug = ? ', [$lookup]);
     if ($post === null || $post->id === 0) {
-        return '';
+        return null;
     }
     if (!is_viewable($post) && !preview_token_valid($post, $_GET['preview'] ?? null)) {
-        return '';
+        return null;
     }
 
     return $post->slug;

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -542,6 +542,11 @@ function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender
         ? discover_endpoint($fetched['body'] ?? '', $fetched['headers'] ?? [], $row->target)
         : null;
 
+    // A target may advertise any URL as its endpoint — only POST to http(s).
+    if ($endpoint !== null && !is_valid_http_url($endpoint)) {
+        $endpoint = null;
+    }
+
     if ($endpoint === null) {
         $row->status = 'skipped';
         R::store($row);
@@ -616,6 +621,5 @@ function send_webmention(string $endpoint, string $source, string $target): int
         return 0;
     }
 
-    $status_line = $http_response_header[0] ?? '';
-    return preg_match('#\s(\d{3})\s#', $status_line, $m) ? (int) $m[1] : 0;
+    return \Lamb\Http\parse_status_line($http_response_header[0] ?? '');
 }

--- a/tests/Unit/HighlightTest.php
+++ b/tests/Unit/HighlightTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\Highlight\extract_code_blocks;
 use function Lamb\Highlight\highlight_code_blocks;
 use function Lamb\parse_bean;
 
@@ -57,6 +58,35 @@ class HighlightTest extends TestCase
         $html = '<p>Hello #world</p>';
 
         $this->assertSame($html, highlight_code_blocks($html));
+    }
+
+    public function testHighlightFallsBackToInputOnPcreFailure(): void
+    {
+        $html = '<pre><code class="language-php">' . str_repeat('a', 100000) . '</code></pre>';
+
+        $old = ini_set('pcre.backtrack_limit', '100');
+        try {
+            $result = highlight_code_blocks($html);
+        } finally {
+            ini_set('pcre.backtrack_limit', $old);
+        }
+
+        $this->assertSame($html, $result);
+    }
+
+    public function testExtractFallsBackToInputOnPcreFailure(): void
+    {
+        $html = '<pre><code class="language-php">' . str_repeat('a', 100000) . '</code></pre>';
+
+        $old = ini_set('pcre.backtrack_limit', '100');
+        try {
+            [$out, $blocks] = extract_code_blocks($html);
+        } finally {
+            ini_set('pcre.backtrack_limit', $old);
+        }
+
+        $this->assertSame($html, $out);
+        $this->assertSame([], $blocks);
     }
 
     public function testParseBeanHighlightsFencedCode(): void

--- a/tests/Unit/HttpFetchTest.php
+++ b/tests/Unit/HttpFetchTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 use function Lamb\Http\build_http_context_options;
 use function Lamb\Http\fetch;
+use function Lamb\Http\parse_status_line;
 
 class HttpFetchTest extends TestCase
 {
@@ -58,6 +59,25 @@ class HttpFetchTest extends TestCase
 
         $this->assertSame('POST', $opts['method']);
         $this->assertSame('source=a&target=b', $opts['content']);
+    }
+
+    // parse_status_line ------------------------------------------------------
+
+    public function testParseStatusLineWithReasonPhrase(): void
+    {
+        $this->assertSame(200, parse_status_line('HTTP/1.1 200 OK'));
+    }
+
+    public function testParseStatusLineWithoutReasonPhrase(): void
+    {
+        // An empty reason phrase is valid; some servers omit it entirely.
+        $this->assertSame(200, parse_status_line('HTTP/1.1 200'));
+    }
+
+    public function testParseStatusLineReturnsZeroForGarbage(): void
+    {
+        $this->assertSame(0, parse_status_line(''));
+        $this->assertSame(0, parse_status_line('not a status line'));
     }
 
     // fetch -----------------------------------------------------------------

--- a/tests/Unit/LambHelpersTest.php
+++ b/tests/Unit/LambHelpersTest.php
@@ -98,10 +98,10 @@ class LambHelpersTest extends TestCase
 
     // post_has_slug
 
-    public function testPostHasSlugReturnsEmptyForNonExistentSlug(): void
+    public function testPostHasSlugReturnsNullForNonExistentSlug(): void
     {
         $result = post_has_slug('this-slug-does-not-exist-' . uniqid());
-        $this->assertSame('', $result);
+        $this->assertNull($result);
     }
 
     public function testPostHasSlugReturnsSlugWhenPostExists(): void
@@ -114,7 +114,7 @@ class LambHelpersTest extends TestCase
         $this->assertSame($bean->slug, $result);
     }
 
-    public function testPostHasSlugReturnEmptyForDraftPost(): void
+    public function testPostHasSlugReturnsNullForDraftPost(): void
     {
         $bean = R::dispense('post');
         $bean->slug = 'draft-slug-' . uniqid();
@@ -122,7 +122,7 @@ class LambHelpersTest extends TestCase
         R::store($bean);
 
         $result = post_has_slug($bean->slug);
-        $this->assertSame('', $result);
+        $this->assertNull($result);
     }
 
     public function testPostHasSlugResolvesDraftForLoggedInAuthor(): void

--- a/tests/Unit/PreviewTokenTest.php
+++ b/tests/Unit/PreviewTokenTest.php
@@ -190,7 +190,7 @@ class PreviewTokenTest extends TestCase
             'preview_token_expires' => date('Y-m-d H:i:s', time() + 3600),
         ]);
 
-        $this->assertSame('', \Lamb\post_has_slug('routed-preview-draft'), 'Draft slug must not resolve without token');
+        $this->assertNull(\Lamb\post_has_slug('routed-preview-draft'), 'Draft slug must not resolve without token');
 
         $_GET['preview'] = 'secret-token';
         $this->assertSame(

--- a/tests/Unit/ScheduledPostTest.php
+++ b/tests/Unit/ScheduledPostTest.php
@@ -137,7 +137,7 @@ class ScheduledPostTest extends TestCase
     {
         $this->makePost('A scheduled page', $this->future(), 'scheduled-page');
 
-        $this->assertSame('', post_has_slug('scheduled-page'), 'Future-dated slugged posts must not resolve publicly');
+        $this->assertNull(post_has_slug('scheduled-page'), 'Future-dated slugged posts must not resolve publicly');
     }
 
     public function testRespondPostReturns404ForFutureSluggedPost(): void

--- a/tests/Unit/WebmentionSendTest.php
+++ b/tests/Unit/WebmentionSendTest.php
@@ -317,6 +317,20 @@ class WebmentionSendTest extends TestCase
         $this->assertSame('skipped', R::findOne('webmentionoutbox')->status);
     }
 
+    public function testProcessSkipsNonHttpDiscoveredEndpoint(): void
+    {
+        $this->seedPending('https://other.example/a');
+
+        $fetcher = fn (string $url) => ['headers' => ['<file:///etc/passwd>; rel="webmention"'], 'body' => ''];
+        $sender = function (string $e, string $s, string $t): int {
+            $this->fail('sender must not be called for a non-http endpoint');
+        };
+
+        $result = process_outbound($fetcher, $sender);
+        $this->assertSame(1, $result['skipped']);
+        $this->assertSame('skipped', R::findOne('webmentionoutbox')->status);
+    }
+
     public function testProcessMarksFailedOnBadStatus(): void
     {
         $this->seedPending('https://other.example/a');


### PR DESCRIPTION
## Summary

A surface-level bug scan of the ~2,800 lines of `src/` code introduced since 0.9.0 (webmentions, websub, preview tokens, highlighting, HTTP helper) surfaced four real issues, each fixed here with a failing test written first (red-green).

1. **Outbound webmention endpoints are now validated before POSTing** (`src/webmention.php`). A site the author links to could advertise `<link rel="webmention" href="file:///...">` (or an otherwise non-http(s) URL) and `process_outbound_row()` would pass it straight to `file_get_contents()`. Discovered endpoints that fail `is_valid_http_url()` are now treated the same as no endpoint — the row is `skipped`.
2. **`preg_replace_callback()` null returns guarded in `src/highlight.php`**. A PCRE failure (e.g. backtrack limit on a very large post) returns null, which previously flowed into `parse_tags()` / the `transformed` column (TypeError, or an emptied post). Both `extract_code_blocks()` and `highlight_code_blocks()` now fall back to their untouched input.
3. **HTTP status lines without a reason phrase parse correctly**. `#\s(\d{3})\s#` required whitespace *after* the code, so a valid `HTTP/1.1 200` read as status 0 — a successfully delivered webmention was recorded as `failed`. Extracted a shared `Lamb\Http\parse_status_line()` used by both `fetch()` and `send_webmention()`.
4. **`post_has_slug()` honours its documented contract**, returning `null` on failure instead of `''` (signature was already `string|null`; the docblock always said null). The only caller (`index.php`) compares with `===` and is unaffected.

Findings reviewed and dismissed during the scan (no change needed): the edit handler's `finalize_slug()` call (runs before `R::store`, so it persists), `$http_response_header` handling in `send_webmention()` (PHP-populated local, unset case handled), `imagecreatetruecolor()` failure in upload.php (dimensions clamped ≥1), and `minify_css()` quoted-string whitespace (no shipped theme triggers it; documented as conservative-for-shipped-themes).

## Test plan

- [x] New failing-first unit tests for each fix (`WebmentionSendTest`, `HttpFetchTest`, `HighlightTest`) and updated `post_has_slug` assertions (`LambHelpersTest`, `PreviewTokenTest`, `ScheduledPostTest`)
- [x] `vendor/bin/codecept run Unit` — 860 tests, 1321 assertions, OK
- [x] `composer lint` clean
- [x] `composer analyse` (PHPStan level 5) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)