### PR TITLE
Report per-reason breakdown of skipped WXR items

### DIFF
--- a/import-wordpress.php
+++ b/import-wordpress.php
@@ -59,11 +59,15 @@ $downloader = $dry_run
 $created = 0;
 $existed = 0;
 $skipped = 0;
+/** @var array<string, int> $skip_reasons */
+$skip_reasons = [];
 $total = count($items);
 
 foreach ($items as $i => $item) {
-    if (!WordPress\should_import($item)) {
+    $reason = WordPress\skip_reason($item);
+    if ($reason !== null) {
         $skipped++;
+        $skip_reasons[$reason] = ($skip_reasons[$reason] ?? 0) + 1;
         continue;
     }
     $uuid = WordPress\wordpress_uuid((string) $item['guid']);
@@ -75,6 +79,9 @@ foreach ($items as $i => $item) {
     $bean = WordPress\import_item($item, $downloader, $dry_run);
     if ($bean === null) {
         $skipped++;
+        $skip_reasons['conversion failed'] = ($skip_reasons['conversion failed'] ?? 0) + 1;
+        echo "[" . ($i + 1) . "/$total] skipped (conversion failed): "
+            . trim((string) $item['title']) . "\n";
         continue;
     }
     $created++;
@@ -84,6 +91,13 @@ foreach ($items as $i => $item) {
 
 $prefix = $dry_run ? '[dry-run] ' : '';
 echo "\n{$prefix}Done. created=$created existed=$existed skipped=$skipped total=$total\n";
+if ($skip_reasons) {
+    arsort($skip_reasons);
+    echo "Skipped breakdown:\n";
+    foreach ($skip_reasons as $reason => $count) {
+        echo "  $count\t$reason\n";
+    }
+}
 
 /**
  * Parses argv into [path, dry_run]. Returns [null, false] when the path is

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -162,8 +162,27 @@ function wxr_local_datetime(string $gmt, string $local, string $pub_date): strin
  */
 function should_import(array $item): bool
 {
-    return ($item['status'] ?? '') === 'publish'
-        && in_array($item['post_type'] ?? '', ['post', 'page'], true);
+    return skip_reason($item) === null;
+}
+
+/**
+ * Explains why an item falls outside import scope, or null when it should be
+ * imported. Single source of truth for should_import(); the importer uses the
+ * reason string to break down its skipped tally.
+ *
+ * @param array<string, mixed> $item
+ */
+function skip_reason(array $item): ?string
+{
+    $type   = (string) ($item['post_type'] ?? '');
+    $status = (string) ($item['status'] ?? '');
+    if (!in_array($type, ['post', 'page'], true)) {
+        return "unsupported post_type '" . ($type === '' ? '(none)' : $type) . "'";
+    }
+    if ($status !== 'publish') {
+        return "non-published status '" . ($status === '' ? '(none)' : $status) . "'";
+    }
+    return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

When importing a WordPress WXR export, the importer previously reported only a bare `skipped=N` count, giving no insight into *why* items fell out of scope. This adds a per-reason breakdown.

- Add `skip_reason()` in `src/wordpress.php` as the single source of truth for import scope; `should_import()` now delegates to it.
- The importer tallies skips by reason, logs conversion failures inline, and prints a sorted breakdown after the summary.

## Example output

```
Done. created=124 existed=0 skipped=51 total=175
Skipped breakdown:
  21	unsupported post_type 'attachment'
  20	non-published status 'draft'
  6	unsupported post_type 'nav_menu_item'
  2	unsupported post_type 'custom_css'
  1	unsupported post_type 'nf_sub'
  1	unsupported post_type 'wp_global_styles'
```

## Test plan

- `php -l` on both changed files
- Dry-run against a real WXR export confirms the breakdown matches the source item types/statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)