### PR TITLE
Fix: use deploy.template.yaml for DO deploy button

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,33 @@
+spec:
+  name: lamb
+  services:
+    - name: web
+      image:
+        registry_type: GHCR
+        registry: svandragt
+        repository: lamb
+        tag: latest
+      instance_size_slug: apps-s-1vcpu-0.5gb
+      instance_count: 1
+      http_port: 80
+      health_check:
+        http_path: /
+        initial_delay_seconds: 10
+        period_seconds: 30
+        timeout_seconds: 5
+      envs:
+        - key: LAMB_LOGIN_PASSWORD
+          scope: RUN_TIME
+          type: SECRET
+          value: REPLACE_WITH_YOUR_HASH
+      storage_mounts:
+        - name: data
+          mount_path: /app/data
+        - name: assets
+          mount_path: /app/src/assets
+
+  storage:
+    - name: data
+      description: SQLite database
+    - name: assets
+      description: Uploaded media files


### PR DESCRIPTION
## Summary

- Renames `.do/app.yaml` → `.do/deploy.template.yaml` — DO's button requires this exact filename
- Wraps the spec under a top-level `spec:` key as required by the template format
- Keeps `app.yaml` for reference/doctl usage (can be removed if it causes confusion)

Fixes the "No template found" error when clicking the deploy button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)