### PR TITLE
UX: position cursor inside [] on image insert to prompt for alt text

### DIFF
--- a/src/scripts/logged_in/upload-image.js
+++ b/src/scripts/logged_in/upload-image.js
@@ -65,7 +65,10 @@ function handleFiles(files, textarea) {
     })
         .then(response => response.json())
         .then(data => {
-            textarea.value = text.slice(0, cursor) + data + text.slice(cursor)
+            const markdown = data.replace(/!\[[^\]]*\]/g, '![]')
+            textarea.value = text.slice(0, cursor) + markdown + text.slice(cursor)
+            const altStart = cursor + markdown.indexOf('![') + 2
+            textarea.setSelectionRange(altStart, altStart)
             textarea.dispatchEvent(new Event('input'))
         })
         .catch(error => console.error(error))

--- a/tests/js/upload-image.test.mjs
+++ b/tests/js/upload-image.test.mjs
@@ -61,3 +61,33 @@ test('handleFiles inserts the upload response at the cursor and fires input', as
   assert.equal(ta.value, 'ab![](/img.webp)cd')
   assert.ok(inputFired, 'an input event should be dispatched')
 })
+
+test('handleFiles strips server alt text so the user sees empty [] to fill in', async () => {
+  const { window, document, api } = load('<!DOCTYPE html><body><textarea></textarea></body>')
+  const ta = document.querySelector('textarea')
+  ta.value = ''
+  ta.setSelectionRange(0, 0)
+
+  window.fetch = () => Promise.resolve({ json: () => Promise.resolve('![photo.jpg](/img.webp)') })
+
+  api.handleFiles([new window.File(['x'], 'photo.jpg', { type: 'image/png' })], ta)
+  await flush()
+
+  assert.equal(ta.value, '![](/img.webp)')
+})
+
+test('handleFiles positions cursor inside [] after insertion', async () => {
+  const { window, document, api } = load('<!DOCTYPE html><body><textarea></textarea></body>')
+  const ta = document.querySelector('textarea')
+  ta.value = 'abcd'
+  ta.setSelectionRange(2, 2) // cursor between "ab" and "cd"
+
+  window.fetch = () => Promise.resolve({ json: () => Promise.resolve('![photo.jpg](/img.webp)') })
+
+  api.handleFiles([new window.File(['x'], 'photo.jpg', { type: 'image/png' })], ta)
+  await flush()
+
+  assert.equal(ta.value, 'ab![](/img.webp)cd')
+  assert.equal(ta.selectionStart, 4) // inside the [], after ![
+  assert.equal(ta.selectionEnd, 4)
+})


### PR DESCRIPTION
## Summary

- Both clipboard paste and drag-and-drop image uploads now land as `![](<url>)` with the cursor placed between the `[` and `]`
- The server-supplied filename (e.g. `pasted-1234-0.png` or the original drag filename) is stripped from the alt text slot, leaving it visibly empty
- This makes the empty alt text immediately obvious and ready to type into, without any extra clicks

## Test plan

- [x] JS unit tests added for alt-text stripping and cursor positioning — all 32 passing
- [x] Paste a screenshot into the editor: confirm `![]` appears with cursor inside brackets
- [x] Drag and drop an image file: confirm same behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)