### PR TITLE
Remove the theme PHP fallback and the default→base alias

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -111,46 +111,41 @@ function parse_ini_safe(string $ini_text): array
 }
 
 /**
- * Resolves a configured theme name to the directory that should be rendered.
+ * Ensures the stored INI records an explicit, renderable top-level `theme` key.
  *
- * Falls back to the bundled `base` theme (the part-fallback library) when no
- * theme is configured, and aliases the legacy name `default` to `base` so
- * installs that explicitly set `theme = default` keep working after the rename.
+ * This is the single place that normalises the legacy theme shapes, so the
+ * render path (`index.php`) can read `$config['theme']` directly without a
+ * runtime fallback or alias (see #291):
+ *  - no `theme` key at all (older installs relied on a PHP fallback): an
+ *    explicit line is prepended;
+ *  - an empty value, or the pre-rename name `default`: the line is rewritten to
+ *    the bundled `base` theme (the part-fallback library).
  *
- * @param string|null $configured The theme name from config, or null when unset.
- * @param string $fallback The theme to use when none is configured.
- * @return string The theme directory name to render.
- */
-function resolve_theme(?string $configured, string $fallback = 'base'): string
-{
-    if (empty($configured)) {
-        return $fallback;
-    }
-    if ($configured === 'default') {
-        return 'base';
-    }
-    return $configured;
-}
-
-/**
- * Ensures the INI text records an explicit top-level `theme` key.
- *
- * Older installs never stored a theme and relied on a PHP fallback. Stamping an
- * explicit value lets that fallback be removed later. Idempotent: returns the
- * text unchanged when a top-level `theme` key is already present.
+ * Idempotent: text that already names a real theme is returned unchanged.
  *
  * @param string $ini_text The raw INI configuration text.
- * @param string $default_theme The theme to record when none is set.
- * @return string The INI text, with a `theme` line prepended when it was absent.
+ * @param string $default_theme The theme to record when none is usable.
+ * @return string The INI text with an explicit, renderable `theme` value.
  */
 function ensure_explicit_theme(string $ini_text, string $default_theme = 'base'): string
 {
     $parsed = parse_ini_safe($ini_text);
-    if (array_key_exists('theme', $parsed)) {
-        return $ini_text;
+
+    if (!array_key_exists('theme', $parsed)) {
+        return "theme = {$default_theme}\n\n" . $ini_text;
     }
 
-    return "theme = {$default_theme}\n\n" . $ini_text;
+    $current = trim((string) $parsed['theme']);
+    if ($current === '' || $current === 'default') {
+        return (string) preg_replace(
+            '/^(\h*theme\h*=).*$/mi',
+            '${1} ' . $default_theme,
+            $ini_text,
+            1
+        );
+    }
+
+    return $ini_text;
 }
 
 /**
@@ -181,8 +176,9 @@ function compose_config(string $stored_ini, string $default_ini): array
     $defaults = parse_ini_safe($default_ini);
 
     // Theme is intentionally not defaulted here. An install without an explicit
-    // theme is resolved/migrated per-install (see resolve_theme / get_ini_text),
-    // so inheriting the seeded theme would silently re-theme existing sites.
+    // theme is migrated per-install on read (see ensure_explicit_theme /
+    // get_ini_text), so inheriting the seeded theme would silently re-theme
+    // existing sites.
     unset($defaults['theme']);
 
     // Personal-identity values are kept commented in the seeded INI, so supply

--- a/src/index.php
+++ b/src/index.php
@@ -17,7 +17,9 @@ $config = Config\load();
 Config\apply_timezone($config);
 
 define('ROOT_URL', (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://" . $_SERVER["HTTP_HOST"]);
-define("THEME", Config\resolve_theme($config['theme'] ?? null));
+// Config\ensure_explicit_theme() guarantees a renderable theme value on read,
+// so no runtime fallback/alias is needed here (see #291).
+define("THEME", (string) $config['theme']);
 define("THEME_DIR", ROOT_DIR . '/themes/' . THEME . '/');
 define("THEME_URL", 'themes/' . THEME . '/');
 

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -9,7 +9,6 @@ use function Lamb\Config\ensure_explicit_theme;
 use function Lamb\Config\get_default_ini_text;
 use function Lamb\Config\get_menu_slugs;
 use function Lamb\Config\is_menu_item;
-use function Lamb\Config\resolve_theme;
 
 // Since we need to test a function that depends on global $config, we'll mock it or set it.
 class ConfigTest extends TestCase
@@ -149,20 +148,36 @@ class ConfigTest extends TestCase
         $this->assertSame($once, $twice);
     }
 
-    public function testResolveThemeFallsBackToBaseWhenUnset(): void
+    public function testEnsureExplicitThemeMigratesLegacyDefaultToBase(): void
     {
-        $this->assertSame('base', resolve_theme(null));
+        $ini = "theme = default\nsite_title = Example\n";
+
+        $migrated = ensure_explicit_theme($ini);
+        $parsed = parse_ini_string($migrated, true, INI_SCANNER_RAW);
+
+        $this->assertSame('base', $parsed['theme']);
+        // Existing content is preserved.
+        $this->assertSame('Example', $parsed['site_title']);
     }
 
-    public function testResolveThemeMapsLegacyDefaultToBase(): void
+    public function testEnsureExplicitThemeReplacesEmptyThemeWithBase(): void
     {
-        $this->assertSame('base', resolve_theme('default'));
+        $ini = "theme =\nsite_title = Example\n";
+
+        $migrated = ensure_explicit_theme($ini);
+        $parsed = parse_ini_string($migrated, true, INI_SCANNER_RAW);
+
+        $this->assertSame('base', $parsed['theme']);
+        $this->assertSame('Example', $parsed['site_title']);
     }
 
-    public function testResolveThemePassesThroughOtherThemes(): void
+    public function testEnsureExplicitThemeLeavesCustomThemeUntouched(): void
     {
-        $this->assertSame('2026', resolve_theme('2026'));
-        $this->assertSame('my-custom', resolve_theme('my-custom'));
+        $this->assertSame('my-custom', parse_ini_string(
+            ensure_explicit_theme("theme = my-custom\n"),
+            true,
+            INI_SCANNER_RAW
+        )['theme']);
     }
 
     public function testDefaultIniSetsSiteTitleForNewInstalls(): void


### PR DESCRIPTION
Closes #291.

## What

Removes the back-compat scaffolding in the old `Config\resolve_theme()`:
- the `?? 'base'` fallback for a missing `theme` key, and
- the `default` → `base` legacy alias.

`resolve_theme()` is deleted; `index.php` reads `$config['theme']` directly.

## How the precondition is met

The ticket asked to first *confirm via production config that no install lacks a `theme` key or uses `theme = default`*. Rather than rely on a manual check, this PR moves that normalisation into the one-time migration so it's handled deterministically:

`Config\ensure_explicit_theme()` (already run on every read in `get_ini_text()`) now guarantees an explicit, **renderable** theme:
- missing key → prepend `theme = base` (unchanged);
- empty value or legacy `default` → rewrite the line to `base` (new).

So by the time `index.php` reads `$config['theme']`, it is always present and never `default`/empty — making the runtime fallback/alias genuinely dead code.

## Tests (red-green)

- `ensure_explicit_theme()` migrates `theme = default` → `base` (new, was red)
- `ensure_explicit_theme()` rewrites an empty `theme =` → `base` (new, was red)
- a real custom theme is left untouched
- existing missing-key / idempotency / `compose_config` theme tests still pass

The old `resolve_theme()` tests are removed.

Full suite: 988 unit tests pass, `composer lint` and `composer analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)