### PR TITLE
Add JavaScript unit test infrastructure (#392)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,27 @@ jobs:
         if: matrix.php-version == '8.2'
         run: composer coverage
 
+  # Client-side JavaScript unit tests (node:test + jsdom). Fast and
+  # dependency-light, so it always runs and feeds the aggregate `ci` gate.
+  js-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run JS tests
+        run: pnpm test
+
   # Browser end-to-end suite. Only runs when e2e-relevant files change
   # (see the `changes` job); otherwise it is skipped and the gate below
   # treats that as a pass.
@@ -152,16 +173,17 @@ jobs:
   # passing — which would let a red PR merge.
   ci:
     runs-on: ubuntu-latest
-    needs: [quality, test, playwright]
+    needs: [quality, test, js-test, playwright]
     if: always()
     steps:
       - name: Verify required jobs succeeded
         run: |
           echo "quality:    ${{ needs.quality.result }}"
           echo "test:       ${{ needs.test.result }}"
+          echo "js-test:    ${{ needs.js-test.result }}"
           echo "playwright: ${{ needs.playwright.result }}"
-          if [ "${{ needs.quality.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ]; then
-            echo "::error::quality or test did not succeed"
+          if [ "${{ needs.quality.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.js-test.result }}" != "success" ]; then
+            echo "::error::quality, test or js-test did not succeed"
             exit 1
           fi
           # playwright is skipped on PRs that don't touch e2e-relevant paths;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,9 @@ vendor/bin/codecept run Unit
 # Run acceptance tests (requires SITE_URL in .env)
 vendor/bin/codecept run Acceptance
 
+# Run client-side JavaScript unit tests (node:test + jsdom)
+pnpm test
+
 # Generate password hash and write .env
 php make-password.php <your-password>
 
@@ -455,6 +458,12 @@ Tests use **Codeception 5** with PHPUnit underneath.
 - **Functional** (`tests/Functional/`): Codeception functional tests.
 
 Config in `codeception.yml` reads env from `.env`.
+
+### JavaScript unit tests
+
+Client-side scripts in `src/scripts/` are unit-tested with Node's built-in test runner (`node:test`) plus `jsdom` — no extra framework. Run them with `pnpm test` (`node --test "tests/js/**/*.test.mjs"`); CI runs the same via the `js-test` job.
+
+The scripts ship as plain `<script>`-tag globals (no module exports), so tests don't import them. Instead `tests/js/helpers.mjs` (`loadScripts()`) concatenates the source(s), evaluates them inside a `jsdom` window (`runScripts: 'outside-only'`), and returns the requested globals — keeping the shipped files untouched. Handlers registered via `onLoaded` (DOMContentLoaded) attach only after you dispatch a `DOMContentLoaded` event, since jsdom finishes parsing before the eval. See `tests/js/paste-link.test.mjs` for the pattern (faking a `paste` event with `clipboardData.getData`).
 
 ### Red-Green TDD
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "jsdom": "^29.1.1"
   },
   "scripts": {
-    "screenshot": "pnpm exec node scripts/screenshot.mjs"
+    "screenshot": "pnpm exec node scripts/screenshot.mjs",
+    "test": "node --test \"tests/js/**/*.test.mjs\""
   }
 }

--- a/tests/js/helpers.mjs
+++ b/tests/js/helpers.mjs
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { JSDOM } from 'jsdom'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const SCRIPTS_DIR = resolve(here, '../../src/scripts')
+
+/**
+ * Load one or more client-side scripts into a fresh jsdom window and return the
+ * globals they declare.
+ *
+ * The scripts in src/scripts/ ship as plain <script>-tag globals (no module
+ * exports), so we concatenate their sources, evaluate them inside the window,
+ * and return the requested bindings — keeping the shipped files untouched.
+ *
+ * @param {object}   opts
+ * @param {string[]} opts.files   Script paths relative to src/scripts/.
+ * @param {string[]} [opts.expose] Names of globals to return from the scripts.
+ * @param {string}   [opts.html]  Initial document HTML.
+ * @returns {{ dom: import('jsdom').JSDOM, window: Window, document: Document, api: Record<string, any> }}
+ */
+export function loadScripts({ files, expose = [], html = '<!DOCTYPE html><html><body></body></html>' }) {
+  const dom = new JSDOM(html, {
+    url: 'https://example.com/',
+    pretendToBeVisual: true,
+    runScripts: 'outside-only', // enables window.eval with DOM globals in scope
+  })
+  const source = files
+    .map((file) => readFileSync(resolve(SCRIPTS_DIR, file), 'utf8'))
+    .join('\n;\n')
+  const wrapped = `(function () {\n${source}\n;return { ${expose.join(', ')} };\n})()`
+  const api = dom.window.eval(wrapped)
+  return { dom, window: dom.window, document: dom.window.document, api }
+}
+
+/**
+ * Build a fake `paste` event whose clipboardData.getData returns `byType`
+ * values, mirroring what the paste-link handler reads.
+ *
+ * @param {Window} window
+ * @param {Record<string, string>} byType  e.g. { 'text/plain': 'https://x' }
+ * @returns {Event}
+ */
+export function pasteEvent(window, byType) {
+  const ev = new window.Event('paste', { bubbles: true, cancelable: true })
+  ev.clipboardData = { getData: (type) => byType[type] ?? '' }
+  return ev
+}

--- a/tests/js/paste-link.test.mjs
+++ b/tests/js/paste-link.test.mjs
@@ -1,0 +1,86 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadScripts, pasteEvent } from './helpers.mjs'
+
+/**
+ * Load shorthand + paste-link and fire DOMContentLoaded so the paste handler
+ * attaches (jsdom has already finished parsing by the time we evaluate).
+ */
+function setup(html = '<!DOCTYPE html><body><textarea></textarea></body>') {
+  const ctx = loadScripts({
+    files: ['shorthand.js', 'logged_in/paste-link.js'],
+    expose: ['isUrl'],
+    html,
+  })
+  ctx.document.dispatchEvent(new ctx.window.Event('DOMContentLoaded'))
+  return ctx
+}
+
+test('isUrl accepts http(s) URLs', () => {
+  const { api } = setup()
+  assert.ok(api.isUrl('https://example.com'))
+  assert.ok(api.isUrl('http://example.com/path?q=1#frag'))
+})
+
+test('isUrl rejects non-URLs, whitespace and non-http schemes', () => {
+  const { api } = setup()
+  const rejects = [
+    '',
+    '   ',
+    'not a url',
+    'hello world',
+    'example.com',            // no scheme
+    'https://ex ample.com',   // internal whitespace
+    'ftp://example.com',      // non-http scheme
+    'mailto:a@b.com',
+    'javascript:alert(1)',
+  ]
+  for (const value of rejects) {
+    assert.equal(api.isUrl(value), false, `expected ${JSON.stringify(value)} to be rejected`)
+  }
+})
+
+test('pasting a URL over a selection wraps it in a markdown link', () => {
+  const { window, document } = setup()
+  const ta = document.querySelector('textarea')
+  ta.value = 'see this site'
+  ta.setSelectionRange(4, 8) // "this"
+  ta.dispatchEvent(pasteEvent(window, { 'text/plain': 'https://example.com' }))
+  assert.equal(ta.value, 'see [this](https://example.com) site')
+})
+
+test('falls back to getData("text") when text/plain is empty (iOS Safari)', () => {
+  const { window, document } = setup()
+  const ta = document.querySelector('textarea')
+  ta.value = 'see this site'
+  ta.setSelectionRange(4, 8)
+  ta.dispatchEvent(pasteEvent(window, { 'text/plain': '', text: 'https://example.com' }))
+  assert.equal(ta.value, 'see [this](https://example.com) site')
+})
+
+test('the pasted URL is trimmed before being wrapped', () => {
+  const { window, document } = setup()
+  const ta = document.querySelector('textarea')
+  ta.value = 'see this site'
+  ta.setSelectionRange(4, 8)
+  ta.dispatchEvent(pasteEvent(window, { 'text/plain': '  https://example.com  ' }))
+  assert.equal(ta.value, 'see [this](https://example.com) site')
+})
+
+test('pasting a non-URL leaves the textarea untouched', () => {
+  const { window, document } = setup()
+  const ta = document.querySelector('textarea')
+  ta.value = 'see this site'
+  ta.setSelectionRange(4, 8)
+  ta.dispatchEvent(pasteEvent(window, { 'text/plain': 'just text' }))
+  assert.equal(ta.value, 'see this site')
+})
+
+test('pasting with no selection does nothing', () => {
+  const { window, document } = setup()
+  const ta = document.querySelector('textarea')
+  ta.value = 'abc'
+  ta.setSelectionRange(1, 1) // collapsed caret
+  ta.dispatchEvent(pasteEvent(window, { 'text/plain': 'https://example.com' }))
+  assert.equal(ta.value, 'abc')
+})

--- a/tests/js/shorthand.test.mjs
+++ b/tests/js/shorthand.test.mjs
@@ -1,0 +1,62 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadScripts } from './helpers.mjs'
+
+test('$ returns the first matching element', () => {
+  const { api } = loadScripts({
+    files: ['shorthand.js'],
+    expose: ['$'],
+    html: '<!DOCTYPE html><body><p class="x">a</p><p class="x">b</p></body>',
+  })
+  assert.equal(api.$('.x').textContent, 'a')
+})
+
+test('$ returns null when nothing matches', () => {
+  const { api } = loadScripts({ files: ['shorthand.js'], expose: ['$'] })
+  assert.equal(api.$('.missing'), null)
+})
+
+test('$$ returns every matching element', () => {
+  const { api } = loadScripts({
+    files: ['shorthand.js'],
+    expose: ['$$'],
+    html: '<!DOCTYPE html><body><p class="x"></p><p class="x"></p><p class="x"></p></body>',
+  })
+  assert.equal(api.$$('.x').length, 3)
+})
+
+test('cancel prevents default and stops propagation', () => {
+  const { api } = loadScripts({ files: ['shorthand.js'], expose: ['cancel'] })
+  let prevented = false
+  let stopped = false
+  api.cancel({
+    preventDefault: () => { prevented = true },
+    stopPropagation: () => { stopped = true },
+  })
+  assert.ok(prevented, 'preventDefault should be called')
+  assert.ok(stopped, 'stopPropagation should be called')
+})
+
+test('Node.prototype.on registers a listener and is chainable', () => {
+  const { window, document } = loadScripts({
+    files: ['shorthand.js'],
+    html: '<!DOCTYPE html><body><button></button></body>',
+  })
+  const button = document.querySelector('button')
+  let clicks = 0
+  const returned = button.on('click', () => { clicks += 1 })
+  assert.equal(returned, button, 'on() should return the node for chaining')
+  button.dispatchEvent(new window.Event('click'))
+  assert.equal(clicks, 1)
+})
+
+test('onLoaded runs its callback on DOMContentLoaded', () => {
+  const { window, document, api } = loadScripts({
+    files: ['shorthand.js'],
+    expose: ['onLoaded'],
+  })
+  let ran = false
+  api.onLoaded(() => { ran = true })
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+  assert.ok(ran)
+})


### PR DESCRIPTION
Closes #392.

## What

Adds a minimal client-side JS test harness so logic in `src/scripts/` can be tested in isolation — prompted by the iOS Safari paste-to-link bug in #391, which a unit test could have guarded against but had nowhere to live.

## Approach

- **Runner:** Node's built-in test runner (`node:test`) + `jsdom`. No extra framework, consistent with "simple over complex" — and `jsdom` was already a devDependency.
- **Globals, untouched:** the scripts ship as plain `<script>`-tag globals (no module exports). Rather than refactor them to ES modules, `tests/js/helpers.mjs` (`loadScripts()`) concatenates the source(s), evaluates them inside a jsdom window (`runScripts: 'outside-only'`), and returns the requested globals. The shipped files are completely unchanged.
- **CI:** a dedicated `js-test` job (latest Node LTS via `lts/*`) runs `pnpm test` on PRs and is wired into the aggregate `ci` gate.

## Tests

Covering the helpers named in the issue:

- `isUrl()` — valid/invalid URLs, whitespace, non-http schemes (`ftp:`, `mailto:`, `javascript:`)
- the paste handler — selection-wrapping into `[selected](url)`, URL trimming, the **iOS Safari `text/plain` fallback** from #391, non-URL paste left untouched, and collapsed-caret no-op
- `shorthand.js` — `$`, `$$`, `cancel`, `Node.prototype.on` (chainable), `onLoaded`

13 tests, all green locally. Verified they have teeth via mutation: reverting the paste handler to the pre-#391 `getData('text')`-only form fails the wrap test, and dropping the `|| getData('text')` fallback fails the iOS test.

## Run it

```bash
pnpm test
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01R3cSmB9ogPYpRycXY4eBq9)_