### PR TITLE
Ignore local tooling/data state and update devbox lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ node_modules/
 
 # pnpm store created when running inside the Workshop env
 /.pnpm-store/
+
+# Local agent/tooling state
+/.serena/
+/.claude/settings.local.json
+
+# Local runtime data (db is covered by *.db above)
+/data/sessions/

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,7 +2,8 @@
   "lockfile_version": "1",
   "packages": {
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "resolved": "github:NixOS/nixpkgs/dad564433178067be1fbdfcce23b546254b6d641?lastModified=1740019556&narHash=sha256-vn285HxnnlHLWnv59Og7muqECNMS33mWLM14soFIv2g%3D"
+      "last_modified": "2026-06-16T10:57:20Z",
+      "resolved": "github:NixOS/nixpkgs/3e41b24abd260e8f71dbe2f5737d24122f972158?lastModified=1781607440&narHash=sha256-rxO%2Buc%2FKFbSJp%2BpgyXRuAX6QlG9hJdnt0BXpEQRXY%2BU%3D"
     },
     "nodejs@24": {
       "last_modified": "2025-12-29T16:45:58Z",
@@ -209,51 +210,59 @@
         }
       }
     },
+    "path:/home/sander/dev/php/lamb/.devbox/virtenv/php/flake": {
+      "last_modified": "2026-06-21T12:25:34Z",
+      "resolved": "path:/home/sander/dev/php/lamb/.devbox/virtenv/php/flake?lastModified=1782044734&narHash=sha256-YK3rOLjOqftyZUcaIcer%2B%2BqWt1AgLW9PnR35inXweiU%3D"
+    },
+    "path:/home/sander/dev/php/lamb/.devbox/virtenv/php/flake#composer": {
+      "last_modified": "2026-06-21T12:25:34Z",
+      "resolved": "path:/home/sander/dev/php/lamb/.devbox/virtenv/php/flake?lastModified=1782044734&narHash=sha256-YK3rOLjOqftyZUcaIcer%2B%2BqWt1AgLW9PnR35inXweiU%3D#composer"
+    },
     "php82Extensions.xdebug@latest": {
-      "last_modified": "2024-03-22T07:26:23-04:00",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#php82Extensions.xdebug",
+      "last_modified": "2026-06-13T05:27:44Z",
+      "resolved": "github:NixOS/nixpkgs/5a722a7155bfc9fbe657f28d26b71860d95324bc#php82Extensions.xdebug",
       "source": "devbox-search",
-      "version": "3.3.1",
+      "version": "3.5.3",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/z47464ilpry3czl0vfrd9slrq4zjfayw-php-xdebug-3.3.1",
+              "path": "/nix/store/ilfr18fqh30w0p7vl7nj765h9vvxwiaw-php-xdebug-3.5.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/z47464ilpry3czl0vfrd9slrq4zjfayw-php-xdebug-3.3.1"
+          "store_path": "/nix/store/ilfr18fqh30w0p7vl7nj765h9vvxwiaw-php-xdebug-3.5.3"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/wi9a3hr35fch5dwwcxa3c238l6ay42cj-php-xdebug-3.3.1",
+              "path": "/nix/store/cvdfj3zjqghyrg18lpw5ic2zxsajhml5-php-xdebug-3.5.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/wi9a3hr35fch5dwwcxa3c238l6ay42cj-php-xdebug-3.3.1"
+          "store_path": "/nix/store/cvdfj3zjqghyrg18lpw5ic2zxsajhml5-php-xdebug-3.5.3"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/4gz2n5yy18gi0lwn3cq9xq51fhbv6jj5-php-xdebug-3.3.1",
+              "path": "/nix/store/g5v9xg2lgzq8cyx63v8wkfgi9y4zfqgc-php-xdebug-3.5.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/4gz2n5yy18gi0lwn3cq9xq51fhbv6jj5-php-xdebug-3.3.1"
+          "store_path": "/nix/store/g5v9xg2lgzq8cyx63v8wkfgi9y4zfqgc-php-xdebug-3.5.3"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/8ixgaygkvqrq218ndprbqb10z3amb7w3-php-xdebug-3.3.1",
+              "path": "/nix/store/xvyjq3i5rk7apcpg2m6qdvgrvyfdkxhp-php-xdebug-3.5.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/8ixgaygkvqrq218ndprbqb10z3amb7w3-php-xdebug-3.3.1"
+          "store_path": "/nix/store/xvyjq3i5rk7apcpg2m6qdvgrvyfdkxhp-php-xdebug-3.5.3"
         }
       }
     },


### PR DESCRIPTION
## Summary
- Add `.gitignore` entries for local-only artifacts that were appearing as untracked: `.serena/` (tooling state), `.claude/settings.local.json`, and `/data/sessions/` (`data/lamb.db` is already covered by the global `*.db` rule).
- Refresh `devbox.lock` via `devbox update`:
  - bump `nixpkgs-unstable`
  - `php82Extensions.xdebug` `3.3.1` → `3.5.3`
  - pin the `php` / `composer` flake paths
  - (a stale `nodejs@24` plugin downgrade was reverted in the process — `0.0.3` restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)