### PR TITLE
Micropub: insufficient_scope → 403 with WWW-Authenticate challenge (#439)

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -210,12 +210,15 @@ class LambMicropubAdapter extends MicropubAdapter
     }
 
     /**
-     * Build the 401 response for a token that lacks the scope an action requires.
+     * Build the 403 response for a token that lacks the scope an action requires.
      *
-     * The W3C Micropub spec (§error-response) and OAuth bearer-token RFC 6750 (§3)
-     * require HTTP 401 with a `WWW-Authenticate: Bearer` challenge naming the error
-     * and the scope needed. taproot/micropub-adapter maps insufficient_scope to 403,
-     * so the callbacks bypass toResponse() by returning this ResponseInterface directly.
+     * Both RFC 6750 §3.1 and the W3C Micropub error-response section map
+     * `insufficient_scope` to HTTP 403 (a valid token was supplied, but it lacks
+     * the privilege) — 401 is reserved for a missing or invalid token. The
+     * taproot/micropub-adapter already returns 403, but without the RFC 6750 §3
+     * `WWW-Authenticate: Bearer` challenge, so the callbacks return this response
+     * directly to attach it. (micropub.rocks test 804 wants 401, contradicting the
+     * spec — see aaronpk/micropub.rocks#101 — so we follow the spec, not the test.)
      *
      * @param string $requiredScope The scope the rejected action needs (e.g. 'create', 'update').
      * @return Response
@@ -223,10 +226,10 @@ class LambMicropubAdapter extends MicropubAdapter
     private function insufficientScopeResponse(string $requiredScope): Response
     {
         return new Response(
-            401,
+            403,
             [
                 'content-type'     => 'application/json',
-                'www-authenticate' => 'Bearer error="insufficient_scope", scope="' . $requiredScope . '"',
+                'www-authenticate' => bearer_challenge('insufficient_scope', $requiredScope),
             ],
             json_encode([
                 'error'             => 'insufficient_scope',
@@ -760,6 +763,34 @@ function mp_log(string $event, array $context = []): void
 }
 
 /**
+ * Build a `WWW-Authenticate: Bearer` challenge value per OAuth bearer-token RFC 6750 §3.
+ *
+ * With no error this returns a bare `Bearer` — RFC 6750 §3.1 says a request that
+ * supplied no credentials at all SHOULD NOT carry an error code. When an error is
+ * given, the optional `error_description` and `scope` attributes are appended in the
+ * spec's listed order (error, error_description, scope).
+ *
+ * @param string|null $error       Error code (e.g. 'invalid_token', 'insufficient_scope').
+ * @param string|null $scope       Scope the action requires (insufficient_scope only).
+ * @param string|null $description Human-readable error description.
+ */
+function bearer_challenge(?string $error = null, ?string $scope = null, ?string $description = null): string
+{
+    $params = [];
+    if ($error !== null) {
+        $params[] = 'error="' . $error . '"';
+    }
+    if ($description !== null) {
+        $params[] = 'error_description="' . $description . '"';
+    }
+    if ($scope !== null) {
+        $params[] = 'scope="' . $scope . '"';
+    }
+
+    return $params === [] ? 'Bearer' : 'Bearer ' . implode(', ', $params);
+}
+
+/**
  * Non-reversible fingerprint of a bearer token: enough to correlate the same token
  * across log lines without ever writing the secret itself.
  */
@@ -840,7 +871,14 @@ function respond_micropub(): void
     }
     $response = $adapter->handleRequest($request);
 
+    // The adapter returns a bare 401 when no access token is supplied; RFC 6750 §3
+    // requires a WWW-Authenticate: Bearer challenge on such responses. (Our own
+    // insufficient_scope path is a 403 that already sets the header, so it is untouched.)
     $status = $response->getStatusCode();
+    if ($status === 401 && !$response->hasHeader('WWW-Authenticate')) {
+        $response = $response->withHeader('WWW-Authenticate', bearer_challenge());
+    }
+
     mp_log('response', [
         'status' => $status,
         // Only echo the body into the log on failures — it carries the error reason.
@@ -863,16 +901,20 @@ function respond_micropub(): void
  * Centralises the status code + Content-Type header + {error, error_description}
  * body that every guard in the media endpoint would otherwise repeat.
  *
- * @param int    $status      HTTP status code.
- * @param string $error       Micropub error code (e.g. 'unauthorized', 'invalid_request').
- * @param string $description Human-readable error description.
+ * @param int         $status          HTTP status code.
+ * @param string      $error           Micropub error code (e.g. 'unauthorized', 'invalid_request').
+ * @param string      $description     Human-readable error description.
+ * @param string|null $wwwAuthenticate Optional RFC 6750 `WWW-Authenticate` challenge (see bearer_challenge()).
  * @return never
  */
-function micropub_error(int $status, string $error, string $description): never
+function micropub_error(int $status, string $error, string $description, ?string $wwwAuthenticate = null): never
 {
     mp_log('response', ['status' => $status, 'error' => $error, 'error_description' => $description]);
     http_response_code($status);
     header('Content-Type: application/json');
+    if ($wwwAuthenticate !== null) {
+        header('WWW-Authenticate: ' . $wwwAuthenticate);
+    }
     echo json_encode(['error' => $error, 'error_description' => $description]);
     exit;
 }
@@ -903,7 +945,8 @@ function respond_micropub_media(): void
     }
 
     if (!$token) {
-        micropub_error(401, 'unauthorized', 'Missing bearer token.');
+        // No credentials supplied: bare Bearer challenge, no error code (RFC 6750 §3.1).
+        micropub_error(401, 'unauthorized', 'Missing bearer token.', bearer_challenge());
     }
 
     $adapter = new LambMicropubAdapter();
@@ -912,7 +955,12 @@ function respond_micropub_media(): void
     }
     $user = $adapter->verifyAccessTokenCallback($token);
     if (!$user) {
-        micropub_error(401, 'unauthorized', 'Invalid or expired token.');
+        micropub_error(
+            401,
+            'unauthorized',
+            'Invalid or expired token.',
+            bearer_challenge('invalid_token', null, 'The access token is invalid or expired.')
+        );
     }
 
     if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST' || empty($_FILES['file'])) {

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -210,6 +210,32 @@ class LambMicropubAdapter extends MicropubAdapter
     }
 
     /**
+     * Build the 401 response for a token that lacks the scope an action requires.
+     *
+     * The W3C Micropub spec (§error-response) and OAuth bearer-token RFC 6750 (§3)
+     * require HTTP 401 with a `WWW-Authenticate: Bearer` challenge naming the error
+     * and the scope needed. taproot/micropub-adapter maps insufficient_scope to 403,
+     * so the callbacks bypass toResponse() by returning this ResponseInterface directly.
+     *
+     * @param string $requiredScope The scope the rejected action needs (e.g. 'create', 'update').
+     * @return Response
+     */
+    private function insufficientScopeResponse(string $requiredScope): Response
+    {
+        return new Response(
+            401,
+            [
+                'content-type'     => 'application/json',
+                'www-authenticate' => 'Bearer error="insufficient_scope", scope="' . $requiredScope . '"',
+            ],
+            json_encode([
+                'error'             => 'insufficient_scope',
+                'error_description' => 'Your access token does not grant the scope required for this action.',
+            ]) ?: ''
+        );
+    }
+
+    /**
      * Handle a micropub create request.
      *
      * @param array<string, mixed> $data  Normalised microformats2 data.
@@ -218,17 +244,9 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     public function createCallback(array $data, array $uploadedFiles = [])
     {
-        // W3C Micropub spec §error-response requires HTTP 401 for insufficient_scope.
-        // taproot/micropub-adapter maps it to 403 instead, so we bypass toResponse() by
-        // returning a ResponseInterface directly from this callback.
-        // TODO: report upstream to taproot/micropub-adapter that insufficient_scope should
-        //       map to HTTP 401 per the W3C Micropub spec.
         $scope = $this->user['scope'] ?? [];
         if ($this->user !== null && !in_array('create', $scope)) {
-            return new Response(401, ['content-type' => 'application/json'], json_encode([
-                'error' => 'insufficient_scope',
-                'error_description' => 'Your access token does not grant the scope required for this action.',
-            ]) ?: '');
+            return $this->insufficientScopeResponse('create');
         }
 
         $props = $data['properties'] ?? [];
@@ -359,10 +377,7 @@ class LambMicropubAdapter extends MicropubAdapter
 
         $scope = $this->user['scope'] ?? [];
         if ($this->user !== null && !in_array('update', $scope)) {
-            return new Response(401, ['content-type' => 'application/json'], json_encode([
-                'error'             => 'insufficient_scope',
-                'error_description' => 'Your access token does not grant the scope required for this action.',
-            ]) ?: '');
+            return $this->insufficientScopeResponse('update');
         }
 
         foreach ($actions['replace'] ?? [] as $property => $values) {

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -723,11 +723,13 @@ class MicropubAdapterTest extends TestCase
         ];
         $result = $adapter->createCallback($data, []);
         $this->assertInstanceOf(\Psr\Http\Message\ResponseInterface::class, $result);
-        $this->assertSame(401, $result->getStatusCode());
+        // RFC 6750 §3.1 and the W3C Micropub spec both map insufficient_scope to 403
+        // (a valid token lacking the required scope), not 401.
+        $this->assertSame(403, $result->getStatusCode());
         $body = json_decode((string) $result->getBody(), true);
         $this->assertSame('insufficient_scope', $body['error']);
-        // RFC 6750 §3: a 401 insufficient_scope response carries a Bearer challenge
-        // naming the error and the scope required for the action.
+        // The 403 still carries a Bearer challenge naming the error and the scope
+        // required for the action (RFC 6750 §3).
         $this->assertSame(
             'Bearer error="insufficient_scope", scope="create"',
             $result->getHeaderLine('WWW-Authenticate')
@@ -1104,12 +1106,36 @@ class MicropubAdapterTest extends TestCase
         );
 
         $this->assertInstanceOf(\Psr\Http\Message\ResponseInterface::class, $result);
-        $this->assertSame(401, $result->getStatusCode());
+        $this->assertSame(403, $result->getStatusCode());
         $body = json_decode((string) $result->getBody(), true);
         $this->assertSame('insufficient_scope', $body['error']);
         $this->assertSame(
             'Bearer error="insufficient_scope", scope="update"',
             $result->getHeaderLine('WWW-Authenticate')
+        );
+    }
+
+    // --- bearer_challenge (RFC 6750 §3 WWW-Authenticate value) ---
+
+    public function testBearerChallengeWithNoArgumentsOmitsErrorCode(): void
+    {
+        // RFC 6750 §3.1: a request lacking any credentials SHOULD NOT carry an error code.
+        $this->assertSame('Bearer', \Lamb\Micropub\bearer_challenge());
+    }
+
+    public function testBearerChallengeWithErrorAndDescription(): void
+    {
+        $this->assertSame(
+            'Bearer error="invalid_token", error_description="The access token is invalid or expired."',
+            \Lamb\Micropub\bearer_challenge('invalid_token', null, 'The access token is invalid or expired.')
+        );
+    }
+
+    public function testBearerChallengeWithErrorAndScope(): void
+    {
+        $this->assertSame(
+            'Bearer error="insufficient_scope", scope="create"',
+            \Lamb\Micropub\bearer_challenge('insufficient_scope', 'create')
         );
     }
 }

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -726,6 +726,12 @@ class MicropubAdapterTest extends TestCase
         $this->assertSame(401, $result->getStatusCode());
         $body = json_decode((string) $result->getBody(), true);
         $this->assertSame('insufficient_scope', $body['error']);
+        // RFC 6750 §3: a 401 insufficient_scope response carries a Bearer challenge
+        // naming the error and the scope required for the action.
+        $this->assertSame(
+            'Bearer error="insufficient_scope", scope="create"',
+            $result->getHeaderLine('WWW-Authenticate')
+        );
     }
 
     // --- updateCallback ---
@@ -1101,5 +1107,9 @@ class MicropubAdapterTest extends TestCase
         $this->assertSame(401, $result->getStatusCode());
         $body = json_decode((string) $result->getBody(), true);
         $this->assertSame('insufficient_scope', $body['error']);
+        $this->assertSame(
+            'Bearer error="insufficient_scope", scope="update"',
+            $result->getHeaderLine('WWW-Authenticate')
+        );
     }
 }


### PR DESCRIPTION
Closes #439.

## TL;DR — the issue's premise was inverted

Issue #439 asked to change `insufficient_scope` from **403 → 401**, citing the W3C Micropub spec and RFC 6750. On verification, **both standards actually require 403**, and the only thing wanting 401 is a known-buggy test. So this PR does the opposite of the issue title — it keeps/uses **403** and adds the missing piece both standards *do* require: the `WWW-Authenticate` challenge.

| Source | insufficient_scope status |
|---|---|
| RFC 6750 §3.1 | **403** |
| W3C Micropub spec (error-response) | **403** |
| micropub.rocks **test 804** | 401 — contradicts the spec, see [aaronpk/micropub.rocks#101](https://github.com/aaronpk/micropub.rocks/issues/101) |
| Lamb (before this PR) | 401 — matched the buggy test, not the spec |

401 is for a *missing or invalid* token; 403 is for a *valid token that lacks the scope*. The maintainer's note on the issue (*"micropub.rocks tests against the incorrect version… best to follow the spec"*) pointed the right way.

## Changes

- **`insufficient_scope` now returns 403** (reverting the prior 401 workaround in `createCallback`/`updateCallback`), carrying the RFC 6750 §3 challenge `WWW-Authenticate: Bearer error="insufficient_scope", scope="create|update"`. The taproot adapter already returns 403 but omits this header, so the callbacks return the response directly to attach it.
- **New pure helper `bearer_challenge()`** builds the RFC 6750 §3 challenge value (correct attribute ordering); every Micropub error challenge now routes through it.
- **Bug sweep — other bearer-token error paths missing the challenge** (same class of bug):
  - Media endpoint missing token → bare `Bearer` (no error code, per §3.1).
  - Media endpoint invalid/expired token → `Bearer error="invalid_token", …`.
  - Main `/micropub` endpoint: attach a bare `Bearer` challenge to the adapter's bare 401 (missing token).

## Tests

Red-green TDD throughout: added unit tests for `bearer_challenge()` (3 cases) and updated the two scope tests to assert **403** + the challenge header. Full unit suite green (1010 tests), `composer lint` and PHPStan level-8 clean.

## Note for reviewers

This will make **micropub.rocks test 804 fail** (it wants 401). That is expected and correct — the test contradicts the spec. Flagging in case green-on-micropub.rocks is a release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MjRRB8eDy56oZZXCRpAhV