### PR TITLE
Extend JS unit test coverage to search, upload, checkbox and delete scripts

### DIFF
--- a/tests/js/confirm-delete.test.mjs
+++ b/tests/js/confirm-delete.test.mjs
@@ -1,0 +1,40 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadScripts } from './helpers.mjs'
+
+function setup(html) {
+  const ctx = loadScripts({ files: ['shorthand.js', 'logged_in/confirm-delete.js'], html })
+  ctx.document.dispatchEvent(new ctx.window.Event('DOMContentLoaded'))
+  return ctx
+}
+
+// The handler confirms inside a 50ms setTimeout, so tests wait it out.
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+test('submitting a delete form confirms before submitting', async () => {
+  const { window, document } = setup('<!DOCTYPE html><body><form class="form-delete" data-id="7"></form></body>')
+  const form = document.querySelector('form')
+  let submitted = false
+  form.submit = () => { submitted = true } // jsdom does not implement form.submit()
+  let prompt = null
+  window.confirm = (msg) => { prompt = msg; return true }
+
+  form.dispatchEvent(new window.Event('submit', { cancelable: true, bubbles: true }))
+  await wait(70)
+
+  assert.equal(prompt, 'Really delete status 7?')
+  assert.equal(submitted, true)
+})
+
+test('declining the confirmation does not submit', async () => {
+  const { window, document } = setup('<!DOCTYPE html><body><form class="form-delete" data-id="7"></form></body>')
+  const form = document.querySelector('form')
+  let submitted = false
+  form.submit = () => { submitted = true }
+  window.confirm = () => false
+
+  form.dispatchEvent(new window.Event('submit', { cancelable: true, bubbles: true }))
+  await wait(70)
+
+  assert.equal(submitted, false)
+})

--- a/tests/js/search-highlight.test.mjs
+++ b/tests/js/search-highlight.test.mjs
@@ -1,0 +1,42 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadScripts } from './helpers.mjs'
+
+// search-highlight.js is an IIFE that runs on load (not DOMContentLoaded), so
+// the relevant DOM must exist in the html before the scripts are evaluated.
+function run(html) {
+  return loadScripts({ files: ['shorthand.js', 'search/search-highlight.js'], html })
+}
+
+const marks = (document) => [...document.querySelectorAll('main mark')].map((m) => m.textContent)
+
+test('wraps each keyword occurrence in <mark>', () => {
+  const { document } = run('<!DOCTYPE html><body class="search"><input id="s" value="quick fox"><main><p>The quick brown fox</p></main></body>')
+  assert.deepEqual(marks(document), ['quick', 'fox'])
+})
+
+test('matching is case-insensitive but preserves the original casing', () => {
+  const { document } = run('<!DOCTYPE html><body class="search"><input id="s" value="QUICK"><main><p>The Quick quick</p></main></body>')
+  assert.deepEqual(marks(document), ['Quick', 'quick'])
+})
+
+test('escapes regex metacharacters in search terms', () => {
+  const { document } = run('<!DOCTYPE html><body class="search"><input id="s" value="c++"><main><p>I love c++ a lot</p></main></body>')
+  assert.deepEqual(marks(document), ['c++'])
+})
+
+test('does nothing when the body lacks the search class', () => {
+  const { document } = run('<!DOCTYPE html><body><input id="s" value="fox"><main><p>quick fox</p></main></body>')
+  assert.equal(document.querySelector('mark'), null)
+})
+
+test('does nothing when the search box is empty or whitespace', () => {
+  const { document } = run('<!DOCTYPE html><body class="search"><input id="s" value="   "><main><p>quick fox</p></main></body>')
+  assert.equal(document.querySelector('mark'), null)
+})
+
+test('does not descend into textarea/input/script/style elements', () => {
+  const { document } = run('<!DOCTYPE html><body class="search"><input id="s" value="fox"><main><textarea>a fox here</textarea><p>a fox there</p></main></body>')
+  // Only the <p> text is highlighted, never the <textarea> contents.
+  assert.deepEqual(marks(document), ['fox'])
+})

--- a/tests/js/toggle-checkbox.test.mjs
+++ b/tests/js/toggle-checkbox.test.mjs
@@ -1,0 +1,72 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadScripts } from './helpers.mjs'
+
+function load() {
+  return loadScripts({
+    files: ['shorthand.js', 'logged_in/toggle-checkbox.js'],
+    expose: ['saveCheckbox'],
+    html: '<!DOCTYPE html><body><article data-post-id="42"><input type="checkbox" data-checkbox-index="3"></article></body>',
+  })
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+test('saveCheckbox posts id, index and checked state to /checkbox', async () => {
+  const { window, document, api } = load()
+  const box = document.querySelector('input')
+  box.checked = true
+
+  let captured
+  window.fetch = (url, opts) => {
+    captured = { url, body: opts.body, method: opts.method }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) })
+  }
+
+  api.saveCheckbox(box)
+  await flush()
+
+  assert.equal(captured.url, '/checkbox')
+  assert.equal(captured.method, 'POST')
+  assert.equal(captured.body.get('id'), '42')
+  assert.equal(captured.body.get('index'), '3')
+  assert.equal(captured.body.get('checked'), '1')
+  assert.equal(box.disabled, false)
+})
+
+test('saveCheckbox reverts the checkbox on an HTTP error', async () => {
+  const { window, document, api } = load()
+  const box = document.querySelector('input')
+  box.checked = true
+  window.fetch = () => Promise.resolve({ ok: false, status: 500 })
+
+  api.saveCheckbox(box)
+  await flush()
+
+  assert.equal(box.checked, false, 'should revert the optimistic toggle')
+  assert.equal(box.disabled, false)
+})
+
+test('saveCheckbox reverts when the server reports failure in JSON', async () => {
+  const { window, document, api } = load()
+  const box = document.querySelector('input')
+  box.checked = false
+  window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: false }) })
+
+  api.saveCheckbox(box)
+  await flush()
+
+  assert.equal(box.checked, true, 'should revert from unchecked back to checked')
+  assert.equal(box.disabled, false)
+})
+
+test('saveCheckbox does nothing without a [data-post-id] ancestor', () => {
+  const { window, document, api } = load()
+  const orphan = document.createElement('input')
+  orphan.type = 'checkbox'
+  let called = false
+  window.fetch = () => { called = true; return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) }) }
+
+  api.saveCheckbox(orphan)
+  assert.equal(called, false, 'should not POST when there is no owning post')
+})

--- a/tests/js/upload-image.test.mjs
+++ b/tests/js/upload-image.test.mjs
@@ -1,0 +1,63 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadScripts } from './helpers.mjs'
+
+function load(html = '<!DOCTYPE html><body></body>') {
+  return loadScripts({
+    files: ['shorthand.js', 'logged_in/upload-image.js'],
+    expose: ['clipboardImageFiles', 'handleFiles'],
+    html,
+  })
+}
+
+// Build a fake clipboard item like the ones DataTransfer.items yields.
+function imageItem(window, type, name = '') {
+  return { kind: 'file', type, getAsFile: () => new window.File(['x'], name, { type }) }
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+test('clipboardImageFiles returns [] for a null clipboard', () => {
+  const { api } = load()
+  assert.equal(api.clipboardImageFiles(null).length, 0)
+})
+
+test('clipboardImageFiles ignores non-file and non-image items', () => {
+  const { window, api } = load()
+  const items = [
+    { kind: 'string', type: 'text/plain', getAsFile: () => null },
+    imageItem(window, 'application/pdf', 'a.pdf'), // file, but not an image
+  ]
+  assert.equal(api.clipboardImageFiles({ items }).length, 0)
+})
+
+test('clipboardImageFiles names pasted images uniquely with a real extension', () => {
+  const { window, api } = load()
+  const files = api.clipboardImageFiles({ items: [imageItem(window, 'image/png'), imageItem(window, 'image/jpeg')] })
+  assert.equal(files.length, 2)
+  assert.match(files[0].name, /^pasted-\d+-0\.png$/)
+  assert.match(files[1].name, /^pasted-\d+-1\.jpeg$/)
+  assert.equal(files[0].type, 'image/png')
+})
+
+test('handleFiles inserts the upload response at the cursor and fires input', async () => {
+  const { window, document, api } = load('<!DOCTYPE html><body><textarea></textarea></body>')
+  const ta = document.querySelector('textarea')
+  ta.value = 'abcd'
+  ta.setSelectionRange(2, 2) // cursor between "ab" and "cd"
+  let inputFired = false
+  ta.addEventListener('input', () => { inputFired = true })
+
+  let posted
+  window.fetch = (url, opts) => {
+    posted = { url, opts }
+    return Promise.resolve({ json: () => Promise.resolve('![](/img.webp)') })
+  }
+
+  api.handleFiles([new window.File(['x'], 'a.png', { type: 'image/png' })], ta)
+  await flush()
+
+  assert.equal(posted.url, '/upload')
+  assert.equal(ta.value, 'ab![](/img.webp)cd')
+  assert.ok(inputFired, 'an input event should be dispatched')
+})


### PR DESCRIPTION
Follow-up to #413 (stacked on the now-merged test infrastructure). That PR added the harness and covered `shorthand.js` + `paste-link.js`; this one extends coverage to the rest of the client-side logic that's tractable in jsdom.

## Coverage review

| Script | Status | Notes |
|---|---|---|
| `shorthand.js` | ✅ (in #413) | — |
| `logged_in/paste-link.js` | ✅ (in #413) | — |
| `search/search-highlight.js` | ✅ **added** | keyword marking, case-insensitivity, regex-metachar escaping, search-page/empty-input guards, skips textarea/input |
| `logged_in/upload-image.js` | ✅ **added** | `clipboardImageFiles()` filtering + unique naming; `handleFiles()` inserts upload response at cursor + fires `input` |
| `logged_in/toggle-checkbox.js` | ✅ **added** | `saveCheckbox()` POST payload; optimistic-toggle **revert** on HTTP and JSON failure; no-op without `[data-post-id]` |
| `logged_in/confirm-delete.js` | ✅ **added** | confirm-gated form submission (submits on accept, not on decline) |
| `image-modal.js` | ⏭️ deferred | relies on `naturalWidth`/`clientWidth` — `0` in jsdom (no layout) |
| `logged_in/growing-input.js` | ⏭️ deferred | relies on `scrollHeight` — `0` in jsdom |
| `logged_in/link-edit-buttons.js` | ⏭️ deferred | only sets `location.href`; navigation isn't implemented in jsdom |

The deferred scripts are layout-/navigation-dependent and are better left to the Playwright e2e suite.

## Tests

16 new tests across 4 files, all green (`pnpm test` → 29 total). Each new test was mutation-checked to confirm it fails when the behaviour it guards is broken (regex escaping, the checkbox revert, the confirm gate, the cursor insertion).

```bash
pnpm test
```

Uses the existing `tests/js/helpers.mjs` `loadScripts()` harness — no new dependencies, no changes to the shipped scripts.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R3cSmB9ogPYpRycXY4eBq9)_