### PR TITLE
Use clean path URLs for pagination; make search redirect permanent

### DIFF
--- a/src/http.php
+++ b/src/http.php
@@ -48,6 +48,28 @@ function extract_page_segment(string $uri): array
 }
 
 /**
+ * Builds the clean pagination URL for a list path at a given page.
+ *
+ * The inverse of extract_page_segment(): strips any existing trailing
+ * `/page/N` off the path, then appends `/page/N` for page 2 onwards. Page 1
+ * is the bare base path (the homepage collapses to `/`), so the first page has
+ * a single canonical URL with no page segment.
+ *
+ * @param string $path The list path (may itself carry a `/page/N` suffix).
+ * @param int    $page The target page number.
+ * @return string The clean pagination URL.
+ */
+function page_path(string $path, int $page): string
+{
+    $base = rtrim((string)preg_replace('#/page/\d+/?$#', '', $path), '/');
+    if ($page <= 1) {
+        return $base === '' ? '/' : $base;
+    }
+
+    return $base . '/page/' . $page;
+}
+
+/**
  * Sanitises a value bound for a `Location:` header.
  *
  * Any request-derived value interpolated into a redirect target (the request

--- a/src/http.php
+++ b/src/http.php
@@ -24,6 +24,30 @@ function get_request_uri(): string|false
 }
 
 /**
+ * Splits a trailing `/page/<N>` pagination segment off a request path.
+ *
+ * Clean pagination URLs append `/page/N` to whatever list path they paginate
+ * (`/page/2`, `/tag/foo/page/2`, `/search/foo/page/2`, …). Stripping it here,
+ * before the router segments the path, lets every list responder keep routing
+ * on its base path while the page number is fed into the normal `$_GET['page']`
+ * pagination path. A bare `/page/N` collapses to `/home`.
+ *
+ * @param string $uri The request path (no query string).
+ * @return array{0: string, 1: int|null} The page-stripped path and the page
+ *                                        number, or the original path and null
+ *                                        when no numeric page segment is present.
+ */
+function extract_page_segment(string $uri): array
+{
+    if (preg_match('#^(.*)/page/(\d+)/?$#', $uri, $matches) === 1) {
+        $path = $matches[1] === '' ? '/home' : $matches[1];
+        return [$path, max(1, (int)$matches[2])];
+    }
+
+    return [$uri, null];
+}
+
+/**
  * Sanitises a value bound for a `Location:` header.
  *
  * Any request-derived value interpolated into a redirect target (the request

--- a/src/index.php
+++ b/src/index.php
@@ -46,10 +46,8 @@ if (in_array($method, ['GET', 'HEAD'], true)) {
     if (isset($query_params['page'])) {
         $page_num = max(1, (int)$query_params['page']);
         unset($query_params['page']);
-        $clean_path = rtrim((string)strtok($_SERVER['REQUEST_URI'] ?? '/', '?'), '/');
-        $target = $page_num <= 1
-            ? ($clean_path === '' ? '/' : $clean_path)
-            : $clean_path . '/page/' . $page_num;
+        $clean_path = (string)strtok($_SERVER['REQUEST_URI'] ?? '/', '?');
+        $target = Http\page_path($clean_path, $page_num);
         $remaining = http_build_query($query_params);
         if ($remaining !== '') {
             $target .= '?' . $remaining;

--- a/src/index.php
+++ b/src/index.php
@@ -31,6 +31,34 @@ header('Link: <' . $config['token_endpoint'] . '>; rel="token_endpoint"', false)
 
 # Routing
 $request_uri = Http\get_request_uri();
+
+# Strip a trailing /page/N pagination segment so list routes keep routing on
+# their base path; the page number flows through the normal $_GET['page'] path.
+[$request_uri, $page_from_path] = Http\extract_page_segment((string)$request_uri);
+if ($page_from_path !== null) {
+    $_GET['page'] = $page_from_path;
+}
+
+# Legacy ?page=N links → permanent redirect to the clean /…/page/N URL.
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if (in_array($method, ['GET', 'HEAD'], true)) {
+    parse_str($_SERVER['QUERY_STRING'] ?? '', $query_params);
+    if (isset($query_params['page'])) {
+        $page_num = max(1, (int)$query_params['page']);
+        unset($query_params['page']);
+        $clean_path = rtrim((string)strtok($_SERVER['REQUEST_URI'] ?? '/', '?'), '/');
+        $target = $page_num <= 1
+            ? ($clean_path === '' ? '/' : $clean_path)
+            : $clean_path . '/page/' . $page_num;
+        $remaining = http_build_query($query_params);
+        if ($remaining !== '') {
+            $target .= '?' . $remaining;
+        }
+        header('Location: ' . Http\sanitize_location($target), true, 301);
+        exit;
+    }
+}
+
 $action = strtok($request_uri, '/');
 $lookup = strtok('/');
 $sublookup = strtok('/');

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -137,7 +137,7 @@ function count_scheduled(): int
 function redirect_search(string $query): void
 {
     $location = \Lamb\Http\sanitize_location("/search/$query");
-    header("Location: $location");
+    header("Location: $location", true, 301);
     die();
 }
 

--- a/src/themes/base/parts/_pagination.php
+++ b/src/themes/base/parts/_pagination.php
@@ -12,16 +12,17 @@ if (!empty($pagination)) :
         return;
     }
 
-    // Parse current request URI and preserve other query params
+    // Derive the base list path from the current request, stripping any existing
+    // /page/N segment and the legacy ?page= query so links stay clean paths.
     $uri = $_SERVER['REQUEST_URI'] ?? '/';
-    $parts = parse_url($uri);
-    parse_str($parts['query'] ?? '', $qs);
+    $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+    $base = rtrim((string)preg_replace('#/page/\d+/?$#', '', $path), '/');
 
-    $build_url = static function (int $page) use ($parts, $qs): string {
-        $qs['page'] = $page;
-        $query = http_build_query($qs);
-        $path = $parts['path'] ?? '/';
-        return $path . ($query ? '?' . $query : '');
+    $build_url = static function (int $page) use ($base): string {
+        if ($page <= 1) {
+            return $base === '' ? '/' : $base;
+        }
+        return $base . '/page/' . $page;
     };
     ?>
     <nav class="pagination" aria-label="Pagination">

--- a/src/themes/base/parts/_pagination.php
+++ b/src/themes/base/parts/_pagination.php
@@ -12,18 +12,13 @@ if (!empty($pagination)) :
         return;
     }
 
-    // Derive the base list path from the current request, stripping any existing
-    // /page/N segment and the legacy ?page= query so links stay clean paths.
+    // Pagination links are clean paths: derive the list path from the current
+    // request (dropping any /page/N suffix and the legacy ?page= query) and let
+    // Http\page_path() build each page's URL.
     $uri = $_SERVER['REQUEST_URI'] ?? '/';
     $path = parse_url($uri, PHP_URL_PATH) ?: '/';
-    $base = rtrim((string)preg_replace('#/page/\d+/?$#', '', $path), '/');
 
-    $build_url = static function (int $page) use ($base): string {
-        if ($page <= 1) {
-            return $base === '' ? '/' : $base;
-        }
-        return $base . '/page/' . $page;
-    };
+    $build_url = static fn(int $page): string => \Lamb\Http\page_path($path, $page);
     ?>
     <nav class="pagination" aria-label="Pagination">
         <?php if (!empty($pagination['prev_page'])) : ?>

--- a/tests/Acceptance/PaginationCest.php
+++ b/tests/Acceptance/PaginationCest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Acceptance;
+
+use Tests\Support\AcceptanceTester;
+
+/**
+ * Pagination uses clean path URLs (/page/N), not ?page= querystrings.
+ *
+ * Seeds enough posts to force a second page (posts_per_page = 2, three posts),
+ * then checks the homepage's "Older" link is a clean path and that the legacy
+ * ?page= form permanently redirects to it.
+ */
+class PaginationCest
+{
+    private function login(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', $_ENV['LAMB_TEST_PASSWORD']);
+        $I->click('Log in');
+    }
+
+    private function seedPaginatedPosts(AcceptanceTester $I): void
+    {
+        $this->login($I);
+
+        // Force a small page size so three posts span two pages.
+        $I->amOnPage('/settings');
+        $I->fillField('ini_text', "theme = base\nposts_per_page = 2\n");
+        $I->click('Save settings');
+
+        foreach (['First post', 'Second post', 'Third post'] as $body) {
+            $I->amOnPage('/');
+            $I->fillField('contents', $body);
+            $I->click('Create post');
+        }
+    }
+
+    public function homepageOlderLinkIsCleanPath(AcceptanceTester $I): void
+    {
+        $this->seedPaginatedPosts($I);
+
+        $I->amOnPage('/');
+        // The "Older" link is a clean path (/page/2), with no ?page= querystring.
+        // An exact-href match proves both: the path is right and no query is appended.
+        $I->seeElement('nav.pagination a.next[href="/page/2"]');
+    }
+
+    public function secondPageRendersViaCleanPath(AcceptanceTester $I): void
+    {
+        $this->seedPaginatedPosts($I);
+
+        // Page one holds the two newest posts.
+        $I->amOnPage('/');
+        $I->seeNumberOfElements('article', 2);
+
+        // Page two holds the remaining third post (posts_per_page = 2).
+        $I->amOnPage('/page/2');
+        $I->seeResponseCodeIs(200);
+        $I->dontSee('Fatal error');
+        $I->dontSee('Warning:');
+        $I->seeNumberOfElements('article', 1);
+    }
+
+    public function legacyPageQueryStringRedirectsToCleanPath(AcceptanceTester $I): void
+    {
+        $this->seedPaginatedPosts($I);
+
+        $I->amOnPage('/?page=2');
+        // PhpBrowser follows the 301; we should land on the clean path.
+        $I->seeCurrentUrlMatches('~/page/2$~');
+    }
+}

--- a/tests/Unit/HttpTest.php
+++ b/tests/Unit/HttpTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+use function Lamb\Http\extract_page_segment;
 use function Lamb\Http\get_request_uri;
 
 class HttpTest extends TestCase
@@ -48,5 +49,40 @@ class HttpTest extends TestCase
     {
         $_SERVER['REQUEST_URI'] = '/tag/php';
         $this->assertSame('/tag/php', get_request_uri());
+    }
+
+    public function testExtractPageSegmentFromRootPageMapsToHome(): void
+    {
+        $this->assertSame(['/home', 2], extract_page_segment('/page/2'));
+    }
+
+    public function testExtractPageSegmentFromTagPath(): void
+    {
+        $this->assertSame(['/tag/foo', 3], extract_page_segment('/tag/foo/page/3'));
+    }
+
+    public function testExtractPageSegmentFromSearchPath(): void
+    {
+        $this->assertSame(['/search/foo', 5], extract_page_segment('/search/foo/page/5'));
+    }
+
+    public function testExtractPageSegmentWithoutPageReturnsUriUnchanged(): void
+    {
+        $this->assertSame(['/tag/foo', null], extract_page_segment('/tag/foo'));
+    }
+
+    public function testExtractPageSegmentLeavesNonNumericPageAlone(): void
+    {
+        $this->assertSame(['/page/abc', null], extract_page_segment('/page/abc'));
+    }
+
+    public function testExtractPageSegmentToleratesTrailingSlash(): void
+    {
+        $this->assertSame(['/tag/foo', 2], extract_page_segment('/tag/foo/page/2/'));
+    }
+
+    public function testExtractPageSegmentClampsToAtLeastOne(): void
+    {
+        $this->assertSame(['/home', 1], extract_page_segment('/page/0'));
     }
 }

--- a/tests/Unit/HttpTest.php
+++ b/tests/Unit/HttpTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 use function Lamb\Http\extract_page_segment;
 use function Lamb\Http\get_request_uri;
+use function Lamb\Http\page_path;
 
 class HttpTest extends TestCase
 {
@@ -84,5 +85,30 @@ class HttpTest extends TestCase
     public function testExtractPageSegmentClampsToAtLeastOne(): void
     {
         $this->assertSame(['/home', 1], extract_page_segment('/page/0'));
+    }
+
+    public function testPagePathAppendsSegmentForLaterPages(): void
+    {
+        $this->assertSame('/tag/foo/page/2', page_path('/tag/foo', 2));
+    }
+
+    public function testPagePathReturnsBaseForFirstPage(): void
+    {
+        $this->assertSame('/tag/foo', page_path('/tag/foo', 1));
+    }
+
+    public function testPagePathHomeFirstPageIsRoot(): void
+    {
+        $this->assertSame('/', page_path('/', 1));
+    }
+
+    public function testPagePathHomeLaterPageHasNoBase(): void
+    {
+        $this->assertSame('/page/3', page_path('/', 3));
+    }
+
+    public function testPagePathStripsExistingPageSegment(): void
+    {
+        $this->assertSame('/tag/foo/page/4', page_path('/tag/foo/page/2', 4));
     }
 }


### PR DESCRIPTION
Closes #306.

## What

Several internal navigation URLs still leaked querystrings. This switches pagination to clean path URLs and makes the search form's bounce a permanent redirect.

### Pagination — `?page=N` → `/page/N`
- `Http\extract_page_segment()` (new, `src/http.php`) strips a trailing `/page/N` off the request path **before** routing and feeds `N` into `$_GET['page']`. Because `paginate_posts()` already falls back to `$_GET['page']`, every list responder (home, tag, search, drafts, trash, scheduled) works unchanged — no signature changes.
- `src/themes/base/parts/_pagination.php` builds clean `/…/page/N` links (page 1 → the base path). `2024`/`2026` fall back to this part.
- Legacy `?page=N` links **301-redirect** to the clean path (`src/index.php`), preserving bookmarks/SEO.

### Search — form bounce 302 → 301
- The clean `/search/<q>` route already existed; typed/linked clean URLs already worked.
- The form keeps emitting `?s=`, but `redirect_search()` now sends a **301** so `/search/<q>` is canonical. (No JS enhancement, per discussion — simplest option.)

### Out of scope (querystring is the right tool)
`?redirect_to=` on `/login`, `?text=` bookmarklet preload, `?q=config`/`?q=source` Micropub discovery — left as querystrings.

## Tests
- Unit: `extract_page_segment()` cases in `tests/Unit/HttpTest.php` (root→home, tag/search paths, no-page passthrough, non-numeric left alone, trailing slash, clamp ≥1).
- Acceptance: new `tests/Acceptance/PaginationCest.php` — clean `/page/2` "Older" link, page-2 content via clean path, and `?page=2` 301 → `/page/2`.
- Full suite green: 928 unit, 59 acceptance. `composer lint` + `composer analyse` (PHPStan 8) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)