### PR TITLE
Add microformats2 (h-entry / h-card) markup to themes

### DIFF
--- a/docs/theme-functions.md
+++ b/docs/theme-functions.md
@@ -52,8 +52,9 @@ re-render `body`), `$bean->description`, `$bean->created`, `$bean->updated`,
 
 | Function | Returns | Description |
 |----------|---------|-------------|
-| `date_created($bean)` | `string` | An `<a>` wrapping a `<time>` element, linking to the post permalink with a human-readable timestamp. `''` when the bean has no created date. |
-| `title_link($bean)` | `string` | An `<a>` linking the post title to its permalink, or `''` when the post has no title. |
+| `date_created($bean)` | `string` | An `<a class="u-url">` wrapping a `<time class="dt-published">` element, linking to the post permalink with a human-readable timestamp. `''` when the bean has no created date. |
+| `title_link($bean)` | `string` | An `<a class="p-name title-link">` linking the post title to its permalink, or `''` when the post has no title. |
+| `author_card()` | `string` | A representative author `<a class="p-author h-card">` (name from `$config['author_name']`, linked to the site root), or `''` when no author name is set. Emit it inside each post's `h-entry`. |
 | `link_source($bean)` | `string` | A "Via …" attribution link for feed-ingested posts (uses `source_url`, falling back to the configured feed URL), or `''` for ordinary posts. |
 | `the_reply_context($bean)` | `string` | A "In reply to …" line with the `u-in-reply-to` microformats class when the post replies to another URL, or `''`. |
 | `anchor_headings($html, $top)` | `string` | Shifts the heading levels in a rendered body so its highest heading sits at level `$top`, keeping the rest relative (clamped at `<h6>`). The built-in themes title posts at `<h2>` and pass `$top = 3`. |
@@ -111,8 +112,22 @@ logged in.
 | `redirect_to()` | `string` | The sanitised `?redirect_to=` query value (used by the login form). |
 | `preload_text()` | `string` | The escaped `?text=` query value, used to pre-fill the entry form. |
 
+## Microformats2 (h-entry / h-card)
+
+The built-in themes mark each post up with [microformats2](https://microformats.org/wiki/h-entry) so Webmention receivers, readers, and other parsers can extract the author, content, permalink and timestamp. If you build a custom `_items.php`, mirror this markup so your outgoing mentions stay parseable:
+
+* `class="h-entry"` on the post's `<article>`.
+* `class="e-content"` on the element wrapping the rendered body.
+* `class="p-name"` on the post title (the helpers above already add it).
+* `date_created($bean)` supplies `u-url` + `dt-published`.
+* `author_card()` supplies the `p-author h-card`, placed inside the `h-entry`.
+* `the_reply_context($bean)` supplies `u-in-reply-to` for replies.
+
+The classes coexist with the schema.org markup the themes also emit, and can be hidden visually (e.g. with `screen-reader-text`) without affecting parsers.
+
 ## Related
 
+* [Webmentions]({{ site.baseurl }}{% link webmentions.md %}): how Lamb sends and receives mentions — the microformats2 markup above is what receivers parse.
 * [Themes]({{ site.baseurl }}{% link themes.md %}): how themes are structured, the fallback to `base`, and the part resolution rules.
 * [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}): the `theme` key and the config values exposed in `$config`.
 * [Post Types]({{ site.baseurl }}{% link post-types.md %}): how status posts and page-style posts differ, which affects `$bean->slug` and permalinks.

--- a/docs/webmentions.md
+++ b/docs/webmentions.md
@@ -49,3 +49,4 @@ When you delete a post that already sent webmentions, Lamb re-sends them on the 
 * [Cron / scheduled tasks]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}): How `/_cron` drives feed ingestion and outbound webmentions.
 * [Scheduling posts]({{ site.baseurl }}{% link scheduling.md %}): Scheduled posts send their webmentions when they go live.
 * [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %}): Pull posts in from other feeds.
+* [Theme functions]({{ site.baseurl }}{% link theme-functions.md %}): The microformats2 (h-entry / h-card) markup the themes emit, which Webmention receivers parse.

--- a/src/theme.php
+++ b/src/theme.php
@@ -142,10 +142,36 @@ function date_created(OODBBean $bean): string
     }
 
     return sprintf(
-        '<a href="/%1$s" title="Timestamp: %2$s"><time datetime="%2$s">%3$s</time></a>',
+        '<a href="/%1$s" class="u-url" title="Timestamp: %2$s"><time class="dt-published" datetime="%2$s">%3$s</time></a>',
         ltrim($slug, '/'),
         $bean->created,
         $human_created
+    );
+}
+
+/**
+ * Returns a representative author h-card for the configured author, or '' when
+ * no author name is set.
+ *
+ * Emitted inside each h-entry as its `p-author` so Webmention receivers and
+ * other microformats2 parsers can attribute the post to its author. For a
+ * single-author blog the author's URL is the site root (ROOT_URL).
+ *
+ * @return string HTML anchor carrying the `p-author h-card` classes, or ''.
+ */
+function author_card(): string
+{
+    global $config;
+
+    $name = trim((string) ($config['author_name'] ?? ''));
+    if ($name === '') {
+        return '';
+    }
+
+    return sprintf(
+        '<a class="p-author h-card" href="%s">%s</a>',
+        escape(ROOT_URL),
+        escape($name)
     );
 }
 
@@ -292,7 +318,7 @@ function title_link(OODBBean $bean): string
     if (empty($bean->title)) {
         return '';
     }
-    return sprintf('<a class="title-link" href="%s">%s</a>', permalink($bean), escape($bean->title));
+    return sprintf('<a class="p-name title-link" href="%s">%s</a>', permalink($bean), escape($bean->title));
 }
 
 /**

--- a/src/themes/2024/parts/_items.php
+++ b/src/themes/2024/parts/_items.php
@@ -8,6 +8,7 @@ use function Lamb\Theme\action_delete;
 use function Lamb\Theme\action_edit;
 use function Lamb\Theme\action_preview;
 use function Lamb\Theme\action_restore;
+use function Lamb\Theme\author_card;
 use function Lamb\Theme\date_created;
 use function Lamb\Theme\anchor_headings;
 use function Lamb\Theme\escape;
@@ -34,7 +35,7 @@ else :
 
         ?>
 
-        <article data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
+        <article class="h-entry" data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
             <header>
                 <?php if ($template !== 'status') : ?>
                     <?php $title = title_link($bean); ?>
@@ -43,13 +44,13 @@ else :
                     <?php endif; ?>
                 <?php endif; ?>
                 <div class="meta">
-                    <strong itemprop="author"><?= escape($config['author_name'] ?? '') ?></strong> @
+                    <span itemprop="author"><?= author_card() ?></span> @
                     <?= date_created($bean) ?>
                 </div>
             </header>
             <?= the_reply_context($bean) ?>
             <?php // List view renders the post title at h2, so the body's top heading sits at h3; otherwise h2 under the site h1. ?>
-            <?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?>
+            <div class="e-content"><?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
                 <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -8,6 +8,7 @@ use function Lamb\Theme\action_delete;
 use function Lamb\Theme\action_edit;
 use function Lamb\Theme\action_preview;
 use function Lamb\Theme\action_restore;
+use function Lamb\Theme\author_card;
 use function Lamb\Theme\date_created;
 use function Lamb\Theme\anchor_headings;
 use function Lamb\Theme\escape;
@@ -34,7 +35,7 @@ else :
 
         ?>
 
-        <article data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
+        <article class="h-entry" data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
             <header>
                 <?php if ($template !== 'status') : ?>
                     <?php $title = title_link($bean); ?>
@@ -43,13 +44,13 @@ else :
                     <?php endif; ?>
                 <?php endif; ?>
                 <div class="meta">
-                    <strong itemprop="author" class="screen-reader-text"><?= escape($config['author_name'] ?? '') ?></strong>
+                    <span itemprop="author" class="screen-reader-text"><?= author_card() ?></span>
                     <?= date_created($bean) ?>
                 </div>
             </header>
             <?= the_reply_context($bean) ?>
             <?php // List view renders the post title at h2, so the body's top heading sits at h3; otherwise h2 under the site h1. ?>
-            <?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?>
+            <div class="e-content"><?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
                 <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -10,6 +10,7 @@ use function Lamb\Theme\action_restore;
 use function Lamb\Theme\date_created;
 use function Lamb\Config\is_menu_item;
 use function Lamb\Theme\anchor_headings;
+use function Lamb\Theme\author_card;
 use function Lamb\Theme\escape;
 use function Lamb\Theme\link_source;
 use function Lamb\Theme\the_reply_context;
@@ -25,16 +26,16 @@ else :
             continue;
         endif;
         ?>
-        <article data-post-id="<?= (int) $bean->id ?>">
+        <article class="h-entry" data-post-id="<?= (int) $bean->id ?>">
             <header>
                 <?php if (!empty($bean->title)) : ?>
-                <h2><?= $template !== 'status' ? title_link($bean) : escape($bean->title) ?></h2>
+                <h2><?= $template !== 'status' ? title_link($bean) : '<span class="p-name">' . escape($bean->title) . '</span>' ?></h2>
                 <?php endif; ?>
-                <small><?= date_created($bean) ?><?= link_source($bean) ?></small>
+                <small><span class="screen-reader-text"><?= author_card() ?></span><?= date_created($bean) ?><?= link_source($bean) ?></small>
             </header>
             <?= the_reply_context($bean) ?>
             <?php // Post title renders at h2, so the body's top heading sits at h3 (h2 under the site h1 when untitled). ?>
-            <?= anchor_headings($bean->transformed, !empty($bean->title) ? 3 : 2) ?>
+            <div class="e-content"><?= anchor_headings($bean->transformed, !empty($bean->title) ? 3 : 2) ?></div>
             <footer>
                 <small><?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
             </footer>

--- a/tests/Unit/MicroformatsTest.php
+++ b/tests/Unit/MicroformatsTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Theme\author_card;
+use function Lamb\Theme\date_created;
+use function Lamb\Theme\title_link;
+
+/**
+ * Verifies the microformats2 (h-entry / h-card) markup that Webmention
+ * receivers and other mf2 parsers rely on to attribute and categorise posts.
+ *
+ * Covers the shared helpers (date_created, title_link, author_card) as units
+ * and the rendered post-list partial of each shipped theme.
+ */
+class MicroformatsTest extends TestCase
+{
+    /** @var mixed */
+    private $originalConfig;
+
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+        $_SESSION = [];
+        global $config;
+        $this->originalConfig = $config;
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        global $config;
+        $config = $this->originalConfig;
+    }
+
+    // Helpers -----------------------------------------------------------------
+
+    public function testDateCreatedCarriesUUrlAndDtPublished(): void
+    {
+        $bean = R::dispense('post');
+        $bean->created = '2024-01-01 12:00:00';
+
+        $result = date_created($bean);
+        $this->assertStringContainsString('class="u-url"', $result);
+        $this->assertStringContainsString('class="dt-published"', $result);
+        $this->assertStringContainsString('datetime="2024-01-01 12:00:00"', $result);
+    }
+
+    public function testTitleLinkCarriesPName(): void
+    {
+        $bean = R::dispense('post');
+        $bean->title = 'My Post';
+        R::store($bean);
+
+        $result = title_link($bean);
+        $this->assertStringContainsString('p-name', $result);
+        $this->assertStringContainsString('title-link', $result);
+    }
+
+    public function testAuthorCardIsAnHCardWithAuthorUrl(): void
+    {
+        global $config;
+        $config = ['author_name' => 'Jane Doe'];
+
+        $result = author_card();
+        $this->assertStringContainsString('p-author', $result);
+        $this->assertStringContainsString('h-card', $result);
+        $this->assertStringContainsString('href="' . ROOT_URL . '"', $result);
+        $this->assertStringContainsString('Jane Doe', $result);
+    }
+
+    public function testAuthorCardEscapesName(): void
+    {
+        global $config;
+        $config = ['author_name' => '<script>xss</script>'];
+
+        $result = author_card();
+        $this->assertStringNotContainsString('<script>', $result);
+    }
+
+    public function testAuthorCardEmptyWhenNoAuthorName(): void
+    {
+        global $config;
+        $config = ['author_name' => ''];
+
+        $this->assertSame('', author_card());
+    }
+
+    // Theme partials ----------------------------------------------------------
+
+    private function renderItems(string $theme, string $tpl, array $props = []): string
+    {
+        $bean = R::dispense('post');
+        $bean->title = $props['title'] ?? '';
+        $bean->transformed = $props['transformed'] ?? '<p>body</p>';
+        $bean->created = '2024-01-01 12:00:00';
+        $bean->deleted = false;
+        R::store($bean);
+
+        global $data, $template, $config;
+        $config = ['menu_items' => [], 'author_name' => 'Jane Doe'];
+        $data = ['posts' => [$bean]];
+        $template = $tpl;
+
+        ob_start();
+        include dirname(__DIR__, 2) . "/src/themes/$theme/parts/_items.php";
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * @dataProvider themeProvider
+     */
+    public function testThemeMarksEntryAndContent(string $theme): void
+    {
+        $html = $this->renderItems($theme, 'home', ['title' => 'Hello']);
+        $this->assertStringContainsString('h-entry', $html, "$theme: article should be an h-entry");
+        $this->assertStringContainsString('e-content', $html, "$theme: body should be e-content");
+    }
+
+    /**
+     * @dataProvider themeProvider
+     */
+    public function testThemeIncludesAuthorHCard(string $theme): void
+    {
+        $html = $this->renderItems($theme, 'home');
+        $this->assertStringContainsString('p-author', $html, "$theme: entry should carry a p-author");
+        $this->assertStringContainsString('h-card', $html, "$theme: author should be an h-card");
+    }
+
+    public function testBaseStatusTitleCarriesPName(): void
+    {
+        $html = $this->renderItems('base', 'status', ['title' => 'Hello World']);
+        $this->assertStringContainsString('p-name', $html);
+        $this->assertStringContainsString('Hello World', $html);
+    }
+
+    public static function themeProvider(): array
+    {
+        return [
+            'base' => ['base'],
+            '2026' => ['2026'],
+            '2024' => ['2024'],
+        ];
+    }
+}

--- a/tests/Unit/ThemeBeanTest.php
+++ b/tests/Unit/ThemeBeanTest.php
@@ -295,7 +295,7 @@ class ThemeBeanTest extends TestCase
         R::store($bean);
 
         $result = title_link($bean);
-        $this->assertStringContainsString('class="title-link"', $result);
+        $this->assertStringContainsString('title-link', $result);
         $this->assertStringContainsString('<a ', $result);
     }
 


### PR DESCRIPTION
Closes #436.

## What

Lamb sends and receives webmentions, but its themes only emitted schema.org markup. Webmention receivers (webmention.io, Bridgy) and other [microformats2](https://microformats.org/wiki/h-entry) parsers rely on mf2 to extract a mention's **author, content, permalink and timestamp** — so our outbound mentions previously carried nothing parseable. This adds mf2 across all three shipped themes (`base`, `2026`, `2024`), kept DRY behind shared helpers.

## How

- **`h-entry`** on each post `<article>`.
- **`e-content`** wrapping the rendered body.
- `date_created()` now carries **`u-url`** (the permalink link) + **`dt-published`** (the `<time>`).
- `title_link()` — and the base theme's status-page title — now carry **`p-name`**.
- New **`author_card()`** helper emits a **`p-author h-card`** inside each entry (name from `$config['author_name']`, linked to the site root). It reuses the existing `screen-reader-text` pattern so it stays visually hidden where a theme doesn't already show the author (base, 2026), while 2024 keeps its visible "Name @" byline.

The existing schema.org `BlogPosting` markup is preserved alongside the mf2 classes — they coexist.

## Tests (red-green)

`tests/Unit/MicroformatsTest.php`:
- helpers: `date_created` carries `u-url`/`dt-published`; `title_link` carries `p-name`; `author_card` is a `p-author h-card` with the site-root URL, escapes the name, and is `''` when no author is configured;
- each theme's `_items.php` renders `h-entry` + `e-content` + a `p-author h-card`;
- the base status title carries `p-name`.

Restoring the global `$config` in the test's `tearDown` also removed an ordering-sensitive config-pollution fragility in the suite.

Full suite: **1052 unit tests pass**; `composer lint` and `composer analyse` (PHPStan level 8) clean.

## Docs

`docs/theme-functions.md` documents `author_card()` and a new "Microformats2 (h-entry / h-card)" section so custom-theme authors mirror the markup; cross-linked with `docs/webmentions.md`.

## Validation

Verified the rendered markup parses cleanly as an `h-entry` with `p-author h-card`, `e-content`, `dt-published` and `u-url` for a note, a titled article, and a reply.

https://claude.ai/code/session_01M6rinkbKWHZnpWQX2cvUNV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6rinkbKWHZnpWQX2cvUNV)_