### PR TITLE
RELEASING: merge next into main after a release when it exists

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -109,6 +109,17 @@ gh release create <version> \
 - [ ] Announce / update any demo site if applicable.
 - [ ] Note that the Docker/Devbox/DDev users pull from `release`; confirm a
       clean checkout of `release` installs and runs.
+- [ ] If a `next` branch exists (work parked for the next version — see
+      `BRANCHES`), open a PR to merge it into `main` now that the release is
+      out:
+
+      ```sh
+      git fetch origin
+      git show-ref --verify --quiet refs/remotes/origin/next && \
+        gh pr create --base main --head next \
+          --title "Merge next into main" \
+          --body "Bring parked next-version work into main after the <version> release."
+      ```
 
 ## Related
 


### PR DESCRIPTION
Adds a post-release checklist step to RELEASING.md: if a `next` branch is parked with next-version work, open a PR to bring it into `main` once the release is out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)