### PR TITLE
Flatten redirect chains periodically in /_cron

### DIFF
--- a/docs/redirections.md
+++ b/docs/redirections.md
@@ -47,6 +47,10 @@ When you edit a page post and change its `slug:` front-matter:
 
 Publishing a new post whose slug matches an existing redirect's source automatically removes the redirect — the new post takes over that URL.
 
+### Chain flattening
+
+Reslugging the same post more than once would otherwise leave a chain of redirects (`old → /newer`, `newer → /newest`), making a visitor follow several 301s. The [`/_cron`]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}) run flattens these so every hop points straight at the final destination, breaks any redirect loops it finds, and removes redirects whose destination no longer resolves to a post (a redirect to a [trashed]({{ site.baseurl }}{% link trash.md %}) post is kept, since the post may be restored). This is automatic maintenance — there is nothing to configure.
+
 ## Precedence rules
 
 A live post is always served directly, regardless of any redirect (manual or automatic) pointing to the same slug. A redirect only fires when no published post has that slug.

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -645,3 +645,115 @@ function find_redirect(string $slug): ?string
 
     return null;
 }
+
+/**
+ * Returns the bare slug a redirect target points at when it can chain to another
+ * redirect's `from_slug`, or null when the target is terminal.
+ *
+ * Only an internal, single-segment target (`/slug`) can chain. External URLs,
+ * multi-segment paths (`/a/b`), and the root (`/`) are terminal destinations.
+ *
+ * @param string $to_url The redirect's stored destination.
+ * @return string|null The chainable target slug, or null when terminal.
+ */
+function redirect_target_slug(string $to_url): ?string
+{
+    if (!str_starts_with($to_url, '/')) {
+        return null;
+    }
+    $slug = ltrim($to_url, '/');
+    if ($slug === '' || str_contains($slug, '/')) {
+        return null;
+    }
+
+    return $slug;
+}
+
+/**
+ * Flattens stored redirect chains so each hop points straight at its final
+ * destination, breaks loops, and drops redirects whose destination no longer
+ * resolves to a post. Intended to run as periodic maintenance from `/_cron`.
+ *
+ * - A chain `a → /b`, `b → /c` is rewritten so `a → /c` (one 301 instead of two).
+ * - A loop (`a → /b`, `b → /a`) cannot resolve, so its rows are deleted.
+ * - A redirect whose final single-segment destination has no post is deleted,
+ *   unless a soft-deleted (trashed) post still holds that slug — it may be
+ *   restored, so the redirect is kept.
+ *
+ * @return int The number of redirect rows rewritten or deleted.
+ */
+function flatten_redirects(): int
+{
+    $redirects = R::findAll('redirect');
+
+    /** @var array<string, \RedBeanPHP\OODBBean> $by_from */
+    $by_from = [];
+    foreach ($redirects as $redirect) {
+        if (is_string($redirect->from_slug) && $redirect->from_slug !== '') {
+            $by_from[$redirect->from_slug] = $redirect;
+        }
+    }
+
+    $delete  = [];
+    $changes = 0;
+
+    // 1. Resolve each redirect to its final destination, collecting loop members.
+    foreach ($by_from as $from => $redirect) {
+        $path  = [];
+        $index = [];
+        $node  = $from;
+        $final = $redirect->to_url;
+        $loop  = null;
+
+        while (true) {
+            $index[$node] = count($path);
+            $path[]       = $node;
+            $final        = $by_from[$node]->to_url;
+
+            $target = redirect_target_slug((string) $by_from[$node]->to_url);
+            if ($target === null || !isset($by_from[$target])) {
+                break;
+            }
+            if (isset($index[$target])) {
+                $loop = $target;
+                break;
+            }
+            $node = $target;
+        }
+
+        if ($loop !== null) {
+            for ($i = $index[$loop]; $i < count($path); $i++) {
+                $delete[$path[$i]] = $by_from[$path[$i]];
+            }
+            continue;
+        }
+
+        if ($final !== $redirect->to_url) {
+            $redirect->to_url = $final;
+            R::store($redirect);
+            $changes++;
+        }
+    }
+
+    // 2. Drop redirects whose final destination resolves to no post, keeping
+    //    those whose slug is still held by a trashed (restorable) post.
+    foreach ($by_from as $from => $redirect) {
+        if (isset($delete[$from])) {
+            continue;
+        }
+        $target = redirect_target_slug((string) $redirect->to_url);
+        if ($target === null) {
+            continue;
+        }
+        if (R::findOne('post', ' slug = ? ', [$target]) === null) {
+            $delete[$from] = $redirect;
+        }
+    }
+
+    foreach ($delete as $redirect) {
+        R::trash($redirect);
+        $changes++;
+    }
+
+    return $changes;
+}

--- a/src/network.php
+++ b/src/network.php
@@ -86,6 +86,11 @@ function purge_deleted_posts(): int
         echo("Pruned $pruned stale feed status row(s)." . PHP_EOL);
     }
 
+    $flattened = \Lamb\flatten_redirects();
+    if ($flattened > 0) {
+        echo("Flattened $flattened redirect(s)." . PHP_EOL);
+    }
+
     echo("Updating feeds..." . PHP_EOL);
     foreach ($feeds as $name => $url) {
         flush();

--- a/tests/Unit/RedirectFlattenTest.php
+++ b/tests/Unit/RedirectFlattenTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\flatten_redirects;
+
+class RedirectFlattenTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+    }
+
+    private function redirect(string $from, string $to): void
+    {
+        $r = R::dispense('redirect');
+        $r->from_slug = $from;
+        $r->to_url = $to;
+        R::store($r);
+    }
+
+    private function post(string $slug, bool $deleted = false): void
+    {
+        $p = R::dispense('post');
+        $p->slug = $slug;
+        $p->body = 'x';
+        $p->deleted = $deleted ? 1 : 0;
+        R::store($p);
+    }
+
+    private function toUrlFor(string $from): ?string
+    {
+        $r = R::findOne('redirect', ' from_slug = ? ', [$from]);
+        return $r?->to_url;
+    }
+
+    public function testTwoHopChainFlattensToOneHop(): void
+    {
+        $this->post('newest');
+        $this->redirect('old', '/newer');
+        $this->redirect('newer', '/newest');
+
+        flatten_redirects();
+
+        $this->assertSame('/newest', $this->toUrlFor('old'), 'old should point straight at the final destination');
+        $this->assertSame('/newest', $this->toUrlFor('newer'));
+    }
+
+    public function testLoopIsBrokenByDeletingTheLoopingRows(): void
+    {
+        $this->redirect('a', '/b');
+        $this->redirect('b', '/a');
+
+        flatten_redirects();
+
+        $this->assertSame(0, R::count('redirect'), 'looping rows are deleted');
+    }
+
+    public function testUnrelatedRedirectsAreUntouched(): void
+    {
+        $this->post('target');
+        $this->redirect('old-page', '/target');
+
+        flatten_redirects();
+
+        $this->assertSame('/target', $this->toUrlFor('old-page'));
+        $this->assertSame(1, R::count('redirect'));
+    }
+
+    public function testDeadRedirectIsDeletedWhenDestinationHasNoPost(): void
+    {
+        $this->redirect('gone', '/nowhere');
+
+        flatten_redirects();
+
+        $this->assertNull($this->toUrlFor('gone'), 'a redirect to a non-existent post is removed');
+    }
+
+    public function testRedirectToTrashedPostIsKept(): void
+    {
+        $this->post('trashed-slug', deleted: true);
+        $this->redirect('old', '/trashed-slug');
+
+        flatten_redirects();
+
+        $this->assertSame('/trashed-slug', $this->toUrlFor('old'), 'a trashed post may be restored, so keep the redirect');
+    }
+
+    public function testExternalRedirectIsKept(): void
+    {
+        $this->redirect('go', 'https://example.com/elsewhere');
+
+        flatten_redirects();
+
+        $this->assertSame('https://example.com/elsewhere', $this->toUrlFor('go'));
+    }
+}


### PR DESCRIPTION
Closes #335.

## Problem

Every slug change stores a `redirect` row. Reslugging the same post more than once chains them (`old → /newer`, `newer → /newest`), so a visitor hitting `old` follows two 301s — and a deleted intermediate can leave a dead hop or a loop.

## What

Adds `flatten_redirects()`, run as periodic maintenance in `process_feeds()` (the `/_cron` run) alongside `purge_deleted_posts()` / `prune_feed_status()`:

- **Flatten:** rewrite each redirect's `to_url` to the chain's final destination, so every hop is a single 301.
- **Loops:** detect a cycle (`a → /b`, `b → /a`) and **delete the looping rows** — they can't resolve to a real destination.
- **Dead rows:** delete a redirect whose final single-segment destination resolves to no post — **unless** a trashed post still holds that slug (it may be restored), in which case it's kept.

External URLs, multi-segment paths, and the root are terminal and left untouched. A small `redirect_target_slug()` helper centralises "can this target chain to another `from_slug`".

## Tests (red-green)

`tests/Unit/RedirectFlattenTest.php`: two-hop chain → one hop; loop deleted (no hang); unrelated redirect untouched; dead redirect deleted; redirect to a trashed post kept; external redirect kept.

Full suite: 994 unit tests pass; `composer lint` and `composer analyse` clean.

## Docs

`docs/redirections.md` gains a "Chain flattening" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)