### PR TITLE
Guard $config['site_title'] reads in feed/home responders

### DIFF
--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -29,7 +29,7 @@ function respond_home(): array
         redirect_created();
     }
 
-    $data['title'] = $config['site_title'];
+    $data['title'] = $config['site_title'] ?? '';
 
     $visible = \Lamb\visible_clause();
     $where_sql = $visible['sql'];
@@ -181,7 +181,7 @@ function get_feed_data(): array
     $first_post = reset($posts);
     return [
         'updated'  => $first_post['updated'] ?? \Lamb\now(),
-        'title'    => $config['site_title'],
+        'title'    => $config['site_title'] ?? '',
         'feed_url' => ROOT_URL . '/feed',
         'posts'    => $posts,
     ];
@@ -292,7 +292,7 @@ function get_tag_feed_data(string $tag): array
 
     return [
         'updated'  => get_feed_updated_date($posts),
-        'title'    => $config['site_title'] . ' — #' . $tag,
+        'title'    => ($config['site_title'] ?? '') . ' — #' . $tag,
         'feed_url' => ROOT_URL . '/tag/' . rawurlencode($tag) . '/feed',
         'posts'    => $posts,
     ];


### PR DESCRIPTION
## Summary

`respond_home()`, `get_feed_data()` and the tag-feed responder in `src/response/feeds.php` read `$config['site_title']` without a fallback. When `$config` is not fully populated, PHP 8 raises an `Undefined array key "site_title"` warning that PHPUnit promotes to a test error.

This surfaced as a pre-existing failure in `MicropubAdapterTest::testCreateCallbackWithFuturePublishedDateHidesFromHome`, which calls `respond_home()` directly. The test only passed by accident — an earlier test in the suite populated the global `$config` first; run in isolation it errored at `feeds.php:32`.

## Fix

Default the title to `''` via the null-coalescing operator at all three sites so the responders no longer depend on a side-effect-populated global. Behaviour in production (where config is always loaded with defaults) is unchanged.

## Testing

- `MicropubAdapterTest::testCreateCallbackWithFuturePublishedDateHidesFromHome` now passes in isolation (was an error before).
- Full Unit suite green: 1007 tests, 1554 assertions.
- `composer lint` and `composer analyse` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsaAcNisVVnubAWFGfsJD6

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsaAcNisVVnubAWFGfsJD6)_