### PR TITLE
Add minimal modal to view images wider than the content area (#382)

### DIFF
--- a/src/scripts/image-modal.js
+++ b/src/scripts/image-modal.js
@@ -1,0 +1,66 @@
+/**
+ * Lets readers view post images larger than the content column at full size.
+ *
+ * Only images that the layout actually shrinks (natural width wider than the
+ * rendered width) get a clickable affordance; clicking opens a native <dialog>
+ * showing the image sized to the viewport. Escape, a backdrop click, or a click
+ * on the image dismisses it.
+ *
+ * Depends on shorthand.js ($$, onLoaded, cancel), which loads first.
+ *
+ * @return {void}
+ */
+onLoaded(() => {
+    const style = document.createElement('style')
+    style.textContent = `
+        img.zoomable { cursor: zoom-in; }
+        dialog.image-modal { border: 0; padding: 0; background: transparent; max-width: 100vw; max-height: 100vh; }
+        dialog.image-modal img { max-width: 95vw; max-height: 95vh; width: auto; height: auto; cursor: zoom-out; }
+        dialog.image-modal::backdrop { background: rgba(0, 0, 0, 0.8); }
+        @media (prefers-reduced-motion: no-preference) {
+            dialog.image-modal[open], dialog.image-modal[open]::backdrop { animation: image-modal-fade 0.15s ease-out; }
+            @keyframes image-modal-fade { from { opacity: 0; } to { opacity: 1; } }
+        }
+    `
+    document.head.appendChild(style)
+
+    const dialog = document.createElement('dialog')
+    dialog.className = 'image-modal'
+    const modalImg = document.createElement('img')
+    dialog.appendChild(modalImg)
+    document.body.appendChild(dialog)
+
+    // Clicking anywhere in the dialog (image or backdrop) closes it.
+    dialog.on('click', () => dialog.close())
+
+    /**
+     * Marks an image as zoomable when the layout renders it smaller than its
+     * natural size.
+     *
+     * @param {HTMLImageElement} img - The post-content image to check.
+     * @return {void}
+     */
+    const markIfWide = img => {
+        if (img.naturalWidth > img.clientWidth) {
+            img.classList.add('zoomable')
+        }
+    }
+
+    $$('article img').forEach(img => {
+        if (img.complete) {
+            markIfWide(img)
+        } else {
+            img.on('load', () => markIfWide(img))
+        }
+
+        img.on('click', ev => {
+            if (!img.classList.contains('zoomable')) {
+                return
+            }
+            cancel(ev)
+            modalImg.src = img.currentSrc || img.src
+            modalImg.alt = img.alt
+            dialog.showModal()
+        })
+    })
+})

--- a/src/theme/assets.php
+++ b/src/theme/assets.php
@@ -108,7 +108,7 @@ function minify_css(string $css): string
 function the_scripts(): void
 {
     $scripts = [
-        '' => ['shorthand.js'],
+        '' => ['shorthand.js', 'image-modal.js'],
         'logged_in' => ['growing-input.js', 'confirm-delete.js', 'link-edit-buttons.js', 'upload-image.js', 'paste-link.js'],
         'search' => ['search-highlight.js'],
     ];

--- a/tests/Unit/ThemeAssetsTest.php
+++ b/tests/Unit/ThemeAssetsTest.php
@@ -186,6 +186,32 @@ class ThemeAssetsTest extends TestCase
         $this->assertStringContainsString('shorthand.js', $output);
     }
 
+    public function testTheScriptsOutputsImageModalJsForAllVisitors(): void
+    {
+        unset($_SESSION[SESSION_LOGIN]);
+
+        ob_start();
+        the_scripts();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('image-modal.js', $output);
+    }
+
+    public function testTheScriptsImageModalJsUrlPointsToExistingFile(): void
+    {
+        ob_start();
+        the_scripts();
+        $output = ob_get_clean();
+
+        preg_match('/src="([^"]*image-modal\.js[^"]*)"/', $output, $m);
+        $this->assertNotEmpty($m, 'image-modal.js src attribute not found in output');
+
+        $url_path = parse_url($m[1], PHP_URL_PATH);
+        $project_src = dirname(__DIR__, 2) . '/src/';
+        $file = $project_src . ltrim($url_path, '/');
+        $this->assertFileExists($file, "Script file not found at $file — URL '$url_path' does not resolve to a real file");
+    }
+
     public function testTheScriptsOutputsScriptDeferTag(): void
     {
         ob_start();


### PR DESCRIPTION
Closes #382.

## What

Uploaded images are capped at `max-width: 100%` by every theme, so a wide screenshot or photo renders shrunk into the content column with no way to view it larger short of opening it in a new tab.

This adds a small vanilla-JS script (`src/scripts/image-modal.js`), loaded for all visitors via `the_scripts()`, that:

- marks **only** the images the layout actually downscales (`naturalWidth > clientWidth`) as zoomable (`cursor: zoom-in`);
- opens the clicked image in a native `<dialog>` sized to the viewport;
- dismisses on Escape (native), backdrop click, or a click on the image.

The script injects its own minimal styles and the single reusable `<dialog>`, so it works across the `base`, `2024` and `2026` themes with **no per-theme CSS changes**. It honours `prefers-reduced-motion` (fade only when motion is allowed) and uses the existing `shorthand.js` helpers.

In keeping with project philosophy: no library, no dependency, no config option — narrow images stay non-clickable.

## Testing

- Red-green unit tests added to `ThemeAssetsTest` asserting `image-modal.js` is emitted for all visitors and resolves to a real file. Full Unit suite green (923 tests).
- `composer lint` and `composer analyse` pass.
- Verified in a real Chromium browser: wide image is zoomable and opens the dialog; narrow image is not clickable; Escape and backdrop click close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)