### PR TITLE
Post-release refactoring: collapse duplication in feeds, IndieWeb endpoints, and timestamps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,18 +65,30 @@ lamb/
 │   ├── index.php         # Entry point: bootstrap, routing, view dispatch
 │   ├── bootstrap.php     # DB init (SQLite via RedBean) + session setup
 │   ├── config.php        # INI-based config stored in DB; load/save/validate
+│   ├── constants.php     # Static app-wide constants (POST_VERSION, SESSION_LOGIN, …)
 │   ├── routes.php        # register_route() / call_route() helpers
-│   ├── lamb.php          # Core helpers: parse_bean, parse_tags, permalink, find_redirect, delete_redirect_for_slug
-│   ├── post.php          # Post helpers: populate_bean, parse_matter, slugify
-│   ├── response.php      # All route handlers (respond_*, redirect_*)
+│   ├── lamb.php          # Core helpers: parse_bean, parse_tags, permalink, visibility clauses, redirects
+│   ├── post.php          # Post helpers: populate_bean, parse_matter, slugify, finalize_slug
+│   ├── response.php      # Response helpers: pagination, conditional GET/304, 404, upgrade_posts
+│   ├── response/         # Route handlers (respond_*, redirect_*), split by area
+│   │   ├── auth.php      # Login/logout/settings
+│   │   ├── feeds.php     # Home, drafts/trash/scheduled, search, tag, Atom + JSON feeds
+│   │   ├── posts.php     # Status/slug pages, create/edit/delete/restore
+│   │   └── upload.php    # Image upload + WebP conversion
 │   ├── security.php      # require_login(), require_csrf()
-│   ├── theme.php         # Template helpers, asset loader, part()
+│   ├── theme.php         # Template helpers, part(); more helpers in theme/
+│   ├── theme/            # Theme helper split: assets.php (styles/scripts), formatting.php (escape, human_time), meta.php (opengraph, titles)
 │   ├── network.php       # Feed ingestion via SimplePie (_cron route)
-│   ├── http.php          # get_request_uri() — normalises / → /home
+│   ├── http.php          # get_request_uri(); shared HTTP client: fetch(), parse_status_line()
+│   ├── micropub.php      # Micropub endpoint (taproot/micropub-adapter subclass) + media endpoint
+│   ├── webmention.php    # Webmention receiving + outbound sending queue (via /_cron)
+│   ├── websub.php        # WebSub hub pings on publish
+│   ├── highlight.php     # Syntax highlighting of fenced code blocks (Phiki)
 │   ├── LambDown.php      # Parsedown subclass (restricts heading levels)
 │   ├── assets/           # Runtime upload storage (created under YYYY/MM)
+│   ├── images/           # Shipped static images (default social embed image)
 │   ├── themes/
-│   │   ├── base/         # Base theme + fallback library (HTML, parts, feed, CSS)
+│   │   ├── base/         # Base theme + fallback library (HTML, parts, feeds, CSS)
 │   │   ├── 2024/         # Alternative theme (overrides parts as needed)
 │   │   └── 2026/         # "Notes" theme — default for new installs
 │   └── scripts/          # JS: shorthand.js + logged_in/ (admin-only)
@@ -114,14 +126,20 @@ Each file declares a namespace; functions are called with the namespace prefix:
 |------|-----------|
 | `bootstrap.php` | `Lamb\Bootstrap` |
 | `config.php` | `Lamb\Config` |
+| `highlight.php` | `Lamb\Highlight` |
 | `http.php` | `Lamb\Http` |
 | `lamb.php` | `Lamb` |
+| `micropub.php` | `Lamb\Micropub` |
 | `network.php` | `Lamb\Network` |
 | `post.php` | `Lamb\Post` |
-| `response.php` | `Lamb\Response` |
+| `response.php` + `response/*.php` | `Lamb\Response` |
 | `routes.php` | `Lamb\Route` |
 | `security.php` | `Lamb\Security` |
-| `theme.php` | `Lamb\Theme` |
+| `theme.php` + `theme/*.php` | `Lamb\Theme` |
+| `webmention.php` | `Lamb\Webmention` |
+| `websub.php` | `Lamb\Websub` |
+
+`response/` and `theme/` are namespace splits, not new namespaces: each file inside declares the parent's namespace, so callers don't care which file a function lives in.
 
 ### Database
 
@@ -131,6 +149,8 @@ RedBeanPHP (fluid mode) on SQLite. Beans are dispensed/loaded with `R::dispense`
 - `post` — blog posts; columns include `body`, `slug`, `title`, `description`, `transformed`, `created`, `updated`, `version`, `feed_name`, `feeditem_uuid`, `source_url`
 - `option` — key/value store (e.g. `site_config_ini`, `last_processed_date`)
 - `redirect` — automatic 301 redirects created when a post slug changes; columns: `from_slug`, `to_url`
+- `webmention` — received (inbound) webmentions; columns: `source`, `target`, `post_id`, `type`, `author`, `content`, `status`, `created`, `verified_at`
+- `webmentionoutbox` — outbound webmention queue processed by `/_cron`; columns: `post_id`, `source`, `target`, `endpoint`, `status`, `attempts`, `created`, `processed_at`
 
 **Post versioning:** startup bootstrapping in `bootstrap_db()` stamps legacy rows with `version = 1` via SQL (`UPDATE post SET version = 1 WHERE version IS NULL`). `upgrade_posts()` in `response.php` is still called on read paths, but it now mainly acts as a safety net for unexpected old rows loaded into memory rather than the primary migration mechanism.
 
@@ -165,10 +185,12 @@ On `main`/`release`, slugs are effectively immutable after creation: editing a p
 **Theme parts (base):**
 - `html.php` — outer HTML shell (includes `parts/home.php`, etc.)
 - `feed.php` — Atom feed output
-- `parts/home.php`, `status.php`, `edit.php`, `search.php`, `tag.php`, `login.php`, `settings.php`, `404.php`
+- `feed_json.php` — JSON Feed output
+- `parts/home.php`, `status.php`, `edit.php`, `search.php`, `tag.php`, `login.php`, `settings.php`, `404.php`, `drafts.php`, `scheduled.php`, `trash.php`
 - `parts/_items.php` — post list partial
 - `parts/_pagination.php` — pagination partial
 - `parts/_related.php` — related posts partial
+- `parts/_webmentions.php` — received-webmentions partial (status pages)
 
 ---
 
@@ -403,7 +425,14 @@ Parts you rarely need to override: `edit.php`, `login.php`, `settings.php`, `404
 
 ### Feed Ingestion (Cron)
 
-`GET /_cron` triggers `Network\process_feeds()`. It reads `[feeds]` from config, fetches each RSS/Atom feed via SimplePie, and creates/updates posts. Rate-limited: minimum 1 minute between full runs, 30 minutes per feed. Feed items get a `feeditem_uuid` (md5 of feed name + item ID) for deduplication.
+`GET /_cron` triggers `Network\process_feeds()`. It reads `[feeds]` from config, fetches each RSS/Atom feed via SimplePie, and creates/updates posts. Rate-limited: minimum 1 minute between full runs, 30 minutes per feed. Feed items get a `feeditem_uuid` (md5 of feed name + item ID) for deduplication. The same run also drains the outbound webmention queue via `Webmention\process_outbound()`.
+
+### IndieWeb Endpoints
+
+- `/micropub` + `/micropub-media` (`micropub.php`) — Micropub create/update/delete/undelete and media uploads, built on `taproot/micropub-adapter` (`LambMicropubAdapter`); bearer tokens are introspected against the configured `token_endpoint`
+- `/webmention` (`webmention.php`) — receives and verifies inbound webmentions (stored in the `webmention` table, rendered by `parts/_webmentions.php`); publishing/editing a post enqueues outbound webmentions in `webmentionoutbox`, sent by `/_cron`
+- WebSub (`websub.php`) — pings the `websub_hubs` configured hubs when a post publishes
+- `index.php` advertises `micropub`, `webmention`, `authorization_endpoint` and `token_endpoint` via `Link` headers
 
 ### Pagination
 

--- a/src/http.php
+++ b/src/http.php
@@ -106,6 +106,38 @@ function parse_status_line(string $line): int
 }
 
 /**
+ * POST a www-form-urlencoded body and return the response HTTP status code.
+ *
+ * The shared outbound notification primitive: webmention sending and WebSub
+ * hub pings both POST a small form and only care about the status (WebSub
+ * ignores even that — it is fire-and-forget). Built on {@see fetch};
+ * follow_location/max_redirects are omitted so PHP's stream defaults apply,
+ * matching the hand-rolled contexts this replaces.
+ *
+ * @param string               $url        The endpoint to POST to.
+ * @param array<string, mixed> $fields     Form fields for the request body.
+ * @param int                  $timeout    Socket timeout in seconds.
+ * @param string               $user_agent User-Agent header value.
+ * @return int HTTP status code, or 0 on transport failure.
+ */
+function post_form(string $url, array $fields, int $timeout, string $user_agent): int
+{
+    $result = fetch($url, [
+        'method' => 'POST',
+        'headers' => [
+            'Content-Type: application/x-www-form-urlencoded',
+            'User-Agent: ' . $user_agent,
+        ],
+        'content' => http_build_query($fields),
+        'timeout' => $timeout,
+        'follow_location' => null,
+        'max_redirects' => null,
+    ]);
+
+    return $result === null ? 0 : $result['status'];
+}
+
+/**
  * Perform a single HTTP request via the streams wrapper.
  *
  * This is the shared low-level fetch used by webmention discovery/verification

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -494,6 +494,32 @@ function post_has_slug(string $lookup): string|null
 }
 
 /**
+ * Resolves a permalink path to the post it points at.
+ *
+ * Recognises the two permalink shapes the app mints: `/status/<id>` for
+ * status posts and `/<slug>` for page-like posts. Shared by the Micropub and
+ * Webmention endpoints, which both map externally supplied URLs back to posts
+ * (each applies its own host policy before/after calling this).
+ *
+ * @param string $path The URL path (e.g. from parse_url(..., PHP_URL_PATH)).
+ * @return OODBBean|null The matching post bean, or null when none exists.
+ */
+function find_post_by_path(string $path): ?OODBBean
+{
+    if (preg_match('#^/status/(\d+)$#', $path, $matches)) {
+        $bean = R::load('post', (int) $matches[1]);
+        return $bean->id ? $bean : null;
+    }
+
+    $slug = trim($path, '/');
+    if ($slug !== '') {
+        return R::findOne('post', ' slug = ? ', [$slug]);
+    }
+
+    return null;
+}
+
+/**
  * Deletes any redirect stored in the DB for the given slug.
  *
  * @param string $slug The from_slug to remove.

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -19,6 +19,17 @@ use function Lamb\Post\parse_matter;
 use function Lamb\Post\set_matter;
 
 /**
+ * Returns the current time in the canonical `Y-m-d H:i:s` format used for every
+ * datetime column in the app, so the format (and timezone basis) lives in one place.
+ *
+ * @return string The current datetime string.
+ */
+function now(): string
+{
+    return date('Y-m-d H:i:s');
+}
+
+/**
  * Retrieves the tags from the given HTML.
  *
  * @param string $html The HTML content to search for tags.
@@ -249,7 +260,7 @@ function apply_scheduling(OODBBean $bean, array $front_matter, mixed $previous_c
     // edits, the feed date for ingested items) so an unparseable front-matter date
     // falls back to it rather than leaving a non-date string in the column.
     $bean->created = normalize_datetime($front_matter['created'])
-        ?? ($previous_created ?: date('Y-m-d H:i:s'));
+        ?? ($previous_created ?: now());
     // Pin the resolved date back into the body so relative phrases like
     // "next friday" don't drift to a new date on the next edit.
     $bean->body = persist_resolved_created($bean->body, $bean->created);
@@ -304,7 +315,7 @@ function not_scheduled_clause(): array
 {
     return [
         'sql'    => ' (created IS NULL OR created <= ?) ',
-        'params' => [date('Y-m-d H:i:s')],
+        'params' => [now()],
     ];
 }
 
@@ -380,7 +391,7 @@ function normalize_datetime(mixed $value): ?string
  */
 function is_scheduled(OODBBean $post): bool
 {
-    return !empty($post->created) && $post->created > date('Y-m-d H:i:s');
+    return !empty($post->created) && $post->created > now();
 }
 
 /**

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -52,20 +52,9 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     private function findPostByUrl(string $url): ?OODBBean
     {
-        $path = parse_url($url, PHP_URL_PATH) ?? '';
+        $path = parse_url($url, PHP_URL_PATH) ?: '';
 
-        if (preg_match('#^/status/(\d+)$#', $path, $matches)) {
-            $bean = R::load('post', (int) $matches[1]);
-            return $bean->id ? $bean : null;
-        }
-
-        $slug = trim($path, '/');
-        if ($slug !== '') {
-            $bean = R::findOne('post', ' slug = ? ', [$slug]);
-            return $bean ?: null;
-        }
-
-        return null;
+        return \Lamb\find_post_by_path($path);
     }
 
     /**

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -358,7 +358,7 @@ class LambMicropubAdapter extends MicropubAdapter
         }
 
         parse_bean($bean);
-        $bean->updated = date('Y-m-d H:i:s');
+        $bean->updated = \Lamb\now();
         R::store($bean);
 
         \Lamb\Webmention\enqueue_for_post($bean);

--- a/src/post.php
+++ b/src/post.php
@@ -33,8 +33,8 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
     }
     $bean->body = $text;
     $bean->slug = $matter['slug'] ?? '';
-    $bean->created = date("Y-m-d H:i:s");
-    $bean->updated = date("Y-m-d H:i:s");
+    $bean->created = \Lamb\now();
+    $bean->updated = \Lamb\now();
     if ($feed_item) {
         $bean->created = $feed_item->get_date("Y-m-d H:i:s");
         $bean->updated = $feed_item->get_updated_date("Y-m-d H:i:s");

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -366,32 +366,20 @@ function respond_search(array $args): array
 
     $data['query'] = $query;
     $data['title'] = 'Searched for "' . $query . '"';
-    $pagination = $paginated['pagination'];
-    return get_results(
-        $pagination['total_posts'],
-        $data,
-        $paginated['items'],
-        $pagination['current'],
-        $pagination['per_page'],
-        $pagination['total_pages'],
-        $pagination['offset']
-    );
+    return get_results($data, $paginated['items'], $paginated['pagination']);
 }
 
 /**
  * Builds the response array for search/tag results, including intro text and pagination.
  *
- * @param int        $total_posts  Total number of matching posts.
- * @param array      $data         Base data array to enrich.
- * @param array      $posts        Posts for the current page.
- * @param mixed      $page         Current page number.
- * @param mixed      $perPage      Items per page.
- * @param int        $total_pages  Total number of pages.
- * @param float|int  $offset       Row offset for the current page.
+ * @param array $data       Base data array to enrich.
+ * @param array $posts      Posts for the current page.
+ * @param array $pagination Pagination metadata, as built by build_pagination_meta().
  * @return array
  */
-function get_results(int $total_posts, array $data, array $posts, mixed $page, mixed $perPage, int $total_pages, float|int $offset): array
+function get_results(array $data, array $posts, array $pagination): array
 {
+    $total_posts = (int) $pagination['total_posts'];
     if ($total_posts > 0) {
         $result = ngettext("result", "results", $total_posts);
         $data['intro'] = $total_posts . " $result found.";
@@ -400,17 +388,7 @@ function get_results(int $total_posts, array $data, array $posts, mixed $page, m
     }
 
     $data['posts'] = $posts;
-
-    // Pagination metadata (same shape as paginate_posts)
-    $data['pagination'] = [
-        'current' => $page,
-        'per_page' => $perPage,
-        'total_posts' => $total_posts,
-        'total_pages' => $total_pages,
-        'prev_page' => $page > 1 ? $page - 1 : null,
-        'next_page' => $page < $total_pages ? $page + 1 : null,
-        'offset' => $offset,
-    ];
+    $data['pagination'] = $pagination;
 
     upgrade_posts($posts);
 
@@ -441,14 +419,5 @@ function respond_tag(array $args): array
 
     $data['title'] = 'Tagged with #' . $tag;
     $data['feed_url'] = ROOT_URL . '/tag/' . rawurlencode($tag) . '/feed';
-    $pagination = $paginated['pagination'];
-    return get_results(
-        $pagination['total_posts'],
-        $data,
-        $paginated['items'],
-        $pagination['current'],
-        $pagination['per_page'],
-        $pagination['total_pages'],
-        $pagination['offset']
-    );
+    return get_results($data, $paginated['items'], $paginated['pagination']);
 }

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -210,6 +210,48 @@ function feed_cache(string $updated): void
 }
 
 /**
+ * Decodes and HTML-escapes the tag name from a tag-feed route's arguments.
+ *
+ * @param array $args Route arguments; the first element is the raw tag segment.
+ * @return string The sanitised tag name.
+ */
+function sanitize_tag_arg(array $args): string
+{
+    [$tag] = $args;
+
+    return htmlspecialchars(urldecode($tag));
+}
+
+/**
+ * Renders a feed template with the given feed data and terminates the request.
+ *
+ * Shared tail of all four feed responders: merge the feed data into the global
+ * view data, emit cache headers (with a conditional-GET 304 short-circuit),
+ * upgrade stale posts, render, die.
+ *
+ * @param array       $feed_data As built by get_feed_data()/get_tag_feed_data().
+ * @param string      $template  Feed template name ('feed' or 'feed_json').
+ * @param string|null $feed_url  Optional feed_url override (the JSON variants).
+ * @return never
+ */
+function emit_feed(array $feed_data, string $template, ?string $feed_url = null): never
+{
+    global $data;
+
+    foreach ($feed_data as $key => $value) {
+        $data[$key] = $value;
+    }
+    if ($feed_url !== null) {
+        $data['feed_url'] = $feed_url;
+    }
+    feed_cache($data['updated']);
+    upgrade_posts($data['posts']);
+
+    part($template, '');
+    die();
+}
+
+/**
  * Responds to a feed request by fetching and rendering the Atom feed.
  *
  * @return void
@@ -217,17 +259,7 @@ function feed_cache(string $updated): void
 #[NoReturn]
 function respond_feed(): void
 {
-    global $data;
-
-    $feed_data = get_feed_data();
-    foreach ($feed_data as $key => $value) {
-        $data[$key] = $value;
-    }
-    feed_cache($data['updated']);
-    upgrade_posts($data['posts']);
-
-    part("feed", '');
-    die();
+    emit_feed(get_feed_data(), 'feed');
 }
 
 /**
@@ -238,18 +270,7 @@ function respond_feed(): void
 #[NoReturn]
 function respond_feed_json(): void
 {
-    global $data;
-
-    $feed_data = get_feed_data();
-    foreach ($feed_data as $key => $value) {
-        $data[$key] = $value;
-    }
-    $data['feed_url'] = ROOT_URL . '/feed.json';
-    feed_cache($data['updated']);
-    upgrade_posts($data['posts']);
-
-    part("feed_json", '');
-    die();
+    emit_feed(get_feed_data(), 'feed_json', ROOT_URL . '/feed.json');
 }
 
 /**
@@ -286,21 +307,7 @@ function get_tag_feed_data(string $tag): array
 #[NoReturn]
 function respond_tag_feed(array $args): void
 {
-    global $data;
-
-    [$tag] = $args;
-    $tag = urldecode($tag);
-    $tag = htmlspecialchars($tag);
-
-    $feed_data = get_tag_feed_data($tag);
-    foreach ($feed_data as $key => $value) {
-        $data[$key] = $value;
-    }
-    feed_cache($data['updated']);
-    upgrade_posts($data['posts']);
-
-    part("feed", '');
-    die();
+    emit_feed(get_tag_feed_data(sanitize_tag_arg($args)), 'feed');
 }
 
 /**
@@ -312,22 +319,8 @@ function respond_tag_feed(array $args): void
 #[NoReturn]
 function respond_tag_feed_json(array $args): void
 {
-    global $data;
-
-    [$tag] = $args;
-    $tag = urldecode($tag);
-    $tag = htmlspecialchars($tag);
-
-    $feed_data = get_tag_feed_data($tag);
-    foreach ($feed_data as $key => $value) {
-        $data[$key] = $value;
-    }
-    $data['feed_url'] = ROOT_URL . '/tag/' . rawurlencode($tag) . '/feed.json';
-    feed_cache($data['updated']);
-    upgrade_posts($data['posts']);
-
-    part("feed_json", '');
-    die();
+    $tag = sanitize_tag_arg($args);
+    emit_feed(get_tag_feed_data($tag), 'feed_json', ROOT_URL . '/tag/' . rawurlencode($tag) . '/feed.json');
 }
 
 /**

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -110,7 +110,7 @@ function respond_scheduled(): array
     Security\require_login();
 
     $data['title'] = 'Scheduled';
-    $paginated = paginate_posts('post', 'created ASC', SQL_IS_SCHEDULED, [date('Y-m-d H:i:s')]);
+    $paginated = paginate_posts('post', 'created ASC', SQL_IS_SCHEDULED, [\Lamb\now()]);
     $data['posts'] = $paginated['items'];
     $data['pagination'] = $paginated['pagination'];
 
@@ -124,7 +124,7 @@ function respond_scheduled(): array
  */
 function count_scheduled(): int
 {
-    return R::count('post', SQL_IS_SCHEDULED, [date('Y-m-d H:i:s')]);
+    return R::count('post', SQL_IS_SCHEDULED, [\Lamb\now()]);
 }
 
 /**
@@ -149,7 +149,7 @@ function redirect_search(string $query): void
 function get_feed_updated_date(array $posts): string
 {
     $first = reset($posts);
-    return $first !== false ? $first->updated : date('Y-m-d H:i:s');
+    return $first !== false ? $first->updated : \Lamb\now();
 }
 
 /**
@@ -179,7 +179,7 @@ function get_feed_data(): array
 
     $first_post = reset($posts);
     return [
-        'updated'  => $first_post['updated'] ?? date('Y-m-d H:i:s'),
+        'updated'  => $first_post['updated'] ?? \Lamb\now(),
         'title'    => $config['site_title'],
         'feed_url' => ROOT_URL . '/feed',
         'posts'    => $posts,

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -120,7 +120,7 @@ function redirect_restored(mixed $args): void
 function soft_delete_post(OODBBean $post): void
 {
     $post->deleted    = 1;
-    $post->deleted_at = date('Y-m-d H:i:s');
+    $post->deleted_at = \Lamb\now();
     R::store($post);
 }
 

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -170,7 +170,7 @@ function redirect_edited(): void
     parse_bean($bean);
     \Lamb\ensure_preview_token($bean);
     $bean->version = 1;
-    $bean->updated = date("Y-m-d H:i:s");
+    $bean->updated = \Lamb\now();
 
     if (is_reserved_route($bean->slug)) {
         $_SESSION['flash'][] = 'Failed to save, slug is in use <code>' . $bean->slug . '</code>';

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -138,18 +138,6 @@ function restore_post(OODBBean $post): void
 }
 
 /**
- * Publish a draft post by clearing its draft flag.
- *
- * @param OODBBean $post
- * @return void
- */
-function publish_post(OODBBean $post): void
-{
-    $post->draft = null;
-    R::store($post);
-}
-
-/**
  * Redirects the user after editing a post.
  *
  * Validates the CSRF token and submit button, parses the updated content, stores

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -91,7 +91,7 @@ function verify_and_store(string $source, string $target, ?callable $fetcher = n
     }
 
     $meta = extract_meta($html);
-    $now = date('Y-m-d H:i:s');
+    $now = \Lamb\now();
 
     $mention = $existing ?: R::dispense('webmention');
     $mention->source = $source;
@@ -459,7 +459,7 @@ function enqueue_outbound(int $post_id, string $source, string $html, string $re
         $row->target = $target;
         $row->status = 'pending';
         $row->attempts = 0;
-        $row->created = date('Y-m-d H:i:s');
+        $row->created = \Lamb\now();
         $row->processed_at = null;
         R::store($row);
         $created++;
@@ -526,7 +526,7 @@ function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender
     $post = R::load('post', (int) $row->post_id);
     if (!$post->id || $post->deleted == 1 || $post->draft == 1) {
         $row->status = 'cancelled';
-        $row->processed_at = date('Y-m-d H:i:s');
+        $row->processed_at = \Lamb\now();
         R::store($row);
         return 'cancelled';
     }
@@ -535,7 +535,7 @@ function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender
     }
 
     $row->attempts = (int) $row->attempts + 1;
-    $row->processed_at = date('Y-m-d H:i:s');
+    $row->processed_at = \Lamb\now();
 
     $fetched = $fetcher($row->target);
     $endpoint = is_array($fetched)

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -593,23 +593,10 @@ function fetch_target(string $url): ?array
  */
 function send_webmention(string $endpoint, string $source, string $target): int
 {
-    $context = stream_context_create([
-        'http' => [
-            'method' => 'POST',
-            'header' => implode("\r\n", [
-                'Content-Type: application/x-www-form-urlencoded',
-                'User-Agent: Lamb-Webmention',
-            ]),
-            'content' => http_build_query(['source' => $source, 'target' => $target]),
-            'timeout' => WEBMENTION_FETCH_TIMEOUT,
-            'ignore_errors' => true,
-        ],
-    ]);
-
-    $response = @file_get_contents($endpoint, false, $context);
-    if ($response === false && empty($http_response_header)) {
-        return 0;
-    }
-
-    return \Lamb\Http\parse_status_line($http_response_header[0] ?? '');
+    return \Lamb\Http\post_form(
+        $endpoint,
+        ['source' => $source, 'target' => $target],
+        WEBMENTION_FETCH_TIMEOUT,
+        'Lamb-Webmention'
+    );
 }

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -126,19 +126,9 @@ function target_post_id(string $target): ?int
     }
 
     $path = parse_url($target, PHP_URL_PATH) ?: '';
+    $bean = \Lamb\find_post_by_path($path);
 
-    if (preg_match('#^/status/(\d+)$#', $path, $matches)) {
-        $bean = R::load('post', (int) $matches[1]);
-        return $bean->id ? (int) $bean->id : null;
-    }
-
-    $slug = trim($path, '/');
-    if ($slug !== '') {
-        $bean = R::findOne('post', ' slug = ? ', [$slug]);
-        return $bean ? (int) $bean->id : null;
-    }
-
-    return null;
+    return $bean !== null ? (int) $bean->id : null;
 }
 
 /**

--- a/src/websub.php
+++ b/src/websub.php
@@ -88,18 +88,10 @@ function ping_for_post(OODBBean $bean, ?array $config = null, ?callable $sender 
  */
 function send_ping(string $hub, string $topic): void
 {
-    $context = stream_context_create([
-        'http' => [
-            'method' => 'POST',
-            'header' => implode("\r\n", [
-                'Content-Type: application/x-www-form-urlencoded',
-                'User-Agent: Lamb-WebSub',
-            ]),
-            'content' => http_build_query(['hub.mode' => 'publish', 'hub.url' => $topic]),
-            'timeout' => WEBSUB_PING_TIMEOUT,
-            'ignore_errors' => true,
-        ],
-    ]);
-
-    @file_get_contents($hub, false, $context);
+    \Lamb\Http\post_form(
+        $hub,
+        ['hub.mode' => 'publish', 'hub.url' => $topic],
+        WEBSUB_PING_TIMEOUT,
+        'Lamb-WebSub'
+    );
 }

--- a/tests/Unit/HttpFetchTest.php
+++ b/tests/Unit/HttpFetchTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use function Lamb\Http\build_http_context_options;
 use function Lamb\Http\fetch;
 use function Lamb\Http\parse_status_line;
+use function Lamb\Http\post_form;
 
 class HttpFetchTest extends TestCase
 {
@@ -97,5 +98,13 @@ class HttpFetchTest extends TestCase
         $this->assertSame('hello-world', $result['body']);
         $this->assertIsArray($result['headers']);
         $this->assertIsInt($result['status']);
+    }
+
+    // post_form ---------------------------------------------------------------
+
+    public function testPostFormReturnsZeroOnTransportFailure(): void
+    {
+        $status = @post_form('file:///nonexistent/path/at/all', ['a' => 'b'], 1, 'Lamb-Test');
+        $this->assertSame(0, $status);
     }
 }

--- a/tests/Unit/LambHelpersTest.php
+++ b/tests/Unit/LambHelpersTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\find_post_by_path;
 use function Lamb\get_option;
 use function Lamb\now;
 use function Lamb\permalink;
@@ -39,6 +40,46 @@ class LambHelpersTest extends TestCase
         $after = date('Y-m-d H:i:s');
         $this->assertGreaterThanOrEqual($before, $value);
         $this->assertLessThanOrEqual($after, $value);
+    }
+
+    // find_post_by_path
+
+    public function testFindPostByPathResolvesStatusPath(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'A status post';
+        R::store($bean);
+
+        $found = find_post_by_path('/status/' . $bean->id);
+        $this->assertNotNull($found);
+        $this->assertEquals($bean->id, $found->id);
+    }
+
+    public function testFindPostByPathResolvesSlugPath(): void
+    {
+        $bean = R::dispense('post');
+        $bean->slug = 'resolver-slug-' . uniqid();
+        R::store($bean);
+
+        $found = find_post_by_path('/' . $bean->slug);
+        $this->assertNotNull($found);
+        $this->assertEquals($bean->id, $found->id);
+    }
+
+    public function testFindPostByPathReturnsNullForUnknownStatusId(): void
+    {
+        $this->assertNull(find_post_by_path('/status/999999999'));
+    }
+
+    public function testFindPostByPathReturnsNullForUnknownSlug(): void
+    {
+        $this->assertNull(find_post_by_path('/no-such-slug-' . uniqid()));
+    }
+
+    public function testFindPostByPathReturnsNullForRootPath(): void
+    {
+        $this->assertNull(find_post_by_path('/'));
+        $this->assertNull(find_post_by_path(''));
     }
 
     // permalink

--- a/tests/Unit/LambHelpersTest.php
+++ b/tests/Unit/LambHelpersTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
 use function Lamb\get_option;
+use function Lamb\now;
 use function Lamb\permalink;
 use function Lamb\post_has_slug;
 use function Lamb\set_option;
@@ -22,6 +23,22 @@ class LambHelpersTest extends TestCase
         if (!defined('ROOT_URL')) {
             define('ROOT_URL', 'http://localhost');
         }
+    }
+
+    // now
+
+    public function testNowReturnsCanonicalDatetimeFormat(): void
+    {
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', now());
+    }
+
+    public function testNowReturnsCurrentTime(): void
+    {
+        $before = date('Y-m-d H:i:s');
+        $value = now();
+        $after = date('Y-m-d H:i:s');
+        $this->assertGreaterThanOrEqual($before, $value);
+        $this->assertLessThanOrEqual($after, $value);
     }
 
     // permalink

--- a/tests/Unit/ResponseExtendedTest.php
+++ b/tests/Unit/ResponseExtendedTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\Response\build_pagination_meta;
 use function Lamb\Response\get_results;
 use function Lamb\Response\respond_search;
 use function Lamb\Response\upgrade_posts;
@@ -23,69 +24,69 @@ class ResponseExtendedTest extends TestCase
 
     public function testGetResultsIntroIsNoResultsFoundWhenZeroPosts(): void
     {
-        $result = get_results(0, ['title' => 'Search'], [], 1, 10, 1, 0);
+        $result = get_results(['title' => 'Search'], [], build_pagination_meta(1, 10, 0, 0));
         $this->assertSame('No results found.', $result['intro']);
     }
 
     public function testGetResultsIntroContainsCountWhenPostsFound(): void
     {
-        $result = get_results(3, ['title' => 'Search'], [], 1, 10, 1, 0);
+        $result = get_results(['title' => 'Search'], [], build_pagination_meta(1, 10, 3, 0));
         $this->assertStringContainsString('3', $result['intro']);
         $this->assertStringContainsString('found', $result['intro']);
     }
 
     public function testGetResultsSingularResultLabelForOnePost(): void
     {
-        $result = get_results(1, [], [], 1, 10, 1, 0);
+        $result = get_results([], [], build_pagination_meta(1, 10, 1, 0));
         $this->assertStringContainsString('result', $result['intro']);
     }
 
     public function testGetResultsPluralResultsLabelForManyPosts(): void
     {
-        $result = get_results(5, [], [], 1, 10, 1, 0);
+        $result = get_results([], [], build_pagination_meta(1, 10, 5, 0));
         $this->assertStringContainsString('results', $result['intro']);
     }
 
     public function testGetResultsPostsKeyEqualsProvidedPosts(): void
     {
-        $result = get_results(0, [], [], 1, 10, 1, 0);
+        $result = get_results([], [], build_pagination_meta(1, 10, 0, 0));
         $this->assertSame([], $result['posts']);
     }
 
     public function testGetResultsPreservesExtraDataKeys(): void
     {
-        $result = get_results(0, ['title' => 'My Search', 'foo' => 'bar'], [], 1, 10, 1, 0);
+        $result = get_results(['title' => 'My Search', 'foo' => 'bar'], [], build_pagination_meta(1, 10, 0, 0));
         $this->assertSame('My Search', $result['title']);
         $this->assertSame('bar', $result['foo']);
     }
 
     public function testGetResultsPaginationCurrentPage(): void
     {
-        $result = get_results(25, [], [], 2, 10, 3, 10);
+        $result = get_results([], [], build_pagination_meta(2, 10, 25, 10));
         $this->assertSame(2, $result['pagination']['current']);
     }
 
     public function testGetResultsPaginationPrevPage(): void
     {
-        $result = get_results(25, [], [], 2, 10, 3, 10);
+        $result = get_results([], [], build_pagination_meta(2, 10, 25, 10));
         $this->assertSame(1, $result['pagination']['prev_page']);
     }
 
     public function testGetResultsPaginationNextPage(): void
     {
-        $result = get_results(25, [], [], 2, 10, 3, 10);
+        $result = get_results([], [], build_pagination_meta(2, 10, 25, 10));
         $this->assertSame(3, $result['pagination']['next_page']);
     }
 
     public function testGetResultsPaginationNullPrevOnFirstPage(): void
     {
-        $result = get_results(25, [], [], 1, 10, 3, 0);
+        $result = get_results([], [], build_pagination_meta(1, 10, 25, 0));
         $this->assertNull($result['pagination']['prev_page']);
     }
 
     public function testGetResultsPaginationNullNextOnLastPage(): void
     {
-        $result = get_results(25, [], [], 3, 10, 3, 20);
+        $result = get_results([], [], build_pagination_meta(3, 10, 25, 20));
         $this->assertNull($result['pagination']['next_page']);
     }
 

--- a/tests/Unit/ResponseFeedTest.php
+++ b/tests/Unit/ResponseFeedTest.php
@@ -7,6 +7,7 @@ use RedBeanPHP\R;
 
 use function Lamb\Response\get_feed_data;
 use function Lamb\Response\get_tag_feed_data;
+use function Lamb\Response\sanitize_tag_arg;
 
 class ResponseFeedTest extends TestCase
 {
@@ -24,6 +25,23 @@ class ResponseFeedTest extends TestCase
 
         global $config;
         $config = ['site_title' => 'Test Blog'];
+    }
+
+    // sanitize_tag_arg
+
+    public function testSanitizeTagArgUrlDecodes(): void
+    {
+        $this->assertSame('café', sanitize_tag_arg(['caf%C3%A9']));
+    }
+
+    public function testSanitizeTagArgEscapesHtmlMetacharacters(): void
+    {
+        $this->assertSame('&lt;b&gt;', sanitize_tag_arg(['<b>']));
+    }
+
+    public function testSanitizeTagArgPassesPlainTagThrough(): void
+    {
+        $this->assertSame('lamb', sanitize_tag_arg(['lamb']));
     }
 
     // get_feed_data

--- a/tests/Unit/ResponseHandlersTest.php
+++ b/tests/Unit/ResponseHandlersTest.php
@@ -8,7 +8,6 @@ use RedBeanPHP\R;
 use function Lamb\Bootstrap\ensure_post_columns;
 use function Lamb\Response\count_drafts;
 use function Lamb\Response\count_trash;
-use function Lamb\Response\publish_post;
 use function Lamb\Response\respond_404;
 use function Lamb\Response\respond_drafts;
 use function Lamb\Response\respond_home;
@@ -690,7 +689,7 @@ class ResponseHandlersTest extends TestCase
         $this->assertSame(1, count_trash());
     }
 
-    // restore_post / publish_post
+    // restore_post
 
     public function testRestorePostClearsDeletedFlag(): void
     {
@@ -707,21 +706,6 @@ class ResponseHandlersTest extends TestCase
         $loaded = R::load('post', $bean->id);
         $this->assertEmpty($loaded->deleted);
         $this->assertEmpty($loaded->deleted_at);
-    }
-
-    public function testPublishPostClearsDraftFlag(): void
-    {
-        $bean = R::dispense('post');
-        $bean->body    = 'Draft post';
-        $bean->draft   = 1;
-        $bean->created = date('Y-m-d H:i:s');
-        $bean->updated = date('Y-m-d H:i:s');
-        R::store($bean);
-
-        publish_post($bean);
-
-        $loaded = R::load('post', $bean->id);
-        $this->assertEmpty($loaded->draft);
     }
 
     public function testRespondSearchExcludesDeletedPosts(): void


### PR DESCRIPTION
## Summary

Post-0.9.0 cleanup pass: a survey of the codebase ranked refactoring opportunities by impact vs complexity; this PR implements the seven quick wins. All are behaviour-preserving — no new features, no config changes.

- **CLAUDE.md refresh** — the project guide predated the `response/`/`theme/` splits and the IndieWeb endpoints; the tree, namespace table, DB tables, and cron section now match the code, with a new IndieWeb endpoints overview.
- **`emit_feed()`** — `respond_feed`, `respond_feed_json`, `respond_tag_feed`, `respond_tag_feed_json` shared an identical merge→cache→upgrade→render→die tail and the tag pair duplicated its sanitisation; each responder is now a one-liner over `emit_feed()` + `sanitize_tag_arg()`.
- **`Lamb\find_post_by_path()`** — Micropub's `findPostByUrl()` and Webmention's `target_post_id()` carried identical `/status/<id>`-or-slug resolution; now shared, with each endpoint keeping its own host policy.
- **`Http\post_form()`** — `send_webmention()` and WebSub's `send_ping()` each hand-rolled the same stream-context POST; both now route through a shared helper built on the existing `Http\fetch()`.
- **`Lamb\now()`** — the `Y-m-d H:i:s` current-time idiom was repeated at 16 call sites across six files; centralised in one helper.
- **`get_results()`** — took seven scalars only to reassemble the exact pagination array `build_pagination_meta()` had already built; now takes the meta array directly.
- **Removed orphaned `publish_post()`** — 4ed48e2 reverted the Publish Draft button (draft state lives in front matter) but left the helper and its test behind.

## Verification

- New helpers added red-green (failing test first): `now()`, `find_post_by_path()`, `sanitize_tag_arg()`, `post_form()`, plus reworked `get_results()` tests.
- Full suite green: **932 tests, 1459 assertions** (Unit + Functional + Acceptance against a fresh dev server).
- `composer lint` and `composer analyse` clean.
- Feed output verified **byte-identical** before/after for `/feed`, `/feed.json`, `/tag/<t>/feed`, `/tag/<t>/feed.json` against a seeded dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)