### PR TITLE
Store sessions in a dedicated dir under the data directory

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -179,13 +179,40 @@ function start_session(): void
 }
 
 /**
- * Initializes and secures a session, starting it only for (previously) logged-in users.
+ * Points PHP's session storage at a dedicated directory under the app's data dir.
  *
+ * The default save_path is usually shared with every other PHP app on the host.
+ * Because PHP's GC sweeps the whole save_path against the running request's
+ * gc_maxlifetime, Lamb's week-long lifetime would otherwise spare other apps'
+ * short-lived sessions (they linger), and their shorter GC would reap Lamb's
+ * week-long sessions early. A dedicated directory isolates Lamb's GC to its own
+ * files in both directions, and putting it under the persistent data dir means
+ * a deploy or container restart that wipes ephemeral storage no longer logs the
+ * author out before the marker cookie expires.
+ *
+ * @param string $data_dir The app data directory (same one that holds lamb.db).
  * @return void
  */
-function bootstrap_session(): void
+function configure_session_save_path(string $data_dir): void
+{
+    $path = $data_dir . '/sessions';
+    if (!is_dir($path)) {
+        // 0700: only the web-server/PHP user should read session files.
+        mkdir($path, 0700, true);
+    }
+    ini_set('session.save_path', $path);
+}
+
+/**
+ * Initializes and secures a session, starting it only for (previously) logged-in users.
+ *
+ * @param string $data_dir The app data directory (same one that holds lamb.db).
+ * @return void
+ */
+function bootstrap_session(string $data_dir): void
 {
     configure_session();
+    configure_session_save_path($data_dir);
     if (should_start_session($_COOKIE)) {
         start_session();
     }

--- a/src/index.php
+++ b/src/index.php
@@ -9,8 +9,9 @@ define('ROOT_DIR', __DIR__);
 
 require '../vendor/autoload.php';
 
-Bootstrap\bootstrap_db(getenv('LAMB_DATA_DIR') ?: '../data');
-Bootstrap\bootstrap_session();
+$data_dir = getenv('LAMB_DATA_DIR') ?: '../data';
+Bootstrap\bootstrap_db($data_dir);
+Bootstrap\bootstrap_session($data_dir);
 
 $config = Config\load();
 Config\apply_timezone($config);

--- a/tests/Unit/SessionBootstrapTest.php
+++ b/tests/Unit/SessionBootstrapTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use function Lamb\Bootstrap\should_start_session;
 use function Lamb\Bootstrap\cache_headers;
 use function Lamb\Bootstrap\configure_session;
+use function Lamb\Bootstrap\configure_session_save_path;
 use function Lamb\Bootstrap\sign_login_marker;
 use function Lamb\Bootstrap\valid_login_marker;
 
@@ -138,5 +139,29 @@ class SessionBootstrapTest extends TestCase
         }
         configure_session();
         $this->assertSame((string) REMEMBER_LIFETIME, ini_get('session.gc_maxlifetime'));
+    }
+
+    /**
+     * Sessions live in a dedicated directory under the app's persistent data dir,
+     * not the shared system default. This isolates Lamb's week-long GC from other
+     * PHP apps on the host (no cross-app session-lifetime bleed in either
+     * direction) and survives deploys/restarts that wipe ephemeral session stores.
+     */
+    public function testSessionSavePathIsDedicatedDirectoryUnderDataDir(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+        $data_dir = sys_get_temp_dir() . '/lamb-session-test-' . getmypid();
+        @mkdir($data_dir, 0700, true);
+
+        configure_session_save_path($data_dir);
+
+        $expected = $data_dir . '/sessions';
+        $this->assertSame($expected, ini_get('session.save_path'));
+        $this->assertDirectoryExists($expected);
+
+        @rmdir($expected);
+        @rmdir($data_dir);
     }
 }


### PR DESCRIPTION
## Summary

Lamb sets `session.gc_maxlifetime` to a week (#419) to keep the author logged in, but left `session.save_path` at the system default — typically **shared** with every other PHP app on the host. PHP's session GC sweeps the entire save_path against the *running request's* `gc_maxlifetime`, so:

- when **Lamb's** GC fires (week-long), it spares other apps' short-lived sessions → they linger longer than intended;
- when **another app's** GC fires (e.g. ~24 min default), it reaps **Lamb's** week-long sessions early → defeating the persistence goal.

This points session storage at a dedicated `<data_dir>/sessions` directory (created `0700`, alongside `lamb.db`). That isolates Lamb's GC to its own files in both directions, and because it lives under the persistent data dir, a deploy or container restart that wipes ephemeral storage no longer logs the author out before the `lamb_logged_in` marker cookie expires.

This keeps the existing **two-cookie** auth model untouched (a stolen marker alone still can't authenticate — it only gates `session_start()`; the real `LAMBSESSID` session is still required), rather than weakening it to a single bearer token.

## Changes

- `bootstrap.php`: new `configure_session_save_path($data_dir)`; `bootstrap_session()` now takes the data dir.
- `index.php`: resolve the data dir once and pass it to both `bootstrap_db()` and `bootstrap_session()`.
- `SessionBootstrapTest.php`: assert the save path is a dedicated dir under the data dir and is created.

## Testing

- `vendor/bin/codecept run Unit` — 988 tests pass
- `composer lint` + `composer analyse` (PHPStan level 8) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)