### PR TITLE
Reissue login marker when session already authenticated

### DIFF
--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -33,8 +33,11 @@ function redirect_login(): array
     header("Pragma: no-cache");
 
     if (isset($_SESSION[SESSION_LOGIN])) {
-        // Already logged in
+        // Already logged in (e.g. an existing session adopted via LAMBSESSID).
+        // Reissue the marker too: the session is authoritative, but without a
+        // valid marker the next request treats the visitor as anonymous.
         session_regenerate_id(true);
+        set_login_marker();
         redirect_uri('/');
     }
     if (!isset($_POST['submit']) || $_POST['submit'] !== SUBMIT_LOGIN) {
@@ -51,14 +54,28 @@ function redirect_login(): array
 
     $_SESSION[SESSION_LOGIN] = true;
     session_regenerate_id(true);
-
-    $uuid = bin2hex(random_bytes(16)); // Generate a UUID
-    // Sign the marker so should_start_session() can confirm we issued it without
-    // touching session storage — a forged cookie can't trigger a session_start().
-    $marker = \Lamb\Bootstrap\sign_login_marker($uuid, LOGIN_PASSWORD);
-    setcookie('lamb_logged_in', $marker, get_cookie_options(time() + REMEMBER_LIFETIME));
+    set_login_marker();
     $where = local_redirect_target(filter_input(INPUT_POST, 'redirect_to', FILTER_SANITIZE_URL) ?: null);
     redirect_uri($where);
+}
+
+/**
+ * Issues the signed lamb_logged_in marker cookie for the current login.
+ *
+ * The marker is a random id signed with the per-install login hash so
+ * should_start_session() can confirm we issued it without touching session
+ * storage — a forged cookie can't trigger a session_start(). Called on every
+ * path that concludes the visitor is authenticated, so the marker never drifts
+ * out of sync with the session.
+ *
+ * @return void
+ * @throws RandomException
+ */
+function set_login_marker(): void
+{
+    $uuid = bin2hex(random_bytes(16));
+    $marker = \Lamb\Bootstrap\sign_login_marker($uuid, LOGIN_PASSWORD);
+    setcookie('lamb_logged_in', $marker, get_cookie_options(time() + REMEMBER_LIFETIME));
 }
 
 /**

--- a/tests/Acceptance/CacheHeadersCest.php
+++ b/tests/Acceptance/CacheHeadersCest.php
@@ -51,6 +51,27 @@ class CacheHeadersCest
         $I->seeResponseHeaderContains('Cache-Control', 'private');
     }
 
+    /**
+     * Regression: visiting /login while the session is still authenticated
+     * server-side but the marker cookie is stale/invalid (e.g. an old cookie
+     * from before marker signing) must re-issue a valid marker. Otherwise the
+     * already-logged-in branch redirects without a marker and the next request
+     * sees an invalid one, leaving the visitor stuck appearing logged out until
+     * they clear cookies.
+     */
+    public function reloginReissuesMarkerWhenSessionAlreadyAuthenticated(AcceptanceTester $I): void
+    {
+        $this->login($I);
+        // Stale, no-longer-valid marker; the LAMBSESSID session stays authed.
+        $I->setCookie('lamb_logged_in', 'stale-unsigned-value');
+        // GET /login lands in the already-logged-in branch and redirects home.
+        $I->amOnPage('/login');
+        // The reissued marker must let the next request resume the session.
+        $I->amOnPage('/settings');
+        $I->seeResponseCodeIs(200);
+        $I->dontSeeInCurrentUrl('/login');
+    }
+
     public function afterLogoutHomepageIsCacheableAgain(AcceptanceTester $I): void
     {
         $this->login($I);


### PR DESCRIPTION
## What

Fixes a login bug: after the marker-signing change in #419, logging in could 302 to the homepage **without** logging you in — the edit box stayed hidden until you cleared cookies.

## Why this is a separate PR

The squash-merge of #419 landed commits 1–2 (week-long lifetime + HMAC-gated marker) but **dropped commit 3** (this fix), so the bug is currently live on `main`. This re-lands it.

## Root cause

Gating session start on the signed marker exposed a latent bug in `redirect_login()`: the "already logged in" branch regenerated the session and redirected **without issuing a marker**. That branch fires when `start_session()` adopts an existing authenticated session via `LAMBSESSID` (e.g. a browser carrying a stale pre-signing marker plus a live session). The visitor ends up authenticated server-side but with no valid marker, so the next request treats them as anonymous — no edit box, stuck until cookies are cleared.

## Fix

Extract `set_login_marker()` and call it on **both** authenticated paths, so the marker never drifts out of sync with the session.

## Tests

New acceptance test `reloginReissuesMarkerWhenSessionAlreadyAuthenticated` reproduces the stale-marker-plus-live-session case (verified red without the fix, green with it). Unit suite green (987), lint + phpstan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)