### PR TITLE
Fix front-matter handling: normalize on every save path, and treat `---` as a leading fence only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,6 +466,13 @@ Always follow red-green TDD when adding or changing behaviour:
 
 Never write implementation code before a failing test exists for it.
 
+### After a bugfix
+
+After fixing any bug, always — without being asked:
+
+1. **Sweep related functionality for the same class of bug.** Identify the other call sites, sibling functions, and code paths that share the faulty pattern (the same helper, the same assumption, the same parsing/encoding step) and check each for the same defect. A bug rarely lives alone — e.g. a fix in one save path usually has twins in the other save paths. Add red-green tests for any further bugs found and fix them.
+2. **Identify refactoring opportunities.** Note duplication the fix exposed (e.g. the same logic copy-pasted across sites) and consolidate it behind a single shared helper where doing so removes the duplication without adding complexity. Prefer fixes that collapse the duplication that allowed the bug to diverge in the first place; leave well enough alone when sharing would complicate more than it simplifies.
+
 ## Environment Setup
 
 Authentication password is stored hashed in the `LAMB_LOGIN_PASSWORD` environment variable:

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -40,7 +40,7 @@ Slugs are unique. If a slug is already taken by another post (or matches a built
 
 You can also set a `created:` date in the front-matter. A future date schedules the post — see [Scheduling]({{ site.baseurl }}{% link scheduling.md %}).
 
-> **iOS note:** iOS "Smart Punctuation" rewrites a typed `---` into em/en dashes (for example `—-`). Lamb recognises a mangled opening and closing fence and restores it to `---` automatically, so front-matter still works from an iPhone or iPad. If you'd rather type plain dashes everywhere, turn the feature off under _Settings → General → Keyboard → Smart Punctuation_.
+> **iOS note:** iOS "Smart Punctuation" rewrites a typed `---` into em/en dashes (for example `—-`). Lamb recognises a mangled opening and closing fence and restores it to `---` automatically — whether you add the front-matter when first writing the post or by editing it later — so front-matter still works from an iPhone or iPad. If you'd rather type plain dashes everywhere, turn the feature off under _Settings → General → Keyboard → Smart Punctuation_.
 
 # System types
 

--- a/src/constants.php
+++ b/src/constants.php
@@ -17,7 +17,7 @@ define('FEED_FETCH_TIMEOUT', 15);
 define('MINUTE_IN_SECONDS', 60);
 // Current post render-format version. Bump when `transformed` output changes
 // (e.g. new syntax highlighting); older posts are re-parsed on read by upgrade_posts().
-define('POST_VERSION', 2);
+define('POST_VERSION', 3);
 define('SESSION_LOGIN', 'logged_in');
 define('SUBMIT_CREATE', 'Create post');
 define('SUBMIT_EDIT', 'Update post');

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -15,6 +15,7 @@ const SQL_IS_SCHEDULED = ' created > ? AND (draft IS NULL OR draft != 1) AND (de
 use RedBeanPHP\R;
 use RedBeanPHP\RedException\SQL;
 
+use function Lamb\Post\normalize_frontmatter_fence;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\set_matter;
 
@@ -153,6 +154,14 @@ function permalink(OODBBean $bean): string
  */
 function parse_bean(OODBBean $bean): void
 {
+    // Restore an iOS Smart-Punctuation front-matter fence (e.g. a single em
+    // dash for a typed `---`) before parsing, and persist the normalised body.
+    // This is the single choke point every save path runs through — web
+    // create/edit, Micropub create/update, feed ingestion, upgrade re-parse —
+    // so the recovery is not limited to populate_bean(). Idempotent for bodies
+    // already using a literal `---` fence.
+    $bean->body = normalize_frontmatter_fence($bean->body);
+
     $markdown = render_body($bean->body);
 
     $front_matter = parse_matter($bean->body);

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -18,6 +18,7 @@ use RedBeanPHP\RedException\SQL;
 use function Lamb\Post\normalize_frontmatter_fence;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\set_matter;
+use function Lamb\Post\split_frontmatter;
 
 /**
  * Returns the current time in the canonical `Y-m-d H:i:s` format used for every
@@ -177,8 +178,10 @@ function parse_bean(OODBBean $bean): void
 }
 
 /**
- * Renders the Markdown body (everything after the front-matter block) to HTML
- * via LambDown with safe mode enabled.
+ * Renders the Markdown body (everything after the leading front-matter block)
+ * to HTML via LambDown with safe mode enabled. A `---` in the body itself — a
+ * horizontal rule, a diff line, or `---` inside a fenced code block — is left
+ * for the Markdown parser to handle rather than being mistaken for a fence.
  *
  * @param string $body The raw post body, optionally prefixed by front matter.
  * @return string The rendered HTML.
@@ -187,12 +190,11 @@ function parse_bean(OODBBean $bean): void
  */
 function render_body(string $body): string
 {
-    $parts = explode('---', $body);
-    $md_text = trim($parts[count($parts) - 1]);
+    [, $content] = split_frontmatter($body);
     $parser = new LambDown();
     $parser->setSafeMode(true);
 
-    return $parser->text($md_text);
+    return $parser->text(trim($content));
 }
 
 /**

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -21,6 +21,7 @@ use function Lamb\Post\build_matter;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\populate_bean;
+use function Lamb\Post\split_frontmatter;
 
 class LambMicropubAdapter extends MicropubAdapter
 {
@@ -69,8 +70,8 @@ class LambMicropubAdapter extends MicropubAdapter
     private function beanToMf2Properties(OODBBean $bean): array
     {
         $body = $bean->body ?? '';
-        $parts = explode('---', $body, 3);
-        $content = trim(count($parts) === 3 ? $parts[2] : $body);
+        [, $content] = split_frontmatter($body);
+        $content = trim($content);
 
         // Strip trailing hashtags — categories appended by buildBody during creation.
         $content = rtrim(preg_replace('/([ \t]+#\S+)+$/', '', $content));

--- a/src/post.php
+++ b/src/post.php
@@ -72,10 +72,13 @@ function populate_bean(string $text, ?Item $feed_item = null, ?string $feed_name
  *
  * Typing `---` on iOS produces em/en dashes (commonly `—-`), which stops the
  * fence from being recognised as a front-matter delimiter. When the body opens
- * with a dash-only fence line and has a matching closing fence line, both are
- * normalised back to a literal `---`. Dashes anywhere else (post body, em-dash
- * punctuation, signatures) are left untouched, and the surrounding whitespace
- * and line endings are preserved.
+ * with a dash-only fence line (two or more dash-like characters) and has a
+ * matching closing fence line, both are normalised back to a literal `---`. A
+ * single dash-like character is never treated as a fence: a lone em/en dash is
+ * ordinary punctuation (or a thematic break) far more often than a mangled
+ * fence, and a lone hyphen could swallow body content. Dashes anywhere else
+ * (post body, em-dash punctuation, signatures) are left untouched, and the
+ * surrounding whitespace and line endings are preserved.
  *
  * @param string $body The raw post body.
  * @return string The body with a normalised opening/closing front-matter fence.

--- a/src/post.php
+++ b/src/post.php
@@ -93,6 +93,29 @@ function normalize_frontmatter_fence(string $body): string
 }
 
 /**
+ * Splits a body into its leading YAML front-matter block and the remaining
+ * content.
+ *
+ * Front matter is recognised only as a *leading* fenced block: a `---` line at
+ * the very start of the body, the YAML up to the next `---` line on its own,
+ * and everything after that as content. A `---` anywhere else — a Markdown
+ * horizontal rule, a `--- a/file` diff line, or `---` inside a fenced code
+ * block — is body and is preserved verbatim. Bodies without a leading fence
+ * return an empty YAML string and the body unchanged.
+ *
+ * @param string $body The raw post body.
+ * @return array{0: string, 1: string} The YAML block (without fences) and the content.
+ */
+function split_frontmatter(string $body): array
+{
+    if (preg_match('/\A---[ \t]*\R(.*?)\R?---[ \t]*(?:\R|\z)/s', $body, $m)) {
+        return [$m[1], substr($body, strlen($m[0]))];
+    }
+
+    return ['', $body];
+}
+
+/**
  * Parses a string body for YAML front matter and returns an associative array of the extracted metadata.
  *
  * @param string $body The string containing the content with optional YAML front matter delimited by '---'.
@@ -100,15 +123,16 @@ function normalize_frontmatter_fence(string $body): string
  */
 function parse_matter(string $body): array
 {
-    $matter = null;
-    $text = explode('---', $body);
+    [$yaml] = split_frontmatter($body);
+    if ($yaml === '') {
+        return [];
+    }
+
     try {
-        if (isset($text[1])) {
-            // PARSE_DATETIME keeps absolute dates as DateTime objects carrying the
-            // author's typed wall-clock time, instead of coercing them to UTC Unix
-            // timestamps (which would shift the time by the server's timezone offset).
-            $matter = Yaml::parse($text[1], Yaml::PARSE_DATETIME);
-        }
+        // PARSE_DATETIME keeps absolute dates as DateTime objects carrying the
+        // author's typed wall-clock time, instead of coercing them to UTC Unix
+        // timestamps (which would shift the time by the server's timezone offset).
+        $matter = Yaml::parse($yaml, Yaml::PARSE_DATETIME);
     } catch (ParseException) {
         // Invalid YAML
         return [];

--- a/tests/Unit/FrontMatterTest.php
+++ b/tests/Unit/FrontMatterTest.php
@@ -5,10 +5,77 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 
 use function Lamb\Post\build_matter;
+use function Lamb\Post\normalize_frontmatter_fence;
+use function Lamb\Post\parse_matter;
 use function Lamb\Post\set_matter;
 
 class FrontMatterTest extends TestCase
 {
+    // normalize_frontmatter_fence — iOS Smart Punctuation recovery
+
+    private const EM = "\xE2\x80\x94"; // — em dash (U+2014)
+    private const EN = "\xE2\x80\x93"; // – en dash (U+2013)
+
+    public function testNormalizeRestoresEmDashHyphenFence(): void
+    {
+        // iOS Smart Punctuation turns a typed `---` into an em dash followed by
+        // a hyphen (`—-`). Both the opening and closing fence must be restored
+        // and the metadata extracted.
+        $em = self::EM;
+        $body = "$em-\nin-reply-to: https://example.com/post\n$em-\n";
+        $normalized = normalize_frontmatter_fence($body);
+
+        $this->assertSame(
+            "---\nin-reply-to: https://example.com/post\n---\n",
+            $normalized
+        );
+        $this->assertSame(
+            'https://example.com/post',
+            parse_matter($normalized)['in-reply-to']
+        );
+    }
+
+    public function testNormalizeLeavesLoneEmDashUntouched(): void
+    {
+        // A single dash-like character is not a fence: a lone em dash is
+        // ordinary punctuation (or a thematic break) far more often than a
+        // mangled `---`, so it must be left alone rather than swallowing the
+        // line between it and the next em dash.
+        $em = self::EM;
+        $body = "$em\nin-reply-to: https://example.com/post\n$em\n";
+        $this->assertSame($body, normalize_frontmatter_fence($body));
+    }
+
+    public function testNormalizeLeavesLoneEnDashUntouched(): void
+    {
+        $en = self::EN;
+        $body = "$en\ntitle: Hello\n$en\n\nBody.";
+        $this->assertSame($body, normalize_frontmatter_fence($body));
+    }
+
+    public function testNormalizeLeavesLiteralTripleDashUnchanged(): void
+    {
+        $body = "---\ntitle: Hello\n---\nBody.";
+        $this->assertSame($body, normalize_frontmatter_fence($body));
+    }
+
+    public function testNormalizeLeavesEmDashProseUntouched(): void
+    {
+        // A standalone em dash used as punctuation must not be mistaken for a
+        // fence — there is no opening/closing pair at the start of the body.
+        $em = self::EM;
+        $body = "Hello $em this is an aside $em world.\n\nMore.";
+        $this->assertSame($body, normalize_frontmatter_fence($body));
+    }
+
+    public function testNormalizeLeavesSingleHyphenLinesUntouched(): void
+    {
+        // A lone hyphen is never an iOS conversion of `---`; leave it alone so
+        // it can't swallow body content.
+        $body = "-\nnot front matter\n-\n";
+        $this->assertSame($body, normalize_frontmatter_fence($body));
+    }
+
     // build_matter
 
     public function testBuildMatterReturnsContentOnlyWhenMatterEmpty(): void

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -395,6 +395,25 @@ class MicropubAdapterTest extends TestCase
         $this->assertStringContainsString('Slugged source content', $result['properties']['content'][0]);
     }
 
+    public function testSourceQueryPreservesBodyContainingHorizontalRules(): void
+    {
+        // A body whose content carries its own `---` (e.g. horizontal rules)
+        // must be returned whole — not truncated to the slice after the last
+        // `---` (issue: explode-based front-matter split dropped content).
+        $bean = R::dispense('post');
+        $bean->body = "First section\n\n---\n\nSecond section\n\n---\n\nThird section";
+        $bean->slug = '';
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->sourceQueryCallback(ROOT_URL . '/status/' . $bean->id);
+        $this->assertStringContainsString('First section', $result['properties']['content'][0]);
+        $this->assertStringContainsString('Second section', $result['properties']['content'][0]);
+        $this->assertStringContainsString('Third section', $result['properties']['content'][0]);
+    }
+
     public function testSourceQueryContentExcludesAppendedCategoryHashtags(): void
     {
         $bean = R::dispense('post');

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -10,6 +10,7 @@ use function Lamb\Post\get_tag_search_conditions;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\posts_by_tag;
 use function Lamb\Post\slugify;
+use function Lamb\render_body;
 
 class PostTest extends TestCase
 {
@@ -193,6 +194,61 @@ class PostTest extends TestCase
         $body = "---\ntitle: My Post Title\nslug: custom-slug\n---\nContent.";
         $result = parse_matter($body);
         $this->assertSame('custom-slug', $result['slug']);
+    }
+
+    // parse_matter — front matter is a *leading* fence only
+
+    public function testParseMatterIgnoresKeyValueLineAfterBodyContent()
+    {
+        // A `key: value` line after a `---` that is *not* the document's leading
+        // fence is body, not front matter. It must not be parsed (and must not
+        // become a bean column).
+        $body = "Check this out\n---\nNote: this is important";
+        $this->assertSame([], parse_matter($body));
+    }
+
+    public function testParseMatterIgnoresInlineTripleDash()
+    {
+        $this->assertSame([], parse_matter('Just a thought --- or three.'));
+    }
+
+    public function testParseMatterReadsLeadingFrontMatterDespiteBodyHorizontalRule()
+    {
+        $body = "---\ntitle: Hello\n---\n\nIntro\n\n---\n\nOutro";
+        $result = parse_matter($body);
+        $this->assertSame('Hello', $result['title']);
+        $this->assertSame('hello', $result['slug']);
+    }
+
+    // render_body — body `---` (horizontal rules, diffs, code) is preserved
+
+    public function testRenderBodyPreservesContentAroundHorizontalRule()
+    {
+        $html = render_body("First paragraph.\n\n---\n\nSecond paragraph.");
+        $this->assertStringContainsString('First paragraph.', $html);
+        $this->assertStringContainsString('Second paragraph.', $html);
+        $this->assertStringContainsString('<hr', $html);
+    }
+
+    public function testRenderBodyPreservesBodyAfterLeadingFrontMatter()
+    {
+        $html = render_body("---\ntitle: Hello\n---\n\nIntro\n\n---\n\nOutro");
+        $this->assertStringNotContainsString('title: Hello', $html);
+        $this->assertStringContainsString('Intro', $html);
+        $this->assertStringContainsString('Outro', $html);
+    }
+
+    public function testRenderBodyPreservesFencedCodeBlockContainingTripleDash()
+    {
+        $body = "Here's a diff:\n\n```diff\n--- a/file\n+++ b/file\n```\n\nAfter the code.";
+        $html = render_body($body);
+        // The lead-in line is dropped by the broken explode('---') split.
+        $this->assertStringContainsString("Here's a diff:", $html);
+        $this->assertStringContainsString('a/file', $html);
+        $this->assertStringContainsString('b/file', $html);
+        $this->assertStringContainsString('After the code.', $html);
+        // The diff lines must stay inside a code block, not leak into a paragraph.
+        $this->assertStringContainsString('<code', $html);
     }
 
     // posts_by_tag

--- a/tests/Unit/ReplyContextTest.php
+++ b/tests/Unit/ReplyContextTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\parse_bean;
 use function Lamb\Post\populate_bean;
 use function Lamb\Theme\the_reply_context;
 
@@ -59,6 +60,28 @@ class ReplyContextTest extends TestCase
             "---\nin-reply-to:\n  - https://first.example/post\n  - https://second.example/post\n---\nHi"
         );
         $this->assertSame('https://first.example/post', $bean->in_reply_to);
+    }
+
+    public function testEditPathNormalizesSmartPunctuationFence(): void
+    {
+        // The web edit and Micropub update paths assign $bean->body directly and
+        // call parse_bean() without going through populate_bean(). An iOS
+        // Smart-Punctuation fence (`—-`) added on edit must still be recognised,
+        // its metadata extracted, and the stored body normalised to `---` so the
+        // post no longer renders the fence as literal text.
+        $em = "\xE2\x80\x94"; // — em dash (U+2014)
+
+        $bean = R::dispense('post');
+        $bean->body = "$em-\nin-reply-to: https://other.example/post\n$em-\n\nReplying.";
+        parse_bean($bean);
+
+        $this->assertSame('https://other.example/post', $bean->in_reply_to);
+        $this->assertSame(
+            "---\nin-reply-to: https://other.example/post\n---\n\nReplying.",
+            $bean->body
+        );
+        $this->assertStringNotContainsString($em, (string) $bean->transformed);
+        $this->assertStringContainsString('Replying.', (string) $bean->transformed);
     }
 
     // the_reply_context helper ----------------------------------------------


### PR DESCRIPTION
## 1. Smart-Punctuation fence recovery wasn't running on edit

Adding an `in-reply-to` to an already-published post from iOS left the fence rendered as literal text, metadata dropped:

```
—-
in-reply-to: https://pfandrade.me/blog/mac-assed-swiftui-app/
—-
```

The fence (`—-`, em dash + hyphen from a typed `---`) was already handled by `normalize_frontmatter_fence()`, **but that ran only inside `populate_bean()`**. The web **edit** path and the **Micropub update** path assign `$bean->body` and call `parse_bean()` directly, bypassing it.

**Fix:** move normalization into `parse_bean()`, the single choke point every save path runs through (web create/edit, Micropub create/update, feed ingestion, upgrade re-parse). Idempotent for literal `---`. The fence rule is unchanged (≥2 dash-like chars) — a lone em/en dash is punctuation, not a fence.

## 2. Body `---` (horizontal rules, diffs, code blocks) was silently dropped

`parse_matter()` and `render_body()` split on *any* `---` via `explode()`, so a `---` that wasn't a leading fence was treated as a delimiter. `render_body()` rendered only the slice after the *last* `---`, deleting the rest of the post; a fenced code block containing a diff (`--- a/file`) was destroyed; and a mid-body `key: value` line could be read as front matter (even minting a bean column).

**Fix:** add `split_frontmatter()` — front matter is only a *leading* `---` fence; everything after is content preserved verbatim. `parse_matter()` and `render_body()` share it, as does the Micropub `beanToMf2Properties()` source-query split (which had the same `explode` bug). `POST_VERSION` bumps 2 → 3 so already-mangled posts re-render via the upgrade-on-read path.

## Tests

Red-green TDD throughout:

- Edit-path normalization (`ReplyContextTest`), `—-` fence recovery + lone-dash safety (`FrontMatterTest`).
- Body `---` preservation for horizontal rules, leading-fence-plus-body-rule, and fenced code blocks; mid-body `key: value` not parsed as front matter (`PostTest`).
- Micropub source query preserves a body with multiple `---` runs (`MicropubAdapterTest`).

Full unit suite (910 tests after merging `main`), `composer lint`, and `composer analyse` all pass.

> Merged `main` (PR #393, "Normalise front-matter keys before matching") into this branch and resolved the overlap: `parse_matter()` now runs both `split_frontmatter()` and `normalize_matter_keys()`.

https://claude.ai/code/session_01LVUmRXntguUnmC4qPRd6cD