### PR TITLE
Redirect failed logins to /login so the error flash is shown (#460)

### DIFF
--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -15,7 +15,7 @@ use Random\RandomException;
  *
  * If the user is already logged in, their session is regenerated and they are redirected to the root URL.
  * If the login form has not been submitted or the submitted value is not SUBMIT_LOGIN, it returns an empty array to show the login page.
- * If the submitted password is incorrect, it sets a flash message and redirects to the root URL.
+ * If the submitted password is incorrect, it sets a flash message and redirects back to the login page so the failure is communicated.
  * If the login is successful, it sets the SESSION_LOGIN session variable to true, regenerates the session ID, and redirects to the specified URL.
  *
  * @return array<string, mixed>
@@ -48,8 +48,12 @@ function redirect_login(): array
 
     $user_pass = $_POST['password'];
     if (!password_verify($user_pass, base64_decode(LOGIN_PASSWORD))) {
+        // Redirect back to /login, not /: redirect_login() always starts a
+        // session (for the CSRF token), so the login page reliably renders the
+        // flash. The anonymous homepage starts no session for a failed login
+        // (no marker cookie), which would silently swallow the message (#460).
         $_SESSION['flash'][] = 'Password is incorrect, please try again.';
-        redirect_uri('/');
+        redirect_uri('/login');
     }
 
     $_SESSION[SESSION_LOGIN] = true;

--- a/tests/Acceptance/LoginCest.php
+++ b/tests/Acceptance/LoginCest.php
@@ -36,6 +36,18 @@ class LoginCest
         $I->dontSee('Warning:');
     }
 
+    public function testWrongPasswordShowsFlashMessage(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', 'definitely-not-the-password');
+        $I->click('Log in');
+
+        // The failure must be communicated: the visitor is bounced back to the
+        // login page with the error flash, not silently dropped on the homepage.
+        $I->seeInCurrentUrl('/login');
+        $I->see('Password is incorrect, please try again.');
+    }
+
     public function testSettingsPageRequiresLogin(AcceptanceTester $I): void
     {
         $I->amOnPage('/settings');


### PR DESCRIPTION
Fixes #460.

## Problem

Submitting the **wrong password** at `/login` set a `Password is incorrect, please try again.` flash and redirected to `/`. But the anonymous homepage starts no session (`should_start_session()` only resumes one when a valid `lamb_logged_in` marker cookie is present, which a failed login never sets), so the flash sitting in session storage was never read. The visitor landed on a normal anonymous homepage with **no feedback** — contradicting the project's "assume success, communicate failure" philosophy.

## Fix

Redirect failed logins back to `/login` instead of `/`. `redirect_login()` already calls `Bootstrap\start_session()` unconditionally (for the CSRF token), so the login page always has a live session and reliably renders the flash. This is the minimal fix suggested in the issue and leaves anonymous homepage caching (#116) untouched.

## Tests

Added `LoginCest::testWrongPasswordShowsFlashMessage` (red before the change, green after) asserting the visitor is bounced back to `/login` and sees the error message. Verified the test fails without the one-line fix.

- `composer lint` ✓
- `composer analyse` ✓ (no errors)
- `vendor/bin/codecept run Unit` ✓ (1010 tests)
- `vendor/bin/codecept run Acceptance LoginCest` ✓ (5 tests)

Swept the other `$_SESSION['flash']` + redirect sites for the same class of bug: `require_login()`'s "Please login" redirects to the login page (which starts a session), and all other flashes occur in logged-in contexts — no twin bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4Tkcz8A52hNj1Ps5bgtaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4Tkcz8A52hNj1Ps5bgtaS)_