### PR TITLE
Post-release refactoring, tier 2: shared validation, INI parsing, and tag-mutation helpers

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -91,6 +91,21 @@ INI;
 }
 
 /**
+ * Parses INI text with warnings suppressed, returning [] when unparseable.
+ *
+ * The tolerant counterpart to validate_ini(): readers treat broken INI as
+ * empty config rather than surfacing errors, so a bad edit can't take the
+ * site down between save and fix.
+ *
+ * @param string $ini_text The raw INI text.
+ * @return array The parsed sections/keys, or [] on failure.
+ */
+function parse_ini_safe(string $ini_text): array
+{
+    return @parse_ini_string($ini_text, true, INI_SCANNER_RAW) ?: [];
+}
+
+/**
  * Resolves a configured theme name to the directory that should be rendered.
  *
  * Falls back to the bundled `base` theme (the part-fallback library) when no
@@ -125,8 +140,8 @@ function resolve_theme(?string $configured, string $fallback = 'base'): string
  */
 function ensure_explicit_theme(string $ini_text, string $default_theme = 'base'): string
 {
-    $parsed = @parse_ini_string($ini_text, true, INI_SCANNER_RAW);
-    if (is_array($parsed) && array_key_exists('theme', $parsed)) {
+    $parsed = parse_ini_safe($ini_text);
+    if (array_key_exists('theme', $parsed)) {
         return $ini_text;
     }
 
@@ -157,8 +172,8 @@ function load(): array
  */
 function compose_config(string $stored_ini, string $default_ini): array
 {
-    $config = @parse_ini_string($stored_ini, true, INI_SCANNER_RAW) ?: [];
-    $defaults = @parse_ini_string($default_ini, true, INI_SCANNER_RAW) ?: [];
+    $config = parse_ini_safe($stored_ini);
+    $defaults = parse_ini_safe($default_ini);
 
     // Theme is intentionally not defaulted here. An install without an explicit
     // theme is resolved/migrated per-install (see resolve_theme / get_ini_text),

--- a/src/http.php
+++ b/src/http.php
@@ -92,6 +92,22 @@ function build_http_context_options(array $opts): array
 }
 
 /**
+ * Whether a string is an absolute http(s) URL with a host.
+ *
+ * The single URL gate for everything that touches the network: webmention
+ * source/target/endpoint checks, outbound link extraction, and feed-config
+ * filtering all share this definition of "fetchable".
+ *
+ * @param string $url
+ * @return bool
+ */
+function is_valid_http_url(string $url): bool
+{
+    $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+    return in_array($scheme, ['http', 'https'], true) && parse_url($url, PHP_URL_HOST) !== null;
+}
+
+/**
  * Extract the status code from an HTTP status line.
  *
  * Accepts status lines with or without a reason phrase ("HTTP/1.1 200 OK"

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -29,6 +29,10 @@ function now(): string
     return date('Y-m-d H:i:s');
 }
 
+// Matches a #hashtag preceded by start-of-string, whitespace, or a closing tag
+// bracket. Capture 1 is the preceding character, capture 2 the tag name.
+const TAG_PATTERN = '/(^|[\s>])#([^\s#&.,!?;:()\[\]{}<]+)/u';
+
 /**
  * Retrieves the tags from the given HTML.
  *
@@ -38,7 +42,7 @@ function now(): string
  */
 function get_tags(string $html): array
 {
-    preg_match_all('/(^|[\s>])#([^\s#&.,!?;:()\[\]{}<]+)/u', $html, $matches);
+    preg_match_all(TAG_PATTERN, $html, $matches);
 
     return $matches[2];
 }
@@ -56,9 +60,61 @@ function get_tags(string $html): array
  */
 function parse_tags(string $html): string
 {
-    return preg_replace_callback('/(^|[\s>])#([^\s#&.,!?;:()\[\]{}<]+)/u', function ($matches) {
+    return preg_replace_callback(TAG_PATTERN, function ($matches) {
         return $matches[1] . '<a href="/tag/' . strtolower($matches[2]) . '">#' . $matches[2] . '</a>';
     }, $html);
+}
+
+/**
+ * Appends the given tags to a body as trailing hashtags, skipping ones the
+ * body already carries. Returns the body unchanged when nothing is missing.
+ *
+ * Counterpart of get_tags(): used by Micropub category `add` updates, where
+ * categories live in the body as hashtags rather than in a column.
+ *
+ * @param string $body The raw post body.
+ * @param array  $tags Tag names (without `#`).
+ * @return string The body with missing tags appended.
+ */
+function add_body_tags(string $body, array $tags): string
+{
+    $to_add = array_diff($tags, get_tags($body));
+    if (empty($to_add)) {
+        return $body;
+    }
+    $hashtags = implode(' ', array_map(fn($tag) => '#' . $tag, $to_add));
+
+    return rtrim($body) . ' ' . $hashtags;
+}
+
+/**
+ * Removes the run of trailing hashtags from a body, leaving inline tags alone.
+ *
+ * Used by Micropub category delete-property updates (drop all categories).
+ *
+ * @param string $body The raw post body.
+ * @return string The body without its trailing hashtag run.
+ */
+function strip_trailing_body_tags(string $body): string
+{
+    return rtrim(preg_replace('/(\s+#[^\s#.,!?;:()\[\]{}<]+)+$/u', '', $body));
+}
+
+/**
+ * Removes the named hashtags (and their preceding whitespace) from a body,
+ * wherever they appear. Used by Micropub category delete-values updates.
+ *
+ * @param string $body The raw post body.
+ * @param array  $tags Tag names (without `#`) to remove.
+ * @return string The body without the named tags.
+ */
+function remove_body_tags(string $body, array $tags): string
+{
+    foreach ($tags as $tag) {
+        $body = preg_replace('/(\s+)#' . preg_quote($tag, '/') . '(?=\s|$)/u', '', $body);
+    }
+
+    return $body;
 }
 
 /**

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -10,10 +10,13 @@ use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
 use Taproot\Micropub\MicropubAdapter;
 
+use function Lamb\add_body_tags;
 use function Lamb\get_tags;
 use function Lamb\is_scheduled;
 use function Lamb\parse_bean;
 use function Lamb\permalink;
+use function Lamb\remove_body_tags;
+use function Lamb\strip_trailing_body_tags;
 use function Lamb\Post\build_matter;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\parse_matter;
@@ -367,12 +370,7 @@ class LambMicropubAdapter extends MicropubAdapter
     private function applyAdd(OODBBean $bean, string $property, array $values): void
     {
         if ($property === 'category') {
-            $existing = get_tags($bean->body ?? '');
-            $toAdd    = array_diff($values, $existing);
-            if (!empty($toAdd)) {
-                $newTags = implode(' ', array_map(fn($t) => '#' . $t, $toAdd));
-                $bean->body = rtrim($bean->body ?? '') . ' ' . $newTags;
-            }
+            $bean->body = add_body_tags($bean->body ?? '', $values);
         }
     }
 
@@ -386,7 +384,7 @@ class LambMicropubAdapter extends MicropubAdapter
     private function applyDeleteProperty(OODBBean $bean, string $property): void
     {
         if ($property === 'category') {
-            $bean->body = rtrim(preg_replace('/(\s+#[^\s#.,!?;:()\[\]{}<]+)+$/u', '', $bean->body ?? ''));
+            $bean->body = strip_trailing_body_tags($bean->body ?? '');
         }
     }
 
@@ -401,9 +399,7 @@ class LambMicropubAdapter extends MicropubAdapter
     private function applyDeleteValues(OODBBean $bean, string $property, array $values): void
     {
         if ($property === 'category') {
-            foreach ($values as $tag) {
-                $bean->body = preg_replace('/(\s+)#' . preg_quote($tag, '/') . '(?=\s|$)/u', '', $bean->body ?? '');
-            }
+            $bean->body = remove_body_tags($bean->body ?? '', $values);
         }
     }
 

--- a/src/network.php
+++ b/src/network.php
@@ -10,6 +10,7 @@ use SimplePie\Item as SimplePieItem;
 use SimplePie\SimplePie;
 
 use function Lamb\get_option;
+use function Lamb\Http\is_valid_http_url;
 use function Lamb\Route\register_route;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\populate_bean;
@@ -25,10 +26,7 @@ function get_feeds(): array
 
     // A setting accidentally placed under [feeds] (e.g. `feeds_draft = false`)
     // would otherwise be fetched as a feed URL. Only keep http(s) URLs.
-    return array_filter($config['feeds'] ?? [], function ($url) {
-        return filter_var($url, FILTER_VALIDATE_URL)
-            && in_array(parse_url($url, PHP_URL_SCHEME), ['http', 'https'], true);
-    });
+    return array_filter($config['feeds'] ?? [], fn($url) => is_valid_http_url((string) $url));
 }
 
 /**

--- a/src/theme.php
+++ b/src/theme.php
@@ -150,6 +150,25 @@ function date_created(OODBBean $bean): string
 }
 
 /**
+ * Wraps a title in an escaped <h1> for HTML output, or returns it as plain text.
+ *
+ * The shared formatting rule behind site_title()/page_title(): escaping only
+ * applies on the HTML path, since plain-text callers (e.g. <title>) escape at
+ * their own output site.
+ *
+ * @param string $title The raw title text.
+ * @param string $type  Output format: 'html' wraps in <h1>, anything else returns plain text.
+ * @return string HTML or plain-text title.
+ */
+function wrap_title(string $title, string $type): string
+{
+    if ($type !== 'html') {
+        return $title;
+    }
+    return sprintf('<h1>%s</h1>', escape($title));
+}
+
+/**
  * Returns the site title as an <h1> element, or plain text when $type !== 'html'.
  *
  * @param string $type Output format: 'html' (default) wraps in <h1>, anything else returns plain text.
@@ -159,10 +178,7 @@ function site_title($type = 'html'): string
 {
     global $config;
 
-    if ($type !== 'html') {
-        return $config['site_title'];
-    }
-    return sprintf('<h1>%s</h1>', escape($config['site_title']));
+    return wrap_title($config['site_title'], $type);
 }
 
 /**
@@ -197,11 +213,7 @@ function page_title(string $type = 'html'): string
         $title = $data['title'];
     }
 
-    if ($type !== 'html') {
-        return $title;
-    }
-
-    return sprintf('<h1>%s</h1>', escape($title));
+    return wrap_title($title, $type);
 }
 
 /**

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -8,6 +8,7 @@ use JetBrains\PhpStorm\NoReturn;
 use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
 
+use function Lamb\Http\is_valid_http_url;
 use function Lamb\is_scheduled;
 use function Lamb\permalink;
 
@@ -211,18 +212,6 @@ function fetch_source(string $url): ?string
     ]);
 
     return $result === null ? null : $result['body'];
-}
-
-/**
- * Whether a string is an absolute http(s) URL with a host.
- *
- * @param string $url
- * @return bool
- */
-function is_valid_http_url(string $url): bool
-{
-    $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
-    return in_array($scheme, ['http', 'https'], true) && parse_url($url, PHP_URL_HOST) !== null;
 }
 
 /**

--- a/tests/Unit/ConfigLoadTest.php
+++ b/tests/Unit/ConfigLoadTest.php
@@ -8,6 +8,7 @@ use RedBeanPHP\R;
 use function Lamb\Config\config_modified_timestamp;
 use function Lamb\Config\get_ini_text;
 use function Lamb\Config\load;
+use function Lamb\Config\parse_ini_safe;
 use function Lamb\Config\save_ini_text;
 
 class ConfigLoadTest extends TestCase
@@ -20,6 +21,25 @@ class ConfigLoadTest extends TestCase
         R::freeze(false);
         // Remove any cached config option so each test starts fresh
         R::exec("DELETE FROM option WHERE name = 'site_config_ini'");
+    }
+
+    // parse_ini_safe
+
+    public function testParseIniSafeParsesValidIni(): void
+    {
+        $parsed = parse_ini_safe("theme = base\n[menu_items]\nHome = /\n");
+        $this->assertSame('base', $parsed['theme']);
+        $this->assertSame(['Home' => '/'], $parsed['menu_items']);
+    }
+
+    public function testParseIniSafeReturnsEmptyArrayForBrokenIni(): void
+    {
+        $this->assertSame([], parse_ini_safe("[unclosed\n=== not ini ==="));
+    }
+
+    public function testParseIniSafeReturnsEmptyArrayForEmptyText(): void
+    {
+        $this->assertSame([], parse_ini_safe(''));
     }
 
     // get_ini_text

--- a/tests/Unit/HttpFetchTest.php
+++ b/tests/Unit/HttpFetchTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 use function Lamb\Http\build_http_context_options;
 use function Lamb\Http\fetch;
+use function Lamb\Http\is_valid_http_url;
 use function Lamb\Http\parse_status_line;
 use function Lamb\Http\post_form;
 
@@ -98,6 +99,25 @@ class HttpFetchTest extends TestCase
         $this->assertSame('hello-world', $result['body']);
         $this->assertIsArray($result['headers']);
         $this->assertIsInt($result['status']);
+    }
+
+    // is_valid_http_url -------------------------------------------------------
+
+    public function testIsValidHttpUrlAcceptsHttpAndHttps(): void
+    {
+        $this->assertTrue(is_valid_http_url('http://example.com/'));
+        $this->assertTrue(is_valid_http_url('https://example.com/path'));
+        // Scheme casing is normalised before the check.
+        $this->assertTrue(is_valid_http_url('HTTPS://EXAMPLE.com/'));
+    }
+
+    public function testIsValidHttpUrlRejectsNonHttpAndHostless(): void
+    {
+        $this->assertFalse(is_valid_http_url('mailto:someone@example.com'));
+        $this->assertFalse(is_valid_http_url('ftp://example.com/'));
+        $this->assertFalse(is_valid_http_url('/relative/path'));
+        $this->assertFalse(is_valid_http_url('not a url'));
+        $this->assertFalse(is_valid_http_url(''));
     }
 
     // post_form ---------------------------------------------------------------

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -4,11 +4,71 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+use function Lamb\add_body_tags;
 use function Lamb\get_tags;
 use function Lamb\parse_tags;
+use function Lamb\remove_body_tags;
+use function Lamb\strip_trailing_body_tags;
 
 class LambTest extends TestCase
 {
+    // add_body_tags
+
+    public function testAddBodyTagsAppendsMissingTags()
+    {
+        $this->assertSame('Hello #foo #bar', add_body_tags('Hello', ['foo', 'bar']));
+    }
+
+    public function testAddBodyTagsSkipsTagsAlreadyPresent()
+    {
+        $this->assertSame('Hello #foo #bar', add_body_tags('Hello #foo', ['foo', 'bar']));
+    }
+
+    public function testAddBodyTagsReturnsBodyUnchangedWhenAllPresent()
+    {
+        $body = "Hello #foo\n";
+        $this->assertSame($body, add_body_tags($body, ['foo']));
+    }
+
+    public function testAddBodyTagsTrimsTrailingWhitespaceBeforeAppending()
+    {
+        $this->assertSame('Hello #new', add_body_tags("Hello \n", ['new']));
+    }
+
+    // strip_trailing_body_tags
+
+    public function testStripTrailingBodyTagsRemovesTrailingRun()
+    {
+        $this->assertSame('Some text', strip_trailing_body_tags('Some text #foo #bar'));
+    }
+
+    public function testStripTrailingBodyTagsLeavesInlineTags()
+    {
+        $this->assertSame('Text #foo more text', strip_trailing_body_tags('Text #foo more text'));
+    }
+
+    public function testStripTrailingBodyTagsHandlesBodyWithoutTags()
+    {
+        $this->assertSame('No tags here.', strip_trailing_body_tags('No tags here.'));
+    }
+
+    // remove_body_tags
+
+    public function testRemoveBodyTagsRemovesNamedTagsOnly()
+    {
+        $this->assertSame('Hello #bar', remove_body_tags('Hello #foo #bar', ['foo']));
+    }
+
+    public function testRemoveBodyTagsRemovesMultipleTags()
+    {
+        $this->assertSame('Hello', remove_body_tags('Hello #foo #bar', ['foo', 'bar']));
+    }
+
+    public function testRemoveBodyTagsIgnoresAbsentTags()
+    {
+        $this->assertSame('Hello #foo', remove_body_tags('Hello #foo', ['bar']));
+    }
+
     // get_tags
 
     public function testGetTagsExtractsSingleTag()

--- a/tests/Unit/ThemePageTest.php
+++ b/tests/Unit/ThemePageTest.php
@@ -8,6 +8,7 @@ use function Lamb\Theme\page_intro;
 use function Lamb\Theme\page_title;
 use function Lamb\Theme\site_or_page_title;
 use function Lamb\Theme\site_title;
+use function Lamb\Theme\wrap_title;
 
 class ThemePageTest extends TestCase
 {
@@ -16,6 +17,24 @@ class ThemePageTest extends TestCase
         global $config, $data;
         $config['site_title'] = 'Test Blog';
         $data = [];
+    }
+
+    // wrap_title
+
+    public function testWrapTitleWrapsInH1ForHtmlType(): void
+    {
+        $this->assertSame('<h1>Hello</h1>', wrap_title('Hello', 'html'));
+    }
+
+    public function testWrapTitleReturnsPlainTextForOtherTypes(): void
+    {
+        $this->assertSame('Hello', wrap_title('Hello', 'text'));
+    }
+
+    public function testWrapTitleEscapesHtmlOnlyWhenWrapping(): void
+    {
+        $this->assertSame('<h1>&lt;b&gt;</h1>', wrap_title('<b>', 'html'));
+        $this->assertSame('<b>', wrap_title('<b>', 'text'));
     }
 
     // site_title

--- a/tests/Unit/WebmentionTest.php
+++ b/tests/Unit/WebmentionTest.php
@@ -8,7 +8,6 @@ use RedBeanPHP\R;
 use function Lamb\Webmention\discover_endpoint;
 use function Lamb\Webmention\extract_meta;
 use function Lamb\Webmention\is_external_http_url;
-use function Lamb\Webmention\is_valid_http_url;
 use function Lamb\Webmention\source_mentions_target;
 use function Lamb\Webmention\target_post_id;
 use function Lamb\Webmention\verify_and_store;
@@ -170,25 +169,6 @@ class WebmentionTest extends TestCase
         $mentions = webmentions_for_post($id);
         $this->assertCount(1, $mentions);
         $this->assertSame('https://other.example/reply', $mentions[0]->source);
-    }
-
-    // is_valid_http_url -----------------------------------------------------
-
-    public function testIsValidHttpUrlAcceptsHttpAndHttps(): void
-    {
-        $this->assertTrue(is_valid_http_url('http://example.com/'));
-        $this->assertTrue(is_valid_http_url('https://example.com/path'));
-        // Scheme casing is normalised before the check.
-        $this->assertTrue(is_valid_http_url('HTTPS://EXAMPLE.com/'));
-    }
-
-    public function testIsValidHttpUrlRejectsNonHttpAndHostless(): void
-    {
-        $this->assertFalse(is_valid_http_url('mailto:someone@example.com'));
-        $this->assertFalse(is_valid_http_url('ftp://example.com/'));
-        $this->assertFalse(is_valid_http_url('/relative/path'));
-        $this->assertFalse(is_valid_http_url('not a url'));
-        $this->assertFalse(is_valid_http_url(''));
     }
 
     // is_external_http_url --------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #389 (stacked on that branch — will retarget to `main` when it merges). Implements the four Tier-2 items from the post-release refactoring survey. All behaviour-preserving.

- **`Config\parse_ini_safe()`** — `compose_config()` and `ensure_explicit_theme()` each hand-rolled `@parse_ini_string(..., INI_SCANNER_RAW)` with their own fallbacks; one tolerant helper now owns the suppression and the `[]`-on-failure rule. `validate_ini()` deliberately keeps its unsuppressed parse (it exists to surface the warning text to the settings form).
- **`Theme\wrap_title()`** — `site_title()`/`page_title()` repeated the escaped-`<h1>`-or-plain-text wrapping; extracted into one helper.
- **`Http\is_valid_http_url()`** — the validator moves from the webmention module to `Lamb\Http` (home of `fetch()`/`post_form()`), and `network.php`'s `get_feeds()` drops its own `filter_var` variant for the shared helper. The feeds filter becomes marginally more lenient than `FILTER_VALIDATE_URL` on exotic-but-http URLs; SimplePie still owns actual fetch failures.
- **Body-hashtag mutation helpers** — Micropub's `applyAdd`/`applyDeleteProperty`/`applyDeleteValues` each carried their own tag extraction/regex logic. The three operations now live next to `get_tags()`/`parse_tags()` in `lamb.php` (`add_body_tags`, `strip_trailing_body_tags`, `remove_body_tags`), and the tag-matching regex duplicated between `get_tags()` and `parse_tags()` is now a `TAG_PATTERN` constant. Regexes unchanged.

## Verification

- Every helper added red-green (failing test first): `parse_ini_safe`, `wrap_title`, `Http\is_valid_http_url` (tests moved to `HttpFetchTest`), and the three tag helpers.
- Full suite green: **948 tests, 1477 assertions** (Unit + Functional + Acceptance against a fresh dev server).
- `composer lint` and `composer analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)