### PR TITLE
Load .env in the dev server so composer serve accepts the login password

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,7 +494,12 @@ php make-password.php mysecretpassword
 # writes LAMB_LOGIN_PASSWORD, SITE_URL to .env
 ```
 
-The app reads `LAMB_LOGIN_PASSWORD` via `getenv()` at runtime.
+The app reads `LAMB_LOGIN_PASSWORD` via `getenv()` at runtime. Production deployments
+(FrankenPHP, nginx+php-fpm, Docker) set it as a real environment variable. The PHP
+built-in dev server (`composer serve`) does not load `.env`, so `Bootstrap\load_dotenv()`
+reads it in — but **only under the `cli-server` SAPI** and **non-overriding** (a real
+env var always wins), so production is unaffected. `phpdotenv` is a dev dependency, so
+this no-ops on a `--no-dev` install.
 
 ## Branching
 

--- a/docs/devbox.md
+++ b/docs/devbox.md
@@ -10,7 +10,10 @@ devbox shell
 # In the shell from now on
 composer install
 
-# Run lamb - Change `hackme` to something more secure, this is the `/login` password!
-LAMB_LOGIN_PASSWORD=$(php make-password.php hackme) composer serve
+# Set your /login password - change `hackme` to something more secure.
+php make-password.php hackme
+
+# Run lamb - the dev server reads .env automatically.
+composer serve
 
 ```

--- a/docs/local-php-setup.md
+++ b/docs/local-php-setup.md
@@ -19,8 +19,12 @@ sudo apt install php8.4 php8.4-gettext php8.4-mbstring php8.4-sqlite3 php8.4-xml
 # install project packages
 composer install
 
-# Run lamb - Change `hackme` to something more secure, this is the `/login` password!
-LAMB_LOGIN_PASSWORD=$(php make-password.php hackme) composer serve
+# Set your /login password - change `hackme` to something more secure.
+# This writes the hashed password to .env.
+php make-password.php hackme
+
+# Run lamb - the dev server reads .env automatically.
+composer serve
 ```
 
 Uploaded images are stored under `src/assets/`, so if you are serving Lamb through PHP-FPM or another web server user, make sure that directory is writable at runtime.

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -2,8 +2,39 @@
 
 namespace Lamb\Bootstrap;
 
+use Dotenv\Dotenv;
+use Dotenv\Repository\Adapter\PutenvAdapter;
+use Dotenv\Repository\RepositoryBuilder;
 use RuntimeException;
 use RedBeanPHP\R;
+
+/**
+ * Loads the project's .env file into the process environment for the dev server.
+ *
+ * The PHP built-in server (`composer serve`) does not read .env, so
+ * LAMB_LOGIN_PASSWORD would be unset and every login would fail. This pulls it
+ * in via getenv() (the Putenv adapter — phpdotenv populates only $_ENV/$_SERVER
+ * by default). Loading is immutable, so a real environment variable always wins
+ * over the file; production deployments set LAMB_LOGIN_PASSWORD directly and are
+ * never affected. phpdotenv is a dev dependency, so this no-ops when it is absent
+ * (e.g. a `--no-dev` production install).
+ *
+ * @param string $root Directory containing the .env file (project root).
+ * @return void
+ */
+function load_dotenv(string $root): void
+{
+    if (!class_exists(Dotenv::class)) {
+        return;
+    }
+
+    $repository = RepositoryBuilder::createWithDefaultAdapters()
+        ->addAdapter(PutenvAdapter::class)
+        ->immutable()
+        ->make();
+
+    Dotenv::create($repository, $root)->safeLoad();
+}
 
 /**
  * Initializes the database by configuring the SQLite connection and setting up the writer cache.

--- a/src/response.php
+++ b/src/response.php
@@ -12,6 +12,13 @@ use function Lamb\parse_bean;
 use function Lamb\Post\inject_title_matter;
 use function Lamb\Post\parse_matter;
 
+// The built-in dev server (`composer serve`) does not load .env, so read it here
+// before LOGIN_PASSWORD is captured. Restricted to the cli-server SAPI so it only
+// affects local development — production (fpm/cli) keeps using real env vars.
+if (PHP_SAPI === 'cli-server') {
+    \Lamb\Bootstrap\load_dotenv(dirname(__DIR__));
+}
+
 define('LOGIN_PASSWORD', getenv("LAMB_LOGIN_PASSWORD") ?: '');
 
 // IMAGE_FILES is defined in constants.php

--- a/tests/Unit/LoadDotenvTest.php
+++ b/tests/Unit/LoadDotenvTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Bootstrap\load_dotenv;
+
+/**
+ * Exercises Bootstrap\load_dotenv(): the dev-server convenience that reads .env
+ * into the process environment (via getenv()) so `composer serve` picks up
+ * LAMB_LOGIN_PASSWORD without an inline prefix.
+ */
+class LoadDotenvTest extends TestCase
+{
+    private string $workspace;
+
+    /** @var string[] Env keys to clear after each test so they don't leak. */
+    private array $touched = [];
+
+    protected function setUp(): void
+    {
+        $this->workspace = sys_get_temp_dir() . '/lamb-load-dotenv-test-' . uniqid();
+        mkdir($this->workspace, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->touched as $key) {
+            putenv($key);
+            unset($_ENV[$key], $_SERVER[$key]);
+        }
+        array_map('unlink', glob($this->workspace . '/.env') ?: []);
+        @rmdir($this->workspace);
+    }
+
+    private function writeEnv(string $contents): void
+    {
+        file_put_contents($this->workspace . '/.env', $contents);
+    }
+
+    public function testLoadsValueIntoGetenv(): void
+    {
+        $this->touched[] = 'LAMB_DOTENV_TEST_LOADS';
+        $this->writeEnv("LAMB_DOTENV_TEST_LOADS='from-file'\n");
+
+        load_dotenv($this->workspace);
+
+        $this->assertSame('from-file', getenv('LAMB_DOTENV_TEST_LOADS'));
+    }
+
+    public function testDoesNotOverrideExistingEnvVar(): void
+    {
+        $this->touched[] = 'LAMB_DOTENV_TEST_PRESET';
+        putenv('LAMB_DOTENV_TEST_PRESET=original');
+        $this->writeEnv("LAMB_DOTENV_TEST_PRESET='from-file'\n");
+
+        load_dotenv($this->workspace);
+
+        $this->assertSame('original', getenv('LAMB_DOTENV_TEST_PRESET'));
+    }
+
+    public function testMissingFileIsSilent(): void
+    {
+        // No .env written; safeLoad must not throw.
+        load_dotenv($this->workspace);
+
+        $this->assertFalse(getenv('LAMB_DOTENV_TEST_NEVER_SET'));
+    }
+}


### PR DESCRIPTION
Follow-up to #445 (now merged).

## Problem

`make-password.php` writes the hashed password to `.env`, but the PHP built-in dev server (`composer serve`) never reads `.env`. So `LAMB_LOGIN_PASSWORD` stayed unset, `LOGIN_PASSWORD` was `''`, and every login failed with "Password is incorrect" — unless you used the documented inline trick:

```bash
LAMB_LOGIN_PASSWORD=$(php make-password.php hackme) composer serve
```

Running `make-password.php` and `composer serve` as two separate steps (the natural thing to do) silently broke login.

## Fix

Add `Bootstrap\load_dotenv()` and call it from `response.php` just before `LOGIN_PASSWORD` is captured — but **only under the `cli-server` SAPI**, so it affects the dev server alone.

Design notes:
- **Non-overriding** (phpdotenv immutable): a real environment variable always wins over `.env`, so production deployments that inject `LAMB_LOGIN_PASSWORD` are unaffected even if a stray `.env` is present.
- **Production-safe**: gated to `cli-server`, so fpm/cli never load `.env`. It also no-ops when `phpdotenv` is absent (a `--no-dev` install), via a `class_exists` guard.
- **Putenv adapter**: the app reads `getenv()`, which phpdotenv does not populate by default — so the loader explicitly enables the Putenv adapter.

This makes the documented flow just work:

```bash
php make-password.php hackme   # writes the hash to .env
composer serve                 # now reads .env
```

## Docs

Dropped the inline-prefix workaround from the local-PHP and devbox setup pages, and documented the dev-server behaviour in `CLAUDE.md`.

## Tests

New `tests/Unit/LoadDotenvTest.php` (red-green): loads a value into `getenv()`, leaves a pre-set env var untouched, and stays silent when `.env` is missing. Full unit suite (997) passes; `composer lint` and `composer analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)