### PR TITLE
docs: explain when to set a site-wide social card

### DIFF
--- a/docs/social-embeds.md
+++ b/docs/social-embeds.md
@@ -34,6 +34,11 @@ For example, `src/og-image.png`. No configuration is needed — the file is pick
 up by convention, exactly like the [feed icon and logo]({{ site.baseurl }}{% link feeds.md %}#feed-icon-and-logo).
 A 1200×630 image is the conventional size for a social card.
 
+If your blog is mostly short text posts without images, setting a site-wide
+card is worthwhile: it gives every shared link a consistent, branded preview —
+your *blog's* identity — rather than the generic built-in card. Image posts
+still preview their own first image automatically.
+
 Lamb reads the image's real dimensions and type for the `og:image:width`,
 `og:image:height`, and `og:image:type` tags when the file is readable, so you
 don't need to declare them anywhere.


### PR DESCRIPTION
## Summary
Adds a short rationale paragraph to `docs/social-embeds.md` explaining *when* a site-wide social card is worth setting up: for blogs that are mostly short text posts without images, it gives every shared link a consistent, branded preview instead of the generic built-in Lamb card. Image posts still preview their own first image automatically.

## Verification
Confirmed against `src/theme/meta.php` `og_image()` — the selection order (embedded image → web-root `og-image.<ext>` → shipped Lamb card) matches the doc's claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)