### PR TITLE
SEO: add meta description; consolidate PHP open/close tags

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -28,6 +28,9 @@ theme = 2026
 ;; Title of the site, in html and feed views
 site_title = My Microblog
 
+;; Short description of the site, used as the meta description on listing pages.
+;site_description = A personal microblog
+
 ;; Your timezone, used for post dates and scheduling (the server is often UTC).
 ;; Use a name from https://www.php.net/manual/en/timezones.php.
 timezone = UTC

--- a/src/theme/meta.php
+++ b/src/theme/meta.php
@@ -25,8 +25,6 @@ function the_opengraph(): void
     $bean = $data['posts'][0];
     $description = $bean->description;
 
-    printf('<meta property="description" content="%s"/>' . PHP_EOL, og_escape($description));
-
     $image = og_image($bean);
 
     $og_tags = [
@@ -167,6 +165,34 @@ function og_local_path(string $url): ?string
         return ROOT_DIR . $url;
     }
     return null;
+}
+
+/**
+ * Emits a <meta name="description"> tag for the current page.
+ *
+ * For single-post (status) pages: uses the post's description field.
+ * For all other pages: uses $config['site_description'] when configured.
+ * Outputs nothing when no description is available.
+ *
+ * @return void
+ */
+function the_meta_description(): void
+{
+    global $template;
+    global $config;
+    global $data;
+
+    if ($template === 'status' && !empty($data['posts'][0])) {
+        $description = (string) ($data['posts'][0]->description ?? '');
+    } else {
+        $description = (string) ($config['site_description'] ?? '');
+    }
+
+    if ($description === '') {
+        return;
+    }
+
+    printf('<meta name="description" content="%s"/>' . PHP_EOL, og_escape($description));
 }
 
 /**

--- a/src/themes/2026/html.php
+++ b/src/themes/2026/html.php
@@ -4,6 +4,7 @@ use function Lamb\Theme\escape;
 use function Lamb\Theme\li_menu_items;
 use function Lamb\Theme\part;
 use function Lamb\Theme\site_or_page_title;
+use function Lamb\Theme\the_meta_description;
 use function Lamb\Theme\the_opengraph;
 use function Lamb\Theme\the_preconnect;
 use function Lamb\Theme\the_scripts;
@@ -42,9 +43,12 @@ global $template;
     <link rel="preload" href="<?= ROOT_URL ?>/<?= THEME_URL ?>styles/fonts/public-sans-400-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="<?= ROOT_URL ?>/<?= THEME_URL ?>styles/fonts/geist-mono-500-latin.woff2" as="font" type="font/woff2" crossorigin>
 
-    <?php the_preconnect(); ?>
-    <?php the_styles(); ?>
-    <?php the_opengraph(); ?>
+    <?php
+    the_meta_description();
+    the_preconnect();
+    the_styles();
+    the_opengraph();
+    ?>
 </head>
 <body class="<?= escape($template) ?>">
 <nav>

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -37,12 +37,12 @@ else :
 
         <article class="h-entry" data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
             <header>
-                <?php if ($template !== 'status') : ?>
-                    <?php $title = title_link($bean); ?>
-                    <?php if (!empty(trim(strip_tags($title)))) : ?>
+                <?php if ($template !== 'status') :
+                    $title = title_link($bean);
+                    if (!empty(trim(strip_tags($title)))) : ?>
                         <h2><?= $title ?></h2>
-                    <?php endif; ?>
-                <?php endif; ?>
+                    <?php endif;
+                endif; ?>
                 <div class="meta">
                     <span itemprop="author" class="screen-reader-text"><?= author_card() ?></span>
                     <?= date_created($bean) ?>

--- a/src/themes/base/html.php
+++ b/src/themes/base/html.php
@@ -4,6 +4,7 @@ use function Lamb\Theme\escape;
 use function Lamb\Theme\li_menu_items;
 use function Lamb\Theme\part;
 use function Lamb\Theme\site_or_page_title;
+use function Lamb\Theme\the_meta_description;
 use function Lamb\Theme\the_opengraph;
 use function Lamb\Theme\the_preconnect;
 use function Lamb\Theme\the_scripts;
@@ -39,11 +40,11 @@ global $template;
           title="<?= escape($data['title'] ?? $config['site_title']) ?>">
     <?php endif; ?>
     <?php
-    the_preconnect(); ?>
-    <?php
-    the_styles(); ?>
-    <?php
-    the_opengraph(); ?>
+    the_meta_description();
+    the_preconnect();
+    the_styles();
+    the_opengraph();
+    ?>
 </head>
 <body class="<?= escape($template) ?>">
 <nav>

--- a/tests/Unit/ThemeMetaTest.php
+++ b/tests/Unit/ThemeMetaTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\Theme\the_meta_description;
 use function Lamb\Theme\the_opengraph;
 
 class ThemeMetaTest extends TestCase
@@ -84,7 +85,7 @@ class ThemeMetaTest extends TestCase
     // the_opengraph — output when template === 'status'
     // -------------------------------------------------------------------------
 
-    public function testOpenGraphOutputsMetaDescriptionTagWhenTemplateIsStatus(): void
+    public function testOpenGraphDoesNotOutputNameDescriptionTag(): void
     {
         global $template, $data;
         $template = 'status';
@@ -100,7 +101,7 @@ class ThemeMetaTest extends TestCase
         the_opengraph();
         $output = ob_get_clean();
 
-        $this->assertStringContainsString('<meta property="description"', $output);
+        $this->assertStringNotContainsString('<meta name="description"', $output);
     }
 
     public function testOpenGraphOutputsOgDescriptionWhenTemplateIsStatus(): void
@@ -196,6 +197,70 @@ class ThemeMetaTest extends TestCase
 
         ob_start();
         the_opengraph();
+        $output = ob_get_clean();
+
+        $this->assertStringNotContainsString('<script>', $output);
+    }
+
+    // -------------------------------------------------------------------------
+    // the_meta_description
+    // -------------------------------------------------------------------------
+
+    public function testMetaDescriptionOutputsNameDescriptionForStatusTemplate(): void
+    {
+        global $template, $data;
+        $template = 'status';
+
+        $bean              = R::dispense('post');
+        $bean->description = 'Hello world post';
+        $bean->created     = date('Y-m-d H:i:s');
+        $bean->updated     = date('Y-m-d H:i:s');
+        R::store($bean);
+        $data = ['posts' => [$bean]];
+
+        ob_start();
+        the_meta_description();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('<meta name="description"', $output);
+        $this->assertStringContainsString('Hello world post', $output);
+    }
+
+    public function testMetaDescriptionOutputsSiteDescriptionForHomeTemplate(): void
+    {
+        global $template, $config;
+        $template = 'home';
+        $config['site_description'] = 'A personal microblog';
+
+        ob_start();
+        the_meta_description();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('<meta name="description"', $output);
+        $this->assertStringContainsString('A personal microblog', $output);
+    }
+
+    public function testMetaDescriptionOutputsNothingWhenNoDescriptionAvailable(): void
+    {
+        global $template, $config;
+        $template = 'home';
+        unset($config['site_description']);
+
+        ob_start();
+        the_meta_description();
+        $output = ob_get_clean();
+
+        $this->assertSame('', $output);
+    }
+
+    public function testMetaDescriptionEscapesContent(): void
+    {
+        global $template, $config;
+        $template = 'home';
+        $config['site_description'] = 'A blog with <script>bad</script>';
+
+        ob_start();
+        the_meta_description();
         $output = ob_get_clean();
 
         $this->assertStringNotContainsString('<script>', $output);


### PR DESCRIPTION
## Summary

- Fixes a Lighthouse SEO audit failure: pages had no `<meta name=\"description\">` tag
- `the_opengraph()` was emitting `property=\"description\"` (non-standard); that line is removed
- New `the_meta_description()` function emits the correct `<meta name=\"description\">` — using the post description on single-post pages, and the new optional `site_description` config key on listing pages
- Consolidates consecutive `<?php ?>` blocks with no HTML between them into single open/close pairs across both html.php themes and `_items.php`

## Test plan

- [ ] `vendor/bin/codecept run Unit ThemeMetaTest` — all 16 tests pass
- [ ] `vendor/bin/codecept run Unit` — all 1177 tests pass
- [ ] Check page source on a single post: `<meta name="description">` present with post content
- [ ] Check page source on home page with `site_description` configured: tag present
- [ ] Check page source on home page without `site_description`: tag absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iA99LyMjXdnMhkW4YD6qG