### PR TITLE
Fix imported image URLs 404ing on nested routes; unify asset URL building

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -524,7 +524,8 @@ class LambMicropubAdapter extends MicropubAdapter
             if ($ext === null) {
                 continue;
             }
-            $uploadDir = \Lamb\Response\get_upload_dir();
+            $sub_path  = \Lamb\Response\upload_subpath();
+            $uploadDir = \Lamb\Response\get_upload_dir($sub_path);
             $seed      = sha1($file->getClientFilename() ?? uniqid('', true));
 
             $filename = \Lamb\Response\persist_image_bytes(
@@ -537,7 +538,7 @@ class LambMicropubAdapter extends MicropubAdapter
                 continue;
             }
 
-            $urls[] = str_replace(ROOT_DIR, ROOT_URL, $uploadDir) . '/' . $filename;
+            $urls[] = \Lamb\Response\asset_url($sub_path, $filename);
         }
 
         return $urls;
@@ -968,7 +969,8 @@ function respond_micropub_media(): void
         micropub_error(400, 'invalid_request', 'Unsupported file type.');
     }
 
-    $uploadDir = \Lamb\Response\get_upload_dir();
+    $sub_path  = \Lamb\Response\upload_subpath();
+    $uploadDir = \Lamb\Response\get_upload_dir($sub_path);
     $seed      = sha1(($file['name'] ?? '') . uniqid('', true));
 
     // Re-encode JPEG/PNG to WebP, falling back to the original bytes on failure.
@@ -978,7 +980,9 @@ function respond_micropub_media(): void
         move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $filename);
     }
 
-    $url = str_replace(ROOT_DIR, ROOT_URL . '/', $uploadDir) . '/' . $filename;
+    // The media endpoint hands this URL back to an external Micropub client, so
+    // it must be absolute (resolvable off-site); content URLs stay root-relative.
+    $url = ROOT_URL . \Lamb\Response\asset_url($sub_path, $filename);
 
     http_response_code(201);
     header('Location: ' . $url);

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -10,7 +10,6 @@ use Lamb\Security;
 use RuntimeException;
 
 use const ROOT_DIR;
-use const ROOT_URL;
 
 /**
  * Responds to an upload request by processing the uploaded files.
@@ -50,22 +49,23 @@ function respond_upload(array $_args): void
             echo json_encode('Unsupported file type.', JSON_THROW_ON_ERROR);
             die();
         }
-        $temp_fp = $f['tmp_name'];
-        $seed    = sha1($f['name']);
+        $temp_fp  = $f['tmp_name'];
+        $seed     = sha1($f['name']);
+        $sub_path = upload_subpath();
+        $dir      = get_upload_dir($sub_path);
 
         // Re-encode JPEG/PNG to WebP for smaller files; fall back to the original
         // bytes if conversion fails (assume success, communicate failure).
-        $new_fn = store_webp_copy($temp_fp, $ext, get_upload_dir(), $seed);
+        $new_fn = store_webp_copy($temp_fp, $ext, $dir, $seed);
         if ($new_fn === null) {
             $new_fn = "$seed.$ext";
-            $new_fp = sprintf("%s/%s", get_upload_dir(), $new_fn);
+            $new_fp = sprintf("%s/%s", $dir, $new_fn);
             if (!move_uploaded_file($temp_fp, $new_fp)) {
                 echo json_encode('Move upload error: ' . $temp_fp, JSON_THROW_ON_ERROR);
                 die();
             }
         }
-        $upload_url = str_replace(ROOT_DIR, ROOT_URL, get_upload_dir());
-        $out .= sprintf("![%s](%s)", $f['name'], "$upload_url/$new_fn");
+        $out .= sprintf("![%s](%s)", $f['name'], asset_url($sub_path, $new_fn));
     }
 
     echo json_encode($out, JSON_THROW_ON_ERROR);
@@ -286,14 +286,27 @@ function scaled_dimensions(int $width, int $height, int $max): array
 }
 
 /**
+ * The YYYY/MM subpath new uploads are stored under (under src/assets/).
+ *
+ * Callers capture this once and pass it to both get_upload_dir() and asset_url()
+ * so the stored file and the URL written into the post can never disagree across
+ * a month boundary.
+ */
+function upload_subpath(): string
+{
+    return date("Y/m");
+}
+
+/**
  * Retrieves the upload directory for storing files, creating it if necessary.
  *
+ * @param string|null $sub_path The YYYY/MM subpath (defaults to the current month).
  * @return string The absolute path to the upload directory.
  * @throws RuntimeException If the directory cannot be created.
  */
-function get_upload_dir(): string
+function get_upload_dir(?string $sub_path = null): string
 {
-    $upload_dir = sprintf("%s/assets/%s", ROOT_DIR, date("Y/m"));
+    $upload_dir = sprintf("%s/assets/%s", ROOT_DIR, $sub_path ?? upload_subpath());
     if (!is_dir($upload_dir)) {
         if (!mkdir($upload_dir, 0777, true) && !is_dir($upload_dir)) {
             throw new RuntimeException(sprintf('Directory "%s" was not created', $upload_dir));
@@ -301,4 +314,20 @@ function get_upload_dir(): string
     }
 
     return $upload_dir;
+}
+
+/**
+ * The public URL for an asset stored at src/assets/<sub_path>/<filename>.
+ *
+ * Root-relative (leading slash) so it resolves on every route — / and /slug but
+ * also nested ones like /page/N, /search/x and /tag/x, where a bare "assets/..."
+ * is resolved against the current path and 404s. It also carries no host, so it
+ * survives a domain change and is produced identically by the CLI WXR importer,
+ * which has no $_SERVER host to build an absolute ROOT_URL from. Callers that
+ * must emit an absolute URL (e.g. the Micropub media endpoint's Location header)
+ * prefix ROOT_URL onto the result.
+ */
+function asset_url(string $sub_path, string $filename): string
+{
+    return "/assets/$sub_path/$filename";
 }

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -15,6 +15,7 @@ use Symfony\Component\Yaml\Yaml;
 use function Lamb\Http\fetch;
 use function Lamb\Post\finalize_and_store_post;
 use function Lamb\Post\populate_bean;
+use function Lamb\Response\asset_url;
 
 const WXR_NS = 'http://wordpress.org/export/1.2/';
 const CONTENT_NS = 'http://purl.org/rss/1.0/modules/content/';
@@ -520,7 +521,7 @@ function rewrite_image_links_in_dom(DOMDocument $dom, string $created, callable 
         if (!is_string($filename) || $filename === '') {
             continue;
         }
-        $img->setAttribute('src', "assets/$sub_path/$filename");
+        $img->setAttribute('src', asset_url($sub_path, $filename));
         foreach (['srcset', 'sizes', 'data-src', 'data-full-url', 'data-link', 'data-orig-file'] as $stale) {
             $img->removeAttribute($stale);
         }
@@ -543,7 +544,7 @@ function rewrite_image_links_in_dom(DOMDocument $dom, string $created, callable 
         if (!is_string($filename) || $filename === '') {
             continue;
         }
-        $a->setAttribute('href', "assets/$sub_path/$filename");
+        $a->setAttribute('href', asset_url($sub_path, $filename));
     }
 }
 

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -4,9 +4,11 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+use function Lamb\Response\asset_url;
 use function Lamb\Response\convert_to_webp;
 use function Lamb\Response\get_upload_dir;
 use function Lamb\Response\safe_upload_extension;
+use function Lamb\Response\upload_subpath;
 use function Lamb\Response\scaled_dimensions;
 use function Lamb\Response\should_convert_to_webp;
 use function Lamb\Response\store_webp_copy;
@@ -102,6 +104,43 @@ class UploadTest extends TestCase
         $result = get_upload_dir();
         $expectedSuffix = 'assets/' . date('Y/m');
         $this->assertStringContainsString($expectedSuffix, $result);
+    }
+
+    // asset_url — the single source of truth for an asset's public URL. Root-relative
+    // (leading slash) so it resolves on every route (/page/N, /search/x, /tag/x), not
+    // just / and /slug, and carries no host so it survives a domain change and works
+    // from the CLI importer (where ROOT_URL has no $_SERVER host to build from).
+
+    public function testAssetUrlIsRootRelative(): void
+    {
+        $this->assertSame('/assets/2024/03/pic.webp', asset_url('2024/03', 'pic.webp'));
+    }
+
+    public function testAssetUrlStartsWithLeadingSlash(): void
+    {
+        // The whole point of the fix: a bare "assets/..." resolves against the
+        // current path and 404s on nested routes. The leading slash prevents that.
+        $this->assertStringStartsWith('/assets/', asset_url('2026/06', 'x.webp'));
+    }
+
+    // upload_subpath / get_upload_dir — uploads land under assets/<Y/m>. Callers
+    // capture the subpath once and pass it to both get_upload_dir() and asset_url()
+    // so the stored file and its URL can never disagree across a month boundary.
+
+    public function testUploadSubpathFollowsYearMonthFormat(): void
+    {
+        $this->assertSame(date('Y/m'), upload_subpath());
+    }
+
+    public function testGetUploadDirHonoursExplicitSubpath(): void
+    {
+        $dir = get_upload_dir('2024/03');
+        $this->assertStringEndsWith('assets/2024/03', $dir);
+    }
+
+    public function testGetUploadDirDefaultsToCurrentSubpath(): void
+    {
+        $this->assertStringEndsWith('assets/' . upload_subpath(), get_upload_dir());
     }
 
     // safe_upload_extension — only image extensions may be written to the web root

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -613,9 +613,28 @@ XML;
             ['https://oldsite.example/thumb.jpg', 'https://oldsite.example/full.jpg'],
             $downloaded
         );
-        $this->assertStringContainsString('href="assets/2024/03/full.jpg"', $out);
-        $this->assertStringContainsString('src="assets/2024/03/full.jpg"', $out);
+        $this->assertStringContainsString('href="/assets/2024/03/full.jpg"', $out);
+        $this->assertStringContainsString('src="/assets/2024/03/full.jpg"', $out);
         $this->assertStringNotContainsString('oldsite.example', $out);
+    }
+
+    public function testRewriteImageLinksUsesRootRelativeUrls(): void
+    {
+        // The rewritten URL must be root-relative (leading slash) so it
+        // resolves to /assets/... on every route. A bare "assets/..." is
+        // resolved against the current path, so it 404s on nested routes
+        // like /page/2, /search/x and /tag/x while working on / and /slug —
+        // the import equivalent of the upload path's absolute ROOT_URL.
+        $downloader = fn(): ?string => 'abc123.jpg';
+
+        $html = '<p><a href="https://oldsite.example/full.jpg">'
+            . '<img src="https://oldsite.example/thumb.jpg" alt="t"/></a></p>';
+        $out = rewrite_image_links($html, '2024-03-03 10:00:00', $downloader);
+
+        $this->assertStringContainsString('src="/assets/2024/03/abc123.jpg"', $out);
+        $this->assertStringContainsString('href="/assets/2024/03/abc123.jpg"', $out);
+        $this->assertStringNotContainsString('src="assets/', $out);
+        $this->assertStringNotContainsString('href="assets/', $out);
     }
 
     public function testRewriteImageLinksLeavesNonImageAnchorsAlone(): void
@@ -654,7 +673,7 @@ XML;
         $out = rewrite_image_links($html, '2024-03-03 10:00:00', $downloader);
 
         $this->assertSame(['https://oldsite.example/img.jpg'], $downloaded);
-        $this->assertStringContainsString('src="assets/2024/03/pic.jpg"', $out);
+        $this->assertStringContainsString('src="/assets/2024/03/pic.jpg"', $out);
         $this->assertStringNotContainsString('<picture', $out);
         $this->assertStringNotContainsString('<source', $out);
         $this->assertStringNotContainsString('oldsite.example', $out);
@@ -677,7 +696,7 @@ XML;
         $out = rewrite_image_links($html, '2024-03-03 10:00:00', $downloader);
 
         $this->assertSame(['https://oldsite.example/big.jpg'], $downloaded);
-        $this->assertStringContainsString('src="assets/2024/03/src.jpg"', $out);
+        $this->assertStringContainsString('src="/assets/2024/03/src.jpg"', $out);
         $this->assertStringNotContainsString('<picture', $out);
         $this->assertStringNotContainsString('<source', $out);
     }


### PR DESCRIPTION
## Problem

WordPress-imported posts stored **relative** image URLs (`assets/YYYY/MM/x.webp`, no leading slash). A relative URL resolves against the current page's path, so an imported image only loaded on top-level routes and 404'd everywhere else:

| Route | Browser requests | Result |
|-------|------------------|--------|
| `/` (home) | `/assets/...` | ✅ |
| `/two-slices-please` (single post) | `/assets/...` | ✅ — why it loaded when clicking in |
| `/page/2` (timeline) | `/page/assets/...` | ❌ 404 |
| `/search/x`, `/tag/x` | `/search/assets/...` | ❌ 404 |

That's why an imported image appeared on the single-post page but was **missing from the timeline and search results**.

The web-upload and Micropub paths didn't have the bug (they emitted absolute `ROOT_URL` URLs), but the same URL-building logic was copy-pasted three ways with subtly different output — one even produced a `//` double slash.

## Fix

- **`Lamb\Response\asset_url($sub_path, $filename)`** — single source of truth, returns root-relative `/assets/...`: resolves on every route, carries no host (survives a domain change), and is producible by the **CLI importer**, which has no `$_SERVER` host to build an absolute `ROOT_URL` from.
- **`upload_subpath()` + optional `$sub_path` on `get_upload_dir()`** — callers capture the subpath once, so the stored file and its URL can't disagree across a month boundary (also collapses 3 redundant `get_upload_dir()` calls in `respond_upload()`).
- Routed the **importer**, **web upload**, and **Micropub inline-photo** paths through `asset_url()` (all now root-relative). The **Micropub media-endpoint `Location`** header stays absolute (external client contract) but is built as `ROOT_URL . asset_url(...)`, which also **fixes the pre-existing `//` double slash**.

## Testing

- Red→green unit tests for `asset_url` / `upload_subpath` / `get_upload_dir` and root-relative import output.
- Full unit suite **1156 passing**, `composer lint` clean, `composer analyse` clean.
- Verified end-to-end locally: fresh WXR re-import, image on `/page/2` now resolves **HTTP 200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)