### PR TITLE
Harden make-password.php: warn on weak passwords, keep cleartext out of .env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Run Codeception tests
         run: |
-          php make-password.php $GITHUB_REF
+          LAMB_WRITE_TEST_PASSWORD=1 php make-password.php $GITHUB_REF
           vendor/bin/codecept run --steps
 
       - name: Check code coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,11 @@ vendor/bin/codecept run Acceptance
 # Run client-side JavaScript unit tests (node:test + jsdom)
 pnpm test
 
-# Generate password hash and write .env
+# Generate password hash and write .env (warns on STDERR if the password is weak).
+# By default the cleartext password is NOT written to .env; the acceptance suite
+# opts in via LAMB_WRITE_TEST_PASSWORD=1 to get LAMB_TEST_PASSWORD.
 php make-password.php <your-password>
+LAMB_WRITE_TEST_PASSWORD=1 php make-password.php <your-password>   # for acceptance tests
 
 # Static analysis
 composer analyse
@@ -454,7 +457,7 @@ Parts you rarely need to override: `edit.php`, `login.php`, `settings.php`, `404
 Tests use **Codeception 5** with PHPUnit underneath.
 
 - **Unit** (`tests/Unit/`): pure PHP, no HTTP.
-- **Acceptance** (`tests/Acceptance/`): browser-level via PhpBrowser. Requires `SITE_URL` set in `.env` (written by `make-password.php`).
+- **Acceptance** (`tests/Acceptance/`): browser-level via PhpBrowser. Requires `SITE_URL` and `LAMB_TEST_PASSWORD` in `.env`. Generate it with `LAMB_WRITE_TEST_PASSWORD=1 php make-password.php <pw>` — `make-password.php` omits the cleartext `LAMB_TEST_PASSWORD` unless that flag is set.
 - **Functional** (`tests/Functional/`): Codeception functional tests.
 
 Config in `codeception.yml` reads env from `.env`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,8 +14,10 @@ no version string in the code — **the Git tag is the source of truth**.
 - [ ] All intended PRs are merged into `main`; nothing release-worthy is still open.
 - [ ] Working tree is clean and `main` is up to date: `git checkout main && git pull`.
 - [ ] Tests pass: `vendor/bin/codecept run` (Unit + Acceptance).
-      Acceptance needs `.env` (`SITE_URL`, `LAMB_TEST_PASSWORD`); it starts its
-      own server, so don't have another server on the test port.
+      Acceptance needs `.env` (`SITE_URL`, `LAMB_TEST_PASSWORD`); generate it with
+      `LAMB_WRITE_TEST_PASSWORD=1 php make-password.php <pw>` so the cleartext
+      `LAMB_TEST_PASSWORD` is written (it is omitted by default). Acceptance starts
+      its own server, so don't have another server on the test port.
 - [ ] Static checks pass: `composer lint` && `composer analyse`.
 - [ ] Docs are accurate for any user-facing change (`docs/`, `README.md`).
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -73,7 +73,10 @@ at `/srv/app`, so the test suites and configuration are available there.
 
 The test runner reads `.env` for its parameters, so make sure you have generated
 one with the `make-password.php` step from [Build from source](#build-from-source) before running the
-tests.
+tests. The acceptance suite also needs the cleartext `LAMB_TEST_PASSWORD`, which is
+omitted from `.env` by default — generate the file with `LAMB_WRITE_TEST_PASSWORD=1`
+set (e.g. `LAMB_WRITE_TEST_PASSWORD=1 php make-password.php hackme`) when you intend
+to run acceptance tests.
 
 ```shell
 # Unit tests (fast, no server required)

--- a/make-password.php
+++ b/make-password.php
@@ -29,10 +29,13 @@ if (($_ENV['PWD'] ?? '') === '/srv/app') {
 $data  = "SITE_URL='" . $site_url . "'" . PHP_EOL;
 $data .= "LAMB_TEST_PORT='" . $test_port . "'" . PHP_EOL;
 $data .= "LAMB_LOGIN_PASSWORD='" . $hash . "'" . PHP_EOL;
-// The plaintext password is only useful to the acceptance suite (LogoutCest).
-// Keep it out of .env by default so a self-hoster's setup file never carries
-// the cleartext secret; the test harness opts in via LAMB_WRITE_TEST_PASSWORD.
-if (!empty($_ENV['LAMB_WRITE_TEST_PASSWORD'])) {
+// The plaintext password is only useful to the acceptance suite (it logs in
+// with $_ENV['LAMB_TEST_PASSWORD']). Keep it out of .env by default so a
+// self-hoster's setup file never carries the cleartext secret; the test harness
+// opts in via LAMB_WRITE_TEST_PASSWORD. Use getenv() rather than $_ENV here: CI
+// runs this script under a variables_order that does not populate $_ENV from the
+// environment, but getenv() reads the process environment regardless.
+if (getenv('LAMB_WRITE_TEST_PASSWORD')) {
     $data .= "LAMB_TEST_PASSWORD='" . $password . "'" . PHP_EOL;
 }
 $env_out = file_put_contents('.env', $data);

--- a/make-password.php
+++ b/make-password.php
@@ -3,7 +3,21 @@
 if (empty($argv[1])) {
     die('Usage: php make-password.php <password>');
 }
-$hash = base64_encode(password_hash($argv[1], PASSWORD_DEFAULT));
+$password = $argv[1];
+
+// Highlight a weak password rather than refusing it: communicate, don't block
+// (a refusal would also break test fixtures that pass a short password). The
+// warning goes to STDERR so STDOUT stays just the hash for callers to copy.
+const MIN_PASSWORD_LENGTH = 12;
+if (mb_strlen($password) < MIN_PASSWORD_LENGTH) {
+    fwrite(
+        STDERR,
+        'Warning: that password is weak (under ' . MIN_PASSWORD_LENGTH
+        . ' characters). Consider a longer passphrase.' . PHP_EOL
+    );
+}
+
+$hash = base64_encode(password_hash($password, PASSWORD_DEFAULT));
 
 $test_port = $_ENV['LAMB_TEST_PORT'] ?? '8747';
 $site_url  = $_ENV['DDEV_PRIMARY_URL'] ?? "http://0.0.0.0:{$test_port}";
@@ -15,7 +29,12 @@ if (($_ENV['PWD'] ?? '') === '/srv/app') {
 $data  = "SITE_URL='" . $site_url . "'" . PHP_EOL;
 $data .= "LAMB_TEST_PORT='" . $test_port . "'" . PHP_EOL;
 $data .= "LAMB_LOGIN_PASSWORD='" . $hash . "'" . PHP_EOL;
-$data .= "LAMB_TEST_PASSWORD='" . $argv[1] . "'" . PHP_EOL;
+// The plaintext password is only useful to the acceptance suite (LogoutCest).
+// Keep it out of .env by default so a self-hoster's setup file never carries
+// the cleartext secret; the test harness opts in via LAMB_WRITE_TEST_PASSWORD.
+if (!empty($_ENV['LAMB_WRITE_TEST_PASSWORD'])) {
+    $data .= "LAMB_TEST_PASSWORD='" . $password . "'" . PHP_EOL;
+}
 $env_out = file_put_contents('.env', $data);
 if (!$env_out) {
     user_error('Problem saving .env', E_USER_WARNING);

--- a/tests/Unit/MakePasswordTest.php
+++ b/tests/Unit/MakePasswordTest.php
@@ -101,4 +101,20 @@ class MakePasswordTest extends TestCase
 
         $this->assertStringContainsString("LAMB_TEST_PASSWORD='hackme'", $contents);
     }
+
+    public function testOptInIsReadFromProcessEnvNotVariablesOrder(): void
+    {
+        // Mirror CI: run with the stock variables_order (which omits 'E', so
+        // $_ENV is not populated from the environment). The opt-in must still
+        // be honoured because it is read with getenv(), not $_ENV.
+        $process = new Process(
+            ['php', '-d', 'variables_order=GPCS', codecept_root_dir('make-password.php'), 'hackme'],
+            $this->workspace,
+            ['LAMB_WRITE_TEST_PASSWORD' => '1']
+        );
+        $process->mustRun();
+
+        $contents = (string)file_get_contents($this->workspace . '/.env');
+        $this->assertStringContainsString("LAMB_TEST_PASSWORD='hackme'", $contents);
+    }
 }

--- a/tests/Unit/MakePasswordTest.php
+++ b/tests/Unit/MakePasswordTest.php
@@ -24,14 +24,21 @@ class MakePasswordTest extends TestCase
         (new Process(['rm', '-rf', $this->workspace]))->run();
     }
 
-    private function runScript(array $env): string
+    private function runProcess(array $env, string $password = 'hackme'): Process
     {
         $process = new Process(
-            ['php', '-d', 'variables_order=EGPCS', codecept_root_dir('make-password.php'), 'hackme'],
+            ['php', '-d', 'variables_order=EGPCS', codecept_root_dir('make-password.php'), $password],
             $this->workspace,
             $env
         );
         $process->mustRun();
+
+        return $process;
+    }
+
+    private function runScript(array $env, string $password = 'hackme'): string
+    {
+        $this->runProcess($env, $password);
 
         return (string)file_get_contents($this->workspace . '/.env');
     }
@@ -52,5 +59,46 @@ class MakePasswordTest extends TestCase
         $contents = $this->runScript($env);
 
         $this->assertStringContainsString("SITE_URL='http://0.0.0.0:8747'", $contents);
+    }
+
+    public function testWeakPasswordWarnsOnStderr(): void
+    {
+        $process = $this->runProcess(['PWD' => $this->workspace], 'hackme');
+
+        $this->assertStringContainsString('weak', strtolower($process->getErrorOutput()));
+    }
+
+    public function testStrongPasswordDoesNotWarn(): void
+    {
+        $process = $this->runProcess(['PWD' => $this->workspace], 'correct-horse-battery-staple');
+
+        $this->assertSame('', trim($process->getErrorOutput()));
+    }
+
+    public function testWeakWarningDoesNotPolluteStdout(): void
+    {
+        // Stdout must stay just the hash so callers can copy it verbatim.
+        $process = $this->runProcess(['PWD' => $this->workspace], 'hackme');
+
+        $stdout = $process->getOutput();
+        $this->assertStringNotContainsString('weak', strtolower($stdout));
+        $this->assertStringNotContainsString("\n", trim($stdout), 'stdout should be a single line (the hash)');
+    }
+
+    public function testPlaintextTestPasswordOmittedByDefault(): void
+    {
+        $contents = $this->runScript(['PWD' => $this->workspace]);
+
+        $this->assertStringNotContainsString('LAMB_TEST_PASSWORD', $contents);
+    }
+
+    public function testPlaintextTestPasswordWrittenWhenOptedIn(): void
+    {
+        $contents = $this->runScript(
+            ['PWD' => $this->workspace, 'LAMB_WRITE_TEST_PASSWORD' => '1'],
+            'hackme'
+        );
+
+        $this->assertStringContainsString("LAMB_TEST_PASSWORD='hackme'", $contents);
     }
 }


### PR DESCRIPTION
## Context

Audit of the admin password/login form. The login plumbing itself is solid (bcrypt + `password_verify`, CSRF with `hash_equals`, `session_regenerate_id(true)` on login, HttpOnly/Secure/SameSite=Strict cookies, signed login marker, no anonymous sessions, local-only post-login redirect). Two low-risk gaps in the **setup tool** are fixed here; the larger items are filed as issues.

## Changes (`make-password.php`)

1. **Highlight a weak password.** Warn on **STDERR** (non-fatal) when the password is under 12 characters. STDOUT stays just the hash so callers that copy `make-password.php` output are unaffected. A hard refusal was deliberately avoided — it would break fixtures/CI that pass a short password, and "communicate failure, don't block" matches the project philosophy. This answers the "can we highlight a weak password?" question; since the password is CLI-set, the CLI is the place to surface it.

2. **Keep the cleartext password out of `.env` by default.** `make-password.php` previously always wrote `LAMB_TEST_PASSWORD='<plaintext>'`. That value is only needed by the acceptance suite (`LogoutCest`), so it is now gated behind `LAMB_WRITE_TEST_PASSWORD=1`. A self-hoster's `.env` no longer carries the cleartext secret.

## Test-harness ripple

- `.github/workflows/ci.yml` now runs `LAMB_WRITE_TEST_PASSWORD=1 php make-password.php $GITHUB_REF` so the acceptance suite still gets `LAMB_TEST_PASSWORD` (read by `LogoutCest` via the `params: .env` → `$_ENV` loader — same mechanism CI already relied on).
- Contributor docs updated to use the flag when running acceptance tests (`CLAUDE.md`, `RELEASING.md`, `docs/docker.md`).

## Tests

Red-green TDD in `tests/Unit/MakePasswordTest.php`:
- weak password → warning on STDERR; strong password → none; STDOUT stays single-line hash.
- `LAMB_TEST_PASSWORD` omitted by default; written when `LAMB_WRITE_TEST_PASSWORD=1`.

`composer lint`, `composer analyse`, and the full Unit suite (993 tests) pass locally. Acceptance can't bind the test port in the dev sandbox, but the `.env` → `$_ENV` wiring is unchanged, so CI exercises it.

## Follow-up issues (not implemented here)

- #443 — Brute-force protection for the admin login (rate limiting / lockout). `/login` has no attempt limit; CSRF-consume is not a throttle; anonymous requests get no session. Design options (global vs per-IP counter) captured for discussion.
- #444 — Log failed admin login attempts (no audit trail today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014xipDNwUxm3DT4L4LfeAGE)_