### PR TITLE
Support a hand-written post summary in front matter

### DIFF
--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -63,6 +63,17 @@ Slugs are unique. If a slug is already taken by another post (or matches a built
 
 You can also set a `created:` date in the front-matter. A future date schedules the post — see [Scheduling]({{ site.baseurl }}{% link scheduling.md %}).
 
+By default Lamb derives a post's description from its first line. Set a `summary:` in the front-matter to write that description yourself — it is used for the post's [social-embed]({{ site.baseurl }}{% link social-embeds.md %}) description (the OpenGraph/Twitter `description` tag) and its feed summary. `description:` works as an alias.
+
+```markdown
+---
+title: My weekend project
+summary: A short, hand-written description for search engines and social cards.
+---
+
+The full post body goes here.
+```
+
 Front-matter keys are forgiving: they are matched case-insensitively, and underscores and dashes are interchangeable. So `Title`, `title`, `in_reply_to` and `in-reply-to` all work — handy on mobile keyboards that auto-capitalise the first letter of a line.
 
 > **iOS note:** iOS "Smart Punctuation" rewrites a typed `---` into em/en dashes (for example `—-`). Lamb recognises a mangled opening and closing fence and restores it to `---` automatically — whether you add the front-matter when first writing the post or by editing it later — so front-matter still works from an iPhone or iPad. If you'd rather type plain dashes everywhere, turn the feature off under _Settings → General → Keyboard → Smart Punctuation_.
@@ -81,6 +92,7 @@ The following sections of the site are special:
 * [Media]({{ site.baseurl }}{% link media.md %}): Add images by drag-and-drop or paste; JPEG/PNG are converted to WebP.
 * [Drafts]({{ site.baseurl }}{% link drafts.md %}): Add `draft: true` to front-matter to save a post as a draft.
 * [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Add a future `created:` date to publish a post later.
+* [Social Embeds]({{ site.baseurl }}{% link social-embeds.md %}): A `summary:` in front-matter sets the description used in social preview cards.
 * [Menu Items]({{ site.baseurl }}{% link menu-items.md %}): Page posts with slugs can be pinned as menu items.
 * [Reply posts]({{ site.baseurl }}{% link replies.md %}): Add `in-reply-to:` to front-matter to mark a post as a reply to another URL.
 * [Syntax Highlighting]({{ site.baseurl }}{% link syntax-highlighting.md %}): Fenced code blocks with a language hint are highlighted server-side.

--- a/docs/social-embeds.md
+++ b/docs/social-embeds.md
@@ -43,6 +43,13 @@ Lamb reads the image's real dimensions and type for the `og:image:width`,
 `og:image:height`, and `og:image:type` tags when the file is readable, so you
 don't need to declare them anywhere.
 
+## The card description
+
+The card's description text (`og:description` / `twitter:description`) comes
+from the post's description. By default Lamb uses the post's first line; set a
+`summary:` in the post's front-matter to write that description yourself. See
+[Post Types]({{ site.baseurl }}{% link post-types.md %}).
+
 ## Related
 
 * [Media]({{ site.baseurl }}{% link media.md %}) — uploading images into posts (these become the card image automatically)

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -174,7 +174,13 @@ function parse_bean(OODBBean $bean): void
     $markdown = render_body($bean->body);
 
     $front_matter = parse_matter($bean->body);
-    $front_matter['description'] = extract_description($markdown);
+    // A hand-written `summary` (or `description`) in front matter wins over the
+    // auto-extracted first line; both feed the post's `description` column, which
+    // drives the feeds and the OpenGraph/meta tags.
+    $front_matter['description'] = front_matter_summary($front_matter) ?? extract_description($markdown);
+    // The summary is stored as the description, so drop the raw `summary` key
+    // before apply_frontmatter()'s blind copy persists it as a stray column.
+    unset($front_matter['summary']);
     $front_matter['transformed'] = highlight_and_link($markdown);
 
     // Capture the existing created date before apply_frontmatter() blind-copies the
@@ -221,6 +227,31 @@ function extract_description(string $markdown): string
     $description = html_entity_decode($description, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
     return html_entity_decode($description, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+}
+
+/**
+ * Returns the author's hand-written summary from front matter, or null when none.
+ *
+ * Accepts `summary` (the canonical key) and `description` as an alias;
+ * parse_matter() has already lower-cased the keys and converted underscores to
+ * dashes. A whitespace-only value is treated as absent, so an empty line falls
+ * back to the auto-generated description.
+ *
+ * @param array<int|string, mixed> $front_matter The parsed front matter.
+ * @return string|null The trimmed manual summary, or null to fall back to auto.
+ *
+ * @internal Decomposed step of parse_bean(); not part of the public API.
+ */
+function front_matter_summary(array $front_matter): ?string
+{
+    foreach (['summary', 'description'] as $key) {
+        $value = $front_matter[$key] ?? null;
+        if (is_string($value) && trim($value) !== '') {
+            return trim($value);
+        }
+    }
+
+    return null;
 }
 
 /**

--- a/tests/Unit/ParseBeanDescriptionTest.php
+++ b/tests/Unit/ParseBeanDescriptionTest.php
@@ -28,4 +28,61 @@ class ParseBeanDescriptionTest extends TestCase
         $this->assertStringNotContainsString('&amp;', $bean->description);
         $this->assertStringContainsString("I'm researching", $bean->description);
     }
+
+    public function testFrontMatterSummaryOverridesAutoDescription()
+    {
+        $bean = R::dispense('post');
+        $bean->body = "---\nsummary: A hand-written summary.\n---\n\nThe body's first line should not become the description.";
+        $bean->slug = '';
+
+        parse_bean($bean);
+
+        $this->assertSame('A hand-written summary.', $bean->description);
+    }
+
+    public function testFrontMatterDescriptionKeyAlsoOverridesAutoDescription()
+    {
+        $bean = R::dispense('post');
+        $bean->body = "---\ndescription: Aliased summary.\n---\n\nFirst body line.";
+        $bean->slug = '';
+
+        parse_bean($bean);
+
+        $this->assertSame('Aliased summary.', $bean->description);
+    }
+
+    public function testWhitespaceOnlySummaryFallsBackToAutoDescription()
+    {
+        $bean = R::dispense('post');
+        $bean->body = "---\nsummary: \"   \"\n---\n\nFirst body line.";
+        $bean->slug = '';
+
+        parse_bean($bean);
+
+        $this->assertSame('First body line.', $bean->description);
+    }
+
+    public function testFallsBackToAutoDescriptionWhenNoSummary()
+    {
+        $bean = R::dispense('post');
+        $bean->body = "---\ntitle: A Title\n---\n\nFirst body line.";
+        $bean->slug = '';
+
+        parse_bean($bean);
+
+        $this->assertSame('First body line.', $bean->description);
+    }
+
+    public function testSummaryDoesNotLeakIntoAStrayColumn()
+    {
+        $bean = R::dispense('post');
+        $bean->body = "---\nsummary: A hand-written summary.\n---\n\nBody.";
+        $bean->slug = '';
+
+        parse_bean($bean);
+
+        // The summary becomes the description; it must not also create a stray
+        // `summary` property that RedBean would persist as an unused column.
+        $this->assertEmpty($bean->summary);
+    }
 }


### PR DESCRIPTION
Closes #28.

## What

Adds a `summary:` front-matter key so authors can hand-write a post's description instead of relying on the auto-extracted first line.

- The summary feeds the post's `description` — used by the Atom/JSON feeds and the OpenGraph/`<meta name="description">` tags.
- `description:` is accepted as an alias (front-matter keys are already lower-cased / underscore-normalised by `parse_matter()`).
- When no summary is set (or it's blank), behaviour is unchanged: the first body line is used.
- **No list-view excerpt change** — list/home/tag views still render full posts.

## Where

The change lives in `parse_bean()`, the single choke point every save path runs through (web create/edit, Micropub, feed ingestion, upgrade re-parse), so it applies everywhere with no per-path duplication. A new `front_matter_summary()` helper resolves the value; the raw `summary` key is dropped before `apply_frontmatter()`'s blind copy so it never persists as a stray column.

## Tests (red-green)

- `summary:` overrides the auto description (was red)
- `description:` alias overrides it (was red)
- whitespace-only summary falls back to auto
- no summary falls back to the first body line
- a `summary` does not leak into a stray bean column (was red)

Full suite: 993 unit tests pass, `composer lint` and `composer analyse` clean.

## Docs

Documents the key in `docs/post-types.md` and cross-links from `docs/social-embeds.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)