### PR TITLE
Persist logins for a week

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -70,8 +70,14 @@ function configure_session(): void
     ini_set("session.cookie_secure", $secure ? 1 : 0);
     ini_set("session.use_strict_mode", 1);
 
+    // Remember the login for a week: persist the server-side session that long so
+    // GC doesn't reap it, and give the session cookie a matching lifetime so it
+    // survives a browser restart instead of dying as a session cookie.
+    ini_set("session.gc_maxlifetime", (string) REMEMBER_LIFETIME);
+
     // Prevent the browser from sending cookies along with cross-site requests (CSRF)
     $cookie_params = [
+        'lifetime' => REMEMBER_LIFETIME,
         'samesite' => 'Strict',
         'path' => '/',
         'httponly' => true,

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -94,19 +94,71 @@ function configure_session(): void
 }
 
 /**
+ * Builds the signed value for the lamb_logged_in marker cookie: a random id
+ * with an HMAC tag so the server can later confirm it issued the cookie without
+ * touching session storage.
+ *
+ * The key is the per-install bcrypt login hash (LAMB_LOGIN_PASSWORD): high
+ * entropy, never sent to the client, and one-way HMAC means the cookie leaks
+ * nothing about it. Changing the password rotates the key and invalidates
+ * outstanding markers (logs the author out everywhere).
+ *
+ * @param string $id     Random opaque identifier.
+ * @param string $secret HMAC key (the bcrypt login hash).
+ * @return string Signed marker value "<id>.<hmac>".
+ */
+function sign_login_marker(string $id, string $secret): string
+{
+    return $id . '.' . hash_hmac('sha256', $id, $secret);
+}
+
+/**
+ * Verifies a lamb_logged_in marker cookie's HMAC in constant time. A missing,
+ * malformed, tampered, or wrong-key value is rejected — so a forged cookie costs
+ * nothing beyond this check and never reaches session_start().
+ *
+ * @param string $value  The cookie value to verify.
+ * @param string $secret HMAC key (the bcrypt login hash).
+ * @return bool
+ */
+function valid_login_marker(string $value, string $secret): bool
+{
+    if ($secret === '') {
+        return false;
+    }
+    $dot = strrpos($value, '.');
+    if ($dot === false) {
+        return false;
+    }
+    $id = substr($value, 0, $dot);
+    $sig = substr($value, $dot + 1);
+    if ($id === '' || $sig === '') {
+        return false;
+    }
+    return hash_equals(hash_hmac('sha256', $id, $secret), $sig);
+}
+
+/**
  * Decides whether a request should resume/start a PHP session.
  *
- * A session is only warranted when the request carries evidence of a (previously)
- * logged-in user: the lamb_logged_in marker cookie set at login, or an existing
- * LAMBSESSID session cookie. Anonymous visitors get no session — and therefore no
- * Set-Cookie and no no-cache headers — so their pages remain cacheable (issue #116).
+ * A session is only warranted when the request carries a lamb_logged_in marker
+ * cookie whose HMAC validates — evidence the server itself issued it at login.
+ * Bare cookie presence (a forged marker, or any LAMBSESSID value) is NOT enough:
+ * starting a session on unvalidated input lets an attacker flood the server with
+ * junk cookies and force a new session file per request (resource-exhaustion DoS).
+ * Anonymous visitors get no session — and therefore no Set-Cookie and no no-cache
+ * headers — so their pages remain cacheable (issue #116).
  *
  * @param array<string, mixed> $cookies Typically $_COOKIE.
  * @return bool
  */
 function should_start_session(array $cookies): bool
 {
-    return isset($cookies['lamb_logged_in']) || isset($cookies['LAMBSESSID']);
+    $marker = $cookies['lamb_logged_in'] ?? null;
+    if (!is_string($marker)) {
+        return false;
+    }
+    return valid_login_marker($marker, (string) getenv('LAMB_LOGIN_PASSWORD'));
 }
 
 /**

--- a/src/constants.php
+++ b/src/constants.php
@@ -18,6 +18,9 @@ define('MINUTE_IN_SECONDS', 60);
 // Current post render-format version. Bump when `transformed` output changes
 // (e.g. new syntax highlighting); older posts are re-parsed on read by upgrade_posts().
 define('POST_VERSION', 3);
+// How long a login is remembered. The session cookie and the server-side session
+// both persist this long, so logins survive a browser restart and idle time.
+define('REMEMBER_LIFETIME', 7 * 24 * 60 * MINUTE_IN_SECONDS); // one week
 define('SESSION_LOGIN', 'logged_in');
 define('SUBMIT_CREATE', 'Create post');
 define('SUBMIT_EDIT', 'Update post');

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -53,7 +53,7 @@ function redirect_login(): array
     session_regenerate_id(true);
 
     $uuid = bin2hex(random_bytes(16)); // Generate a UUID
-    setcookie('lamb_logged_in', $uuid, get_cookie_options(time() + 3600));
+    setcookie('lamb_logged_in', $uuid, get_cookie_options(time() + REMEMBER_LIFETIME));
     $where = local_redirect_target(filter_input(INPUT_POST, 'redirect_to', FILTER_SANITIZE_URL) ?: null);
     redirect_uri($where);
 }

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -53,7 +53,10 @@ function redirect_login(): array
     session_regenerate_id(true);
 
     $uuid = bin2hex(random_bytes(16)); // Generate a UUID
-    setcookie('lamb_logged_in', $uuid, get_cookie_options(time() + REMEMBER_LIFETIME));
+    // Sign the marker so should_start_session() can confirm we issued it without
+    // touching session storage — a forged cookie can't trigger a session_start().
+    $marker = \Lamb\Bootstrap\sign_login_marker($uuid, LOGIN_PASSWORD);
+    setcookie('lamb_logged_in', $marker, get_cookie_options(time() + REMEMBER_LIFETIME));
     $where = local_redirect_target(filter_input(INPUT_POST, 'redirect_to', FILTER_SANITIZE_URL) ?: null);
     redirect_uri($where);
 }

--- a/tests/Unit/SessionBootstrapTest.php
+++ b/tests/Unit/SessionBootstrapTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 use function Lamb\Bootstrap\should_start_session;
 use function Lamb\Bootstrap\cache_headers;
+use function Lamb\Bootstrap\configure_session;
 
 /**
  * Sessions for previously logged-in users only (issue #116).
@@ -57,5 +58,33 @@ class SessionBootstrapTest extends TestCase
     {
         $this->assertStringContainsString('Vary: Cookie', implode("\n", cache_headers(false)));
         $this->assertStringContainsString('Vary: Cookie', implode("\n", cache_headers(true)));
+    }
+
+    /**
+     * Remember-me: the session cookie persists for a week rather than dying on
+     * browser close, so logins survive restarts (no checkbox — always on).
+     */
+    public function testSessionCookiePersistsForRememberLifetime(): void
+    {
+        // configure_session() runs at bootstrap before any session is active;
+        // in the shared test process another test may have left one open.
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+        configure_session();
+        $this->assertSame(REMEMBER_LIFETIME, session_get_cookie_params()['lifetime']);
+    }
+
+    /**
+     * The server-side session must outlive the cookie too, or GC reaps the
+     * session data before the persistent cookie expires.
+     */
+    public function testServerSessionLifetimeMatchesRememberLifetime(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+        configure_session();
+        $this->assertSame((string) REMEMBER_LIFETIME, ini_get('session.gc_maxlifetime'));
     }
 }

--- a/tests/Unit/SessionBootstrapTest.php
+++ b/tests/Unit/SessionBootstrapTest.php
@@ -7,17 +7,43 @@ use PHPUnit\Framework\TestCase;
 use function Lamb\Bootstrap\should_start_session;
 use function Lamb\Bootstrap\cache_headers;
 use function Lamb\Bootstrap\configure_session;
+use function Lamb\Bootstrap\sign_login_marker;
+use function Lamb\Bootstrap\valid_login_marker;
 
 /**
  * Sessions for previously logged-in users only (issue #116).
  *
  * Anonymous visitors must not get a session started: that forces a Set-Cookie
  * and PHP's no-cache headers, which makes every public page uncacheable.
- * A session is only started when the request carries evidence of a logged-in
- * user (the lamb_logged_in marker cookie, or an existing LAMBSESSID).
+ *
+ * A session is only started when the request carries a lamb_logged_in marker
+ * cookie whose HMAC validates against the server secret. Bare cookie presence
+ * is not enough: forged markers (and a bare LAMBSESSID) must NOT start a session,
+ * or an attacker could flood requests with junk cookies and make the server
+ * write a new session file per request (resource-exhaustion DoS).
  */
 class SessionBootstrapTest extends TestCase
 {
+    private const SECRET = 'test-bcrypt-hash-secret';
+
+    /** @var string|false */
+    private $previous_secret;
+
+    protected function setUp(): void
+    {
+        $this->previous_secret = getenv('LAMB_LOGIN_PASSWORD');
+        putenv('LAMB_LOGIN_PASSWORD=' . self::SECRET);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previous_secret === false) {
+            putenv('LAMB_LOGIN_PASSWORD');
+        } else {
+            putenv('LAMB_LOGIN_PASSWORD=' . $this->previous_secret);
+        }
+    }
+
     public function testAnonymousVisitorWithNoCookiesDoesNotStartSession(): void
     {
         $this->assertFalse(should_start_session([]));
@@ -28,14 +54,40 @@ class SessionBootstrapTest extends TestCase
         $this->assertFalse(should_start_session(['theme' => 'dark', 'consent' => '1']));
     }
 
-    public function testLoginMarkerCookieStartsSession(): void
+    public function testValidlySignedMarkerStartsSession(): void
     {
-        $this->assertTrue(should_start_session(['lamb_logged_in' => 'abc123']));
+        $marker = sign_login_marker('deadbeef', self::SECRET);
+        $this->assertTrue(should_start_session(['lamb_logged_in' => $marker]));
     }
 
-    public function testExistingSessionCookieStartsSession(): void
+    public function testForgedUnsignedMarkerDoesNotStartSession(): void
     {
-        $this->assertTrue(should_start_session(['LAMBSESSID' => 'deadbeef']));
+        $this->assertFalse(should_start_session(['lamb_logged_in' => 'abc123']));
+    }
+
+    public function testTamperedMarkerDoesNotStartSession(): void
+    {
+        $marker = sign_login_marker('deadbeef', self::SECRET) . 'x';
+        $this->assertFalse(should_start_session(['lamb_logged_in' => $marker]));
+    }
+
+    public function testMarkerSignedWithWrongSecretDoesNotStartSession(): void
+    {
+        $marker = sign_login_marker('deadbeef', 'a-different-secret');
+        $this->assertFalse(should_start_session(['lamb_logged_in' => $marker]));
+    }
+
+    public function testBareSessionCookieDoesNotStartSession(): void
+    {
+        // The whole point of the marker gate: a forged LAMBSESSID must not be
+        // enough to trigger session_start() and a per-request disk write.
+        $this->assertFalse(should_start_session(['LAMBSESSID' => 'deadbeef']));
+    }
+
+    public function testValidMarkerRejectedWhenNoServerSecretConfigured(): void
+    {
+        putenv('LAMB_LOGIN_PASSWORD');
+        $this->assertFalse(valid_login_marker(sign_login_marker('deadbeef', ''), ''));
     }
 
     public function testAnonymousPagesAreCacheable(): void


### PR DESCRIPTION
## What

Two related changes:

1. **Persist logins for a week.** Logins now survive a browser restart and idle time instead of being lost after ~24 min idle / on browser close.
2. **Gate session start on a signed marker.** Hardens the session-start path against a forged-cookie DoS that the week-long lifetime would otherwise amplify.

## Why

Login state lives in the server-side session, but `LAMBSESSID` was a browser-session cookie (gone on close), the session was GC'd after PHP's default ~24-min `gc_maxlifetime`, and the `lamb_logged_in` marker cookie only lasted an hour. Net effect: frequent forced re-logins.

`configure_session()` now gives the session cookie and the server-side session a one-week lifetime (`REMEMBER_LIFETIME`). No checkbox — remember-me is always on, per Lamb's opinionated-defaults philosophy.

But `should_start_session()` started a session on *bare presence* of `lamb_logged_in` **or** `LAMBSESSID`, with no validation. A forged cookie makes PHP write a new session file per request, and the week-long `gc_maxlifetime` lets those files linger 7 days → disk-exhaustion DoS.

## How

The marker cookie is now `<id>.<hmac>`. `should_start_session()` validates the HMAC (constant-time) and only trusts a valid marker; the bare-`LAMBSESSID` trigger is removed. A forged cookie fails cheaply and never reaches `session_start()`. Routes that need a session pre-login (login page, CSRF POSTs) already call `start_session()` explicitly, so nothing legitimate regresses.

The HMAC key is the per-install bcrypt login hash (`LAMB_LOGIN_PASSWORD`): high entropy, never sent to the client, one-way so the cookie leaks nothing about it, and no new stored secret. Changing the password rotates the key and logs the author out everywhere.

## Tests

New unit tests for the cookie/GC lifetimes and for marker signing/validation (valid, forged, tampered, wrong-key, bare-LAMBSESSID, no-secret). Full Unit suite green (987 tests), lint + phpstan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)