### PR TITLE
Disable Geist Mono ligatures in the 2026 editor textarea

### DIFF
--- a/src/themes/2026/styles/styles.css
+++ b/src/themes/2026/styles/styles.css
@@ -711,6 +711,11 @@ section.entry-form {
 
 textarea {
     font: 400 var(--text-sm)/1.5 var(--font-mono);
+    /* Geist Mono ligates triple characters (###, ---, ===); the fused glyph
+       overhangs left and looks like a negative indent in the editor. Keep
+       literal characters when typing Markdown. */
+    font-variant-ligatures: none;
+    font-feature-settings: "liga" 0, "calt" 0;
     width: 100%;
     max-width: 100%;
     min-height: 7em;


### PR DESCRIPTION
The 2026 theme's post editor uses `Geist Mono`, a coding font that ligates triple characters (`###`, `---`, `===`, …). The fused glyph's left side-bearing overhangs, so a line like `### foo` or `---` looked negatively indented in the textarea while `## foo` (two characters, no ligature) sat normally. Only the 2026 theme is affected; `base` and `2024` don't use Geist Mono there.

Markdown editing wants literal characters, so this turns ligatures and contextual alternates off on the textarea:

```css
font-variant-ligatures: none;
font-feature-settings: "liga" 0, "calt" 0;
```

Scoped to the editor only — rendered post bodies are untouched.