### PR TITLE
docs(nginx): add optional fastcgi_cache recipe for PHP responses

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -65,6 +65,103 @@ Without it, NGINX serves static files with no `Cache-Control`, which Lighthouse
 flags as *"Use efficient cache lifetimes"* and which forces repeat visitors to
 re-download fonts, CSS and images on every visit.
 
+## Caching PHP responses (optional)
+
+The static-asset block above only helps repeat visits to the same browser. If
+you expect traffic spikes (a link from Hacker News, Reddit, etc.) you can also
+let NGINX cache the **HTML responses** themselves with `fastcgi_cache`, serving
+them straight from disk without invoking PHP-FPM or SQLite at all.
+
+This is **opt-in and not enabled by default.** Lamb already emits correct cache
+headers for anonymous visitors (`Cache-Control: max-age=300`, `Vary: Cookie`)
+and `private, no-store` for logged-in ones, so a CDN such as Cloudflare in front
+of Lamb gives you the same edge-caching for free. Only reach for `fastcgi_cache`
+if you are running NGINX directly *and* expect load that the browser cache can't
+absorb (many distinct first-time visitors).
+
+> **Footgun warning.** `fastcgi_cache` ignores `Vary`, so it will *not*
+> automatically key anonymous and logged-in responses apart the way the browser
+> cache does. You **must** bypass the cache for logged-in requests explicitly
+> (below), or NGINX may store and re-serve a logged-in page — complete with the
+> admin toolbar and a stale CSRF token — to anonymous visitors.
+
+### 1. Define the cache zone and bypass rules (http context)
+
+Create `/etc/nginx/conf.d/lamb-cache.conf` (the `http {}` context — these
+directives cannot live inside a `server {}` snippet):
+
+```nginx
+# Where cached responses live, plus a 100 MB in-memory key zone.
+fastcgi_cache_path /var/cache/nginx/lamb levels=1:2 keys_zone=lamb:100m
+                   inactive=60m max_size=1g;
+
+# Skip the cache for logged-in visitors: Lamb sets the signed `lamb_logged_in`
+# cookie on login, so its presence means "do not cache / do not serve cached".
+map $cookie_lamb_logged_in $lamb_skip_cache_cookie {
+    default 1;   # cookie present → skip
+    ""      0;   # anonymous      → cacheable
+}
+
+# Only ever cache safe, idempotent methods.
+map $request_method $lamb_skip_cache_method {
+    default 1;
+    GET     0;
+    HEAD    0;
+}
+```
+
+`/var/cache/nginx/` must be writable by the NGINX worker user (usually
+`www-data`); create it with `sudo install -d -o www-data -g www-data
+/var/cache/nginx/lamb`.
+
+### 2. Enable the cache on the PHP location (server context)
+
+Add the cache directives to the `location ~ \.php$` block in
+`snippets/php-82.conf` (or your own copy):
+
+```nginx
+location ~ \.php$  {
+    include snippets/fastcgi-php.conf;
+    fastcgi_pass unix:/run/php/php8.2-fpm.sock;
+
+    # --- fastcgi_cache (optional) ---
+    fastcgi_cache       lamb;
+    fastcgi_cache_key   "$scheme$request_method$host$request_uri";
+
+    # Honour the app's own Cache-Control (max-age=300 for anonymous pages);
+    # this fallback only applies to responses without a cache lifetime.
+    fastcgi_cache_valid 200 5m;
+    fastcgi_cache_valid 404 1m;
+
+    # Never store, and never serve from cache, when either rule says skip.
+    # `_bypass` = don't read from cache; `no_cache` = don't write to it.
+    fastcgi_cache_bypass $lamb_skip_cache_cookie $lamb_skip_cache_method;
+    fastcgi_no_cache     $lamb_skip_cache_cookie $lamb_skip_cache_method;
+
+    # Optional: expose hits/misses for debugging (HIT / MISS / BYPASS).
+    add_header X-Cache-Status $upstream_cache_status always;
+}
+```
+
+Lamb's `private, no-store` header on logged-in responses already prevents NGINX
+from caching them, so the cookie bypass is defence-in-depth — but keep it: it
+also stops a cached *anonymous* page from being served back to a logged-in user
+within the TTL.
+
+### 3. Verify
+
+```shell
+sudo systemctl reload nginx
+curl -sI https://your-site/ | grep -i x-cache-status   # MISS, then HIT
+curl -sI https://your-site/ -b lamb_logged_in=anything | grep -i x-cache-status  # BYPASS
+```
+
+Because the TTL matches the app's `max-age` (5 minutes), a freshly published
+post can take up to that long to appear for anonymous visitors — the same
+staleness window the browser cache already has. If that's not acceptable, drop
+the TTL or purge the zone on publish (a paid `ngx_cache_purge` / NGINX Plus
+feature).
+
 ## Restart services
 
 ```shell


### PR DESCRIPTION
## Summary

Refreshes #115 (browser/proxy cacheability) with an **opt-in** `fastcgi_cache` recipe in `docs/nginx.md`.

Investigation found the four blockers from the issue are already resolved on `main`:
- Anonymous vs authenticated requests are distinguished by the signed `lamb_logged_in` cookie (#116) — anonymous responses get `max-age=300` + `Vary: Cookie`, logged-in get `private, no-store`.
- CSRF tokens only appear on logged-in pages and `/login` (excluded from caching), so no cacheable anonymous page carries one.
- The homepage no longer needs a query string (#32); legacy `?page=N` 301-redirects to clean paths.
- Conditional GET / ETag / 304 are in place (#116, #279).

The application side is done. The only remaining gap was a server-side cache recipe for the HTML responses, so this documents one.

## What's in the docs section

- A `fastcgi_cache_path` zone plus two `map` blocks that skip the cache for logged-in requests (the `lamb_logged_in` cookie) and non-`GET`/`HEAD` methods — necessary because `fastcgi_cache` ignores `Vary: Cookie`.
- The `location ~ \.php$` additions (`fastcgi_cache*`, `_bypass`/`no_cache`, an `X-Cache-Status` debug header).
- A verify snippet and a note that the 5-minute TTL matches the app's `max-age`, so anonymous staleness is unchanged from today.

## Why opt-in / default-off

Lamb already emits proxy-friendly headers, so a CDN in front gives the same edge caching for free. `fastcgi_cache` adds a real footgun (it can serve a logged-in page to anonymous visitors if the cookie bypass is misconfigured), so it's documented as opt-in rather than shipped enabled — in keeping with Lamb's "simple, safe defaults" philosophy. The shipped `.nginx` config is unchanged.

Docs-only change.

https://claude.ai/code/session_01JnmMsbdTPezp64NWRCaXMy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnmMsbdTPezp64NWRCaXMy)_