### PR TITLE
Sanitise Location headers against CR/LF injection

### DIFF
--- a/src/http.php
+++ b/src/http.php
@@ -24,6 +24,29 @@ function get_request_uri(): string|false
 }
 
 /**
+ * Sanitises a value bound for a `Location:` header.
+ *
+ * Any request-derived value interpolated into a redirect target (the request
+ * URI, a search query, a fallback URL) is a header-injection surface: a CR or
+ * LF would let a client smuggle extra response headers. They are stripped (along
+ * with null bytes) before output. An empty result falls back to the site root so
+ * callers never emit a bare `Location:`.
+ *
+ * This is the pure core of the redirect helpers — it takes its input as an
+ * argument and returns the safe string, so it is unit-testable without the
+ * surrounding `header()`/`die()` shell.
+ *
+ * @param string $location The proposed redirect target.
+ * @return string The CR/LF-stripped target, or '/' when empty.
+ */
+function sanitize_location(string $location): string
+{
+    $location = str_replace(["\r", "\n", "\0"], '', $location);
+
+    return $location === '' ? '/' : $location;
+}
+
+/**
  * Default User-Agent sent by {@see fetch} when no header overrides it.
  */
 const DEFAULT_USER_AGENT = 'Lamb-Webmention';

--- a/src/index.php
+++ b/src/index.php
@@ -77,7 +77,7 @@ if (post_has_slug($action) === $action) {
 } elseif ($action !== false && !Route\is_reserved_route($action)) {
     $redirect_url = find_redirect($action);
     if ($redirect_url !== null) {
-        header('Location: ' . $redirect_url, true, 301);
+        header('Location: ' . Http\sanitize_location($redirect_url), true, 301);
         exit;
     }
 }

--- a/src/response.php
+++ b/src/response.php
@@ -130,8 +130,9 @@ function build_pagination_meta(int $page, int $per_page, int $total_posts, int $
 function redirect_404(string $fallback): void
 {
     global $request_uri;
-    header("Location: $fallback$request_uri");
-    die("Redirecting to $fallback$request_uri");
+    $location = \Lamb\Http\sanitize_location($fallback . $request_uri);
+    header("Location: $location");
+    die();
 }
 
 /**
@@ -169,11 +170,9 @@ function respond_404(array $_args = [], bool $use_fallback = false): array
 #[NoReturn]
 function redirect_uri(string $where): never
 {
-    if (empty($where)) {
-        $where = '/';
-    }
-    header("Location: $where");
-    die("Redirecting to $where");
+    $location = \Lamb\Http\sanitize_location($where);
+    header("Location: $location");
+    die();
 }
 
 /**

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -136,8 +136,9 @@ function count_scheduled(): int
 #[NoReturn]
 function redirect_search(string $query): void
 {
-    header("Location: /search/$query");
-    die("Redirecting to /search/$query");
+    $location = \Lamb\Http\sanitize_location("/search/$query");
+    header("Location: $location");
+    die();
 }
 
 /**

--- a/tests/Unit/SanitizeLocationTest.php
+++ b/tests/Unit/SanitizeLocationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Http\sanitize_location;
+
+/**
+ * Pure core extracted from the redirect shells: any request-derived value
+ * interpolated into a `Location:` header is a CR/LF header-injection surface,
+ * so it is stripped before output. Tested here without process death.
+ */
+class SanitizeLocationTest extends TestCase
+{
+    public function testLeavesPlainPathUntouched(): void
+    {
+        $this->assertSame('/search/foo?page=2', sanitize_location('/search/foo?page=2'));
+    }
+
+    public function testStripsCarriageReturnAndNewlineInjection(): void
+    {
+        $this->assertSame(
+            '/dashboardSet-Cookie: x=1',
+            sanitize_location("/dashboard\r\nSet-Cookie: x=1")
+        );
+    }
+
+    public function testStripsBareNewline(): void
+    {
+        $this->assertSame('/aX-Injected: 1', sanitize_location("/a\nX-Injected: 1"));
+    }
+
+    public function testStripsBareCarriageReturn(): void
+    {
+        $this->assertSame('/ab', sanitize_location("/a\rb"));
+    }
+
+    public function testStripsNullByte(): void
+    {
+        $this->assertSame('/ab', sanitize_location("/a\0b"));
+    }
+
+    public function testEmptyFallsBackToRoot(): void
+    {
+        $this->assertSame('/', sanitize_location(''));
+    }
+
+    public function testWhitespaceOnlyAfterStrippingFallsBackToRoot(): void
+    {
+        // A value that is nothing but CR/LF collapses to empty, then to root.
+        $this->assertSame('/', sanitize_location("\r\n"));
+    }
+}


### PR DESCRIPTION
## What

Extracts a pure `Lamb\Http\sanitize_location()` core that strips CR/LF/NUL from any value bound for a `Location:` header and falls back to `/` when empty. Routes every request-derived `Location:` site through it:

- `Lamb\Response\redirect_uri()`
- `Lamb\Response\redirect_404()` (interpolates `$request_uri`)
- `Lamb\Response\redirect_search()` (interpolates the search `$query`)
- the 301 redirect in `index.php` (stored `to_url`, keyed off the request path)

## Why

Any request-derived value interpolated into a `Location:` header is a header-injection surface — a smuggled `\r\n` lets a client append extra response headers. The fix is the **functional core / imperative shell** split: the sanitiser is a pure, unit-tested function; the thin `header()`/`die()` shells stay covered by the acceptance suite.

Dead `die("Redirecting to …")` bodies are dropped — a 3xx response body is never shown.

`micropub.php`'s `Location:` is a generated, slugified permalink, so it is left as-is.

## Tests

7 new unit tests in `tests/Unit/SanitizeLocationTest.php` (plain path, CR/LF injection, bare CR, bare LF, NUL byte, empty→root, whitespace-only→root). Full unit suite: 917 pass. Lint + PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)