### PR TITLE
Add GitHub-style task list checkboxes with logged-in toggling (#36)

### DIFF
--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -20,6 +20,17 @@ Permalinks for statuses are in the form of `/status/<integer>`.
 This is a status post #hello
 ```
 
+### Task lists
+
+Write GitHub-style task lists with `- [ ]` for an open item and `- [x]` for a done one:
+
+```markdown
+- [ ] buy milk
+- [x] walk the dog
+```
+
+These render as real checkboxes. When you are logged in the checkboxes are interactive: tick or untick one straight on the page and Lamb saves it as an edit, rewriting the `[ ]`/`[x]` in the post source for you. Visitors see the checkboxes as read-only.
+
 ## Page
 
 This is a status plus YAML-parsed front-matter, this is metadata and will not be rendered.

--- a/src/LambDown.php
+++ b/src/LambDown.php
@@ -44,6 +44,25 @@ class LambDown extends Parsedown
     }
 
     /**
+     * Classifies the leading task-list marker of a line.
+     *
+     * The single source of truth for what counts as a task marker, shared by
+     * block detection and list-item tagging so the two can never diverge.
+     *
+     * @param string $text The line text (leading/trailing whitespace ignored).
+     * @return bool|null True when checked (`[x] `/`[X] `), false when unchecked
+     *                   (`[ ] `), null when the line is not a task marker.
+     */
+    private function checkboxState(string $text): ?bool
+    {
+        return match (substr(trim($text), 0, 4)) {
+            '[ ] '          => false,
+            '[x] ', '[X] '  => true,
+            default         => null,
+        };
+    }
+
+    /**
      * Detects a task-list marker (`[ ] ` or `[x] `) at the start of a line.
      *
      * @param array<string, mixed> $line The current line.
@@ -52,15 +71,12 @@ class LambDown extends Parsedown
     protected function blockCheckbox($line)
     {
         $text = trim($line['text']);
-        $marker = substr($text, 0, 4);
-        if ($marker === '[ ] ') {
-            return ['handler' => 'checkboxUnchecked', 'text' => substr($text, 4)];
-        }
-        if ($marker === '[x] ' || $marker === '[X] ') {
-            return ['handler' => 'checkboxChecked', 'text' => substr($text, 4)];
+        $checked = $this->checkboxState($text);
+        if ($checked === null) {
+            return null;
         }
 
-        return null;
+        return ['checked' => $checked, 'text' => substr($text, 4)];
     }
 
     /**
@@ -83,7 +99,7 @@ class LambDown extends Parsedown
     protected function blockCheckboxComplete(array $block)
     {
         $block['element'] = [
-            'rawHtml'                => $this->{$block['handler']}($block['text']),
+            'rawHtml'                => $this->renderCheckbox($block['text'], $block['checked']),
             'allowRawHtmlInSafeMode' => true,
         ];
 
@@ -103,8 +119,7 @@ class LambDown extends Parsedown
 
         foreach ($block['element']['elements'] as &$li) {
             foreach ($li['handler']['argument'] as $text) {
-                $marker = substr(trim($text), 0, 4);
-                if ($marker === '[ ] ' || $marker === '[x] ' || $marker === '[X] ') {
+                if ($this->checkboxState($text) !== null) {
                     $li['attributes'] = ['class' => 'task-list-item'];
                     break;
                 }
@@ -116,33 +131,21 @@ class LambDown extends Parsedown
     }
 
     /**
-     * Renders an unchecked task checkbox followed by its inline-formatted label.
+     * Renders a disabled task checkbox followed by its inline-formatted label.
      *
-     * @param string $text The label text.
+     * @param string $text    The label text.
+     * @param bool   $checked Whether the box is ticked.
      * @return string The checkbox HTML.
      */
-    protected function checkboxUnchecked($text)
+    protected function renderCheckbox($text, $checked)
     {
         if ($this->markupEscaped || $this->safeMode) {
             $text = self::escape($text);
         }
 
-        return '<input type="checkbox" disabled> ' . $this->formatLabel($text);
-    }
+        $checkedAttr = $checked ? ' checked' : '';
 
-    /**
-     * Renders a checked task checkbox followed by its inline-formatted label.
-     *
-     * @param string $text The label text.
-     * @return string The checkbox HTML.
-     */
-    protected function checkboxChecked($text)
-    {
-        if ($this->markupEscaped || $this->safeMode) {
-            $text = self::escape($text);
-        }
-
-        return '<input type="checkbox" checked disabled> ' . $this->formatLabel($text);
+        return '<input type="checkbox"' . $checkedAttr . ' disabled> ' . $this->formatLabel($text);
     }
 
     /**

--- a/src/LambDown.php
+++ b/src/LambDown.php
@@ -7,6 +7,171 @@ use Parsedown;
 class LambDown extends Parsedown
 {
     /**
+     * Registers the GitHub-style task-list checkbox block.
+     *
+     * Internalised from leblanc-simon/parsedown-checkbox (which targets
+     * ParsedownExtra) and adapted for plain Parsedown. Base Parsedown has no
+     * constructor, so this does not call parent::__construct().
+     */
+    public function __construct()
+    {
+        array_unshift($this->BlockTypes['['], 'Checkbox');
+    }
+
+    /**
+     * Renders Markdown to HTML, then numbers each task-list checkbox with a
+     * zero-based `data-checkbox-index` in document order.
+     *
+     * The index is assigned in a final DOM-order pass rather than during block
+     * parsing, so the Nth rendered checkbox always maps to the Nth `[ ]`/`[x]`
+     * marker in the source — the mapping the toggle endpoint relies on.
+     *
+     * @param string $text The Markdown source.
+     * @return string The rendered HTML with indexed checkboxes.
+     */
+    public function text($text)
+    {
+        $html = parent::text($text);
+
+        $index = 0;
+        return preg_replace_callback(
+            '/<input type="checkbox"/',
+            static function (array $m) use (&$index): string {
+                return $m[0] . ' data-checkbox-index="' . $index++ . '"';
+            },
+            $html
+        ) ?? $html;
+    }
+
+    /**
+     * Detects a task-list marker (`[ ] ` or `[x] `) at the start of a line.
+     *
+     * @param array<string, mixed> $line The current line.
+     * @return array<string, mixed>|null A checkbox block, or null when not a task line.
+     */
+    protected function blockCheckbox($line)
+    {
+        $text = trim($line['text']);
+        $marker = substr($text, 0, 4);
+        if ($marker === '[ ] ') {
+            return ['handler' => 'checkboxUnchecked', 'text' => substr($text, 4)];
+        }
+        if ($marker === '[x] ' || $marker === '[X] ') {
+            return ['handler' => 'checkboxChecked', 'text' => substr($text, 4)];
+        }
+
+        return null;
+    }
+
+    /**
+     * Task checkboxes are single-line; no continuation.
+     *
+     * @param array<string, mixed> $block The current block.
+     * @return null
+     */
+    protected function blockCheckboxContinue(array $block)
+    {
+        return null;
+    }
+
+    /**
+     * Finalises a checkbox block into raw HTML.
+     *
+     * @param array<string, mixed> $block The checkbox block.
+     * @return array<string, mixed> The completed block.
+     */
+    protected function blockCheckboxComplete(array $block)
+    {
+        $block['element'] = [
+            'rawHtml'                => $this->{$block['handler']}($block['text']),
+            'allowRawHtmlInSafeMode' => true,
+        ];
+
+        return $block;
+    }
+
+    /**
+     * Adds a `task-list-item` class to list items that contain a task marker,
+     * after running base Parsedown's loose-list completion.
+     *
+     * @param array<string, mixed> $block The completed list block.
+     * @return array<string, mixed> The block with task-list classes applied.
+     */
+    protected function blockListComplete(array $block)
+    {
+        $block = parent::blockListComplete($block);
+
+        foreach ($block['element']['elements'] as &$li) {
+            foreach ($li['handler']['argument'] as $text) {
+                $marker = substr(trim($text), 0, 4);
+                if ($marker === '[ ] ' || $marker === '[x] ' || $marker === '[X] ') {
+                    $li['attributes'] = ['class' => 'task-list-item'];
+                    break;
+                }
+            }
+        }
+        unset($li);
+
+        return $block;
+    }
+
+    /**
+     * Renders an unchecked task checkbox followed by its inline-formatted label.
+     *
+     * @param string $text The label text.
+     * @return string The checkbox HTML.
+     */
+    protected function checkboxUnchecked($text)
+    {
+        if ($this->markupEscaped || $this->safeMode) {
+            $text = self::escape($text);
+        }
+
+        return '<input type="checkbox" disabled> ' . $this->formatLabel($text);
+    }
+
+    /**
+     * Renders a checked task checkbox followed by its inline-formatted label.
+     *
+     * @param string $text The label text.
+     * @return string The checkbox HTML.
+     */
+    protected function checkboxChecked($text)
+    {
+        if ($this->markupEscaped || $this->safeMode) {
+            $text = self::escape($text);
+        }
+
+        return '<input type="checkbox" checked disabled> ' . $this->formatLabel($text);
+    }
+
+    /**
+     * Inline-formats a checkbox label without double-escaping.
+     *
+     * The label has already been escaped under safe mode, so markup escaping and
+     * safe mode are toggled off around the inline pass (then restored), exactly
+     * as the upstream extension does.
+     *
+     * @param string $text The (already escaped) label text.
+     * @return string The inline-formatted label.
+     */
+    protected function formatLabel($text)
+    {
+        $markupEscaped = $this->markupEscaped;
+        $safeMode      = $this->safeMode;
+
+        $this->setMarkupEscaped(false);
+        $this->setSafeMode(false);
+
+        $text = $this->line($text);
+
+        $this->setMarkupEscaped($markupEscaped);
+        $this->setSafeMode($safeMode);
+
+        return $text;
+    }
+
+    /**
      * Determines if the given line is a valid header block in Markdown format.
      *
      * @param array<string, mixed> $Line The line to be checked.

--- a/src/index.php
+++ b/src/index.php
@@ -70,6 +70,7 @@ Route\register_route('webmention', __NAMESPACE__ . '\\Webmention\respond_webment
 Route\register_route('micropub', __NAMESPACE__ . '\\Micropub\respond_micropub');
 Route\register_route('micropub-media', __NAMESPACE__ . '\\Micropub\respond_micropub_media');
 Route\register_route('upload', __NAMESPACE__ . '\\Response\respond_upload', $lookup);
+Route\register_route('checkbox', __NAMESPACE__ . '\\Response\respond_checkbox', $lookup);
 $template = $action;
 if (post_has_slug($action) === $action) {
     Route\register_route($action, __NAMESPACE__ . '\\Response\respond_post', $action);

--- a/src/post.php
+++ b/src/post.php
@@ -349,6 +349,38 @@ function finalize_slug(OODBBean $bean): bool
 }
 
 /**
+ * Toggles the checked state of the Nth GitHub-style task-list marker in a body.
+ *
+ * Task markers are list lines of the form `- [ ] ` / `* [x] ` / `+ [X] `. They
+ * are counted in document order (the same order LambDown numbers the rendered
+ * checkboxes with `data-checkbox-index`), so the Nth rendered checkbox maps to
+ * the Nth source marker. Only the target marker's state character is rewritten;
+ * every other marker and all surrounding text is preserved verbatim. An index
+ * past the last marker returns the body unchanged.
+ *
+ * @param string $body    The raw post body.
+ * @param int    $index   Zero-based index of the marker to toggle.
+ * @param bool   $checked True to check the marker, false to uncheck it.
+ * @return string The body with the target marker toggled.
+ */
+function toggle_checkbox(string $body, int $index, bool $checked): string
+{
+    $seen = 0;
+    return preg_replace_callback(
+        '/^(\s*[-*+]\s+\[)[ xX](\]\s)/m',
+        function (array $m) use (&$seen, $index, $checked): string {
+            $state = $seen === $index ? ($checked ? 'x' : ' ') : null;
+            $seen++;
+            if ($state === null) {
+                return $m[0];
+            }
+            return $m[1] . $state . $m[2];
+        },
+        $body
+    ) ?? $body;
+}
+
+/**
  * Returns a broad SQL prefilter for posts whose body contains the given tag.
  *
  * The SQL is deliberately permissive (it also matches longer tags that share

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -15,6 +15,7 @@ use function Lamb\delete_redirect_for_slug;
 use function Lamb\parse_bean;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\populate_bean;
+use function Lamb\Post\toggle_checkbox;
 use function Lamb\Route\is_reserved_route;
 
 /**
@@ -213,6 +214,79 @@ function redirect_edited(): void
     $redirect = $_SESSION['edit-referrer'];
     unset($_SESSION['edit-referrer']);
     redirect_uri($redirect);
+}
+
+/**
+ * Toggles a GitHub-style task-list checkbox and persists it as a post edit.
+ *
+ * AJAX endpoint for the logged-in author: flips the Nth `[ ]`/`[x]` marker in
+ * the post body (the index supplied by the rendered checkbox's
+ * `data-checkbox-index`), re-parses so `transformed` reflects the new state,
+ * and bumps `updated`. Login-only, no CSRF — matching respond_upload() and the
+ * SameSite=Strict session, which already blocks cross-site POSTs. Webmention
+ * and WebSub are intentionally skipped: ticking a box is a minor edit and must
+ * not re-notify subscribers.
+ *
+ * @param array<int, string> $_args Unused route arguments.
+ * @return void
+ * @throws \JsonException
+ */
+#[NoReturn]
+function respond_checkbox(array $_args): void
+{
+    Security\require_login();
+
+    header('Content-Type: application/json');
+
+    $id      = (int) ($_POST['id'] ?? 0);
+    $index   = (int) ($_POST['index'] ?? -1);
+    $checked = filter_var($_POST['checked'] ?? false, FILTER_VALIDATE_BOOLEAN);
+
+    if (!apply_checkbox_toggle($id, $index, $checked)) {
+        header('HTTP/1.1 404 Not Found');
+        echo json_encode(['ok' => false], JSON_THROW_ON_ERROR);
+        die();
+    }
+
+    echo json_encode(['ok' => true, 'checked' => $checked], JSON_THROW_ON_ERROR);
+    die();
+}
+
+/**
+ * Toggles a task-list checkbox in a post and persists it as an edit.
+ *
+ * Loads the post, flips the Nth `[ ]`/`[x]` marker in its body, re-parses so
+ * `transformed`/`description` reflect the new state, and bumps `updated`. The
+ * testable core of respond_checkbox() (which adds auth and the JSON response).
+ *
+ * @param int  $id      The post id.
+ * @param int  $index   Zero-based checkbox index.
+ * @param bool $checked The desired checked state.
+ * @return bool True on success, false when the post is missing or the index invalid.
+ */
+function apply_checkbox_toggle(int $id, int $index, bool $checked): bool
+{
+    if ($index < 0) {
+        return false;
+    }
+
+    $bean = R::load('post', $id);
+    if (!$bean->id) {
+        return false;
+    }
+
+    $bean->body = toggle_checkbox((string) $bean->body, $index, $checked);
+    parse_bean($bean);
+    $bean->updated = \Lamb\now();
+
+    try {
+        R::store($bean);
+    } catch (SQL $e) {
+        $_SESSION['flash'][] = 'Failed to update checkbox: ' . $e->getMessage();
+        return false;
+    }
+
+    return true;
 }
 
 /**

--- a/src/scripts/logged_in/toggle-checkbox.js
+++ b/src/scripts/logged_in/toggle-checkbox.js
@@ -1,0 +1,39 @@
+onLoaded(() => {
+    for (const box of $$('input[type=checkbox][data-checkbox-index]')) {
+        box.disabled = false
+        box.on('change', () => saveCheckbox(box))
+    }
+})
+
+/**
+ * Persist a task-list checkbox toggle as a post edit.
+ *
+ * Posts the owning post id (from the nearest [data-post-id] ancestor), the
+ * checkbox's document-order index, and its new state to /checkbox. On failure
+ * the checkbox is reverted so the UI keeps matching the stored source.
+ *
+ * @param {HTMLInputElement} box
+ */
+function saveCheckbox(box) {
+    const article = box.closest('[data-post-id]')
+    if (!article) return
+
+    const checked = box.checked
+    const body = new FormData()
+    body.append('id', article.dataset.postId)
+    body.append('index', box.dataset.checkboxIndex)
+    body.append('checked', checked ? '1' : '0')
+
+    box.disabled = true
+    fetch('/checkbox', { method: 'POST', body })
+        .then(response => response.ok ? response.json() : Promise.reject(response.status))
+        .then(data => {
+            if (!data.ok) return Promise.reject('save failed')
+            box.disabled = false
+        })
+        .catch(error => {
+            console.error(error)
+            box.checked = !checked
+            box.disabled = false
+        })
+}

--- a/src/theme/assets.php
+++ b/src/theme/assets.php
@@ -109,7 +109,7 @@ function the_scripts(): void
 {
     $scripts = [
         '' => ['shorthand.js'],
-        'logged_in' => ['growing-input.js', 'confirm-delete.js', 'link-edit-buttons.js', 'upload-image.js', 'paste-link.js'],
+        'logged_in' => ['growing-input.js', 'confirm-delete.js', 'link-edit-buttons.js', 'upload-image.js', 'paste-link.js', 'toggle-checkbox.js'],
         'search' => ['search-highlight.js'],
     ];
     $assets = asset_loader($scripts, 'scripts');

--- a/src/themes/2024/parts/_items.php
+++ b/src/themes/2024/parts/_items.php
@@ -33,7 +33,7 @@ else :
 
         ?>
 
-        <article itemscope itemtype="https://schema.org/BlogPosting">
+        <article data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
             <header>
                 <?php if ($template !== 'status') : ?>
                     <?php $title = title_link($bean); ?>

--- a/src/themes/2024/styles/styles.css
+++ b/src/themes/2024/styles/styles.css
@@ -397,3 +397,12 @@ textarea {
 
 
 }
+
+/* GitHub-style task lists */
+.task-list-item {
+    list-style: none;
+}
+
+.task-list-item input[type="checkbox"] {
+    margin: 0 .4em 0 -1.4em;
+}

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -33,7 +33,7 @@ else :
 
         ?>
 
-        <article itemscope itemtype="https://schema.org/BlogPosting">
+        <article data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
             <header>
                 <?php if ($template !== 'status') : ?>
                     <?php $title = title_link($bean); ?>

--- a/src/themes/2026/styles/styles.css
+++ b/src/themes/2026/styles/styles.css
@@ -937,3 +937,12 @@ footer a:hover { color: var(--accent-link); }
         background-color: var(--phiki-dark-background-color) !important;
     }
 }
+
+/* GitHub-style task lists */
+.task-list-item {
+    list-style: none;
+}
+
+.task-list-item input[type="checkbox"] {
+    margin: 0 .4em 0 -1.4em;
+}

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -24,7 +24,7 @@ else :
             continue;
         endif;
         ?>
-        <article>
+        <article data-post-id="<?= (int) $bean->id ?>">
             <header>
                 <?php if (!empty($bean->title)) : ?>
                 <h2><?= $template !== 'status' ? title_link($bean) : escape($bean->title) ?></h2>

--- a/src/themes/base/styles/styles.css
+++ b/src/themes/base/styles/styles.css
@@ -233,3 +233,12 @@ mark {
         margin: 2em -2em 0;
     }
 }
+
+/* GitHub-style task lists */
+.task-list-item {
+    list-style: none;
+}
+
+.task-list-item input[type="checkbox"] {
+    margin: 0 .4em 0 -1.4em;
+}

--- a/tests/Unit/CheckboxTest.php
+++ b/tests/Unit/CheckboxTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Post\toggle_checkbox;
+
+class CheckboxTest extends TestCase
+{
+    public function testCheckFirstMarker(): void
+    {
+        $body = "- [ ] one\n- [ ] two\n";
+        $this->assertSame("- [x] one\n- [ ] two\n", toggle_checkbox($body, 0, true));
+    }
+
+    public function testCheckSecondMarker(): void
+    {
+        $body = "- [ ] one\n- [ ] two\n";
+        $this->assertSame("- [ ] one\n- [x] two\n", toggle_checkbox($body, 1, true));
+    }
+
+    public function testUncheckMarker(): void
+    {
+        $body = "- [x] one\n- [x] two\n";
+        $this->assertSame("- [x] one\n- [ ] two\n", toggle_checkbox($body, 1, false));
+    }
+
+    public function testOutOfRangeIndexIsNoOp(): void
+    {
+        $body = "- [ ] one\n";
+        $this->assertSame($body, toggle_checkbox($body, 5, true));
+    }
+
+    public function testOnlyTargetLineChanges(): void
+    {
+        $body = "intro text\n\n- [ ] one\n- [ ] two\n- [ ] three\n\noutro";
+        $out = toggle_checkbox($body, 1, true);
+        $this->assertSame("intro text\n\n- [ ] one\n- [x] two\n- [ ] three\n\noutro", $out);
+    }
+
+    public function testMixedMarkerCharacters(): void
+    {
+        $body = "* [ ] star\n+ [ ] plus\n- [ ] dash\n";
+        $this->assertSame("* [ ] star\n+ [x] plus\n- [ ] dash\n", toggle_checkbox($body, 1, true));
+    }
+
+    public function testUppercaseXCounted(): void
+    {
+        $body = "- [X] one\n- [ ] two\n";
+        $this->assertSame("- [X] one\n- [x] two\n", toggle_checkbox($body, 1, true));
+    }
+
+    public function testIndentedTaskMarker(): void
+    {
+        $body = "- [ ] one\n  - [ ] nested\n";
+        $this->assertSame("- [ ] one\n  - [x] nested\n", toggle_checkbox($body, 1, true));
+    }
+}

--- a/tests/Unit/LambDownTest.php
+++ b/tests/Unit/LambDownTest.php
@@ -57,4 +57,63 @@ class LambDownTest extends TestCase
         $html = $this->parser->text('Hello <b>world</b>');
         $this->assertStringNotContainsString('<b>', $html);
     }
+
+    public function testUncheckedTaskRendersDisabledCheckbox(): void
+    {
+        $html = $this->parser->text("- [ ] buy milk");
+        $this->assertStringContainsString('type="checkbox"', $html);
+        $this->assertStringContainsString('disabled', $html);
+        $this->assertStringNotContainsString('checked', $html);
+        $this->assertStringContainsString('buy milk', $html);
+        $this->assertStringNotContainsString('[ ]', $html);
+    }
+
+    public function testCheckedTaskRendersCheckedCheckbox(): void
+    {
+        $html = $this->parser->text("- [x] walk dog");
+        $this->assertStringContainsString('checked', $html);
+        $this->assertStringContainsString('disabled', $html);
+        $this->assertStringContainsString('walk dog', $html);
+        $this->assertStringNotContainsString('[x]', $html);
+    }
+
+    public function testUppercaseXIsTreatedAsChecked(): void
+    {
+        $html = $this->parser->text("- [X] done");
+        $this->assertStringContainsString('checked', $html);
+    }
+
+    public function testTaskItemsGetSequentialIndices(): void
+    {
+        $html = $this->parser->text("- [ ] a\n- [x] b\n- [ ] c");
+        $this->assertStringContainsString('data-checkbox-index="0"', $html);
+        $this->assertStringContainsString('data-checkbox-index="1"', $html);
+        $this->assertStringContainsString('data-checkbox-index="2"', $html);
+    }
+
+    public function testPlainListItemIsNotACheckbox(): void
+    {
+        $html = $this->parser->text("- normal item");
+        $this->assertStringNotContainsString('type="checkbox"', $html);
+    }
+
+    public function testTaskListItemGetsClass(): void
+    {
+        $html = $this->parser->text("- [ ] a");
+        $this->assertStringContainsString('task-list-item', $html);
+    }
+
+    public function testLooseTaskListRendersCheckbox(): void
+    {
+        $html = $this->parser->text("- [ ] a\n\n- [x] b\n");
+        $this->assertStringContainsString('type="checkbox"', $html);
+        $this->assertStringContainsString('data-checkbox-index="0"', $html);
+        $this->assertStringContainsString('data-checkbox-index="1"', $html);
+    }
+
+    public function testCheckboxLabelMarkdownIsFormatted(): void
+    {
+        $html = $this->parser->text("- [ ] read **the** docs");
+        $this->assertStringContainsString('<strong>the</strong>', $html);
+    }
 }

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\Response\apply_checkbox_toggle;
 use function Lamb\Response\redirect_created;
 use function Lamb\Response\redirect_edited;
 use function Lamb\Response\respond_edit;
@@ -207,5 +208,57 @@ class ResponsePostsTest extends TestCase
         respond_edit([$post->id]);
 
         $this->assertNull($_SESSION['edit-referrer']);
+    }
+
+    // -------------------------------------------------------------------------
+    // apply_checkbox_toggle
+    // -------------------------------------------------------------------------
+
+    public function testApplyCheckboxToggleChecksMarkerAndReparses(): void
+    {
+        $post          = R::dispense('post');
+        $post->body    = "- [ ] one\n- [ ] two\n";
+        $post->version = 1;
+        $post->created = date('Y-m-d H:i:s');
+        $post->updated = '2000-01-01 00:00:00';
+        R::store($post);
+
+        $this->assertTrue(apply_checkbox_toggle($post->id, 1, true));
+
+        $reloaded = R::load('post', $post->id);
+        $this->assertSame("- [ ] one\n- [x] two\n", $reloaded->body);
+        // Re-parsed: stored HTML reflects the new checked state.
+        $this->assertStringContainsString('checked', (string) $reloaded->transformed);
+        // Saved as an edit: updated bumped away from the seeded value.
+        $this->assertNotSame('2000-01-01 00:00:00', $reloaded->updated);
+    }
+
+    public function testApplyCheckboxToggleUnchecks(): void
+    {
+        $post          = R::dispense('post');
+        $post->body    = "- [x] done\n";
+        $post->version = 1;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $this->assertTrue(apply_checkbox_toggle($post->id, 0, false));
+
+        $this->assertSame("- [ ] done\n", R::load('post', $post->id)->body);
+    }
+
+    public function testApplyCheckboxToggleFailsForMissingPost(): void
+    {
+        $this->assertFalse(apply_checkbox_toggle(99999, 0, true));
+    }
+
+    public function testApplyCheckboxToggleFailsForNegativeIndex(): void
+    {
+        $post          = R::dispense('post');
+        $post->body    = "- [ ] one\n";
+        $post->version = 1;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $this->assertFalse(apply_checkbox_toggle($post->id, -1, true));
     }
 }


### PR DESCRIPTION
Closes #36.

## What

GitHub-style Markdown task lists:

```markdown
- [ ] buy milk
- [x] walk the dog
```

…now render as real checkboxes. A **logged-in author** can tick/untick a box directly on the page and the change is saved as an edit (the `[ ]`/`[x]` in the post source is rewritten). Anonymous visitors see the checkboxes read-only (disabled), like GitHub.

## How

- **`src/LambDown.php`** — internalises the `leblanc-simon/parsedown-checkbox` logic (no new dependency), adapted for plain `Parsedown`. Registers a `Checkbox` block, renders the input + inline-formatted label, and tags task `<li>`s with `task-list-item`. `blockListComplete()` calls `parent::` first so base loose-list handling is preserved. A `text()` override numbers each checkbox with a document-order `data-checkbox-index`.
- **`src/post.php`** — `toggle_checkbox()` flips the Nth source marker, counted in the same order LambDown numbers them.
- **`src/response/posts.php`** — new `/checkbox` AJAX handler (`respond_checkbox` + testable `apply_checkbox_toggle`): login-only (matches `respond_upload`; sessions are `SameSite=Strict`), re-parses and bumps `updated`. Skips webmention/WebSub so a tick doesn't re-notify subscribers.
- **`src/scripts/logged_in/toggle-checkbox.js`** — enables the boxes for logged-in users and posts toggles, reverting on failure.
- Themes (`base`/`2024`/`2026`): `data-post-id` on the post `<article>` + a `.task-list-item` CSS rule.
- Docs: task-list section in `docs/post-types.md`.

## Tests

Red-green TDD. New coverage in `LambDownTest`, `CheckboxTest`, and `ResponsePostsTest`. Full unit suite (941 tests), `composer lint`, and `composer analyse` (PHPStan level 8) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)