### PR TITLE
Add "Cut release" workflow to create releases via workflow_dispatch

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,61 @@
+name: Cut release
+
+# Creates the GitHub Release (and its tag) at the tip of `release`. Publishing the
+# release fires `release-artifacts.yml` (on `release: published`), which builds the
+# no-Composer tarball and the Docker image. Run this *after* promoting main → release
+# (see RELEASING.md): the release is tagged at the current `release` tip.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag, e.g. 0.11.0 or 0.11.0-rc1'
+        required: true
+        type: string
+      prerelease:
+        description: 'Mark as a pre-release (use for -rcN tags)'
+        type: boolean
+        default: false
+      latest:
+        description: 'Mark as the latest release (final releases only)'
+        type: boolean
+        default: false
+      notes:
+        description: 'Release notes in Markdown'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: release
+          fetch-depth: 0
+
+      - name: Create release
+        # All inputs are passed via env (never interpolated into the script) so
+        # release notes can contain quotes/backticks without breaking the shell.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          NOTES: ${{ inputs.notes }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          LATEST: ${{ inputs.latest }}
+        run: |
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists — refusing to overwrite." >&2
+            exit 1
+          fi
+          printf '%s' "$NOTES" > "$RUNNER_TEMP/notes.md"
+          flags=()
+          [ "$PRERELEASE" = "true" ] && flags+=(--prerelease)
+          [ "$LATEST" = "true" ] && flags+=(--latest)
+          gh release create "$VERSION" \
+            --target release \
+            --title "Lamb $VERSION" \
+            --notes-file "$RUNNER_TEMP/notes.md" \
+            "${flags[@]}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -89,6 +89,21 @@ gh release create <version> \
 # add --latest to mark a final release as the latest
 ```
 
+**No local `gh`?** The `Cut release` workflow (`.github/workflows/cut-release.yml`)
+does the same `gh release create --target release` server-side from a
+`workflow_dispatch`, so it can be driven without a local checkout or token (e.g.
+from an automation session that can trigger workflows but not create releases):
+
+```sh
+gh workflow run cut-release.yml \
+  -f version=<version> \
+  -f prerelease=true \
+  -f notes="$(cat /tmp/notes.md)"
+# omit prerelease (or set =false) for a final; add -f latest=true to mark it latest
+```
+
+It tags the current `release` tip, so promote main → release (step 4) first.
+
 - [ ] Merge the release PR (step 4) first, so `--target release` tags the
       intended commit. If the tag landed on the wrong commit, move it — the
       release object and its notes follow the tag:


### PR DESCRIPTION
## Why

Cutting a release needs `gh release create` (it creates the tag + publishes, which fires `release-artifacts.yml`). A session driving the release can run the documented pre-flight, open and merge the `main → release` promotion PR, and trigger workflows — but this environment's GitHub tools are **read-only for releases** and there's no local `gh`/token, so the final publish couldn't be automated.

## What

- **`.github/workflows/cut-release.yml`** — a `workflow_dispatch` workflow that runs `gh release create --target release` server-side using the built-in `github.token` (no new secret). Inputs: `version`, `prerelease`, `latest`, `notes`. It refuses to overwrite an existing tag, and passes all inputs via env (never interpolated into the script) so notes with quotes/backticks are safe. Publishing the release chains into the existing `release-artifacts.yml` (`release: published`) exactly as today.
- **`RELEASING.md`** — documents the dispatch path next to the local `gh` command in step 5.

End-to-end this makes the release fully drivable from a session: pre-flight → promotion PR → merge → trigger `cut-release` with the curated notes. Least-privilege: the token never leaves CI.

## Note

Promote `main → release` (step 4) before triggering — the workflow tags the current `release` tip.

https://claude.ai/code/session_014tksPKohNz2CuXW1PJJ4nY

---
_Generated by [Claude Code](https://claude.ai/code/session_014tksPKohNz2CuXW1PJJ4nY)_