### PR TITLE
Dedupe feed re-ingestion by uuid; lock author-edited posts

### DIFF
--- a/docs/cross-posting.md
+++ b/docs/cross-posting.md
@@ -36,6 +36,12 @@ The first cron run after adding a feed imports every item currently present in t
 
 After that first run, only items published or updated since the previous run are imported.
 
+An item is matched to its existing post by a stable identifier, so a later crawl never creates a duplicate of something it has already imported — even if the publisher restamps the item's date.
+
+## Editing an imported post
+
+Imported posts start as [drafts]({{ site.baseurl }}{% link drafts.md %}) by default. As soon as you edit one through Lamb — for example to publish it, change its slug, or tidy the text — Lamb treats it as yours: later crawls stop syncing changes from the source onto it, so your edits are never overwritten (and it is still never duplicated). Posts you have not edited continue to pick up updates from the source feed as before.
+
 ## Checking crawl status
 
 When `/_cron` runs unattended you don't see its live output, so Lamb records the health

--- a/src/network.php
+++ b/src/network.php
@@ -204,17 +204,7 @@ function record_feed_crawl(string $name, string $url, SimplePie $feed): array
     $items     = 0;
     /** @var SimplePieItem $item */
     foreach ($feed->get_items() as $item) {
-        $pub_date = $item->get_date('U');
-        $mod_date = $item->get_updated_date('U');
-
-        // Compare the publication date of the item with the success watermark.
-        if ($pub_date > $watermark) {
-            create_item($item, $name);
-            $items++;
-            continue;
-        }
-        if ($mod_date > $watermark) {
-            update_item($item, $name);
+        if (ingest_item($item, $name, $watermark)) {
             $items++;
         }
     }
@@ -275,6 +265,44 @@ function prune_feed_status(): int
     }
 
     return $removed;
+}
+
+/**
+ * Decides whether a single feed item is created, updated, or skipped, keyed on
+ * its `feeditem_uuid` rather than dates alone.
+ *
+ * Deduplication lives here: an item that already has a post is never recreated
+ * (the source of the recreated-draft bug when a feed re-stamps an item's
+ * publication date past the watermark). A brand-new item is created only when
+ * its publication date is newer than the watermark. An already-ingested post is
+ * re-synced from the source only when the item was modified after the watermark
+ * AND the author has not taken the post over via the edit form
+ * (`feed_locked`) — so a published, re-slugged post is left intact.
+ *
+ * @param SimplePieItem $item      The feed item.
+ * @param string        $name      Feed name from config.
+ * @param int           $watermark The feed's last-success timestamp.
+ * @return bool True when a post was created or updated (counts toward the run total).
+ */
+function ingest_item(SimplePieItem $item, string $name, int $watermark): bool
+{
+    $uuid     = md5($name . $item->get_id());
+    $existing = R::findOne('post', ' feeditem_uuid = ? ', [$uuid]);
+
+    if (!$existing) {
+        if ((int) $item->get_date('U') > $watermark) {
+            create_item($item, $name);
+            return true;
+        }
+        return false;
+    }
+
+    if (!$existing->feed_locked && (int) $item->get_updated_date('U') > $watermark) {
+        update_item($item, $name);
+        return true;
+    }
+
+    return false;
 }
 
 function update_item(SimplePieItem $item, string $name): void

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -183,6 +183,10 @@ function redirect_edited(): void
     // pinned into the body's front matter so the edit form shows it.
     finalize_slug($bean);
 
+    // Editing a feed-sourced post through the form marks it author-owned, so
+    // later crawls stop overwriting it (they still never duplicate it).
+    lock_if_feed_sourced($bean);
+
     try {
         R::store($bean);
     } catch (SQL $e) {
@@ -214,6 +218,25 @@ function redirect_edited(): void
     $redirect = $_SESSION['edit-referrer'];
     unset($_SESSION['edit-referrer']);
     redirect_uri($redirect);
+}
+
+/**
+ * Marks a feed-sourced post as author-owned so feed re-ingestion leaves it alone.
+ *
+ * Feed crawls dedupe on `feeditem_uuid` and re-sync source updates onto matching
+ * posts. Once the author edits such a post through the edit form, that auto-sync
+ * would clobber their changes, so set `feed_locked` to opt the post out of future
+ * updates. Posts that did not originate from a feed (`feeditem_uuid` empty) are
+ * left untouched.
+ *
+ * @param OODBBean $bean The post being saved.
+ * @return void
+ */
+function lock_if_feed_sourced(OODBBean $bean): void
+{
+    if (!empty($bean->feeditem_uuid)) {
+        $bean->feed_locked = 1;
+    }
 }
 
 /**

--- a/tests/Unit/NetworkFeedTest.php
+++ b/tests/Unit/NetworkFeedTest.php
@@ -8,6 +8,7 @@ use SimplePie\Item as SimplePieItem;
 
 use function Lamb\Network\create_item;
 use function Lamb\Network\get_feeds;
+use function Lamb\Network\ingest_item;
 use function Lamb\Network\prepare_item;
 use function Lamb\Network\update_item;
 
@@ -295,5 +296,91 @@ class NetworkFeedTest extends TestCase
         update_item($item, 'TestBlog');
 
         $this->assertSame($countBefore, R::count('post'));
+    }
+
+    // ingest_item — create/update decision keyed on feeditem_uuid
+
+    public function testIngestItemDoesNotDuplicateExistingPost(): void
+    {
+        // An already-ingested item (post exists with this uuid) must never be
+        // recreated, even when its pub_date is past the watermark — the
+        // feed-reingest duplicate-draft bug.
+        $uuid = md5('TestBlog' . 'existing-id');
+        $bean = R::dispense('post');
+        $bean->feeditem_uuid = $uuid;
+        $bean->body = 'Original body';
+        $bean->version = 1;
+        $bean->created = '2024-01-01 10:00:00';
+        $bean->updated = '2024-01-01 10:00:00';
+        R::store($bean);
+
+        $countBefore = R::count('post');
+        $item = $this->makeItem('Title', 'Body', 'https://example.com', 'existing-id');
+        ingest_item($item, 'TestBlog', 0);
+
+        // The existing row may be re-synced, but no duplicate is ever inserted.
+        $this->assertSame($countBefore, R::count('post'));
+    }
+
+    public function testIngestItemCreatesNewItemWhenNewerThanWatermark(): void
+    {
+        $countBefore = R::count('post');
+        $item = $this->makeItem('Fresh', 'Body', 'https://example.com', 'fresh-id');
+        $created = ingest_item($item, 'TestBlog', 0);
+
+        $this->assertTrue($created);
+        $this->assertSame($countBefore + 1, R::count('post'));
+    }
+
+    public function testIngestItemSkipsNewItemOlderThanWatermark(): void
+    {
+        $countBefore = R::count('post');
+        // makeItem date '2024-...' casts to 2024; a large watermark is "newer".
+        $item = $this->makeItem('Old', 'Body', 'https://example.com', 'old-id');
+        $created = ingest_item($item, 'TestBlog', PHP_INT_MAX);
+
+        $this->assertFalse($created);
+        $this->assertSame($countBefore, R::count('post'));
+    }
+
+    public function testIngestItemUpdatesUnlockedExistingPostOnModification(): void
+    {
+        $uuid = md5('TestBlog' . 'unlocked-id');
+        $bean = R::dispense('post');
+        $bean->feeditem_uuid = $uuid;
+        $bean->body = 'Original body';
+        $bean->version = 1;
+        $bean->created = '2024-01-01 10:00:00';
+        $bean->updated = '2024-01-01 10:00:00';
+        R::store($bean);
+
+        // mod_date '2024-06-01...' casts to 2024 > watermark 0.
+        $item = $this->makeItem('New Title', 'New body', 'https://example.com', 'unlocked-id', '2024-01-01 10:00:00', '2024-06-01 15:00:00');
+        $changed = ingest_item($item, 'TestBlog', 0);
+
+        $this->assertTrue($changed);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('2024-06-01 15:00:00', $updated->updated);
+    }
+
+    public function testIngestItemDoesNotUpdateLockedExistingPost(): void
+    {
+        $uuid = md5('TestBlog' . 'locked-id');
+        $bean = R::dispense('post');
+        $bean->feeditem_uuid = $uuid;
+        $bean->feed_locked = 1;
+        $bean->body = 'Author edited body';
+        $bean->version = 1;
+        $bean->created = '2024-01-01 10:00:00';
+        $bean->updated = '2024-01-01 10:00:00';
+        R::store($bean);
+
+        $item = $this->makeItem('New Title', 'New body', 'https://example.com', 'locked-id', '2024-01-01 10:00:00', '2024-06-01 15:00:00');
+        $changed = ingest_item($item, 'TestBlog', 0);
+
+        $this->assertFalse($changed);
+        $reloaded = R::load('post', $bean->id);
+        $this->assertSame('Author edited body', $reloaded->body);
+        $this->assertSame('2024-01-01 10:00:00', $reloaded->updated);
     }
 }

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
 use function Lamb\Response\apply_checkbox_toggle;
+use function Lamb\Response\lock_if_feed_sourced;
 use function Lamb\Response\redirect_created;
 use function Lamb\Response\redirect_edited;
 use function Lamb\Response\respond_edit;
@@ -260,5 +261,29 @@ class ResponsePostsTest extends TestCase
         R::store($post);
 
         $this->assertFalse(apply_checkbox_toggle($post->id, -1, true));
+    }
+
+    // -------------------------------------------------------------------------
+    // lock_if_feed_sourced
+    // -------------------------------------------------------------------------
+
+    public function testLockIfFeedSourcedLocksFeedPost(): void
+    {
+        $bean = R::dispense('post');
+        $bean->feeditem_uuid = md5('Feed' . 'item-id');
+
+        lock_if_feed_sourced($bean);
+
+        $this->assertSame(1, (int) $bean->feed_locked);
+    }
+
+    public function testLockIfFeedSourcedLeavesNonFeedPostUntouched(): void
+    {
+        $bean = R::dispense('post');
+        $bean->feeditem_uuid = '';
+
+        lock_if_feed_sourced($bean);
+
+        $this->assertEmpty($bean->feed_locked);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #415 — feed re-ingestion recreating a draft for a post the author has already taken over (published and re-slugged).

Deduplication during a crawl was purely date-based: `create_item()` ran for any item whose `pub_date` was past the feed's watermark, with **no check for an existing post**. Only `update_item()` deduped by `feeditem_uuid`. A feed that restamps an already-ingested item's date therefore inserted a duplicate draft.

## Changes

- **`src/network.php`** — new `ingest_item()` houses the create/update/skip decision, keyed on `feeditem_uuid`:
  - an item that already has a post is **never recreated** (the duplication fix);
  - a brand-new item is created only when newer than the watermark;
  - an existing post is re-synced from the source only when it was modified *and* not author-locked.
  `record_feed_crawl()` now just delegates to it. `create_item()`/`update_item()` are unchanged low-level primitives.
- **`src/response/posts.php`** — `lock_if_feed_sourced()` sets `feed_locked` when a feed-sourced post is saved through the edit form, so later crawls leave the author's version intact. Column is auto-created by RedBeanPHP fluid mode; absent reads as falsy, so untouched feed posts keep syncing.
- **`docs/cross-posting.md`** — documents no-duplicate and the "editing an imported post takes it over" behaviour.

## Tests (red-green)

Added to `tests/Unit/NetworkFeedTest.php` (no duplicate for existing uuid; create when newer; skip when older; update unlocked on modification; **don't** touch locked) and `tests/Unit/ResponsePostsTest.php` (`lock_if_feed_sourced` sets the flag only for feed posts). All 962 unit tests pass; `composer lint` and `composer analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
