### PR TITLE
Sitemap: deduplicate URLs sharing a slug

### DIFF
--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -42,6 +42,10 @@ function sitemap_date(?string $datetime): ?string
  * them. Menu/standalone pages are intentionally included — unlike the home and
  * Atom feeds they are real public URLs worth indexing.
  *
+ * Two distinct posts can share a slug (slugs are not DB-unique), which would
+ * otherwise emit the same <loc> twice — invalid for a sitemap. Entries are
+ * deduplicated by URL, keeping the first (newest, since ordered by updated DESC).
+ *
  * @return list<array{loc: string, lastmod: string|null}>
  */
 function sitemap_urls(): array
@@ -50,9 +54,15 @@ function sitemap_urls(): array
     $posts = R::find('post', $visible['sql'] . 'ORDER BY updated DESC', $visible['params']);
 
     $entries = [];
+    $seen = [];
     foreach ($posts as $post) {
+        $loc = \Lamb\permalink($post);
+        if (isset($seen[$loc])) {
+            continue;
+        }
+        $seen[$loc] = true;
         $entries[] = [
-            'loc'     => \Lamb\permalink($post),
+            'loc'     => $loc,
             'lastmod' => sitemap_date($post->updated),
         ];
     }

--- a/tests/Unit/SitemapTest.php
+++ b/tests/Unit/SitemapTest.php
@@ -86,6 +86,36 @@ class SitemapTest extends TestCase
         $this->assertNotContains(ROOT_URL . "/status/$id", $this->locs());
     }
 
+    public function testDeduplicatesPostsSharingASlug(): void
+    {
+        // Two distinct posts can end up with the same slug; the sitemap must
+        // still list that canonical URL only once (duplicate <loc>s are invalid).
+        $this->makePost(['slug' => 'dup', 'updated' => '2026-06-01 09:00:00']);
+        $this->makePost(['slug' => 'dup', 'updated' => '2026-06-02 09:00:00']);
+
+        $locs = $this->locs();
+        $matches = array_filter($locs, static fn ($loc) => $loc === ROOT_URL . '/dup');
+        $this->assertCount(1, $matches);
+    }
+
+    public function testDeduplicatedEntryKeepsNewestLastmod(): void
+    {
+        // Posts are ordered newest-first, so the surviving entry keeps the
+        // freshest post's lastmod.
+        $this->makePost(['slug' => 'dup', 'updated' => '2026-06-01 09:00:00']);
+        $this->makePost(['slug' => 'dup', 'updated' => '2026-06-02 09:00:00']);
+
+        $entry = null;
+        foreach (sitemap_urls() as $url) {
+            if ($url['loc'] === ROOT_URL . '/dup') {
+                $entry = $url;
+                break;
+            }
+        }
+        $this->assertNotNull($entry);
+        $this->assertSame(date('c', strtotime('2026-06-02 09:00:00')), $entry['lastmod']);
+    }
+
     public function testEntryCarriesIso8601Lastmod(): void
     {
         $this->makePost(['updated' => '2026-06-01 09:30:00']);


### PR DESCRIPTION
## Problem

`sitemap.xml` listed the same URL twice — e.g. `https://vandragt.com/lamb-releases-0-3-0` appeared as a duplicate `<loc>`. Duplicate URLs are invalid in a sitemap and get flagged by search engines.

## Root cause

Slugs are **not** unique in the database. `sitemap_urls()` walks every publicly visible post and builds each `<loc>` from `permalink()`, which returns `ROOT_URL/<slug>` whenever a slug is set. When two distinct posts share a slug, `permalink()` produces the same URL for both, so the sitemap emitted it twice.

(Confirmed locally: two `post` rows with the same slug both appear in the sitemap query.)

## Fix

Deduplicate sitemap entries by URL, keeping the first occurrence. The query already orders by `updated DESC`, so the surviving entry is the newest post and carries the freshest `lastmod`.

This is the minimal, spec-correct fix for the sitemap itself. The deeper data question — *how* two posts ended up sharing a slug, and whether slug uniqueness should be enforced at write time — is left out of scope here.

## Tests

Red-green TDD: added `testDeduplicatesPostsSharingASlug` and `testDeduplicatedEntryKeepsNewestLastmod` to `SitemapTest`. Full Unit suite (1039 tests), lint, and phpstan all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)