### PR TITLE
Fix paste-to-link not wrapping selection on iOS Safari

### DIFF
--- a/src/scripts/logged_in/paste-link.js
+++ b/src/scripts/logged_in/paste-link.js
@@ -6,7 +6,10 @@ onLoaded(() => {
         const end = ta.selectionEnd
         if (start === end) return // nothing selected
 
-        const pasted = (ev.clipboardData || window.clipboardData).getData('text')
+        // iOS Safari returns an empty string for getData('text'); the
+        // standards-compliant 'text/plain' type works there, so try it first.
+        const clipboard = ev.clipboardData || window.clipboardData
+        const pasted = clipboard.getData('text/plain') || clipboard.getData('text')
         if (!isUrl(pasted)) return
 
         cancel(ev)


### PR DESCRIPTION
## Problem

When you select text in the post editor on iOS and paste a URL, the selected text gets **replaced with the raw URL** instead of being wrapped in a Markdown link (`[selected](url)`). It works correctly on desktop.

## Cause

The paste handler read the clipboard with `clipboardData.getData('text')`. On iOS Safari that shorthand type frequently returns an **empty string** (the standards-compliant `'text/plain'` type works there). With an empty value, `isUrl('')` is `false`, so the handler returned early *before* calling `preventDefault()` — letting iOS perform its native paste, which replaces the selection with the URL.

## Fix

Read the clipboard via `getData('text/plain')` first, falling back to `getData('text')`. Both work on desktop; iOS now returns the URL so the handler can wrap the selection as intended.

https://claude.ai/code/session_018AVZ8VwnwsxbU47hRX7dPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018AVZ8VwnwsxbU47hRX7dPJ)_