### PR TITLE
Add opt-in diagnostic logging to the Micropub endpoint (#199)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.db
 /.docker/*.env
 /data/cache/
+/data/*.log
 /src/assets/
 /vendor/
 /src/config.ini

--- a/docs/micropub.md
+++ b/docs/micropub.md
@@ -53,6 +53,20 @@ A Micropub `h-entry` with a `content` property creates a status post (no title, 
 
 Posts created with `post-status: draft` or a future `published` date are not publicly visible, so their permalink returns a 404 to anyone who isn't logged in. Because Micropub clients open the post URL right after creating it, Lamb appends a secret preview token to the URL it returns (`?preview=…`). That link shows the unpublished post to anyone who has it — without logging in — and expires after 24 hours. The plain permalink (without the token) stays hidden until the post is published.
 
+## Troubleshooting
+
+If a client can't connect — for example it reports "something went wrong setting up your Micropub endpoint" — you can turn on diagnostic logging to see exactly what the client sent and why Lamb responded as it did.
+
+Add this to your site configuration at `/settings`:
+
+```ini
+micropub_debug = true
+```
+
+Reproduce the problem with your client, then read `data/micropub.log` (next to your `lamb.db`). Each line is one event: the incoming request (method, client `User-Agent`, whether a token was supplied), the token-verification outcome (including a `me_mismatch` reason when the token's identity doesn't match your site URL), and the response status. The bearer token itself is never written — only a non-reversible fingerprint.
+
+Comparing the log from a client that works against one that fails usually pinpoints the difference. **Turn it back off (`micropub_debug = false`) when you're done** so the log stops growing.
+
 ## How to test
 
 Visit [MicroPub Rocks](https://micropub.rocks/) and enter your site. Lamb's implementation report is available at [micropub.rocks/implementation-reports/servers/962](https://micropub.rocks/implementation-reports/servers/962/GYKIHp3O03m9vNil9Qcq).

--- a/src/config.php
+++ b/src/config.php
@@ -43,6 +43,11 @@ feeds_draft = true
 authorization_endpoint = https://indieauth.com/auth
 token_endpoint = https://tokens.indieauth.com/token
 
+;; Diagnostic logging for the Micropub endpoint. Off by default. Set to true only to
+;; debug a misbehaving client — it writes request/token-verification details (never the
+;; token itself) to data/micropub.log. Turn it back off when you are done.
+;micropub_debug = false
+
 ;; When content is not found, instead of a 404 by setting the following value the user is redirected to the same
 ;; relative path on another site.
 ;; Useful where old content is archived to an archive site, or the lamb blog is still under construction but public.

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -8,6 +8,7 @@ use Nyholm\Psr7\UploadedFile;
 use Psr\Http\Message\UploadedFileInterface;
 use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
+use Psr\Log\AbstractLogger;
 use Taproot\Micropub\MicropubAdapter;
 
 use function Lamb\add_body_tags;
@@ -122,15 +123,40 @@ class LambMicropubAdapter extends MicropubAdapter
         $endpoint = $config['token_endpoint'] ?? 'https://tokens.indieauth.com/token';
 
         $data = $this->introspectToken($token, $endpoint);
-        if ($data === null || empty($data['me'])) {
+        if ($data === null) {
+            mp_log('token_verify', [
+                'reason'   => 'introspection_failed',
+                'endpoint' => $endpoint,
+                'token'    => token_fingerprint($token),
+            ]);
+            return false;
+        }
+        if (empty($data['me'])) {
+            mp_log('token_verify', [
+                'reason' => 'no_me',
+                'token'  => token_fingerprint($token),
+            ]);
             return false;
         }
 
         if (rtrim($data['me'], '/') !== rtrim(ROOT_URL, '/')) {
+            mp_log('token_verify', [
+                'reason'   => 'me_mismatch',
+                'me'       => $data['me'],
+                'expected' => ROOT_URL,
+                'token'    => token_fingerprint($token),
+            ]);
             return false;
         }
 
         $scope = isset($data['scope']) ? explode(' ', $data['scope']) : [];
+
+        mp_log('token_verify', [
+            'reason' => 'ok',
+            'me'     => $data['me'],
+            'scope'  => $scope,
+            'token'  => token_fingerprint($token),
+        ]);
 
         return [
             'me'    => $data['me'],
@@ -161,16 +187,26 @@ class LambMicropubAdapter extends MicropubAdapter
         ]);
 
         if ($result === null) {
+            mp_log('introspect', ['endpoint' => $endpoint, 'reason' => 'fetch_failed']);
             return null;
         }
 
         $statusLine = $result['headers'][0] ?? '';
         if (!str_contains($statusLine, ' 200 ')) {
+            mp_log('introspect', ['endpoint' => $endpoint, 'reason' => 'non_200', 'status' => trim($statusLine)]);
             return null;
         }
 
         $data = json_decode($result['body'], true);
-        return is_array($data) ? $data : null;
+        if (!is_array($data)) {
+            mp_log('introspect', ['endpoint' => $endpoint, 'reason' => 'bad_json']);
+            return null;
+        }
+
+        // Log only the response's keys (e.g. me, scope, client_id) — never the values,
+        // which can echo the token on some endpoints.
+        mp_log('introspect', ['endpoint' => $endpoint, 'reason' => 'ok', 'keys' => array_keys($data)]);
+        return $data;
     }
 
     /**
@@ -638,6 +674,89 @@ class LambMicropubAdapter extends MicropubAdapter
 }
 
 /**
+ * A minimal PSR-3 logger that funnels the taproot adapter's own trace into mp_log().
+ *
+ * Wired into the adapter's $logger (only when micropub_debug is on), so its
+ * info/warning/error messages — token verification, query handling, error
+ * responses — land in the same file as Lamb's own diagnostic log points. An
+ * anonymous class keeps micropub.php to a single named class (PSR1).
+ */
+function mp_adapter_logger(): \Psr\Log\LoggerInterface
+{
+    return new class extends AbstractLogger {
+        /**
+         * @param mixed              $level
+         * @param string|\Stringable $message
+         * @param array<mixed>       $context
+         */
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+            mp_log('adapter', ['level' => (string) $level, 'message' => (string) $message] + $context);
+        }
+    };
+}
+
+/**
+ * Whether opt-in Micropub diagnostic logging is enabled (config key `micropub_debug`).
+ * Off by default and for any non-truthy value, so no token/PII is ever written unless
+ * the operator explicitly turns it on at /settings to debug a client.
+ */
+function mp_debug_enabled(): bool
+{
+    global $config;
+    $value = $config['micropub_debug'] ?? false;
+    if (is_bool($value)) {
+        return $value;
+    }
+    return in_array(strtolower(trim((string) $value)), ['1', 'true', 'yes', 'on'], true);
+}
+
+/**
+ * Path of the Micropub diagnostic log. Lives next to the SQLite DB in data/.
+ * Overridable via $GLOBALS['lamb_mp_log_path'] for tests.
+ */
+function mp_log_path(): string
+{
+    if (!empty($GLOBALS['lamb_mp_log_path'])) {
+        return (string) $GLOBALS['lamb_mp_log_path'];
+    }
+    return ROOT_DIR . '/../data/micropub.log';
+}
+
+/**
+ * Append one diagnostic event to the Micropub log. No-op unless micropub_debug is on.
+ *
+ * The token itself is never passed in here — callers log token_fingerprint() instead.
+ *
+ * @param string       $event   Short event name (e.g. 'request', 'token_verify', 'response').
+ * @param array<mixed> $context Structured fields to record alongside the event.
+ */
+function mp_log(string $event, array $context = []): void
+{
+    if (!mp_debug_enabled()) {
+        return;
+    }
+
+    $line = json_encode(
+        ['ts' => \Lamb\now(), 'event' => $event] + $context,
+        JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+    ) ?: '';
+    @file_put_contents(mp_log_path(), $line . PHP_EOL, FILE_APPEND | LOCK_EX);
+}
+
+/**
+ * Non-reversible fingerprint of a bearer token: enough to correlate the same token
+ * across log lines without ever writing the secret itself.
+ */
+function token_fingerprint(string $token): string
+{
+    if ($token === '') {
+        return 'empty';
+    }
+    return 'len=' . strlen($token) . ' sha256=' . substr(hash('sha256', $token), 0, 12);
+}
+
+/**
  * Route handler for GET/POST /micropub.
  * Builds a PSR-7 request from globals, delegates to LambMicropubAdapter,
  * emits the response and exits — same pattern as respond_feed.
@@ -688,10 +807,32 @@ function respond_micropub(): void
         $request = $request->withUploadedFiles($psr7Files);
     }
 
-    $adapter  = new LambMicropubAdapter();
+    $lcHeaders = array_change_key_case($headers, CASE_LOWER);
+    mp_log('request', [
+        'method'          => $request->getMethod(),
+        'uri'             => (string) $request->getUri(),
+        'q'               => $request->getQueryParams()['q'] ?? null,
+        'content_type'    => $lcHeaders['content-type'] ?? null,
+        'user_agent'      => $lcHeaders['user-agent'] ?? null,
+        'has_auth_header' => isset($lcHeaders['authorization']),
+        'has_body_token'  => isset($_POST['access_token']),
+        'body_len'        => $rawBody !== null ? strlen($rawBody) : 0,
+    ]);
+
+    $adapter = new LambMicropubAdapter();
+    if (mp_debug_enabled()) {
+        $adapter->logger = mp_adapter_logger();
+    }
     $response = $adapter->handleRequest($request);
 
-    http_response_code($response->getStatusCode());
+    $status = $response->getStatusCode();
+    mp_log('response', [
+        'status' => $status,
+        // Only echo the body into the log on failures — it carries the error reason.
+        'body'   => $status >= 400 ? substr((string) $response->getBody(), 0, 300) : null,
+    ]);
+
+    http_response_code($status);
     foreach ($response->getHeaders() as $name => $values) {
         foreach ($values as $value) {
             header("$name: $value", false);
@@ -714,6 +855,7 @@ function respond_micropub(): void
  */
 function micropub_error(int $status, string $error, string $description): never
 {
+    mp_log('response', ['status' => $status, 'error' => $error, 'error_description' => $description]);
     http_response_code($status);
     header('Content-Type: application/json');
     echo json_encode(['error' => $error, 'error_description' => $description]);
@@ -730,6 +872,15 @@ function respond_micropub_media(): void
 {
     $headers = getallheaders() ?: [];
     $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
+    $lcHeaders = array_change_key_case($headers, CASE_LOWER);
+
+    mp_log('media_request', [
+        'method'          => $_SERVER['REQUEST_METHOD'] ?? null,
+        'content_type'    => $lcHeaders['content-type'] ?? null,
+        'user_agent'      => $lcHeaders['user-agent'] ?? null,
+        'has_auth_header' => $authHeader !== '',
+        'has_file'        => !empty($_FILES['file']),
+    ]);
 
     $token = null;
     if (preg_match('/^Bearer\s+(.+)$/i', $authHeader, $m)) {
@@ -741,6 +892,9 @@ function respond_micropub_media(): void
     }
 
     $adapter = new LambMicropubAdapter();
+    if (mp_debug_enabled()) {
+        $adapter->logger = mp_adapter_logger();
+    }
     $user = $adapter->verifyAccessTokenCallback($token);
     if (!$user) {
         micropub_error(401, 'unauthorized', 'Invalid or expired token.');

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -25,6 +25,24 @@ class MicropubAdapterTest extends TestCase
         if (!defined('ROOT_DIR')) {
             define('ROOT_DIR', sys_get_temp_dir() . '/lamb_test');
         }
+
+        // Route any diagnostic logging to an isolated temp file (see mp_log_path()).
+        $path = tempnam(sys_get_temp_dir(), 'lamb_mplog_');
+        if ($path !== false) {
+            // tempnam creates the file; start each test from a clean slate.
+            @unlink($path);
+            $GLOBALS['lamb_mp_log_path'] = $path;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        global $config;
+        unset($config['micropub_debug']);
+        if (isset($GLOBALS['lamb_mp_log_path'])) {
+            @unlink($GLOBALS['lamb_mp_log_path']);
+            unset($GLOBALS['lamb_mp_log_path']);
+        }
     }
 
     // --- handleRequest ---
@@ -44,6 +62,72 @@ class MicropubAdapterTest extends TestCase
         $body = json_decode((string) $response->getBody(), true);
         $this->assertArrayHasKey('media-endpoint', $body);
         $this->assertArrayHasKey('syndicate-to', $body);
+    }
+
+    // --- diagnostic logging (micropub_debug) ---
+
+    public function testMpLogWritesWhenDebugEnabled(): void
+    {
+        global $config;
+        $config['micropub_debug'] = true;
+
+        \Lamb\Micropub\mp_log('unit_test_event', ['foo' => 'bar']);
+
+        $path = $GLOBALS['lamb_mp_log_path'];
+        $this->assertFileExists($path);
+        $contents = (string) file_get_contents($path);
+        $this->assertStringContainsString('unit_test_event', $contents);
+        $this->assertStringContainsString('bar', $contents);
+    }
+
+    public function testMpLogWritesNothingWhenDebugDisabled(): void
+    {
+        global $config;
+        $config['micropub_debug'] = false;
+
+        \Lamb\Micropub\mp_log('should_not_appear', []);
+
+        $path = $GLOBALS['lamb_mp_log_path'];
+        $this->assertFalse(
+            is_file($path) && str_contains((string) file_get_contents($path), 'should_not_appear'),
+            'mp_log must write nothing when micropub_debug is disabled'
+        );
+    }
+
+    public function testVerifyTokenLogsMeMismatchReasonWithoutLeakingToken(): void
+    {
+        global $config;
+        $config['micropub_debug'] = true;
+
+        $adapter = new StubMicropubAdapter();
+        $adapter->stubResponse = [
+            'me'    => 'https://other.example.com/',
+            'scope' => 'create',
+        ];
+        $adapter->verifyAccessTokenCallback('secret-token-value');
+
+        $contents = (string) file_get_contents($GLOBALS['lamb_mp_log_path']);
+        $this->assertStringContainsString('me_mismatch', $contents);
+        $this->assertStringContainsString('https://other.example.com/', $contents);
+        $this->assertStringContainsString(ROOT_URL, $contents);
+        $this->assertStringNotContainsString('secret-token-value', $contents);
+    }
+
+    public function testVerifyTokenLogsOkReasonWithScope(): void
+    {
+        global $config;
+        $config['micropub_debug'] = true;
+
+        $adapter = new StubMicropubAdapter();
+        $adapter->stubResponse = [
+            'me'    => ROOT_URL . '/',
+            'scope' => 'create update',
+        ];
+        $adapter->verifyAccessTokenCallback('valid-jwt');
+
+        $contents = (string) file_get_contents($GLOBALS['lamb_mp_log_path']);
+        $this->assertStringContainsString('"reason":"ok"', $contents);
+        $this->assertStringContainsString('create', $contents);
     }
 
     // --- verifyAccessTokenCallback ---


### PR DESCRIPTION
## Summary
micro.blog can't set up vandragt.com as a Micropub endpoint ("sorry, something went wrong setting up your Micropub endpoint") even though the **same IndieAuth → token → Micropub flow works with iA Writer**. The endpoint had **no logging**, so there was no way to see what micro.blog actually sends or why Lamb rejects it — every token-verification branch returned silently.

This adds a config-gated diagnostic log so the operator can flip it on, reproduce the micro.blog setup, and compare the trace against the working iA Writer trace. **Observation only — no behavioural change to the endpoint.**

## What it logs
Enable with `micropub_debug = true` at `/settings` (default off). One JSON line per event to `data/micropub.log`:
- **request** — method, `q`, Content-Type, `User-Agent` (identifies the client), whether a token was supplied, body size
- **token_verify** — outcome with an explicit `reason`: `introspection_failed` / `no_me` / `me_mismatch` (logs the offending `me` vs the expected site URL — the classic micro.blog cause) / `ok` (+ scope). The previously combined null/no-me branch is split so each silent path logs a distinct reason.
- **introspect** — token endpoint, status line, response **keys** (never values)
- **response** — status code (+ body snippet / error code on failures)
- the taproot adapter's own PSR-3 trace, via an anonymous logger wired only when debug is on

The bearer **token is never written** — only a non-reversible fingerprint (`len` + sha256 prefix). Off by default ⇒ `NullLogger` and zero overhead.

## Tests
Red-green TDD; 4 new unit tests in `MicropubAdapterTest` (writes when on / nothing when off / `me_mismatch` reason without leaking the token / `ok` + scope). Full suite green (921 tests), `composer lint` + `composer analyse` clean.

## Notes
This is a diagnostic aid, not a fix — Lamb's Micropub passes micropub.rocks and works with iA Writer, so the bug may be on micro.blog's side. The real end-to-end step is enabling the flag on the live site and capturing the micro.blog trace.

Closes nothing yet — keeps #199 open until the captured logs identify the divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)