### PR TITLE
Fix double pagination on drafts/trash/scheduled pages

### DIFF
--- a/src/themes/base/parts/drafts.php
+++ b/src/themes/base/parts/drafts.php
@@ -6,4 +6,3 @@ use function Lamb\Theme\part;
 echo page_title();
 
 part('_items');
-part('_pagination');

--- a/src/themes/base/parts/scheduled.php
+++ b/src/themes/base/parts/scheduled.php
@@ -6,4 +6,3 @@ use function Lamb\Theme\part;
 echo page_title();
 
 part('_items');
-part('_pagination');

--- a/src/themes/base/parts/trash.php
+++ b/src/themes/base/parts/trash.php
@@ -6,4 +6,3 @@ use function Lamb\Theme\part;
 echo page_title();
 
 part('_items');
-part('_pagination');

--- a/tests/Unit/ThemeScheduledPartTest.php
+++ b/tests/Unit/ThemeScheduledPartTest.php
@@ -21,10 +21,36 @@ class ThemeScheduledPartTest extends TestCase
         );
     }
 
-    public function testScheduledPartRendersPostListAndPagination(): void
+    public function testScheduledPartRendersPostList(): void
     {
         $source = file_get_contents($this->partsDir() . '/scheduled.php');
         $this->assertStringContainsString("part('_items')", $source);
-        $this->assertStringContainsString("part('_pagination')", $source);
+    }
+
+    /**
+     * html.php renders the pagination part once for every template, so the
+     * admin list parts must NOT render it again — doing so produced two
+     * pagination navs on /drafts, /trash and /scheduled.
+     *
+     * @dataProvider adminListParts
+     */
+    public function testAdminListPartDoesNotDoublePaginate(string $part): void
+    {
+        $source = file_get_contents($this->partsDir() . '/' . $part);
+        $this->assertStringNotContainsString(
+            "part('_pagination')",
+            $source,
+            "$part must not render _pagination — html.php already does, which double-paginates the page"
+        );
+    }
+
+    /** @return array<string, array{string}> */
+    public static function adminListParts(): array
+    {
+        return [
+            'drafts'    => ['drafts.php'],
+            'trash'     => ['trash.php'],
+            'scheduled' => ['scheduled.php'],
+        ];
     }
 }


### PR DESCRIPTION
## Summary

Some logged-in list pages (`/drafts`, `/trash`, `/scheduled`) rendered the pagination nav **twice**.

`html.php` already renders `part("_pagination")` once for every template (after `<main>`), which is why the public `home`/`search`/`tag` parts don't call it themselves. But the three admin list parts (`drafts.php`, `trash.php`, `scheduled.php`) *also* called `part('_pagination')` inside `<main>`, producing a second pagination nav.

This was reported on `next` and confirmed to be present on `main` too (the `2026` and `2024` themes inherit these parts from `base`, and both `html.php` shells render pagination once), so the fix lands on `main`.

## Changes

- Drop the redundant `part('_pagination')` call from `base/parts/drafts.php`, `trash.php`, and `scheduled.php` — bringing them in line with `home`/`search`/`tag`, which rely on `html.php`'s single render.
- Update `ThemeScheduledPartTest` with a data-provider regression guard asserting none of the three admin list parts render `_pagination` directly.

## Testing

- `vendor/bin/codecept run Unit` — 1013 tests green
- `composer lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bhpw575srQsSgaheHXLzh1)_