### PR TITLE
Settings: add Redirections tab

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -657,6 +657,24 @@ function find_post_by_path(string $path): ?OODBBean
 }
 
 /**
+ * Returns all automatic DB redirects sorted by from_slug.
+ *
+ * @return array<int, array{from_slug:string, to_url:string}>
+ */
+function get_all_redirects(): array
+{
+    $beans = R::findAll('redirect', ' ORDER BY from_slug ASC ');
+    $out = [];
+    foreach ($beans as $bean) {
+        $out[] = [
+            'from_slug' => (string) $bean->from_slug,
+            'to_url'    => (string) $bean->to_url,
+        ];
+    }
+    return $out;
+}
+
+/**
  * Deletes any redirect stored in the DB for the given slug.
  *
  * @param string $slug The from_slug to remove.

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -311,6 +311,7 @@ function respond_settings(): array
         'title' => 'Settings',
         'ini_text' => Config\get_ini_text(),
         'feed_statuses' => Network\get_feed_statuses(),
+        'redirects' => \Lamb\get_all_redirects(),
     ];
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/src/themes/base/parts/settings.php
+++ b/src/themes/base/parts/settings.php
@@ -7,6 +7,7 @@ use function Lamb\Theme\escape;
 use function Lamb\Theme\human_time;
 
 $feed_statuses = $data['feed_statuses'] ?? [];
+$redirects     = $data['redirects'] ?? [];
 
 ?>
 <h1>Settings</h1>
@@ -49,6 +50,7 @@ $feed_statuses = $data['feed_statuses'] ?? [];
         display: none;
     }
     #settings-tab-config:checked ~ .settings-tabs__nav label[for="settings-tab-config"],
+    #settings-tab-redirects:checked ~ .settings-tabs__nav label[for="settings-tab-redirects"],
     #settings-tab-logs:checked ~ .settings-tabs__nav label[for="settings-tab-logs"] {
         opacity: 1;
         border-color: currentColor;
@@ -56,6 +58,7 @@ $feed_statuses = $data['feed_statuses'] ?? [];
         font-weight: bold;
     }
     #settings-tab-config:checked ~ #settings-panel-config,
+    #settings-tab-redirects:checked ~ #settings-panel-redirects,
     #settings-tab-logs:checked ~ #settings-panel-logs {
         display: block;
     }
@@ -77,10 +80,12 @@ $feed_statuses = $data['feed_statuses'] ?? [];
 
 <div class="settings-tabs">
     <input type="radio" name="settings-tab" id="settings-tab-config" checked>
+    <input type="radio" name="settings-tab" id="settings-tab-redirects">
     <input type="radio" name="settings-tab" id="settings-tab-logs">
 
     <nav class="settings-tabs__nav">
         <label for="settings-tab-config">Configuration</label>
+        <label for="settings-tab-redirects">Redirections</label>
         <label for="settings-tab-logs">Logs</label>
     </nav>
 
@@ -100,6 +105,34 @@ $feed_statuses = $data['feed_statuses'] ?? [];
                 <button type="submit" name="action" value="reset" onclick="return confirm('Are you sure you want to reset all settings to defaults? This cannot be undone.')">Reset to defaults</button>
             </div>
         </form>
+    </section>
+
+    <section class="settings-tabs__panel" id="settings-panel-redirects">
+        <p>
+            Automatic 301 redirects created when a post slug changes. These are stored in the
+            database and resolve before any page is served.
+        </p>
+
+        <?php if (empty($redirects)) : ?>
+            <p>No automatic redirects stored yet.</p>
+        <?php else : ?>
+            <table style="width:100%;border-collapse:collapse;">
+                <thead>
+                    <tr>
+                        <th style="text-align:left;padding:.4rem .5rem;border-bottom:1px solid currentColor;">From</th>
+                        <th style="text-align:left;padding:.4rem .5rem;border-bottom:1px solid currentColor;">To</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($redirects as $redirect) : ?>
+                        <tr>
+                            <td style="padding:.4rem .5rem;border-bottom:1px solid currentColor;font-family:monospace;">/<?= escape($redirect['from_slug']) ?></td>
+                            <td style="padding:.4rem .5rem;border-bottom:1px solid currentColor;font-family:monospace;"><?= escape($redirect['to_url']) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
     </section>
 
     <section class="settings-tabs__panel settings-logs" id="settings-panel-logs">

--- a/tests/Unit/RedirectTest.php
+++ b/tests/Unit/RedirectTest.php
@@ -7,6 +7,7 @@ use RedBeanPHP\R;
 
 use function Lamb\delete_redirect_for_slug;
 use function Lamb\find_redirect;
+use function Lamb\get_all_redirects;
 
 class RedirectTest extends TestCase
 {
@@ -141,6 +142,44 @@ class RedirectTest extends TestCase
         // Should not throw; no redirect to delete
         delete_redirect_for_slug('non-existent-slug-' . uniqid());
         $this->assertTrue(true);
+    }
+
+    // get_all_redirects
+
+    public function testGetAllRedirectsReturnsEmptyArrayWhenNoneExist(): void
+    {
+        $this->assertSame([], get_all_redirects());
+    }
+
+    public function testGetAllRedirectsReturnsSingleRedirect(): void
+    {
+        $r = R::dispense('redirect');
+        $r->from_slug = 'old-page';
+        $r->to_url = '/new-page';
+        R::store($r);
+
+        $results = get_all_redirects();
+        $this->assertCount(1, $results);
+        $this->assertSame('old-page', $results[0]['from_slug']);
+        $this->assertSame('/new-page', $results[0]['to_url']);
+    }
+
+    public function testGetAllRedirectsReturnsMultipleRedirectsSortedByFromSlug(): void
+    {
+        $a = R::dispense('redirect');
+        $a->from_slug = 'zebra';
+        $a->to_url = '/z';
+        R::store($a);
+
+        $b = R::dispense('redirect');
+        $b->from_slug = 'apple';
+        $b->to_url = '/a';
+        R::store($b);
+
+        $results = get_all_redirects();
+        $this->assertCount(2, $results);
+        $this->assertSame('apple', $results[0]['from_slug']);
+        $this->assertSame('zebra', $results[1]['from_slug']);
     }
 
     public function testDeleteRedirectForSlugMakesFindRedirectReturnNull(): void


### PR DESCRIPTION
## Summary

- Adds a **Redirections** tab to `/settings` between Configuration and Logs
- Lists every automatic 301 redirect stored in the `redirect` table (`from_slug` → `to_url`), sorted alphabetically
- Shows a friendly empty state when no redirects exist yet
- Introduces `get_all_redirects()` in `lamb.php` (returns `[from_slug, to_url][]` sorted by slug)

## Test plan

- [x] `vendor/bin/codecept run Unit RedirectTest` — 3 new tests covering empty, single, and multi-entry (sorted) cases, all green
- [x] Full unit suite passes (1173 tests)
- [ ] Visit `/settings` → Redirections tab appears between Configuration and Logs
- [ ] With no redirects: tab shows "No automatic redirects stored yet."
- [ ] After editing and saving a post slug (which creates a redirect row): tab lists the redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iA99LyMjXdnMhkW4YD6qG