### PR TITLE
Fix release-verify: write test password, add ondrej PPA

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -39,8 +39,10 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Generate credentials
+        # LAMB_WRITE_TEST_PASSWORD=1 writes the cleartext LAMB_TEST_PASSWORD to
+        # .env (omitted by default); the Acceptance login steps read it via $_ENV.
         run: |
-          php make-password.php ci-verify-password
+          LAMB_WRITE_TEST_PASSWORD=1 php make-password.php ci-verify-password
           sed -i "s|^SITE_URL=.*|SITE_URL='http://localhost:8080'|" .env
 
       - name: Build release image
@@ -88,13 +90,19 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Generate credentials
+        # LAMB_WRITE_TEST_PASSWORD=1 writes the cleartext LAMB_TEST_PASSWORD to
+        # .env (omitted by default); the Acceptance login steps read it via $_ENV.
         run: |
-          php make-password.php ci-verify-password
+          LAMB_WRITE_TEST_PASSWORD=1 php make-password.php ci-verify-password
           sed -i "s|^SITE_URL=.*|SITE_URL='http://127.0.0.1:8080'|" .env
 
       - name: Install nginx and php-fpm
-        # setup-php adds the ondrej/php PPA, so php8.2-fpm is installable on any runner image.
-        run: sudo apt-get update && sudo apt-get install -y nginx php8.2-fpm php8.2-sqlite3 php8.2-mbstring php8.2-xml
+        # Add the ondrej/php PPA explicitly so php8.2-* is installable on runner
+        # images whose default PHP is newer (e.g. Ubuntu 24.04 ships 8.3).
+        run: |
+          sudo add-apt-repository -y ppa:ondrej/php
+          sudo apt-get update
+          sudo apt-get install -y nginx php8.2-fpm php8.2-sqlite3 php8.2-mbstring php8.2-xml
 
       - name: Configure php-fpm pool
         run: |


### PR DESCRIPTION
The `release-verify` workflow's two jobs both fail on the 0.11.0 promotion PR (#468). Both are CI-harness bugs introduced after `0.11.0-rc1`, not problems with the released code:

- **docker-frankenphp / nginx-fpm acceptance:** the Acceptance login steps read `$_ENV['LAMB_TEST_PASSWORD']`, but `make-password.php` now omits it from `.env` unless `LAMB_WRITE_TEST_PASSWORD=1` is set (hardening change). The verify jobs didn't set the flag, so every login-based test errored. Now set it, mirroring `ci.yml`.
- **nginx-fpm:** the runner (Ubuntu 24.04) ships PHP 8.3, so `php8.2-fpm` isn't installable. Add the `ondrej/php` PPA explicitly instead of relying on setup-php leaving it in apt sources.

CI-only; no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)