### PR TITLE
Bump devbox plugin_version 0.0.2 → 0.0.3

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -6,7 +6,7 @@
     },
     "nodejs@24": {
       "last_modified": "2025-12-29T16:45:58Z",
-      "plugin_version": "0.0.2",
+      "plugin_version": "0.0.3",
       "resolved": "github:NixOS/nixpkgs/346dd96ad74dc4457a9db9de4f4f57dab2e5731d#nodejs_24",
       "source": "devbox-search",
       "version": "24.12.0",


### PR DESCRIPTION
Syncs `devbox.lock` with the latest installed devbox plugin revision (`plugin_version` 0.0.2 → 0.0.3). Lockfile-only; no functional change to the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)