### PR TITLE
Log failed admin login attempts via error_log() (#444)

### DIFF
--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -48,6 +48,7 @@ function redirect_login(): array
 
     $user_pass = $_POST['password'];
     if (!password_verify($user_pass, base64_decode(LOGIN_PASSWORD))) {
+        log_failed_login();
         $_SESSION['flash'][] = 'Password is incorrect, please try again.';
         redirect_uri('/');
     }
@@ -57,6 +58,29 @@ function redirect_login(): array
     set_login_marker();
     $where = local_redirect_target(filter_input(INPUT_POST, 'redirect_to', FILTER_SANITIZE_URL) ?: null);
     redirect_uri($where);
+}
+
+/**
+ * Writes an audit line for a failed admin login attempt via error_log().
+ *
+ * The line carries a fixed "failed admin login" marker (easy to grep) and the
+ * client IP from REMOTE_ADDR, falling back to "unknown" when it is absent. It
+ * deliberately records no secret — never the submitted password. error_log()
+ * respects the host's configured log destination (web server / PHP-FPM), so a
+ * self-hoster needs no new dependency to capture brute-force attempts.
+ *
+ * Trust the IP only behind a known proxy: REMOTE_ADDR is the immediate peer, so
+ * behind a reverse proxy it is the proxy's address rather than the real client.
+ *
+ * @return void
+ */
+function log_failed_login(): void
+{
+    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+    if (!is_string($ip) || $ip === '') {
+        $ip = 'unknown';
+    }
+    error_log(sprintf('failed admin login from %s', $ip));
 }
 
 /**

--- a/tests/Unit/ResponseAuthTest.php
+++ b/tests/Unit/ResponseAuthTest.php
@@ -5,10 +5,14 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 
 use function Lamb\Response\local_redirect_target;
+use function Lamb\Response\log_failed_login;
 use function Lamb\Response\redirect_login;
 
 class ResponseAuthTest extends TestCase
 {
+    /** @var string|false */
+    private $previousErrorLog;
+
     protected function setUp(): void
     {
         $_SESSION = [];
@@ -19,12 +23,60 @@ class ResponseAuthTest extends TestCase
         if (!defined('ROOT_URL')) {
             define('ROOT_URL', 'http://localhost');
         }
+
+        $this->previousErrorLog = ini_get('error_log');
     }
 
     protected function tearDown(): void
     {
         $_SESSION = [];
         $_POST    = [];
+        unset($_SERVER['REMOTE_ADDR']);
+        ini_set('error_log', $this->previousErrorLog === false ? '' : $this->previousErrorLog);
+    }
+
+    /**
+     * Routes error_log() to a temp file, runs the callback, returns the captured log.
+     */
+    private function captureErrorLog(callable $fn): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'lamb-log');
+        ini_set('error_log', $tmp);
+        try {
+            $fn();
+            return file_get_contents($tmp) ?: '';
+        } finally {
+            @unlink($tmp);
+        }
+    }
+
+    // log_failed_login — audit trail for failed admin login attempts (issue #444)
+
+    public function testLogFailedLoginWritesMarkerAndClientIp(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+        $log = $this->captureErrorLog(static fn() => log_failed_login());
+
+        $this->assertStringContainsString('failed admin login', $log);
+        $this->assertStringContainsString('203.0.113.7', $log);
+    }
+
+    public function testLogFailedLoginFallsBackWhenIpMissing(): void
+    {
+        unset($_SERVER['REMOTE_ADDR']);
+        $log = $this->captureErrorLog(static fn() => log_failed_login());
+
+        $this->assertStringContainsString('failed admin login', $log);
+        $this->assertStringContainsString('unknown', $log);
+    }
+
+    public function testLogFailedLoginNeverIncludesSubmittedPassword(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+        $_POST['password']      = 'hunter2-secret';
+        $log = $this->captureErrorLog(static fn() => log_failed_login());
+
+        $this->assertStringNotContainsString('hunter2-secret', $log);
     }
 
     // redirect_login — paths that return without calling die()


### PR DESCRIPTION
Closes #444.

## What

A failed `/login` attempt previously produced only a user-facing flash message — nothing was logged, so an operator had no way to notice a series of failed logins or a brute-force attempt after the fact.

This adds `log_failed_login()` in `src/response/auth.php`, called from the single failure branch of `redirect_login()`. It emits one line via `error_log()`:

```
failed admin login from 203.0.113.7
```

- **Fixed marker** (`failed admin login`) for easy grepping.
- **Client IP** from `$_SERVER['REMOTE_ADDR']`, falling back to `unknown` when absent. (Trust the IP only behind a known proxy — REMOTE_ADDR is the immediate peer.)
- **No secrets**: the submitted password is never recorded.
- `error_log()` respects the host's configured log destination (web server / PHP-FPM), so there's no new dependency.

Successful logins stay unlogged, keeping it minimal (per the issue and the project's "opinionated, minimal" philosophy). This pairs naturally with the brute-force throttle (#443): the same hook can later increment a counter.

## Tests (red-green TDD)

Three unit tests in `ResponseAuthTest`, each routing `error_log()` to a temp file via `ini_set('error_log', ...)`:

- writes the marker and client IP,
- falls back to `unknown` when `REMOTE_ADDR` is missing,
- never includes the submitted password.

Full suite green (1013 tests), `phpcs` and `phpstan` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmpaDnDZqF1SerZcFtxSv3)_