### PR TITLE
Fix: absolutise root-relative image URLs in feeds and OG tags

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -141,6 +141,53 @@ function permalink(OODBBean $bean): string
     return ROOT_URL . '/status/' . $bean->id;
 }
 
+/**
+ * Rewrites root-relative src/href attributes in an HTML fragment to absolute URLs.
+ *
+ * Posts store asset links as root-relative URLs ("/assets/Y/m/hash.webp" via
+ * asset_url()) so they survive a domain change and work from the CLI importer.
+ * That resolves correctly on-site, but a feed reader or syndication service that
+ * re-hosts the content (micro.blog, etc.) resolves "/assets/..." against its own
+ * host, leaving a broken image. Feed templates pass content through here so the
+ * syndicated copy keeps loading images and following links.
+ *
+ * Only root-relative values ("/path") are rewritten: already-absolute
+ * ("https://...") and protocol-relative ("//host/...") URLs are left untouched.
+ *
+ * @param string      $html The HTML fragment (e.g. a post's transformed body).
+ * @param string|null $base The base URL to prefix (defaults to ROOT_URL); a
+ *                          trailing slash is trimmed so paths don't double up.
+ * @return string The HTML with root-relative URLs made absolute.
+ */
+function absolute_urls(string $html, ?string $base = null): string
+{
+    return preg_replace_callback(
+        '#\b(src|href)="(/[^/][^"]*)"#i',
+        static fn(array $m): string => $m[1] . '="' . absolute_url($m[2], $base) . '"',
+        $html
+    ) ?? $html;
+}
+
+/**
+ * Makes a single root-relative URL absolute against $base (defaults to ROOT_URL).
+ *
+ * Already-absolute ("https://...") and protocol-relative ("//host/...") URLs are
+ * returned unchanged. Used for one-off URLs (e.g. an Open Graph image src pulled
+ * from a post body) where {@see absolute_urls} would be overkill.
+ *
+ * @param string      $url  A URL that may be root-relative.
+ * @param string|null $base The base URL to prefix (defaults to ROOT_URL).
+ * @return string The absolute URL.
+ */
+function absolute_url(string $url, ?string $base = null): string
+{
+    if ($url === '' || $url[0] !== '/' || str_starts_with($url, '//')) {
+        return $url;
+    }
+
+    return rtrim($base ?? ROOT_URL, '/') . $url;
+}
+
 
 /**
  * Parses the given bean to extract and transform its content.

--- a/src/theme/meta.php
+++ b/src/theme/meta.php
@@ -87,7 +87,10 @@ function og_image(\RedBeanPHP\OODBBean $bean): array
 {
     $embedded = first_embedded_image((string) ($bean->transformed ?? ''));
     if ($embedded !== null) {
-        return ['url' => $embedded, 'card' => 'summary_large_image'] + image_dimensions($embedded);
+        // Post images are stored root-relative ("/assets/..."); OG/Twitter scrapers
+        // require an absolute URL or the social card image is broken.
+        $url = \Lamb\absolute_url($embedded);
+        return ['url' => $url, 'card' => 'summary_large_image'] + image_dimensions($url);
     }
 
     if (defined('ROOT_DIR')) {

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -54,7 +54,7 @@ foreach ($data['posts'] as $bean) {
     $Entry->addChild('title', escape($bean->title ?: ''));
     $Entry->addChild('published', date(DATE_ATOM, strtotime($bean->created)));
     $Entry->addChild('updated', date(DATE_ATOM, strtotime($bean->updated)));
-    $Content = $Entry->addChild('content', $bean->transformed);
+    $Content = $Entry->addChild('content', Lamb\absolute_urls($bean->transformed));
     $Content->addAttribute('type', 'html');
     if (!empty($bean->in_reply_to)) {
         // Raw URL: SimpleXML escapes attribute values itself, so pre-escaping

--- a/src/themes/base/feed_json.php
+++ b/src/themes/base/feed_json.php
@@ -34,7 +34,7 @@ foreach ($data['posts'] as $bean) {
     $item = [
         'id'             => $url,
         'url'            => $url,
-        'content_html'   => $bean->transformed,
+        'content_html'   => Lamb\absolute_urls($bean->transformed),
         'date_published' => date(DATE_RFC3339, strtotime($bean->created)),
         'date_modified'  => date(DATE_RFC3339, strtotime($bean->updated)),
     ];

--- a/tests/Unit/AbsoluteUrlsTest.php
+++ b/tests/Unit/AbsoluteUrlsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\absolute_urls;
+
+/**
+ * absolute_urls() rewrites root-relative src/href attributes to absolute URLs.
+ *
+ * Posts store image links as root-relative URLs ("/assets/Y/m/hash.webp") via
+ * asset_url() so they survive a domain change. That works on-site, but feed
+ * readers and syndication services (micro.blog, etc.) that re-host the content
+ * resolve "/assets/..." against their own host, leaving a broken image. Feed
+ * templates absolutise the content so syndicated images load.
+ */
+class AbsoluteUrlsTest extends TestCase
+{
+    public function testRewritesRootRelativeImageSrc(): void
+    {
+        $html = '<p><img src="/assets/2026/06/abc.webp" alt=""></p>';
+        $this->assertSame(
+            '<p><img src="https://example.com/assets/2026/06/abc.webp" alt=""></p>',
+            absolute_urls($html, 'https://example.com')
+        );
+    }
+
+    public function testRewritesRootRelativeAnchorHref(): void
+    {
+        $html = '<a href="/tag/php">#php</a>';
+        $this->assertSame(
+            '<a href="https://example.com/tag/php">#php</a>',
+            absolute_urls($html, 'https://example.com')
+        );
+    }
+
+    public function testStripsTrailingSlashFromBase(): void
+    {
+        $html = '<img src="/x.webp">';
+        $this->assertSame(
+            '<img src="https://example.com/x.webp">',
+            absolute_urls($html, 'https://example.com/')
+        );
+    }
+
+    public function testLeavesAbsoluteUrlsUntouched(): void
+    {
+        $html = '<img src="https://cdn.example.org/cat.jpg">';
+        $this->assertSame($html, absolute_urls($html, 'https://example.com'));
+    }
+
+    public function testLeavesProtocolRelativeUrlsUntouched(): void
+    {
+        $html = '<img src="//cdn.example.org/cat.jpg">';
+        $this->assertSame($html, absolute_urls($html, 'https://example.com'));
+    }
+
+    public function testLeavesContentWithoutLinksUntouched(): void
+    {
+        $html = '<p>Just some text, no links.</p>';
+        $this->assertSame($html, absolute_urls($html, 'https://example.com'));
+    }
+
+    public function testRewritesMultipleAttributesInOnePass(): void
+    {
+        $html = '<a href="/status/1"><img src="/assets/a.webp"></a>';
+        $this->assertSame(
+            '<a href="https://example.com/status/1"><img src="https://example.com/assets/a.webp"></a>',
+            absolute_urls($html, 'https://example.com')
+        );
+    }
+}

--- a/tests/Unit/FeedJsonTemplateTest.php
+++ b/tests/Unit/FeedJsonTemplateTest.php
@@ -123,6 +123,24 @@ class FeedJsonTemplateTest extends TestCase
         $this->assertArrayNotHasKey('hubs', $json, 'No hubs field should be emitted without websub_hubs config');
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedJsonAbsolutisesRootRelativeImageUrls(): void
+    {
+        // Same syndication concern as the Atom feed: content_html must carry
+        // absolute image URLs so a re-hosting reader doesn't break the image.
+        $json = $this->renderJsonFeedWithPost([
+            'title'       => 'Pasted Image',
+            'transformed' => '<p><img src="/assets/2026/06/abc.webp" alt="pasted-1-0.png"></p>',
+        ]);
+
+        $html = $json['items'][0]['content_html'];
+        $this->assertStringContainsString('src="http://localhost/assets/2026/06/abc.webp"', $html);
+        $this->assertStringNotContainsString('src="/assets', $html);
+    }
+
     private function renderJsonFeedWithPost(array $fields, array $extraConfig = []): array
     {
         require_once __DIR__ . '/../../vendor/autoload.php';

--- a/tests/Unit/FeedTemplateTest.php
+++ b/tests/Unit/FeedTemplateTest.php
@@ -124,6 +124,27 @@ class FeedTemplateTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
+    public function testFeedContentAbsolutisesRootRelativeImageUrls(): void
+    {
+        // Pasted/uploaded images are stored as root-relative URLs. In a syndicated
+        // feed those must be absolute or the reader resolves them against its own
+        // host and shows a broken image (falling back to the alt text).
+        $transformed = '<p><img src="/assets/2026/06/abc.webp" alt="pasted-1-0.png"></p>';
+
+        $xml = $this->renderFeedWithPost([
+            'title'       => 'Pasted Image',
+            'transformed' => $transformed,
+        ]);
+
+        $content = (string) $xml->entry[0]->content;
+        $this->assertStringContainsString('src="' . ROOT_URL . '/assets/2026/06/abc.webp"', $content);
+        $this->assertStringNotContainsString('src="/assets', $content);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testFeedAuthorHasNoEmailAndIncludesUri(): void
     {
         $xml = $this->renderFeedWithPost([

--- a/tests/Unit/ThemeMetaTest.php
+++ b/tests/Unit/ThemeMetaTest.php
@@ -220,6 +220,26 @@ class ThemeMetaTest extends TestCase
         $this->assertStringNotContainsString('og-image-lamb.webp', $output);
     }
 
+    public function testOpenGraphAbsolutisesRootRelativeEmbeddedImage(): void
+    {
+        // Uploaded/pasted images are stored root-relative ("/assets/..."). OG and
+        // Twitter scrapers require an absolute URL, so the embedded image must be
+        // absolutised or the social card image is broken.
+        $output = $this->renderStatus([
+            'transformed' => '<p>Hi</p><img src="/assets/2026/06/abc.webp" alt="pasted-1-0.png">',
+        ]);
+
+        $this->assertStringContainsString(
+            'property="og:image" content="' . ROOT_URL . '/assets/2026/06/abc.webp"',
+            $output
+        );
+        $this->assertStringContainsString(
+            'property="twitter:image" content="' . ROOT_URL . '/assets/2026/06/abc.webp"',
+            $output
+        );
+        $this->assertStringNotContainsString('content="/assets', $output);
+    }
+
     public function testOpenGraphUsesWebRootOgImageConventionWhenPostHasNoImage(): void
     {
         $webRoot = $this->resetWebRoot();


### PR DESCRIPTION
## Problem

Pasting a clipboard image into the entry form and publishing produced a post whose image **breaks once syndicated** — the syndicated copy shows "a broken filename ending in png" (e.g. https://vandragt.com/status/268).

Root cause: **the image URL is root-relative**. Uploads are stored as root-relative URLs (`/assets/Y/m/<hash>.webp`) via `asset_url()` so they survive a domain change. That resolves correctly on-site, but:

- The **Atom/JSON feed `<content>`** emitted the relative URL verbatim. A feed reader or aggregator (micro.blog, etc.) that re-hosts the content resolves `/assets/...` against *its own* host → broken image. A broken `<img>` falls back to its `alt` text, which for a clipboard paste is the synthetic filename `pasted-<timestamp>-0.png` — hence "a broken filename ending in png once syndicated."
- **`og:image` / `twitter:image`** used the first embedded image straight from the post body, so social-card scrapers (which require absolute URLs) got the same broken relative URL.

The bug is present on both `main` and `release`; this PR targets `release` (the deployed branch) since the live site is affected.

## Fix

Add two helpers in `Lamb`:

- `absolute_url($url, $base = ROOT_URL)` — makes a single root-relative URL absolute; leaves already-absolute (`https://…`) and protocol-relative (`//host/…`) URLs untouched.
- `absolute_urls($html, $base = ROOT_URL)` — rewrites root-relative `src`/`href` attributes in an HTML fragment.

Apply them when rendering feed content (`feed.php`, `feed_json.php`) and when resolving the Open Graph image (`theme/meta.php`). On-site storage is unchanged — URLs are only absolutised at the point they leave the site.

## Tests (red-green TDD)

- `AbsoluteUrlsTest` — the new helpers.
- `FeedTemplateTest` / `FeedJsonTemplateTest` — feed content now carries absolute image URLs.
- `ThemeMetaTest` — `og:image`/`twitter:image` absolutise a root-relative embedded image.

Full unit suite (1023 tests on the release base), `composer lint`, and `composer analyse` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)