### PR TITLE
Lock body scroll while image modal is open

### DIFF
--- a/src/scripts/image-modal.js
+++ b/src/scripts/image-modal.js
@@ -33,6 +33,14 @@ onLoaded(() => {
     // Clicking anywhere in the dialog (image or backdrop) closes it.
     dialog.on('click', () => dialog.close())
 
+    // A native <dialog> does not lock the page behind it, so the content
+    // underneath the backdrop stays scrollable while the modal is open. Pin the
+    // body's overflow while the modal is shown and restore it on close (covers
+    // Escape, backdrop click, and image click alike).
+    dialog.on('close', () => {
+        document.body.style.overflow = ''
+    })
+
     /**
      * Marks an image as zoomable when the layout renders it smaller than its
      * natural size.
@@ -60,6 +68,7 @@ onLoaded(() => {
             cancel(ev)
             modalImg.src = img.currentSrc || img.src
             modalImg.alt = img.alt
+            document.body.style.overflow = 'hidden'
             dialog.showModal()
         })
     })


### PR DESCRIPTION
## Summary

When an image is opened in the new image modal, the content underneath the backdrop could still be scrolled. A native `<dialog>` opened with `showModal()` darkens the page behind it but does **not** lock the underlying page scroll, so wheel/touch scrolling leaked through to the article.

This pins `document.body` overflow to `hidden` when the modal opens and restores it on the dialog's `close` event. Routing the restore through `close` means every dismissal path is covered — Escape, backdrop click, and image click all fire `close`.

## Changes

- `src/scripts/image-modal.js`: set `body` overflow to `hidden` before `showModal()`, restore it on the dialog `close` event.

## Testing

The image modal is browser-side JS with no JS test harness in the repo. Verified manually by reasoning through the dismissal paths; all three (Escape, backdrop click, image click) go through `dialog.close()`/`close`, restoring scroll.

https://claude.ai/code/session_01TkhvGbTBmcWkMYZRoUbWsS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkhvGbTBmcWkMYZRoUbWsS)_