### PR TITLE
Raise PHPStan analysis from level 5 to level 8

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,13 +2,27 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 5
+    level: 8
     parallel:
         maximumNumberOfProcesses: 1
     paths:
         - src
     excludePaths:
         - src/index.php
+    ignoreErrors:
+        # RedBeanPHP's stubs type Facade::find()'s $sql as literal-string to
+        # discourage interpolating user input into SQL. Our listing queries
+        # assemble the clause from constant SQL fragments (SQL_PUBLISHED, the
+        # visibility/pagination helpers) with every value bound as a parameter,
+        # so they are safe but not a single literal — accept the non-literal SQL.
+        -
+            message: '#expects literal-string\|null, non-falsy-string given#'
+            identifier: argument.type
+            paths:
+                - src/post.php
+                - src/response.php
+                - src/response/feeds.php
+                - src/theme.php
     bootstrapFiles:
         - vendor/autoload.php
         - phpstan-bootstrap.php

--- a/src/LambDown.php
+++ b/src/LambDown.php
@@ -9,16 +9,16 @@ class LambDown extends Parsedown
     /**
      * Determines if the given line is a valid header block in Markdown format.
      *
-     * @param array $Line The line to be checked.
+     * @param array<string, mixed> $Line The line to be checked.
      *
-     * @return array[]|void Returns the result of the parent's blockHeader method, or null if the line is not a valid header block.
+     * @return array<string, mixed>|null Returns the result of the parent's blockHeader method, or null if the line is not a valid header block.
      */
     protected function blockHeader($Line)
     {
         $level = strspn($Line['text'], '#');
         $tag = substr($Line['text'], $level - 1, 2);
         if ($tag !== '# ') {
-            return;
+            return null;
         }
 
         return parent::blockHeader($Line);
@@ -27,6 +27,10 @@ class LambDown extends Parsedown
     /**
      * Inject lazy-loading attributes on every inline image so post bodies
      * with embedded screenshots do not block first paint on the homepage.
+     *
+     * @param array<string, mixed> $Excerpt The inline excerpt to be parsed.
+     *
+     * @return array<string, mixed>|null The parsed image element, or null when not an image.
      */
     protected function inlineImage($Excerpt)
     {

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -95,7 +95,7 @@ function configure_session(): void
  * LAMBSESSID session cookie. Anonymous visitors get no session — and therefore no
  * Set-Cookie and no no-cache headers — so their pages remain cacheable (issue #116).
  *
- * @param array $cookies Typically $_COOKIE.
+ * @param array<string, mixed> $cookies Typically $_COOKIE.
  * @return bool
  */
 function should_start_session(array $cookies): bool
@@ -197,7 +197,7 @@ function content_etag(int $contentTs, int $configTs): string
  * Honours both If-None-Match (against the ETag) and If-Modified-Since (against
  * the last-modified timestamp).
  *
- * @param array  $server          Typically $_SERVER.
+ * @param array<string, mixed> $server          Typically $_SERVER.
  * @param string $etag            The current response ETag.
  * @param int    $lastModifiedTs  The current last-modified Unix timestamp.
  * @return bool

--- a/src/config.php
+++ b/src/config.php
@@ -98,7 +98,7 @@ INI;
  * site down between save and fix.
  *
  * @param string $ini_text The raw INI text.
- * @return array The parsed sections/keys, or [] on failure.
+ * @return array<string, mixed> The parsed sections/keys, or [] on failure.
  */
 function parse_ini_safe(string $ini_text): array
 {
@@ -151,7 +151,7 @@ function ensure_explicit_theme(string $ini_text, string $default_theme = 'base')
 /**
  * Loads the configuration settings.
  *
- * @return array The configuration settings.
+ * @return array<string, mixed> The configuration settings.
  */
 function load(): array
 {
@@ -168,7 +168,7 @@ function load(): array
  *
  * @param string $stored_ini  The raw stored INI text.
  * @param string $default_ini The seeded default INI text.
- * @return array The effective configuration.
+ * @return array<string, mixed> The effective configuration.
  */
 function compose_config(string $stored_ini, string $default_ini): array
 {
@@ -199,7 +199,7 @@ function compose_config(string $stored_ini, string $default_ini): array
  * author's wall clock. Falls back to UTC when the configured value is missing or
  * not a recognised timezone identifier.
  *
- * @param array $config The loaded configuration.
+ * @param array<string, mixed> $config The loaded configuration.
  * @return string The timezone identifier that was applied.
  */
 function apply_timezone(array $config): string
@@ -314,7 +314,7 @@ function validate_ini(string $ini_text): array
 /**
  * Retrieves a list of slugs derived from menu items that should be excluded from the timeline.
  *
- * @return array An array of slugs to exclude.
+ * @return list<string> An array of slugs to exclude.
  */
 function get_menu_slugs(): array
 {
@@ -340,11 +340,11 @@ function get_menu_slugs(): array
 
         // Otherwise, if it's not a full URL, we treat it as a slug.
         if (!filter_var($value, FILTER_VALIDATE_URL)) {
-            $slugs[] = $value;
+            $slugs[] = (string) $value;
         }
     }
 
-    return array_unique($slugs);
+    return array_values(array_unique($slugs));
 }
 
 /**

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -40,7 +40,7 @@ const TAG_PATTERN = '/(^|[\s>])#([^\s#&.,!?;:()\[\]{}<]+)/u';
  *
  * @param string $html The HTML content to search for tags.
  *
- * @return array An array of tags found in the HTML.
+ * @return list<string> An array of tags found in the HTML.
  */
 function get_tags(string $html): array
 {
@@ -64,7 +64,7 @@ function parse_tags(string $html): string
 {
     return preg_replace_callback(TAG_PATTERN, function ($matches) {
         return $matches[1] . '<a href="/tag/' . strtolower($matches[2]) . '">#' . $matches[2] . '</a>';
-    }, $html);
+    }, $html) ?? $html;
 }
 
 /**
@@ -74,8 +74,8 @@ function parse_tags(string $html): string
  * Counterpart of get_tags(): used by Micropub category `add` updates, where
  * categories live in the body as hashtags rather than in a column.
  *
- * @param string $body The raw post body.
- * @param array  $tags Tag names (without `#`).
+ * @param string       $body The raw post body.
+ * @param list<string> $tags Tag names (without `#`).
  * @return string The body with missing tags appended.
  */
 function add_body_tags(string $body, array $tags): string
@@ -99,21 +99,21 @@ function add_body_tags(string $body, array $tags): string
  */
 function strip_trailing_body_tags(string $body): string
 {
-    return rtrim(preg_replace('/(\s+#[^\s#.,!?;:()\[\]{}<]+)+$/u', '', $body));
+    return rtrim(preg_replace('/(\s+#[^\s#.,!?;:()\[\]{}<]+)+$/u', '', $body) ?? $body);
 }
 
 /**
  * Removes the named hashtags (and their preceding whitespace) from a body,
  * wherever they appear. Used by Micropub category delete-values updates.
  *
- * @param string $body The raw post body.
- * @param array  $tags Tag names (without `#`) to remove.
+ * @param string       $body The raw post body.
+ * @param list<string> $tags Tag names (without `#`) to remove.
  * @return string The body without the named tags.
  */
 function remove_body_tags(string $body, array $tags): string
 {
     foreach ($tags as $tag) {
-        $body = preg_replace('/(\s+)#' . preg_quote($tag, '/') . '(?=\s|$)/u', '', $body);
+        $body = preg_replace('/(\s+)#' . preg_quote($tag, '/') . '(?=\s|$)/u', '', $body) ?? $body;
     }
 
     return $body;
@@ -207,7 +207,7 @@ function render_body(string $body): string
  */
 function extract_description(string $markdown): string
 {
-    $description = strtok(strip_tags($markdown), "\n");
+    $description = strtok(strip_tags($markdown), "\n") ?: '';
     // Decode twice: feed-ingested bodies already contain HTML entities (e.g. `&#039;`),
     // which Parsedown then re-encodes (`&amp;#039;`). A single decode only undoes one layer.
     $description = html_entity_decode($description, ENT_QUOTES | ENT_HTML5, 'UTF-8');
@@ -246,7 +246,7 @@ function highlight_and_link(string $markdown): string
  * hyphenated key is never written as an invalid column by the blind copy in
  * apply_frontmatter().
  *
- * @param array $front_matter The parsed front matter, modified in place.
+ * @param array<int|string, mixed> $front_matter The parsed front matter, modified in place.
  * @return string The normalised reply target, or '' when absent.
  *
  * @internal Decomposed step of parse_bean(); not part of the public API.
@@ -273,8 +273,8 @@ function normalize_in_reply_to(array &$front_matter): string
  * map to columns. Date normalisation is handled separately by
  * apply_scheduling().
  *
- * @param OODBBean $bean         The bean to mutate.
- * @param array    $front_matter The parsed front matter (including derived keys).
+ * @param OODBBean                  $bean         The bean to mutate.
+ * @param array<int|string, mixed>  $front_matter The parsed front matter (including derived keys).
  * @return void
  *
  * @internal Decomposed step of parse_bean(); not part of the public API.
@@ -319,9 +319,9 @@ function apply_frontmatter(OODBBean $bean, array $front_matter): void
  * passed in by parse_bean() so the unparseable-date fallback uses the genuine
  * prior value rather than the raw front-matter string now sitting on the bean.
  *
- * @param OODBBean $bean             The bean to mutate.
- * @param array    $front_matter     The parsed front matter.
- * @param mixed    $previous_created The created date held before apply_frontmatter().
+ * @param OODBBean                 $bean             The bean to mutate.
+ * @param array<int|string, mixed> $front_matter     The parsed front matter.
+ * @param mixed                    $previous_created The created date held before apply_frontmatter().
  * @return void
  *
  * @internal Decomposed step of parse_bean(); not part of the public API.
@@ -385,7 +385,7 @@ function set_option(OODBBean $bean, mixed $value): void
  * The current time is bound as a parameter so the comparison uses the same
  * timezone basis as the stored `created` values (both produced by PHP's date()).
  *
- * @return array{sql: string, params: array}
+ * @return array{sql: string, params: array<int, string>}
  */
 function not_scheduled_clause(): array
 {
@@ -405,7 +405,7 @@ function not_scheduled_clause(): array
  * not_scheduled_clause(), so a new query cannot accidentally omit one of the
  * conditions (which is how scheduled posts leaked into related posts).
  *
- * @return array{sql: string, params: array}
+ * @return array{sql: string, params: array<int, string>}
  */
 function visible_clause(): array
 {

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -29,8 +29,8 @@ class LambMicropubAdapter extends MicropubAdapter
      * Return the source properties of a post identified by URL.
      *
      * @param string $url
-     * @param array|null $properties Specific properties to return; null means all.
-     * @return array|false
+     * @param list<string>|null $properties Specific properties to return; null means all.
+     * @return array{type: list<string>, properties: array<string, mixed>}|false
      */
     public function sourceQueryCallback(string $url, ?array $properties = null)
     {
@@ -65,7 +65,7 @@ class LambMicropubAdapter extends MicropubAdapter
      * Convert a post bean to a flat MF2 properties array.
      *
      * @param OODBBean $bean
-     * @return array
+     * @return array<string, mixed>
      */
     private function beanToMf2Properties(OODBBean $bean): array
     {
@@ -74,7 +74,7 @@ class LambMicropubAdapter extends MicropubAdapter
         $content = trim($content);
 
         // Strip trailing hashtags — categories appended by buildBody during creation.
-        $content = rtrim(preg_replace('/([ \t]+#\S+)+$/', '', $content));
+        $content = rtrim(preg_replace('/([ \t]+#\S+)+$/', '', $content) ?? $content);
 
         $props = ['content' => [$content]];
 
@@ -104,7 +104,7 @@ class LambMicropubAdapter extends MicropubAdapter
         if (strtolower($request->getMethod()) === 'get' && ($request->getQueryParams()['q'] ?? '') === 'config') {
             $this->request = $request;
             $configResult = $this->configurationQueryCallback($request->getQueryParams());
-            return new Response(200, ['content-type' => 'application/json'], json_encode($configResult));
+            return new Response(200, ['content-type' => 'application/json'], json_encode($configResult) ?: '');
         }
 
         return parent::handleRequest($request);
@@ -114,7 +114,7 @@ class LambMicropubAdapter extends MicropubAdapter
      * Verify the bearer token by introspecting it against the configured token endpoint.
      *
      * @param string $token
-     * @return array|false
+     * @return array{me: mixed, scope: list<string>}|false
      */
     public function verifyAccessTokenCallback(string $token)
     {
@@ -144,7 +144,7 @@ class LambMicropubAdapter extends MicropubAdapter
      *
      * @param string $token
      * @param string $endpoint
-     * @return array|null
+     * @return array<string, mixed>|null
      */
     protected function introspectToken(string $token, string $endpoint): ?array
     {
@@ -176,9 +176,9 @@ class LambMicropubAdapter extends MicropubAdapter
     /**
      * Handle a micropub create request.
      *
-     * @param array $data  Normalised microformats2 data.
-     * @param array $uploadedFiles
-     * @return string|array|\Psr\Http\Message\ResponseInterface
+     * @param array<string, mixed> $data  Normalised microformats2 data.
+     * @param array<string, mixed> $uploadedFiles
+     * @return string|array<string, mixed>|\Psr\Http\Message\ResponseInterface
      */
     public function createCallback(array $data, array $uploadedFiles = [])
     {
@@ -192,7 +192,7 @@ class LambMicropubAdapter extends MicropubAdapter
             return new Response(401, ['content-type' => 'application/json'], json_encode([
                 'error' => 'insufficient_scope',
                 'error_description' => 'Your access token does not grant the scope required for this action.',
-            ]));
+            ]) ?: '');
         }
 
         $props = $data['properties'] ?? [];
@@ -257,8 +257,8 @@ class LambMicropubAdapter extends MicropubAdapter
     /**
      * Return the configuration query response including an empty syndicate-to list.
      *
-     * @param array $params
-     * @return array
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
      */
     public function configurationQueryCallback(array $params): array
     {
@@ -311,8 +311,8 @@ class LambMicropubAdapter extends MicropubAdapter
      * Handle a micropub update request (replace/add/delete operations).
      *
      * @param string $url
-     * @param array  $actions
-     * @return true|string|array|\Psr\Http\Message\ResponseInterface
+     * @param array<string, mixed>  $actions
+     * @return true|string|array<string, mixed>|\Psr\Http\Message\ResponseInterface
      */
     public function updateCallback(string $url, array $actions)
     {
@@ -326,7 +326,7 @@ class LambMicropubAdapter extends MicropubAdapter
             return new Response(401, ['content-type' => 'application/json'], json_encode([
                 'error'             => 'insufficient_scope',
                 'error_description' => 'Your access token does not grant the scope required for this action.',
-            ]));
+            ]) ?: '');
         }
 
         foreach ($actions['replace'] ?? [] as $property => $values) {
@@ -363,9 +363,9 @@ class LambMicropubAdapter extends MicropubAdapter
     /**
      * Apply an add operation for a single property to a post bean.
      *
-     * @param OODBBean $bean
-     * @param string   $property
-     * @param array    $values
+     * @param OODBBean     $bean
+     * @param string       $property
+     * @param list<string> $values
      * @return void
      */
     private function applyAdd(OODBBean $bean, string $property, array $values): void
@@ -392,9 +392,9 @@ class LambMicropubAdapter extends MicropubAdapter
     /**
      * Apply a delete-values operation for a single property to a post bean.
      *
-     * @param OODBBean $bean
-     * @param string   $property
-     * @param array    $values
+     * @param OODBBean     $bean
+     * @param string       $property
+     * @param list<string> $values
      * @return void
      */
     private function applyDeleteValues(OODBBean $bean, string $property, array $values): void
@@ -407,9 +407,9 @@ class LambMicropubAdapter extends MicropubAdapter
     /**
      * Apply a replace operation for a single property to a post bean.
      *
-     * @param OODBBean $bean
-     * @param string   $property
-     * @param array    $values
+     * @param OODBBean    $bean
+     * @param string      $property
+     * @param list<mixed> $values
      * @return void
      */
     private function applyReplace(OODBBean $bean, string $property, array $values): void
@@ -453,8 +453,8 @@ class LambMicropubAdapter extends MicropubAdapter
     /**
      * Save uploaded photo files to the assets directory and return their public URLs.
      *
-     * @param array $uploadedFiles Associative array of field name → UploadedFileInterface (or array thereof).
-     * @return string[]
+     * @param array<string, mixed> $uploadedFiles Associative array of field name → UploadedFileInterface (or array thereof).
+     * @return list<string>
      */
     private function saveUploadedPhotos(array $uploadedFiles): array
     {
@@ -502,7 +502,7 @@ class LambMicropubAdapter extends MicropubAdapter
      * Extract content from micropub properties.
      * Returns ['content' => string|null, 'is_html' => bool].
      *
-     * @param array $props
+     * @param array<string, mixed> $props
      * @return array{content: string|null, is_html: bool}
      */
     private function extractContent(array $props): array
@@ -526,7 +526,7 @@ class LambMicropubAdapter extends MicropubAdapter
     /**
      * Build a Lamb post body (YAML front matter + markdown content).
      *
-     * @param array  $props   Micropub properties.
+     * @param array<string, mixed> $props   Micropub properties.
      * @param string $content Plain-text body content.
      * @return string
      */
@@ -565,7 +565,7 @@ class LambMicropubAdapter extends MicropubAdapter
      * Serialize any extra nested MF2 properties (not content/name/category/photo/published)
      * as a JSON code block so they are preserved in storage.
      *
-     * @param array $props
+     * @param array<string, mixed> $props
      * @return string
      */
     private function buildExtraProperties(array $props): string
@@ -600,7 +600,7 @@ class LambMicropubAdapter extends MicropubAdapter
     /**
      * Convert an array of photo URLs to newline-separated Markdown images.
      *
-     * @param array $photos
+     * @param array<int, mixed> $photos
      * @return string
      */
     private function buildPhotos(array $photos): string
@@ -624,7 +624,7 @@ class LambMicropubAdapter extends MicropubAdapter
     /**
      * Convert an array of category strings to space-separated hashtags.
      *
-     * @param array $categories
+     * @param array<int, mixed> $categories
      * @return string
      */
     private function buildTags(array $categories): string
@@ -664,8 +664,9 @@ function respond_micropub(): void
         $psr7Files = [];
         foreach ($_FILES as $field => $info) {
             if (is_array($info['tmp_name'])) {
+                $fieldFiles = [];
                 foreach ($info['tmp_name'] as $i => $tmpName) {
-                    $psr7Files[$field][] = new UploadedFile(
+                    $fieldFiles[] = new UploadedFile(
                         $tmpName,
                         (int) $info['size'][$i],
                         (int) $info['error'][$i],
@@ -673,6 +674,7 @@ function respond_micropub(): void
                         $info['type'][$i]
                     );
                 }
+                $psr7Files[$field] = $fieldFiles;
             } else {
                 $psr7Files[$field] = new UploadedFile(
                     $info['tmp_name'],

--- a/src/network.php
+++ b/src/network.php
@@ -20,6 +20,9 @@ use function Lamb\set_option;
 
 register_route('_cron', __NAMESPACE__ . '\\process_feeds');
 
+/**
+ * @return array<array-key, mixed> Configured feed URLs keyed by feed name.
+ */
 function get_feeds(): array
 {
     global $config;
@@ -300,7 +303,7 @@ function prepare_item(SimplePieItem $item, string $name, ?OODBBean $bean = null)
     return populate_bean($contents, $item, $name, $bean);
 }
 
-function create_item(SimplePieItem $item, string $name)
+function create_item(SimplePieItem $item, string $name): void
 {
     $contents = get_structured_content($item, $name);
     $bean = populate_bean($contents, $item, $name);
@@ -326,7 +329,7 @@ function create_item(SimplePieItem $item, string $name)
 function get_structured_content(SimplePieItem $item, string $name): string
 {
     $contents = attributed_content($item, $name);
-    $title = sanitize_feed_title($item->get_title());
+    $title = sanitize_feed_title($item->get_title() ?? '');
     if (!empty($title)) {
         $contents = <<<MATTER
 ---
@@ -373,7 +376,7 @@ function sanitize_feed_title(string $title): string
  */
 function attributed_content(SimplePieItem $item, string $name): string
 {
-    $contents = strip_tags($item->get_description());
+    $contents = strip_tags($item->get_description() ?? '');
     $lines = explode(PHP_EOL, $contents);
     $lines = array_slice($lines, 0, 5); // Get only the first 5 lines
     foreach ($lines as &$line) {

--- a/src/post.php
+++ b/src/post.php
@@ -119,7 +119,7 @@ function split_frontmatter(string $body): array
  * Parses a string body for YAML front matter and returns an associative array of the extracted metadata.
  *
  * @param string $body The string containing the content with optional YAML front matter delimited by '---'.
- * @return array An associative array of parsed YAML metadata. Returns an empty array if the YAML is invalid or absent.
+ * @return array<int|string, mixed> An associative array of parsed YAML metadata. Returns an empty array if the YAML is invalid or absent.
  */
 function parse_matter(string $body): array
 {
@@ -163,8 +163,8 @@ function parse_matter(string $body): array
  * sequence indices) are left untouched. When two source keys normalise to the
  * same canonical key, the later one wins.
  *
- * @param array $matter The parsed front matter.
- * @return array The front matter with canonicalised keys.
+ * @param array<int|string, mixed> $matter The parsed front matter.
+ * @return array<int|string, mixed> The front matter with canonicalised keys.
  */
 function normalize_matter_keys(array $matter): array
 {
@@ -204,7 +204,7 @@ function inject_title_matter(string $body, string $title): string
 
 function slugify(string $text): string
 {
-    return strtolower(preg_replace('/\W+/m', "-", $text));
+    return strtolower(preg_replace('/\W+/m', "-", $text) ?? $text);
 }
 
 /**
@@ -357,7 +357,7 @@ function finalize_slug(OODBBean $bean): bool
  * inline tag renderer (Lamb\parse_tags).
  *
  * @param string $tag The tag to match.
- * @return array{sql: string, params: array}
+ * @return array{sql: string, params: array<int, string>}
  */
 function get_tag_search_conditions(string $tag): array
 {
@@ -388,7 +388,7 @@ function body_has_tag(string $tag, string $body): bool
  *
  * @param string $tag The tag to search for within post content.
  *
- * @return array An array of posts that match the specified tag.
+ * @return list<\RedBeanPHP\OODBBean> An array of posts that match the specified tag.
  */
 function posts_by_tag(string $tag): array
 {

--- a/src/response.php
+++ b/src/response.php
@@ -20,7 +20,7 @@ define('LOGIN_PASSWORD', getenv("LAMB_LOGIN_PASSWORD") ?: '');
  * Returns cookie options with the given expiry timestamp.
  *
  * @param int $expires Unix timestamp for cookie expiry.
- * @return array Cookie options array.
+ * @return array<string, mixed> Cookie options array.
  */
 function get_cookie_options(int $expires): array
 {
@@ -82,8 +82,8 @@ function send_304_if_current(int $contentTs, int $configTs): void
 /**
  * Builds a SQL NOT IN clause for excluding posts by slug.
  *
- * @param array $slugs Slugs to exclude.
- * @return array{sql: string, params: array}|null Clause and params, or null when list is empty.
+ * @param list<string> $slugs Slugs to exclude.
+ * @return array{sql: string, params: list<string>}|null Clause and params, or null when list is empty.
  */
 function build_exclude_slugs_clause(array $slugs): ?array
 {
@@ -104,7 +104,7 @@ function build_exclude_slugs_clause(array $slugs): ?array
  * @param int $per_page     Items per page.
  * @param int $total_posts  Total number of matching posts.
  * @param int $offset       Row offset for the current page.
- * @return array
+ * @return array{current: int, per_page: int, total_posts: int, total_pages: int, prev_page: int|null, next_page: int|null, offset: int}
  */
 function build_pagination_meta(int $page, int $per_page, int $total_posts, int $offset): array
 {
@@ -138,9 +138,9 @@ function redirect_404(string $fallback): void
 /**
  * Responds with a 404 error page.
  *
- * @param array $_args   Unused.
+ * @param array<int, string> $_args   Unused.
  * @param bool  $use_fallback Whether to redirect to the configured fallback URL.
- * @return array An array containing the title, intro, and action of the 404 error page.
+ * @return array{title: string, intro: string, action: string} An array containing the title, intro, and action of the 404 error page.
  */
 function respond_404(array $_args = [], bool $use_fallback = false): array
 {
@@ -178,13 +178,13 @@ function redirect_uri(string $where): never
 /**
  * Upgrades the given posts by transforming the beans and storing them in the database if not already transformed.
  *
- * @param array $posts The array of posts to upgrade.
+ * @param array<int, mixed> $posts The array of posts to upgrade.
  * @return void
  */
 function upgrade_posts(array $posts): void
 {
     foreach ($posts as $bean) {
-        if ($bean === null) {
+        if (!$bean instanceof \RedBeanPHP\OODBBean) {
             continue;
         }
         if ((int)$bean->version === POST_VERSION) {
@@ -222,10 +222,10 @@ function upgrade_posts(array $posts): void
 /**
  * Paginates an in-memory array of items.
  *
- * @param array $values   Flat array of items to paginate.
+ * @param list<mixed> $values   Flat array of items to paginate.
  * @param int   $page     Current page (1-based, already clamped by caller).
  * @param int   $per_page Items per page.
- * @return array{items: array, pagination: array}
+ * @return array{items: list<mixed>, pagination: array<string, mixed>}
  */
 function paginate_array(array $values, int $page, int $per_page): array
 {
@@ -246,10 +246,10 @@ function paginate_array(array $values, int $page, int $per_page): array
  * @param string      $bean_type       RedBeanPHP bean type.
  * @param string      $order_by_clause SQL ORDER BY expression (without keyword).
  * @param string|null $where_sql       Optional WHERE clause.
- * @param array       $params          Bound parameters for the WHERE clause.
+ * @param array<int, mixed> $params    Bound parameters for the WHERE clause.
  * @param int         $page            Current page (1-based, already clamped by caller).
  * @param int         $per_page        Items per page.
- * @return array{items: array, pagination: array}
+ * @return array{items: array<int, \RedBeanPHP\OODBBean>, pagination: array<string, mixed>}
  */
 function paginate_db(string $bean_type, string $order_by_clause, ?string $where_sql, array $params, int $page, int $per_page): array
 {
@@ -283,10 +283,10 @@ function paginate_db(string $bean_type, string $order_by_clause, ?string $where_
  * @param mixed       $source          Array of items, or a bean type string for DB pagination.
  * @param string      $order_by_clause SQL ORDER BY expression (DB path only).
  * @param string|null $where_sql       Optional WHERE clause (DB path only).
- * @param array       $params          Bound parameters for the WHERE clause.
+ * @param array<int, mixed> $params    Bound parameters for the WHERE clause.
  * @param int|null    $per_page        Items per page; falls back to config when null.
  * @param int|null    $page            Current page; falls back to $_GET['page'] when null.
- * @return array{items: array, pagination: array}
+ * @return array{items: array<int, mixed>, pagination: array<string, mixed>}
  */
 function paginate_posts(mixed $source, string $order_by_clause = 'created DESC', ?string $where_sql = null, array $params = [], ?int $per_page = null, ?int $page = null): array
 {

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -18,7 +18,7 @@ use Random\RandomException;
  * If the submitted password is incorrect, it sets a flash message and redirects to the root URL.
  * If the login is successful, it sets the SESSION_LOGIN session variable to true, regenerates the session ID, and redirects to the specified URL.
  *
- * @return array
+ * @return array<string, mixed>
  * @throws RandomException
  */
 function redirect_login(): array
@@ -54,7 +54,7 @@ function redirect_login(): array
 
     $uuid = bin2hex(random_bytes(16)); // Generate a UUID
     setcookie('lamb_logged_in', $uuid, get_cookie_options(time() + 3600));
-    $where = local_redirect_target(filter_input(INPUT_POST, 'redirect_to', FILTER_SANITIZE_URL));
+    $where = local_redirect_target(filter_input(INPUT_POST, 'redirect_to', FILTER_SANITIZE_URL) ?: null);
     redirect_uri($where);
 }
 
@@ -97,7 +97,7 @@ function redirect_logout(): void
     // Expire the session cookie too, so subsequent requests are fully anonymous
     // (no session started, responses cacheable again — issue #116).
     $params = session_get_cookie_params();
-    setcookie(session_name(), '', [
+    setcookie(session_name() ?: '', '', [
         'expires'  => time() - 3600,
         'path'     => $params['path'],
         'secure'   => $params['secure'],
@@ -114,7 +114,7 @@ function redirect_logout(): void
 /**
  * Handles the settings page logic, including displaying, validating, and saving settings.
  *
- * @return array An array containing the page title and the current or updated INI configuration text.
+ * @return array<string, mixed> An array containing the page title and the current or updated INI configuration text.
  */
 function respond_settings(): array
 {

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -20,7 +20,7 @@ use const ROOT_URL;
 /**
  * Retrieves and prepares the homepage data, including paginated posts and site title.
  *
- * @return array The prepared homepage data, including posts, pagination details, and the site title.
+ * @return array<string, mixed> The prepared homepage data, including posts, pagination details, and the site title.
  */
 function respond_home(): array
 {
@@ -49,7 +49,7 @@ function respond_home(): array
 /**
  * Responds with the drafts page showing all draft posts (login required).
  *
- * @return array The drafts page data including posts and pagination.
+ * @return array<string, mixed> The drafts page data including posts and pagination.
  */
 function respond_drafts(): array
 {
@@ -66,7 +66,7 @@ function respond_drafts(): array
 /**
  * Returns paginated soft-deleted posts for the Trash view.
  *
- * @return array
+ * @return array<string, mixed>
  */
 function respond_trash(): array
 {
@@ -103,7 +103,7 @@ function count_trash(): int
 /**
  * Responds with the scheduled page showing posts dated in the future (login required).
  *
- * @return array The scheduled page data including posts and pagination.
+ * @return array<string, mixed> The scheduled page data including posts and pagination.
  */
 function respond_scheduled(): array
 {
@@ -144,7 +144,7 @@ function redirect_search(string $query): void
 /**
  * Returns the updated timestamp for the feed.
  *
- * @param array $posts List of post beans.
+ * @param array<int, \RedBeanPHP\OODBBean> $posts List of post beans.
  * @return string Date string suitable for strtotime(), falls back to current time when empty.
  */
 function get_feed_updated_date(array $posts): string
@@ -156,7 +156,7 @@ function get_feed_updated_date(array $posts): string
 /**
  * Returns the data needed to render the main Atom feed.
  *
- * @return array{posts: array, title: string, feed_url: string, updated: string}
+ * @return array{posts: array<int, \RedBeanPHP\OODBBean>, title: mixed, feed_url: string, updated: mixed}
  */
 function get_feed_data(): array
 {
@@ -213,7 +213,7 @@ function feed_cache(string $updated): void
 /**
  * Decodes and HTML-escapes the tag name from a tag-feed route's arguments.
  *
- * @param array $args Route arguments; the first element is the raw tag segment.
+ * @param array<int, string> $args Route arguments; the first element is the raw tag segment.
  * @return string The sanitised tag name.
  */
 function sanitize_tag_arg(array $args): string
@@ -230,7 +230,7 @@ function sanitize_tag_arg(array $args): string
  * view data, emit cache headers (with a conditional-GET 304 short-circuit),
  * upgrade stale posts, render, die.
  *
- * @param array       $feed_data As built by get_feed_data()/get_tag_feed_data().
+ * @param array<string, mixed> $feed_data As built by get_feed_data()/get_tag_feed_data().
  * @param string      $template  Feed template name ('feed' or 'feed_json').
  * @param string|null $feed_url  Optional feed_url override (the JSON variants).
  * @return never
@@ -278,16 +278,15 @@ function respond_feed_json(): void
  * Returns the data needed to render a tag Atom feed.
  *
  * @param string $tag The already-sanitised tag name.
- * @return array{posts: array, title: string, feed_url: string, updated: string}
+ * @return array{posts: array<int, \RedBeanPHP\OODBBean>, title: string, feed_url: string, updated: string}
  */
 function get_tag_feed_data(string $tag): array
 {
     global $config;
 
-    $all_posts = posts_by_tag($tag);
+    $posts = posts_by_tag($tag);
 
     // Sort by updated DESC and limit to 20
-    $posts = array_values($all_posts);
     usort($posts, fn($a, $b) => strtotime($b->updated) - strtotime($a->updated));
     $posts = array_slice($posts, 0, 20);
 
@@ -302,7 +301,7 @@ function get_tag_feed_data(string $tag): array
 /**
  * Responds to a tag feed request by rendering an Atom feed for posts with a specific tag.
  *
- * @param array $args An array where the first element is the tag name.
+ * @param array<int, string> $args An array where the first element is the tag name.
  * @return void
  */
 #[NoReturn]
@@ -314,7 +313,7 @@ function respond_tag_feed(array $args): void
 /**
  * Responds to a tag JSON feed request by rendering a JSON Feed for posts with a specific tag.
  *
- * @param array $args An array where the first element is the tag name.
+ * @param array<int, string> $args An array where the first element is the tag name.
  * @return void
  */
 #[NoReturn]
@@ -327,8 +326,8 @@ function respond_tag_feed_json(array $args): void
 /**
  * Responds to a search query with paginated results.
  *
- * @param array $args The first element should be the search query.
- * @return array
+ * @param array<int, string> $args The first element should be the search query.
+ * @return array<string, mixed>
  */
 function respond_search(array $args): array
 {
@@ -366,10 +365,10 @@ function respond_search(array $args): array
 /**
  * Builds the response array for search/tag results, including intro text and pagination.
  *
- * @param array $data       Base data array to enrich.
- * @param array $posts      Posts for the current page.
- * @param array $pagination Pagination metadata, as built by build_pagination_meta().
- * @return array
+ * @param array<string, mixed> $data       Base data array to enrich.
+ * @param array<int, mixed>    $posts      Posts for the current page.
+ * @param array<string, mixed> $pagination Pagination metadata, as built by build_pagination_meta().
+ * @return array<string, mixed>
  */
 function get_results(array $data, array $posts, array $pagination): array
 {
@@ -392,8 +391,8 @@ function get_results(array $data, array $posts, array $pagination): array
 /**
  * Retrieves posts tagged with the given tag and returns paginated, enriched data.
  *
- * @param array $args The first element is the tag name.
- * @return array
+ * @param array<int, string> $args The first element is the tag name.
+ * @return array<string, mixed>
  */
 function respond_tag(array $args): array
 {

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -157,7 +157,7 @@ function redirect_edited(): void
     }
 
     $contents = trim(($_POST['contents']));
-    $id = trim(filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT));
+    $id = trim(filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT) ?: '');
     if (empty($contents) || empty($id)) {
         return;
     }
@@ -218,8 +218,8 @@ function redirect_edited(): void
 /**
  * Responds with the status of a post.
  *
- * @param array $args An array containing the post ID.
- * @return array The transformed data representing the post's status.
+ * @param array<int, string> $args An array containing the post ID.
+ * @return array<string, mixed> The transformed data representing the post's status.
  */
 function respond_status(array $args): array
 {
@@ -242,8 +242,8 @@ function respond_status(array $args): array
 /**
  * Responds to an edit request, returning the post to render in the edit form.
  *
- * @param array $args The first element should be the post ID.
- * @return array
+ * @param array<int, string> $args The first element should be the post ID.
+ * @return array<string, mixed>
  */
 function respond_edit(array $args): array
 {
@@ -262,8 +262,8 @@ function respond_edit(array $args): array
 /**
  * Responds to a slug-based post request by retrieving and transforming a single post.
  *
- * @param array $args The first element is the post slug.
- * @return array The transformed post.
+ * @param array<int, string> $args The first element is the post slug.
+ * @return array<string, mixed> The transformed post.
  */
 function respond_post(array $args): array
 {

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -15,7 +15,7 @@ use const ROOT_URL;
 /**
  * Responds to an upload request by processing the uploaded files.
  *
- * @param array $_args The arguments for the upload request.
+ * @param array<int, string> $_args The arguments for the upload request.
  * @return void
  * @throws JsonException
  */
@@ -180,7 +180,7 @@ function convert_to_webp(string $src_path, string $dest_path, int $quality = 82,
 
     [$new_width, $new_height] = scaled_dimensions(imagesx($image), imagesy($image), $max_dimension);
     if ($new_width !== imagesx($image) || $new_height !== imagesy($image)) {
-        $resized = imagecreatetruecolor($new_width, $new_height);
+        $resized = imagecreatetruecolor(max(1, $new_width), max(1, $new_height));
         imagealphablending($resized, false);
         imagesavealpha($resized, true);
         imagecopyresampled($resized, $image, 0, 0, 0, 0, $new_width, $new_height, imagesx($image), imagesy($image));

--- a/src/routes.php
+++ b/src/routes.php
@@ -24,7 +24,7 @@ function register_route(bool|string $action, string $callback, mixed ...$args): 
  *
  * @param bool|string $action The action to call the callback function for.
  *
- * @return array The result of the callback function.
+ * @return array<string, mixed> The result of the callback function.
  */
 function call_route(bool|string $action): array
 {

--- a/src/theme.php
+++ b/src/theme.php
@@ -236,7 +236,7 @@ function page_intro(): string
  *
  * @param string $body       Post body Markdown text to extract hashtags from.
  * @param int    $exclude_id Post ID to exclude from results.
- * @return array Associative array with a 'posts' key containing matching OODBBean objects.
+ * @return array{posts: list<OODBBean>} Associative array with a 'posts' key containing matching OODBBean objects.
  */
 function related_posts(string $body, int $exclude_id = 0): array
 {
@@ -248,10 +248,10 @@ function related_posts(string $body, int $exclude_id = 0): array
 /**
  * Finds all posts that contain at least one of the given tags, ordered by created date descending.
  *
- * @param array $tags       List of tag strings to search for.
+ * @param list<string> $tags List of tag strings to search for.
  * @param int   $exclude_id Post ID to exclude from results (e.g. the current post).
  * @param int   $limit      Maximum number of posts to return.
- * @return array Unique OODBBean post objects matching any of the tags.
+ * @return list<OODBBean> Unique OODBBean post objects matching any of the tags.
  */
 function get_posts_by_tags(array $tags, int $exclude_id = 0, int $limit = 10): array
 {

--- a/src/theme/assets.php
+++ b/src/theme/assets.php
@@ -78,7 +78,7 @@ function rewrite_css_urls(string $css, string $base_url): string
             return "url('" . $base_url . $url . "')";
         },
         $css
-    );
+    ) ?? $css;
 }
 
 /**
@@ -92,9 +92,9 @@ function rewrite_css_urls(string $css, string $base_url): string
  */
 function minify_css(string $css): string
 {
-    $css = preg_replace('#/\*.*?\*/#s', '', $css);
-    $css = preg_replace('/\s+/', ' ', $css);
-    $css = preg_replace('/\s*([{}:;,>])\s*/', '$1', $css);
+    $css = preg_replace('#/\*.*?\*/#s', '', $css) ?? $css;
+    $css = preg_replace('/\s+/', ' ', $css) ?? $css;
+    $css = preg_replace('/\s*([{}:;,>])\s*/', '$1', $css) ?? $css;
     $css = str_replace(';}', '}', $css);
 
     return trim($css);
@@ -146,9 +146,9 @@ function asset_version(string $local_path, string $href): string
  * - 'logged_in' loaded only when the user is authenticated
  * - any other string is matched against the current $template
  *
- * @param array  $assets    Associative array: key = subdirectory condition, value = array of filenames.
+ * @param array<string, list<string>> $assets Associative array: key = subdirectory condition, value = array of filenames.
  * @param string $asset_dir Base directory for the assets.
- * @return Generator Yields asset_version($contents) => $href for each asset to load.
+ * @return Generator<string, string> Yields asset_version($contents) => $href for each asset to load.
  */
 function asset_loader(array $assets, string $asset_dir): Generator
 {

--- a/src/themes/2026/parts/_related.php
+++ b/src/themes/2026/parts/_related.php
@@ -19,7 +19,7 @@ if ($current === null) {
 
 $current_id = (int) $current->id;
 $body = (string) $current->body;
-$related = related_posts($body, $current_id)['posts'] ?? [];
+$related = related_posts($body, $current_id)['posts'];
 
 // Hide menu items from the related list.
 $related = array_values(array_filter($related, static function ($bean) {
@@ -52,7 +52,8 @@ $primary_tag = $tags[0] ?? null;
                 $title = mb_strimwidth($excerpt, 0, 90, '…');
                 $excerpt = '';
             }
-            $human = isset($bean->created) ? human_time(strtotime((string) $bean->created)) : '';
+            $created_ts = isset($bean->created) ? strtotime((string) $bean->created) : false;
+            $human = $created_ts !== false ? human_time($created_ts) : '';
             ?>
             <li class="related-item">
                 <?php if ($human !== '') : ?>

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -19,6 +19,7 @@ if (empty($data['posts'])) :
     <?php
 else :
     foreach ($data['posts'] as $bean) :
+        /** @var \RedBeanPHP\OODBBean $bean */
         if (is_menu_item($bean->is_menu_item ?? $bean->id)) :
             continue;
         endif;

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -26,7 +26,7 @@ const WEBMENTION_FETCH_TIMEOUT = 10;
  * verifies them, and persists a verified mention. Always terminates the
  * request with a plain-text response.
  *
- * @param array $_args Unused route arguments.
+ * @param array<int, string> $_args Unused route arguments.
  * @return void
  */
 #[NoReturn]
@@ -318,7 +318,7 @@ function discover_endpoint(string $html, array $link_headers, string $target_url
  */
 function rel_has_webmention(string $rel): bool
 {
-    foreach (preg_split('/\s+/', strtolower($rel)) as $token) {
+    foreach (preg_split('/\s+/', strtolower($rel)) ?: [] as $token) {
         if (trim($token, " \t\"'") === 'webmention') {
             return true;
         }
@@ -498,7 +498,7 @@ function process_outbound(?callable $fetcher = null, ?callable $sender = null, i
  * @param OODBBean $row
  * @param callable $fetcher fn(string $url): ?array{headers: string[], body: string}
  * @param callable $sender  fn(string $endpoint, string $source, string $target): int
- * @return string|null Stat bucket name, or null when the row is deferred.
+ * @return 'sent'|'failed'|'skipped'|'cancelled'|null Stat bucket name, or null when the row is deferred.
  */
 function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender): ?string
 {

--- a/src/websub.php
+++ b/src/websub.php
@@ -19,8 +19,8 @@ const WEBSUB_PING_TIMEOUT = 2;
  *
  * `websub_hubs` is a comma-separated list; most sites need just one.
  *
- * @param array|null $config Config array; defaults to the global config.
- * @return string[]
+ * @param array<string, mixed>|null $config Config array; defaults to the global config.
+ * @return list<string>
  */
 function hub_urls(?array $config = null): array
 {
@@ -41,7 +41,7 @@ function hub_urls(?array $config = null): array
  * subscribers fall back to polling if a ping is missed. The sender is
  * injectable for testing; in production it defaults to {@see send_ping}.
  *
- * @param array|null    $config Config array; defaults to the global config.
+ * @param array<string, mixed>|null $config Config array; defaults to the global config.
  * @param callable|null $sender fn(string $hub, string $topic): void.
  * @return void
  */
@@ -63,7 +63,7 @@ function ping_hub(?array $config = null, ?callable $sender = null): void
  * same eligibility rules as outbound webmentions.
  *
  * @param OODBBean      $bean   A stored post bean.
- * @param array|null    $config Config array; defaults to the global config.
+ * @param array<string, mixed>|null $config Config array; defaults to the global config.
  * @param callable|null $sender Injectable sender, see {@see ping_hub}.
  * @return void
  */


### PR DESCRIPTION
## Summary

Bumps the PHPStan level in `phpstan.neon` from **5 to 8** (the highest level that catches real null-safety bugs) and resolves all 133 errors that surfaced along the way. The baseline stays empty.

Most of the work was mechanical — adding value types to array params/returns. The rest tightened the genuine null/false-safety gaps that levels 6–8 expose.

## Changes

- **Array generics** — added `array<…>`/`list<…>`/shape annotations to every array param and return PHPStan flagged (config, front matter, pagination, MF2 properties, route args, feed data, theme helpers, etc.).
- **Null/false guards** — handled the nullable/false returns that were previously coerced silently:
  - `preg_replace`/`preg_replace_callback` → `?? $original`
  - `strtok`/`filter_input`/`session_name`/`json_encode` → `?: ''`/`?: null`
  - SimplePie `get_title()`/`get_description()` → `?? ''`
- **`upgrade_posts()`** — replaced the dead `=== null` check with an `instanceof OODBBean` guard, so it accepts and safely narrows `mixed` arrays (also skips any non-bean elements).
- **`imagecreatetruecolor()`** — clamped dimensions to `>= 1` (`int<1, max>`).
- **`process_outbound_row()`** — narrowed to a literal-union return (`'sent'|'failed'|'skipped'|'cancelled'|null`) so the caller's stats shape is preserved.
- **RedBeanPHP `Facade::find()`** — its stubs type `$sql` as `literal-string` to discourage interpolating user input. Our listing queries assemble the clause from constant SQL fragments with every value bound as a parameter, so they're safe but not a single literal. Those four call sites (and only those) are ignored in `phpstan.neon` with a documented rationale.

## Verification

- `composer analyse` → **No errors** at level 8
- `composer lint` → clean (PSR-12)
- `vendor/bin/codecept run Unit` → **917 tests, 1415 assertions, all passing**

No behavioural change intended: every new guard fires only on the error paths that were previously type-unsafe.

https://claude.ai/code/session_0175GDdArcjzESDEuES1qibP

---
_Generated by [Claude Code](https://claude.ai/code/session_0175GDdArcjzESDEuES1qibP)_