### PR TITLE
Sitemap: harden <loc> escaping against malformed UTF-8

### DIFF
--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -90,7 +90,11 @@ function render_sitemap(array $urls): string
     ];
     foreach ($urls as $url) {
         $lines[] = '  <url>';
-        $lines[] = '    <loc>' . htmlspecialchars($url['loc'], ENT_XML1) . '</loc>';
+        // Match the Atom feed's escaping (themes/base/feed.php): ENT_SUBSTITUTE
+        // means a malformed UTF-8 byte degrades to U+FFFD instead of making
+        // htmlspecialchars() return '' for the whole string — which would emit
+        // an empty, invalid <loc>.
+        $lines[] = '    <loc>' . htmlspecialchars($url['loc'], ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE) . '</loc>';
         if (!empty($url['lastmod'])) {
             $lines[] = '    <lastmod>' . $url['lastmod'] . '</lastmod>';
         }

--- a/tests/Unit/SitemapTest.php
+++ b/tests/Unit/SitemapTest.php
@@ -142,6 +142,17 @@ class SitemapTest extends TestCase
         $this->assertStringNotContainsString('&c=2', $xml);
     }
 
+    public function testRenderSitemapKeepsLocWithMalformedUtf8(): void
+    {
+        // A slug may carry a malformed UTF-8 byte. Without ENT_SUBSTITUTE,
+        // htmlspecialchars() returns '' for the whole string, emitting an empty
+        // <loc></loc> — invalid, since <loc> is required. The bad byte must
+        // degrade to U+FFFD instead, leaving the rest of the URL intact.
+        $xml = render_sitemap([['loc' => "https://example.com/b\xC3\x28d", 'lastmod' => null]]);
+        $this->assertStringNotContainsString('<loc></loc>', $xml);
+        $this->assertStringContainsString('https://example.com/b', $xml);
+    }
+
     public function testRenderSitemapOmitsEmptyLastmod(): void
     {
         $xml = render_sitemap([['loc' => 'https://example.com/', 'lastmod' => null]]);


### PR DESCRIPTION
## What

`render_sitemap()` escaped `<loc>` with bare `ENT_XML1`. PHP's `htmlspecialchars()` returns `''` for the **entire** string when it hits any invalid UTF-8 byte (unless `ENT_SUBSTITUTE`/`ENT_IGNORE` is set). So a single malformed byte in a slug/permalink would emit an empty `<loc></loc>` — invalid, since `<loc>` is required and must be a URL.

This aligns the sitemap's escaping with the Atom feed (`src/themes/base/feed.php`), which already uses `ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE`. A bad byte now degrades to U+FFFD and the rest of the URL survives.

## Why

Reviewing the sitemap work (#437 / #449 / #450) surfaced this as the one remaining gap: the feed and the sitemap had diverged on escaping flags, and the sitemap's was the unsafe variant.

## Test

Red-green: `testRenderSitemapKeepsLocWithMalformedUtf8` fails on `next` (emits `<loc></loc>`) and passes with the fix. Full Unit suite green (1040 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)