### PR TITLE
Make /login sessionless via signed double-submit CSRF (#462)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.db
+/tests/Support/Data/sessions/
 /.docker/*.env
 /data/cache/
 /data/*.log

--- a/src/constants.php
+++ b/src/constants.php
@@ -9,6 +9,10 @@
  */
 
 define('HIDDEN_CSRF_NAME', 'csrf');
+// Cookie holding the anonymous /login double-submit CSRF token (issue #462).
+// Distinct from LAMBSESSID/lamb_logged_in: /login issues no session, so its
+// CSRF token lives in this signed cookie + a matching hidden field instead.
+define('LOGIN_CSRF_COOKIE', 'lamb_login_csrf');
 define('IMAGE_FILES', 'imageFiles');
 // Image extensions accepted for upload. SVG is excluded: it can carry scripts.
 define('IMAGE_UPLOAD_EXTENSIONS', ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif']);
@@ -21,6 +25,10 @@ define('POST_VERSION', 3);
 // How long a login is remembered. The session cookie and the server-side session
 // both persist this long, so logins survive a browser restart and idle time.
 define('REMEMBER_LIFETIME', 7 * 24 * 60 * MINUTE_IN_SECONDS); // one week
+// How long an anonymous /login CSRF token stays valid. Short-lived: the login
+// page is never cached (no-store), so a visitor always gets a fresh token, and
+// an expired one just means reloading /login.
+define('LOGIN_CSRF_LIFETIME', 60 * MINUTE_IN_SECONDS); // one hour
 define('SESSION_LOGIN', 'logged_in');
 define('SUBMIT_CREATE', 'Create post');
 define('SUBMIT_EDIT', 'Update post');

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -15,7 +15,7 @@ use Random\RandomException;
  *
  * If the user is already logged in, their session is regenerated and they are redirected to the root URL.
  * If the login form has not been submitted or the submitted value is not SUBMIT_LOGIN, it returns an empty array to show the login page.
- * If the submitted password is incorrect, it sets a flash message and redirects to the root URL.
+ * If the submitted password is incorrect, it sets a flash message and redirects back to the login page so the failure is communicated.
  * If the login is successful, it sets the SESSION_LOGIN session variable to true, regenerates the session ID, and redirects to the specified URL.
  *
  * @return array<string, mixed>
@@ -48,8 +48,12 @@ function redirect_login(): array
 
     $user_pass = $_POST['password'];
     if (!password_verify($user_pass, base64_decode(LOGIN_PASSWORD))) {
+        // Redirect back to /login, not /: redirect_login() always starts a
+        // session (for the CSRF token), so the login page reliably renders the
+        // flash. The anonymous homepage starts no session for a failed login
+        // (no marker cookie), which would silently swallow the message (#460).
         $_SESSION['flash'][] = 'Password is incorrect, please try again.';
-        redirect_uri('/');
+        redirect_uri('/login');
     }
 
     $_SESSION[SESSION_LOGIN] = true;

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -11,29 +11,37 @@ use Lamb\Security;
 use Random\RandomException;
 
 /**
- * Redirects the user to the login page if not already logged in.
+ * Handles the /login route without starting a session for anonymous visitors.
  *
- * If the user is already logged in, their session is regenerated and they are redirected to the root URL.
- * If the login form has not been submitted or the submitted value is not SUBMIT_LOGIN, it returns an empty array to show the login page.
- * If the submitted password is incorrect, it sets a flash message and redirects back to the login page so the failure is communicated.
- * If the login is successful, it sets the SESSION_LOGIN session variable to true, regenerates the session ID, and redirects to the specified URL.
+ * /login is the one anonymous-reachable route, so starting a session here let an
+ * attacker mint a week-lived session file per request — a disk-exhaustion DoS
+ * through the single endpoint that couldn't refuse a session (issue #462). The
+ * form's CSRF protection therefore rides in a signed double-submit cookie + a
+ * matching hidden field (issue_login_csrf()/valid_login_csrf()) instead of the
+ * session, and a server-side session is only established *after* the password
+ * verifies — so anonymous traffic never writes a session file.
+ *
+ * - Already logged in (a valid marker let bootstrap start a session): the marker
+ *   is reissued and the visitor is bounced to the root URL.
+ * - Form not submitted: returns the login page data (including the double-submit
+ *   token) so the form renders.
+ * - Wrong password: the page is re-rendered in place with the error in the
+ *   returned data — there is no session flash to carry it (issue #460).
+ * - Correct password: a session is started, SESSION_LOGIN is set, the id is
+ *   regenerated, the marker is issued, and the visitor is redirected.
  *
  * @return array<string, mixed>
  * @throws RandomException
  */
 function redirect_login(): array
 {
-    // The login page needs a session for the CSRF token and any flash messages,
-    // even for an otherwise-anonymous visitor who carries no session cookie yet.
-    \Lamb\Bootstrap\start_session();
-
     // Prevent caching for this page
     header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
     header("Cache-Control: post-check=0, pre-check=0", false);
     header("Pragma: no-cache");
 
     if (isset($_SESSION[SESSION_LOGIN])) {
-        // Already logged in (e.g. an existing session adopted via LAMBSESSID).
+        // Already logged in (bootstrap started a session from a valid marker).
         // Reissue the marker too: the session is authoritative, but without a
         // valid marker the next request treats the visitor as anonymous.
         session_regenerate_id(true);
@@ -41,27 +49,158 @@ function redirect_login(): array
         redirect_uri('/');
     }
     if (!isset($_POST['submit']) || $_POST['submit'] !== SUBMIT_LOGIN) {
-        // Show login page by returning a non-empty array.
-        return [];
+        // Show login page (no session started for the anonymous visitor).
+        return login_page_data();
     }
-    Security\require_csrf();
+    require_login_csrf();
 
-    $user_pass = $_POST['password'];
+    $user_pass = $_POST['password'] ?? '';
     if (!password_verify($user_pass, base64_decode(LOGIN_PASSWORD))) {
         log_failed_login();
-        // Redirect back to /login, not /: redirect_login() always starts a
-        // session (for the CSRF token), so the login page reliably renders the
-        // flash. The anonymous homepage starts no session for a failed login
-        // (no marker cookie), which would silently swallow the message (#460).
-        $_SESSION['flash'][] = 'Password is incorrect, please try again.';
-        redirect_uri('/login');
+        // Re-render the login page in place with the error: /login is sessionless
+        // now, so there is no flash to carry the message across a redirect (#462).
+        return login_page_data('Password is incorrect, please try again.');
     }
 
+    // Password verified — only now do we establish server-side state.
+    \Lamb\Bootstrap\start_session();
     $_SESSION[SESSION_LOGIN] = true;
     session_regenerate_id(true);
     set_login_marker();
+    clear_login_csrf();
     $where = local_redirect_target(filter_input(INPUT_POST, 'redirect_to', FILTER_SANITIZE_URL) ?: null);
     redirect_uri($where);
+}
+
+/**
+ * Builds the data array used to render the (sessionless) login page.
+ *
+ * Always issues a fresh-or-reused double-submit CSRF token for the form, and
+ * optionally carries an inline error message to re-render after a failed login.
+ *
+ * @param string|null $error Inline error to display, or null for a clean form.
+ * @return array<string, mixed>
+ * @throws RandomException
+ */
+function login_page_data(?string $error = null): array
+{
+    $data = ['login_csrf' => issue_login_csrf()];
+    if ($error !== null) {
+        $data['login_error'] = $error;
+    }
+    return $data;
+}
+
+/**
+ * Derives the HMAC key used to sign the anonymous /login CSRF token.
+ *
+ * Deliberately distinct from the raw login hash (the key used for lamb_logged_in
+ * markers): if the two shared a key, a CSRF token harvested from GET /login would
+ * itself be a valid login marker, and replaying it as lamb_logged_in would start
+ * a session per request — reopening the very DoS this endpoint avoids (#462).
+ *
+ * @param string $loginHash The per-install login hash (LAMB_LOGIN_PASSWORD).
+ * @return string A derived HMAC key, distinct from $loginHash.
+ */
+function login_csrf_secret(string $loginHash): string
+{
+    return hash_hmac('sha256', 'lamb-login-csrf', $loginHash);
+}
+
+/**
+ * Returns options for the /login CSRF cookie, reusing the hardened defaults.
+ *
+ * Like the session cookie (configure_session()), `secure` tracks the connection
+ * scheme rather than being forced on: the token this cookie replaces — the
+ * session-backed CSRF token — rode in LAMBSESSID, which is only marked secure
+ * under HTTPS, so a plain-HTTP dev server still round-trips it. SameSite=Strict
+ * is the load-bearing control: a cross-site POST never carries the cookie, so the
+ * double-submit comparison fails.
+ *
+ * @param int $expires Unix timestamp for cookie expiry.
+ * @return array<string, mixed>
+ */
+function login_csrf_cookie_options(int $expires): array
+{
+    $options = get_cookie_options($expires);
+    $options['secure'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on');
+    return $options;
+}
+
+/**
+ * Issues (or reuses) the anonymous /login double-submit CSRF token.
+ *
+ * Returns the token to embed in the form's hidden field and, when no valid token
+ * cookie is already present, sets a matching signed cookie. A still-valid cookie
+ * is reused rather than rotated so two tabs both sitting on /login don't
+ * invalidate each other's hidden field. No session is touched.
+ *
+ * @return string The signed double-submit token.
+ * @throws RandomException
+ */
+function issue_login_csrf(): string
+{
+    $secret   = login_csrf_secret(LOGIN_PASSWORD);
+    $existing = $_COOKIE[LOGIN_CSRF_COOKIE] ?? null;
+    if (is_string($existing) && \Lamb\Bootstrap\valid_login_marker($existing, $secret)) {
+        return $existing;
+    }
+    $token = \Lamb\Bootstrap\sign_login_marker(bin2hex(random_bytes(16)), $secret);
+    setcookie(LOGIN_CSRF_COOKIE, $token, login_csrf_cookie_options(time() + LOGIN_CSRF_LIFETIME));
+    // Reflect for any same-request read (e.g. validation in tests).
+    $_COOKIE[LOGIN_CSRF_COOKIE] = $token;
+    return $token;
+}
+
+/**
+ * Validates the anonymous /login double-submit CSRF token.
+ *
+ * Passes only when the hidden field is byte-for-byte equal to the cookie (the
+ * double-submit check) AND the value carries a valid signature under the derived
+ * CSRF key (proving the server issued it). No session is consulted.
+ *
+ * @return bool
+ */
+function valid_login_csrf(): bool
+{
+    $field  = $_POST[HIDDEN_CSRF_NAME] ?? '';
+    $cookie = $_COOKIE[LOGIN_CSRF_COOKIE] ?? '';
+    if (!is_string($field) || !is_string($cookie) || $field === '' || $cookie === '') {
+        return false;
+    }
+    if (!hash_equals($cookie, $field)) {
+        return false;
+    }
+    return \Lamb\Bootstrap\valid_login_marker($field, login_csrf_secret(LOGIN_PASSWORD));
+}
+
+/**
+ * Enforces the /login double-submit CSRF check, mirroring Security\require_csrf():
+ * a failed check sends 405 Method Not Allowed and terminates the request.
+ *
+ * @return void
+ */
+function require_login_csrf(): void
+{
+    if (!valid_login_csrf()) {
+        $txt = ($_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1') . ' 405 Method Not Allowed';
+        header($txt);
+        die($txt);
+    }
+}
+
+/**
+ * Clears the /login CSRF cookie once it has served its purpose (after a
+ * successful login). Best-effort tidy-up; an expired token is harmless.
+ *
+ * @return void
+ */
+function clear_login_csrf(): void
+{
+    if (isset($_COOKIE[LOGIN_CSRF_COOKIE])) {
+        setcookie(LOGIN_CSRF_COOKIE, '', login_csrf_cookie_options(time() - 3600));
+        unset($_COOKIE[LOGIN_CSRF_COOKIE]);
+    }
 }
 
 /**

--- a/src/security.php
+++ b/src/security.php
@@ -35,9 +35,11 @@ function get_login_url(string $current_uri): string
 function require_login(): void
 {
     if (! isset($_SESSION[SESSION_LOGIN])) {
-        // Anonymous visitors carry no session; start one so the flash survives the redirect.
-        \Lamb\Bootstrap\start_session();
-        $_SESSION['flash'][] = "Please login";
+        // Don't start a session for an anonymous visitor: that would write a
+        // per-request session file off unauthenticated input (the DoS surface
+        // #462 closes for /login). The redirect carries ?redirect_to=, which the
+        // sessionless login page renders as the "Please login" prompt in place of
+        // a session flash.
         Response\redirect_uri(get_login_url($_SERVER['REQUEST_URI'] ?? ''));
     }
 }

--- a/src/themes/base/parts/login.php
+++ b/src/themes/base/parts/login.php
@@ -1,10 +1,22 @@
 <?php
 
-use function Lamb\Theme\csrf_token;
 use function Lamb\Theme\escape;
 use function Lamb\Theme\redirect_to;
 
-?>
+global $data;
+
+// /login is sessionless (issue #462): the CSRF token and any error are passed
+// in via $data rather than the session, and "Please login" is inferred from the
+// presence of a redirect_to (set when require_login() bounced a gated request).
+$login_csrf  = $data['login_csrf'] ?? '';
+$login_error = $data['login_error'] ?? '';
+$redirect    = redirect_to();
+
+if ($login_error !== '') : ?>
+    <div class="flash">⚠️ <?= escape($login_error) ?></div>
+<?php elseif ($redirect !== '') : ?>
+    <div class="flash">⚠️ Please login</div>
+<?php endif; ?>
 <form method="post" action="/login">
     <p style="text-align: center">
         <label> Password:
@@ -13,6 +25,6 @@ use function Lamb\Theme\redirect_to;
         <input type="submit" name="submit" value="<?php
         echo SUBMIT_LOGIN; ?>">
     </p>
-    <input type="hidden" name="<?= HIDDEN_CSRF_NAME ?>" value="<?= csrf_token() ?>"/>
-    <input type="hidden" name="redirect_to" value="<?= escape(redirect_to()) ?>"/>
+    <input type="hidden" name="<?= HIDDEN_CSRF_NAME ?>" value="<?= escape($login_csrf) ?>"/>
+    <input type="hidden" name="redirect_to" value="<?= escape($redirect) ?>"/>
 </form>

--- a/tests/Acceptance.suite.yml
+++ b/tests/Acceptance.suite.yml
@@ -17,7 +17,15 @@ extensions:
         # Pass LAMB_LOGIN_PASSWORD through to the test web server: the app reads it
         # via getenv(), but .env is only loaded into Codeception's %param% space, not
         # exported to this child process. Without it, every login-gated test fails.
-        0: env LAMB_DATA_DIR=../tests/Support/Data LAMB_LOGIN_PASSWORD=%LAMB_LOGIN_PASSWORD% php -S 0.0.0.0:%LAMB_TEST_PORT% -t src
+        #
+        # Redirect the server's stderr to a log file. `php -S` writes one access-log
+        # line per request to stderr; RunProcess starts the server via Symfony Process
+        # but never drains its output pipe until suite end, so once that pipe's OS
+        # buffer (~64 KB) fills, the server blocks on write() and stops responding —
+        # every later request then fails with cURL "Operation timed out after 30s"
+        # (a 0-byte read). Sending the log to a file keeps the pipe empty (and the
+        # log inspectable) so a long suite no longer wedges the server.
+        0: sh -c "env LAMB_DATA_DIR=../tests/Support/Data LAMB_LOGIN_PASSWORD='%LAMB_LOGIN_PASSWORD%' php -S 0.0.0.0:%LAMB_TEST_PORT% -t src 2> tests/_output/dev-server.log"
         sleep: 1
 step_decorators:
   - Codeception\Step\ConditionalAssertion

--- a/tests/Acceptance/CacheHeadersCest.php
+++ b/tests/Acceptance/CacheHeadersCest.php
@@ -52,24 +52,23 @@ class CacheHeadersCest
     }
 
     /**
-     * Regression: visiting /login while the session is still authenticated
-     * server-side but the marker cookie is stale/invalid (e.g. an old cookie
-     * from before marker signing) must re-issue a valid marker. Otherwise the
-     * already-logged-in branch redirects without a marker and the next request
-     * sees an invalid one, leaving the visitor stuck appearing logged out until
-     * they clear cookies.
+     * A stale or invalid lamb_logged_in marker makes the visitor anonymous
+     * everywhere (issue #462): /login no longer starts a session off a lingering
+     * LAMBSESSID cookie — doing so would write a session file off the very
+     * unvalidated cookie input the marker gate exists to refuse. The marker is
+     * therefore the single source of truth, so a stale one means anonymous and
+     * a gated page bounces to /login (re-entering the password recovers, as the
+     * other login tests cover).
      */
-    public function reloginReissuesMarkerWhenSessionAlreadyAuthenticated(AcceptanceTester $I): void
+    public function staleMarkerFallsBackToAnonymous(AcceptanceTester $I): void
     {
         $this->login($I);
-        // Stale, no-longer-valid marker; the LAMBSESSID session stays authed.
+        // Corrupt the marker; the lingering server-side session must NOT be
+        // resumed — the visitor is treated as anonymous and gated from /settings.
         $I->setCookie('lamb_logged_in', 'stale-unsigned-value');
-        // GET /login lands in the already-logged-in branch and redirects home.
-        $I->amOnPage('/login');
-        // The reissued marker must let the next request resume the session.
         $I->amOnPage('/settings');
-        $I->seeResponseCodeIs(200);
-        $I->dontSeeInCurrentUrl('/login');
+        $I->seeInCurrentUrl('/login');
+        $I->dontSeeElement('//textarea[@name="contents"]');
     }
 
     public function afterLogoutHomepageIsCacheableAgain(AcceptanceTester $I): void

--- a/tests/Acceptance/EditPostCest.php
+++ b/tests/Acceptance/EditPostCest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Acceptance;
+
+use Tests\Support\AcceptanceTester;
+
+/**
+ * Covers the core "edit an existing post" flow (respond_edit / redirect_edited).
+ *
+ * The delete/restore and draft suites exercise creating posts, but editing — a
+ * primary CRUD operation for the single author — had no browser-level coverage.
+ */
+class EditPostCest
+{
+    private string $original = '';
+
+    private function login(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', $_ENV['LAMB_TEST_PASSWORD']);
+        $I->click('Log in');
+    }
+
+    private function createPost(AcceptanceTester $I): void
+    {
+        $this->original = 'edit-test-original-' . uniqid();
+        $I->amOnPage('/');
+        $I->fillField('contents', $this->original);
+        $I->click('Create post');
+    }
+
+    private function editId(AcceptanceTester $I): string
+    {
+        // The edit control is a <button class="button-edit" data-id="N"> that JS
+        // upgrades into an /edit/N link; read the post id straight off data-id.
+        return (string) $I->grabAttributeFrom(
+            '//article[contains(., "' . $this->original . '")]//button[contains(@class, "button-edit")]',
+            'data-id'
+        );
+    }
+
+    public function testEditUpdatesPostContent(AcceptanceTester $I): void
+    {
+        $this->login($I);
+        $this->createPost($I);
+        $I->see($this->original);
+
+        $id      = $this->editId($I);
+        $updated = 'edit-test-updated-' . uniqid();
+
+        $I->amOnPage('/edit/' . $id);
+        $I->seeInField('contents', $this->original);
+        $I->fillField('contents', $updated);
+        $I->click('Update post');
+
+        $I->amOnPage('/');
+        $I->see($updated);
+        $I->dontSee($this->original);
+    }
+
+    public function testEditHasNoErrors(AcceptanceTester $I): void
+    {
+        $this->login($I);
+        $this->createPost($I);
+
+        $id = $this->editId($I);
+        $I->amOnPage('/edit/' . $id);
+        $I->fillField('contents', 'edit-test-noerror-' . uniqid());
+        $I->click('Update post');
+
+        $I->dontSee('Fatal error');
+        $I->dontSee('Warning:');
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function testEditPageRequiresLogin(AcceptanceTester $I): void
+    {
+        // Seed a post while logged in, then drop the session.
+        $this->login($I);
+        $this->createPost($I);
+        $id = $this->editId($I);
+
+        $I->amOnPage('/logout');
+        $I->amOnPage('/edit/' . $id);
+
+        // Anonymous visitors are bounced to the login page, never the edit form.
+        $I->seeInCurrentUrl('/login');
+        $I->dontSeeElement('#editform');
+    }
+}

--- a/tests/Acceptance/LoginCest.php
+++ b/tests/Acceptance/LoginCest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Acceptance;
+
+use Tests\Support\AcceptanceTester;
+
+/**
+ * Covers the login sad-path and login-gating of admin pages.
+ *
+ * The cache-headers suite proves a *correct* password logs in; the security-
+ * critical rejection of a *wrong* password, and the gating of settings/scheduled
+ * (LogoutCest covers drafts/trash) had no browser-level coverage.
+ */
+class LoginCest
+{
+    public function testWrongPasswordLeavesVisitorAnonymous(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', 'definitely-not-the-password');
+        $I->click('Log in');
+
+        // A rejected login must not authenticate the visitor: the author-only
+        // entry form must not appear, and admin pages must still bounce to login.
+        $I->dontSeeElement('//textarea[@name="contents"]');
+        $I->amOnPage('/settings');
+        $I->seeInCurrentUrl('/login');
+    }
+
+    public function testWrongPasswordHasNoErrors(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', 'definitely-not-the-password');
+        $I->click('Log in');
+
+        $I->dontSee('Fatal error');
+        $I->dontSee('Warning:');
+    }
+
+    public function testSettingsPageRequiresLogin(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/settings');
+        $I->seeInCurrentUrl('/login');
+    }
+
+    public function testScheduledPageRequiresLogin(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/scheduled');
+        $I->seeInCurrentUrl('/login');
+    }
+}

--- a/tests/Acceptance/LoginCest.php
+++ b/tests/Acceptance/LoginCest.php
@@ -48,6 +48,36 @@ class LoginCest
         $I->see('Password is incorrect, please try again.');
     }
 
+    /**
+     * The heart of #462: an anonymous GET /login must not start a server-side
+     * session, so it never writes a session file (the disk-exhaustion DoS).
+     */
+    public function testAnonymousLoginPageStartsNoSession(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->seeResponseCodeIs(200);
+        $I->dontSeeResponseHeaderContains('Set-Cookie', 'LAMBSESSID');
+    }
+
+    /**
+     * A rejected login must also leave no session behind: the failure is
+     * re-rendered in place, not flashed through a freshly minted session.
+     */
+    public function testWrongPasswordStartsNoSession(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', 'definitely-not-the-password');
+        $I->click('Log in');
+        $I->dontSeeResponseHeaderContains('Set-Cookie', 'LAMBSESSID');
+    }
+
+    public function testGatedPagePromptsToLogIn(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/settings');
+        $I->seeInCurrentUrl('/login');
+        $I->see('Please login');
+    }
+
     public function testSettingsPageRequiresLogin(AcceptanceTester $I): void
     {
         $I->amOnPage('/settings');

--- a/tests/Acceptance/LoginCest.php
+++ b/tests/Acceptance/LoginCest.php
@@ -36,6 +36,18 @@ class LoginCest
         $I->dontSee('Warning:');
     }
 
+    public function testWrongPasswordShowsFlashMessage(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', 'definitely-not-the-password');
+        $I->click('Log in');
+
+        // The failure must be communicated: the visitor is bounced back to the
+        // login page with the error flash, not silently dropped on the homepage.
+        $I->seeInCurrentUrl('/login');
+        $I->see('Password is incorrect, please try again.');
+    }
+
     public function testSettingsPageRequiresLogin(AcceptanceTester $I): void
     {
         $I->amOnPage('/settings');

--- a/tests/Unit/LoginCsrfTest.php
+++ b/tests/Unit/LoginCsrfTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Bootstrap\sign_login_marker;
+use function Lamb\Bootstrap\valid_login_marker;
+use function Lamb\Bootstrap\should_start_session;
+use function Lamb\Response\issue_login_csrf;
+use function Lamb\Response\login_csrf_secret;
+use function Lamb\Response\valid_login_csrf;
+
+/**
+ * Stateless double-submit CSRF for the anonymous /login form (issue #462).
+ *
+ * /login must not start a server-side session for anonymous visitors (no
+ * per-request session file → no disk-exhaustion DoS), so its CSRF token is a
+ * signed value carried in a cookie + matching hidden field rather than in the
+ * session. The signature reuses the login-marker signing helpers, but under a
+ * derived key so a CSRF token can never double as a lamb_logged_in marker.
+ */
+class LoginCsrfTest extends TestCase
+{
+    /** @var string|false */
+    private $previousSecret;
+
+    protected function setUp(): void
+    {
+        $_POST   = [];
+        $_COOKIE = [];
+        $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
+        $this->previousSecret = getenv('LAMB_LOGIN_PASSWORD');
+    }
+
+    protected function tearDown(): void
+    {
+        $_POST   = [];
+        $_COOKIE = [];
+        if ($this->previousSecret === false) {
+            putenv('LAMB_LOGIN_PASSWORD');
+        } else {
+            putenv('LAMB_LOGIN_PASSWORD=' . $this->previousSecret);
+        }
+    }
+
+    public function testValidWhenFieldEqualsCookieAndSignatureValid(): void
+    {
+        $token = issue_login_csrf();
+        $_POST[HIDDEN_CSRF_NAME] = $token;
+        // issue_login_csrf reflects the value into $_COOKIE for same-request reads.
+        $this->assertTrue(valid_login_csrf());
+    }
+
+    public function testInvalidWhenFieldMissing(): void
+    {
+        issue_login_csrf();
+        // No matching hidden field submitted.
+        $this->assertFalse(valid_login_csrf());
+    }
+
+    public function testInvalidWhenCookieMissing(): void
+    {
+        $_POST[HIDDEN_CSRF_NAME] = sign_login_marker('abc', login_csrf_secret('hash'));
+        $_COOKIE = [];
+        $this->assertFalse(valid_login_csrf());
+    }
+
+    public function testInvalidWhenFieldAndCookieDiffer(): void
+    {
+        $token = issue_login_csrf();
+        // A different (but on its own validly signed) value in the field must
+        // still fail: double-submit requires the two to be identical.
+        $_POST[HIDDEN_CSRF_NAME] = sign_login_marker('other', login_csrf_secret((string) getenv('LAMB_LOGIN_PASSWORD')));
+        $this->assertNotSame($token, $_POST[HIDDEN_CSRF_NAME]);
+        $this->assertFalse(valid_login_csrf());
+    }
+
+    public function testInvalidWhenSignatureTampered(): void
+    {
+        $token = issue_login_csrf();
+        $tampered = $token . 'x';
+        $_POST[HIDDEN_CSRF_NAME]   = $tampered;
+        $_COOKIE[LOGIN_CSRF_COOKIE] = $tampered;
+        $this->assertFalse(valid_login_csrf());
+    }
+
+    /**
+     * The crux of the design: a CSRF token is signed with a key derived from —
+     * but distinct from — the login hash, so feeding it back as a lamb_logged_in
+     * marker must NOT start a session. Otherwise an attacker could harvest a CSRF
+     * token from GET /login and replay it as a marker to reopen the DoS.
+     */
+    public function testCsrfTokenIsNotAcceptedAsLoginMarker(): void
+    {
+        $secret = 'a-realistic-bcrypt-login-hash';
+        putenv('LAMB_LOGIN_PASSWORD=' . $secret);
+
+        $token = sign_login_marker('deadbeef', login_csrf_secret($secret));
+
+        // Valid as a CSRF token under the derived key …
+        $this->assertTrue(valid_login_marker($token, login_csrf_secret($secret)));
+        // … but never valid as a login marker under the raw key …
+        $this->assertFalse(valid_login_marker($token, $secret));
+        // … so it can never trigger a session start.
+        $this->assertFalse(should_start_session(['lamb_logged_in' => $token]));
+    }
+
+    public function testDerivedSecretDiffersFromRawLoginHash(): void
+    {
+        $this->assertNotSame('a-hash', login_csrf_secret('a-hash'));
+        $this->assertNotSame('', login_csrf_secret(''));
+    }
+
+    public function testReusesExistingValidCookieAcrossIssues(): void
+    {
+        $first  = issue_login_csrf();
+        $second = issue_login_csrf();
+        // A valid cookie is reused rather than rotated, so two tabs that both
+        // GET /login don't invalidate each other's hidden field.
+        $this->assertSame($first, $second);
+    }
+}

--- a/tests/Unit/ResponseAuthTest.php
+++ b/tests/Unit/ResponseAuthTest.php
@@ -17,6 +17,7 @@ class ResponseAuthTest extends TestCase
     {
         $_SESSION = [];
         $_POST    = [];
+        $_COOKIE  = [];
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
         $_SERVER['REQUEST_URI']     = '/';
 
@@ -31,6 +32,7 @@ class ResponseAuthTest extends TestCase
     {
         $_SESSION = [];
         $_POST    = [];
+        $_COOKIE  = [];
         unset($_SERVER['REMOTE_ADDR']);
         ini_set('error_log', $this->previousErrorLog === false ? '' : $this->previousErrorLog);
     }
@@ -80,37 +82,68 @@ class ResponseAuthTest extends TestCase
     }
 
     // redirect_login — paths that return without calling die()
+    //
+    // The login page is now stateless for anonymous visitors (issue #462): no
+    // session is started, and the form's CSRF token rides in a signed cookie +
+    // hidden field instead of the session. So "show the login page" no longer
+    // means an empty array — it means an array carrying the double-submit token
+    // (login_csrf) and no authenticated session.
 
-    public function testRedirectLoginReturnsEmptyArrayWhenNoPostData(): void
+    public function testRedirectLoginShowsFormWhenNoPostData(): void
     {
         // No POST at all — login form should be rendered
         $result = redirect_login();
         $this->assertIsArray($result);
-        $this->assertCount(0, $result);
+        $this->assertArrayHasKey('login_csrf', $result);
+        $this->assertArrayNotHasKey('login_error', $result);
+        $this->assertArrayNotHasKey(SESSION_LOGIN, $_SESSION);
     }
 
-    public function testRedirectLoginReturnsEmptyArrayWhenSubmitKeyAbsent(): void
+    public function testRedirectLoginShowsFormWhenSubmitKeyAbsent(): void
     {
         $_POST['other_field'] = 'value';
         $result = redirect_login();
         $this->assertIsArray($result);
-        $this->assertCount(0, $result);
+        $this->assertArrayHasKey('login_csrf', $result);
+        $this->assertArrayNotHasKey('login_error', $result);
     }
 
-    public function testRedirectLoginReturnsEmptyArrayWhenSubmitValueIsNotLogin(): void
+    public function testRedirectLoginShowsFormWhenSubmitValueIsNotLogin(): void
     {
         $_POST['submit'] = 'some other action';
         $result = redirect_login();
         $this->assertIsArray($result);
-        $this->assertCount(0, $result);
+        $this->assertArrayHasKey('login_csrf', $result);
     }
 
-    public function testRedirectLoginReturnsEmptyArrayWhenSubmitValueIsEmpty(): void
+    public function testRedirectLoginShowsFormWhenSubmitValueIsEmpty(): void
     {
         $_POST['submit'] = '';
         $result = redirect_login();
         $this->assertIsArray($result);
-        $this->assertCount(0, $result);
+        $this->assertArrayHasKey('login_csrf', $result);
+    }
+
+    /**
+     * Wrong password re-renders the login page in place with the error rather
+     * than redirecting through a session flash (issue #462): the flash carrier
+     * is gone now that /login is sessionless, so the message must travel in the
+     * returned data. The visitor must remain anonymous (no session started).
+     */
+    public function testRedirectLoginWrongPasswordRendersErrorWithoutSession(): void
+    {
+        $token = \Lamb\Response\issue_login_csrf();
+        $_POST['submit']          = SUBMIT_LOGIN;
+        $_POST[HIDDEN_CSRF_NAME]  = $token;
+        $_POST['password']        = 'definitely-the-wrong-password-xyz';
+
+        $result = redirect_login();
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('login_error', $result);
+        $this->assertSame('Password is incorrect, please try again.', $result['login_error']);
+        $this->assertArrayHasKey('login_csrf', $result);
+        $this->assertArrayNotHasKey(SESSION_LOGIN, $_SESSION);
     }
 
     // local_redirect_target — the post-login redirect must stay on this site


### PR DESCRIPTION
Closes #462. Targets `next`.

## Problem

`/login` was the one anonymous-reachable route that started a server-side session unconditionally — purely to hold a CSRF token (and, since #460, a failed-login flash). Combined with the week-long `session.gc_maxlifetime` and `use_strict_mode`, a flood of unauthenticated `GET`/`POST /login` could mint one week-lived session file per request: a disk-exhaustion DoS through the single endpoint that couldn't refuse a session.

## Change

Replace the session-backed login CSRF token with a **signed double-submit cookie**:

- `issue_login_csrf()` / `valid_login_csrf()` carry the token in a signed cookie + matching hidden field. The signature reuses `sign_login_marker()` / `valid_login_marker()` but under a **derived** key (`login_csrf_secret()`), so a CSRF token can never double as a `lamb_logged_in` marker — otherwise an attacker could harvest one from `GET /login` and replay it as a marker to reopen the DoS. (This domain separation is the security crux and is covered by a dedicated test.)
- `redirect_login()` starts a session **only after** the password verifies; the already-logged-in branch (valid marker) is unchanged.
- **Wrong password** is re-rendered in place with the error in the returned `$data` rather than via a session flash (the flash carrier is gone) — the in-place alternative noted in #460. No session is written on a rejected login.
- `require_login()` no longer starts a session/flash for anonymous visitors; the **"Please login"** prompt is rendered from the presence of `?redirect_to=` on the now-sessionless login page.

### Cookie hardening notes

- Reuses `get_cookie_options()` but tracks the connection scheme for `secure` (exactly like the session cookie it replaces) so plain-HTTP dev still round-trips it. `SameSite=Strict` is the load-bearing CSRF control: a cross-site POST never carries the cookie, so the double-submit comparison fails.
- Kept **`HttpOnly`** (a deliberate deviation from the issue's "HttpOnly-free" note): the server renders the hidden field itself, so JS never needs to read the cookie, and `HttpOnly` keeps it out of reach of XSS.

## Tests

- New `tests/Unit/LoginCsrfTest.php`: double-submit validation, signature tampering, and the **domain-separation** invariant (a CSRF token is rejected by `should_start_session()`).
- `tests/Unit/ResponseAuthTest.php`: updated for the new return shape (login page = data carrying `login_csrf`, no session) + wrong-password renders the error without a session.
- `tests/Acceptance/LoginCest.php`: anonymous `GET /login` and a rejected login set no `LAMBSESSID`; gated pages prompt "Please login".
- `tests/Acceptance/CacheHeadersCest.php`: the relogin-reissue regression test is reframed — with the marker now the single source of truth, a stale marker means anonymous (no silent session resume); normal re-login recovers.

All 1093 unit tests, the full acceptance suite (72), `composer lint`, and `composer analyse` pass.

> Note: this branch also merges `main` into `next` to pull in #460/#461 (the wrong-password flash fix this builds on), as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WW3Uxzn41eJmoHnHS67NnT)_