### PR TITLE
Fix scroll jump when editing near the end of a long post

### DIFF
--- a/src/scripts/logged_in/growing-input.js
+++ b/src/scripts/logged_in/growing-input.js
@@ -10,6 +10,11 @@ onLoaded(() => {
 function growing_input(ev)
 {
     const target = ev.target
+    // Resetting height to 'auto' momentarily collapses the textarea, so the
+    // browser clamps the page scroll. Save and restore it to avoid jumping when
+    // editing near the end of a long post.
+    const scrollY = window.scrollY
     target.style.height = 'auto'
     target.style.height = (20 + target.scrollHeight) + 'px'
+    window.scrollTo(window.scrollX, scrollY)
 }

--- a/tests/js/growing-input.test.mjs
+++ b/tests/js/growing-input.test.mjs
@@ -1,0 +1,30 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadScripts } from './helpers.mjs'
+
+function load(html) {
+  return loadScripts({ files: ['shorthand.js', 'logged_in/growing-input.js'], html })
+}
+
+// Setting the textarea height to 'auto' momentarily collapses it, which makes a
+// browser clamp the window scroll to the (smaller) page height. The handler must
+// save the scroll position and restore it so editing near the end of a long post
+// does not jump the page.
+test('resizing the textarea restores the window scroll position', () => {
+  const { window, document } = load('<!DOCTYPE html><body><textarea></textarea></body>')
+
+  let scrollY = 0
+  Object.defineProperty(window, 'scrollY', { configurable: true, get: () => scrollY })
+  const calls = []
+  window.scrollTo = (x, y) => { calls.push([x, y]); scrollY = y }
+
+  // DOMContentLoaded runs the initial resize once.
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+  const ta = document.querySelector('textarea')
+
+  // Pretend the user has scrolled down a long post, then types.
+  scrollY = 500
+  ta.dispatchEvent(new window.Event('input'))
+
+  assert.deepEqual(calls.at(-1), [0, 500])
+})


### PR DESCRIPTION
## Problem

When editing a long post, typing near the end made the page scrollbar jump irregularly.

## Cause

`growing-input.js` resets the textarea height to `auto` on every keystroke to measure `scrollHeight`. That momentary collapse shrinks the page, so the browser clamps the window scroll to the smaller height — and the position was never restored. The further you'd scrolled down, the more visible the jump.

## Fix

Save `window.scrollY` before the resize and restore it with `window.scrollTo` afterward.

## Tests

New `tests/js/growing-input.test.mjs` (node:test + jsdom) asserts the scroll position is restored after a resize. Written red-green; full JS suite (30 tests) and PHP unit suite (988 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)