### PR TITLE
cut-release: trigger artifacts build after creating the release

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -59,3 +59,13 @@ jobs:
             --title "Lamb $VERSION" \
             --notes-file "$RUNNER_TEMP/notes.md" \
             "${flags[@]}"
+
+      - name: Build release artifacts
+        # A release created with GITHUB_TOKEN does not fire the `release: published`
+        # event (GitHub suppresses GITHUB_TOKEN-triggered events to avoid recursion),
+        # so release-artifacts.yml won't auto-run. workflow_dispatch is the documented
+        # exception to that rule, so trigger the build explicitly here.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: gh workflow run release-artifacts.yml -f tag="$VERSION"


### PR DESCRIPTION
## Problem found while cutting 0.11.0-rc1

The `Cut release` workflow (#426) published `0.11.0-rc1` correctly, but `release-artifacts.yml` did **not** auto-run — so no tarball/Docker image was built.

Cause: a release created with the built-in `GITHUB_TOKEN` does not fire the `release: published` event (GitHub suppresses `GITHUB_TOKEN`-triggered events to avoid recursive runs). So the downstream artifacts workflow never started.

## Fix

`cut-release.yml` now explicitly dispatches `release-artifacts.yml` (`-f tag=$VERSION`) after creating the release. `workflow_dispatch` / `repository_dispatch` are the documented exception to the `GITHUB_TOKEN` no-recursion rule, so this works without a PAT.

For the already-published `0.11.0-rc1`, I triggered `release-artifacts.yml` manually (same mechanism) to attach the tarball and push the Docker image.

https://claude.ai/code/session_014tksPKohNz2CuXW1PJJ4nY

---
_Generated by [Claude Code](https://claude.ai/code/session_014tksPKohNz2CuXW1PJJ4nY)_