### PR TITLE
WebSub: ping hub when a scheduled post publishes

### DIFF
--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -57,7 +57,10 @@ With a hub configured, Lamb:
 
 Any public hub works — the IndieWeb wiki keeps a
 [list of hubs](https://indieweb.org/WebSub#Hubs) to choose from.
-Drafts, scheduled posts, and cross-posted feed items do not trigger pings.
+Drafts and cross-posted feed items do not trigger pings. A **scheduled** post
+can't ping at save time (its publication time hasn't arrived yet), so the hub
+is pinged for it on the next [`/_cron`]({{ site.baseurl }}{% link cron-scheduled-tasks.md %})
+run after it goes live — keep `/_cron` on a schedule for timely real-time push of scheduled posts.
 
 ## Related
 

--- a/src/network.php
+++ b/src/network.php
@@ -120,6 +120,11 @@ function purge_deleted_posts(): int
         }
     }
 
+    $published = \Lamb\Websub\ping_scheduled_publishes();
+    if ($published > 0) {
+        printf("WebSub: pinged hub for %d scheduled post(s) now published." . PHP_EOL, $published);
+    }
+
     $sent = \Lamb\Webmention\process_outbound();
     if ($sent['sent'] || $sent['failed'] || $sent['skipped'] || $sent['cancelled']) {
         printf(

--- a/src/websub.php
+++ b/src/websub.php
@@ -5,8 +5,17 @@
 namespace Lamb\Websub;
 
 use RedBeanPHP\OODBBean;
+use RedBeanPHP\R;
+
+use function Lamb\get_option;
+use function Lamb\set_option;
 
 use const ROOT_URL;
+
+/**
+ * Option key holding the wall-clock time of the last scheduled-publish sweep.
+ */
+const SCHEDULED_PUBLISH_WATERMARK = 'websub_last_scheduled_publish';
 
 /**
  * Seconds before a hub ping is abandoned. Pings run in the publish request,
@@ -94,4 +103,56 @@ function send_ping(string $hub, string $topic): void
         WEBSUB_PING_TIMEOUT,
         'Lamb-WebSub'
     );
+}
+
+/**
+ * Ping the hub for scheduled posts whose publication time has arrived since the
+ * last cron run. Intended to run from `/_cron`.
+ *
+ * ping_for_post() skips future-dated posts at save time, and a scheduled post
+ * with no external links has no webmention queue row to piggyback on, so the
+ * publication-time notification has to happen here. A watermark records the
+ * wall-clock time of the previous sweep; a scheduled post that crossed from the
+ * future into the past during the window pings the hub once (one ping covers
+ * all crossings in the window, since the feed is the topic).
+ *
+ * Scheduled posts are distinguished from ordinary posts — which already pinged
+ * at save time — by `created > updated`: their publish date is later than the
+ * last save. The first sweep on an install records the watermark without
+ * pinging, so a backlog of already-published posts is not swept into a single
+ * catch-up ping.
+ *
+ * @param array<string, mixed>|null $config Config array; defaults to the global config.
+ * @param callable|null $sender Injectable sender, see {@see ping_hub}.
+ * @return int Number of scheduled posts found to have published this run.
+ */
+function ping_scheduled_publishes(?array $config = null, ?callable $sender = null): int
+{
+    $option = get_option(SCHEDULED_PUBLISH_WATERMARK, 0);
+    $now    = time();
+
+    if ((int) $option->id === 0) {
+        set_option($option, $now);
+        return 0;
+    }
+
+    $since   = date('Y-m-d H:i:s', (int) $option->value);
+    $now_str = date('Y-m-d H:i:s', $now);
+
+    $posts = R::find(
+        'post',
+        ' (draft IS NULL OR draft != 1) AND (deleted IS NULL OR deleted != 1) '
+        . " AND (feed_name IS NULL OR feed_name = '') "
+        . ' AND created > updated AND created > ? AND created <= ? ',
+        [$since, $now_str]
+    );
+
+    $count = count($posts);
+    if ($count > 0) {
+        ping_hub($config, $sender);
+    }
+
+    set_option($option, $now);
+
+    return $count;
 }

--- a/tests/Unit/WebsubScheduledTest.php
+++ b/tests/Unit/WebsubScheduledTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\get_option;
+use function Lamb\set_option;
+use function Lamb\Websub\ping_scheduled_publishes;
+
+class WebsubScheduledTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'https://example.com');
+        }
+    }
+
+    /** @var list<array{string,string}> */
+    private array $pings = [];
+
+    private function sender(): callable
+    {
+        $this->pings = [];
+        return function (string $hub, string $topic): void {
+            $this->pings[] = [$hub, $topic];
+        };
+    }
+
+    private function config(): array
+    {
+        return ['websub_hubs' => 'https://hub.example.com/'];
+    }
+
+    private function seedWatermark(string $datetime): void
+    {
+        // Persist the option so the run is not treated as the first run.
+        set_option(get_option('websub_last_scheduled_publish', 0), strtotime($datetime));
+    }
+
+    private function post(array $fields): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'x';
+        $bean->draft = 0;
+        $bean->deleted = 0;
+        $bean->feed_name = '';
+        foreach ($fields as $k => $v) {
+            $bean->$k = $v;
+        }
+        R::store($bean);
+    }
+
+    public function testPingsHubWhenScheduledPostCrossesIntoPublic(): void
+    {
+        $this->seedWatermark('2020-01-01 00:00:00');
+        // created > updated marks a scheduled post; created is now in the past.
+        $this->post(['created' => '2020-06-01 00:00:00', 'updated' => '2020-05-01 00:00:00']);
+
+        $count = ping_scheduled_publishes($this->config(), $this->sender());
+
+        $this->assertSame(1, $count);
+        $this->assertNotEmpty($this->pings, 'the hub should be pinged');
+    }
+
+    public function testDoesNotPingNormalPost(): void
+    {
+        $this->seedWatermark('2020-01-01 00:00:00');
+        // Normal post: created == updated (not scheduled) — already pinged at save.
+        $this->post(['created' => '2020-06-01 00:00:00', 'updated' => '2020-06-01 00:00:00']);
+
+        $count = ping_scheduled_publishes($this->config(), $this->sender());
+
+        $this->assertSame(0, $count);
+        $this->assertEmpty($this->pings);
+    }
+
+    public function testDoesNotPingStillFutureScheduledPost(): void
+    {
+        $this->seedWatermark('2020-01-01 00:00:00');
+        $this->post(['created' => '2099-01-01 00:00:00', 'updated' => '2026-01-01 00:00:00']);
+
+        $count = ping_scheduled_publishes($this->config(), $this->sender());
+
+        $this->assertSame(0, $count);
+        $this->assertEmpty($this->pings);
+    }
+
+    public function testDoesNotPingDraftScheduledPost(): void
+    {
+        $this->seedWatermark('2020-01-01 00:00:00');
+        $this->post(['created' => '2020-06-01 00:00:00', 'updated' => '2020-05-01 00:00:00', 'draft' => 1]);
+
+        $this->assertSame(0, ping_scheduled_publishes($this->config(), $this->sender()));
+    }
+
+    public function testDoesNotPingFeedItem(): void
+    {
+        $this->seedWatermark('2020-01-01 00:00:00');
+        $this->post([
+            'created' => '2020-06-01 00:00:00',
+            'updated' => '2020-05-01 00:00:00',
+            'feed_name' => 'somefeed',
+        ]);
+
+        $this->assertSame(0, ping_scheduled_publishes($this->config(), $this->sender()));
+    }
+
+    public function testDoesNotRepingAfterWatermarkAdvances(): void
+    {
+        $this->seedWatermark('2020-01-01 00:00:00');
+        $this->post(['created' => '2020-06-01 00:00:00', 'updated' => '2020-05-01 00:00:00']);
+
+        $this->assertSame(1, ping_scheduled_publishes($this->config(), $this->sender()));
+        // The watermark has advanced past the post's created date.
+        $this->assertSame(0, ping_scheduled_publishes($this->config(), $this->sender()));
+    }
+
+    public function testFirstRunSeedsWatermarkWithoutPinging(): void
+    {
+        // No watermark option seeded — this is the first run on the install.
+        $this->post(['created' => '2020-06-01 00:00:00', 'updated' => '2020-05-01 00:00:00']);
+
+        $count = ping_scheduled_publishes($this->config(), $this->sender());
+
+        $this->assertSame(0, $count, 'first run watches from now rather than sweeping history');
+        $this->assertEmpty($this->pings);
+    }
+}


### PR DESCRIPTION
Closes #330.

## Problem

`Websub\ping_for_post()` skips future-dated posts at save time, and (unlike webmentions) a scheduled post with no external links has no outbox row to piggyback on. So when a scheduled post's publication time arrived, nothing pinged the hub — subscribers only found out on the next unrelated publish.

## What

Adds `Websub\ping_scheduled_publishes()`, run from `/_cron` alongside the other maintenance.

- A watermark option (`websub_last_scheduled_publish`) records the previous sweep's wall-clock time. A scheduled post that crossed from the future into the past during the window pings the hub once (one ping covers the feed, regardless of how many crossed).
- **Avoids double-pinging ordinary posts** (which already pinged at save) by selecting only `created > updated` — i.e. the publish date is later than the last save, which is exactly what a scheduled post looks like and an ordinary post never does. Drafts, deleted, and feed items are excluded.
- The **first sweep** on an install just records the watermark without pinging, so a backlog of already-published scheduled posts isn't swept into one catch-up ping.

This is a refinement of the ticket's suggested "track newest public `created`" approach that also avoids re-pinging real-time publishes.

## Tests (red-green)

`tests/Unit/WebsubScheduledTest.php`: pings when a scheduled post crosses into public; does **not** ping a normal post, a still-future post, a draft, or a feed item; does not re-ping after the watermark advances; first run seeds the watermark without pinging.

Full suite: 995 unit tests pass; `composer lint` and `composer analyse` clean.

## Docs

`docs/feeds.md` WebSub section now explains scheduled posts ping on the next `/_cron` run after they go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)