### PR TITLE
Support drag-and-drop video uploads in the post editor

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -14,9 +14,10 @@ RUN touch /usr/local/etc/php/conf.d/app.ini && \
     echo "display_errors = off" >> /usr/local/etc/php/conf.d/app.ini && \
     echo "log_errors = On" >> /usr/local/etc/php/conf.d/app.ini && \
     echo "error_log = /dev/stderr" >> /usr/local/etc/php/conf.d/app.ini && \
-    # Uploads are converted to WebP and resized server-side, so accept large originals.
-    echo "upload_max_filesize = 20M" >> /usr/local/etc/php/conf.d/app.ini && \
-    echo "post_max_size = 25M" >> /usr/local/etc/php/conf.d/app.ini
+    # Images are converted to WebP and resized server-side, so large photo
+    # originals are fine; video is stored as-is and can be much larger still.
+    echo "upload_max_filesize = 100M" >> /usr/local/etc/php/conf.d/app.ini && \
+    echo "post_max_size = 100M" >> /usr/local/etc/php/conf.d/app.ini
 
 # Allow FrankenPHP to bind :80 when running as the (remapped) www-data user.
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/frankenphp

--- a/.docker/Dockerfile.release
+++ b/.docker/Dockerfile.release
@@ -18,9 +18,10 @@ RUN install-php-extensions gettext pdo_mysql gd
 
 RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Uploads are converted to WebP and resized server-side, so accept large
-# originals (phone photos easily exceed PHP's 2M default).
-RUN printf 'upload_max_filesize = 20M\npost_max_size = 25M\n' > "$PHP_INI_DIR/conf.d/uploads.ini"
+# Images are converted to WebP and resized server-side, so large photo
+# originals are fine (phone photos easily exceed PHP's 2M default); video is
+# stored as-is and can be much larger still.
+RUN printf 'upload_max_filesize = 100M\npost_max_size = 100M\n' > "$PHP_INI_DIR/conf.d/uploads.ini"
 
 COPY .docker/Caddyfile.release /etc/frankenphp/Caddyfile
 

--- a/.nginx/snippets/lamb.conf
+++ b/.nginx/snippets/lamb.conf
@@ -1,6 +1,7 @@
-# Uploads are converted to WebP and resized server-side, so accept large
-# originals (nginx's default client_max_body_size is only 1m).
-client_max_body_size 25m;
+# Images are converted to WebP and resized server-side, so large photo
+# originals are fine (nginx's default client_max_body_size is only 1m); video
+# is stored as-is and can be much larger still.
+client_max_body_size 100m;
 
 location / {
      try_files $uri $uri/ /index.php$is_args$args;

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -46,9 +46,9 @@ $ echo "LAMB_LOGIN_PASSWORD=$(docker exec -it lamb-app bash -c 'php make-passwor
 
 Your site is now ready at http://localhost
 
-Uploaded images are stored under `src/assets/` inside the app container.
+Uploaded images and video are stored under `src/assets/` inside the app container.
 
-Both images accept uploads up to 20&nbsp;MB (`upload_max_filesize = 20M`, `post_max_size = 25M`) — see [Media]({{ site.baseurl }}{% link media.md %}).
+Both images accept uploads up to 100&nbsp;MB (`upload_max_filesize = 100M`, `post_max_size = 100M`) — see [Media]({{ site.baseurl }}{% link media.md %}).
 
 Errors can be inspected with `docker compose logs -f app`.
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -4,7 +4,7 @@ title: Media
 
 # Media
 
-Lamb lets you add images to posts without leaving the editor. Uploaded files are stored under `src/assets/YYYY/MM/` and served from your own site — there is no external image host.
+Lamb lets you add images and video to posts without leaving the editor. Uploaded files are stored under `src/assets/YYYY/MM/` and served from your own site — there is no external host.
 
 ## Adding images
 
@@ -15,6 +15,14 @@ When logged in, there are two ways to add an image to the post editor:
 
 Either way the file is uploaded and a markdown image link (`![name](url)`) is inserted at the cursor. Pasted screenshots arrive without a real filename, so each is given a unique name before upload.
 
+## Adding video
+
+**Drag and drop** one or more video files onto the editor textarea, the same way you would an image. The file is uploaded and a markdown link is inserted at the cursor, just like an image — Lamb tells the two apart by file extension and renders the published post with an embedded `<video controls>` player instead of an `<img>`.
+
+Video is not re-encoded or resized: unlike JPEG/PNG, the file is stored exactly as uploaded, so keep an eye on the file size (see [Upload size limits](#upload-size-limits) below). Playback depends on the visitor's browser and operating system being able to decode the file — Lamb does not transcode. `mp4` and `webm` play natively in effectively every modern browser; `mov` (the common iPhone export format) plays reliably in Safari/macOS/iOS but may fail to decode in some Linux browser builds that lack HEVC support.
+
+A video-only post has no image for social sharing previews to pick up — see [Social Embeds]({{ site.baseurl }}{% link social-embeds.md %}).
+
 ## Supported formats
 
 These image types are accepted:
@@ -22,6 +30,10 @@ These image types are accepted:
 `jpg`, `jpeg`, `png`, `gif`, `webp`, `avif`
 
 SVG is **not** accepted, because SVG files can carry scripts.
+
+These video types are accepted:
+
+`mp4`, `webm`, `mov`
 
 ## WebP conversion
 
@@ -32,11 +44,13 @@ To keep stored files small, **JPEG and PNG uploads are automatically re-encoded 
 - **GIF** may be animated, and converting would flatten it to a single frame.
 - **WebP** and **AVIF** are already efficient formats.
 
+**Video is always stored as-is** — there is no server-side re-encoding or resizing for video, so a large source file stays large.
+
 If conversion ever fails (for example on a server whose PHP GD extension lacks WebP support), Lamb falls back to storing the original file unchanged, so uploads never break.
 
 ## Micropub uploads
 
-Images sent via Micropub — both inline `photo` files on a post and files sent to the media endpoint — go through the same storage and WebP conversion as editor uploads.
+Images and video sent via Micropub — both inline `photo` files on a post and files sent to the media endpoint — go through the same storage (and, for images, WebP conversion) as editor uploads.
 
 ## Server requirements
 
@@ -44,12 +58,12 @@ Uploads require the directory `src/assets/` to be writable by the web server or 
 
 ### Upload size limits
 
-Because uploads are converted to WebP and resized server-side, the original file size mostly doesn't matter — large phone photos are fine. What limits the upload is the server configuration:
+Images are converted to WebP and resized server-side, so the original file size mostly doesn't matter — large phone photos are fine. Video is stored unchanged, so its file size is exactly what limits the upload. Either way, what caps the upload is the server configuration:
 
-- **PHP** caps uploads with `upload_max_filesize` (default **2M**) and `post_max_size` (default **8M**). The Lamb Docker images raise these to `20M` / `25M`; on other hosts raise them in `php.ini` or a `conf.d` file.
-- **NGINX** additionally caps the request body with `client_max_body_size` (default **1m**). The shipped `.nginx/snippets/lamb.conf` sets it to `25m`.
+- **PHP** caps uploads with `upload_max_filesize` (default **2M**) and `post_max_size` (default **8M**). The Lamb Docker images raise these to `100M` / `100M`; on other hosts raise them in `php.ini` or a `conf.d` file. Raise them further still if you plan to share longer or higher-resolution clips.
+- **NGINX** additionally caps the request body with `client_max_body_size` (default **1m**). The shipped `.nginx/snippets/lamb.conf` sets it to `100m`.
 
-If an upload over the limit fails, it fails silently from the editor's point of view — check the server limits first when a large image won't upload.
+If an upload over the limit fails, it fails silently from the editor's point of view — check the server limits first when a large image or video won't upload.
 
 WebP conversion relies on PHP's [GD extension](https://www.php.net/manual/en/book.image.php) being built **with WebP support**. This is the common default, but it isn't guaranteed on every host. WebP support is the only thing the conversion needs — if it's missing, nothing breaks: Lamb stores each upload in its original format instead, so JPEG and PNG files are saved as-is rather than being converted. You simply don't get the smaller WebP files.
 
@@ -75,8 +89,8 @@ If WebP support is missing and you want it, install or enable the WebP-capable G
 
 ## Related
 
-* [Post Types]({{ site.baseurl }}{% link post-types.md %}): Add images to status and page posts.
+* [Post Types]({{ site.baseurl }}{% link post-types.md %}): Add images and video to status and page posts.
 * [Micropub]({{ site.baseurl }}{% link micropub.md %}): Publish posts and upload photos from external apps.
-* [Social Embeds]({{ site.baseurl }}{% link social-embeds.md %}): A post's first image becomes its social preview card.
+* [Social Embeds]({{ site.baseurl }}{% link social-embeds.md %}): A post's first image becomes its social preview card; video-only posts fall back to the default card.
 * [Themes]({{ site.baseurl }}{% link themes.md %}): Uploaded files live in `src/assets/`, not in theme directories.
 * [WordPress import]({{ site.baseurl }}{% link wordpress-import.md %}): The importer downloads referenced images into `src/assets/` too.

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -15,18 +15,18 @@ Update the `lamb.test` file to point to your preferred server_name, logs and doc
 
 The `data` and `src/assets` directory must be writable by the user php-fpm runs under, this is usually `www-data`.
 
-`src/assets` is the runtime upload directory used for images dropped into posts. Theme CSS and application JavaScript live elsewhere and do not need to be writable at runtime.
+`src/assets` is the runtime upload directory used for images and video dropped into posts. Theme CSS and application JavaScript live elsewhere and do not need to be writable at runtime.
 
 ### Upload size limits
 
-PHP's defaults (`upload_max_filesize = 2M`, `post_max_size = 8M`) reject photos larger than 2&nbsp;MB. Raise them in your php.ini or FPM pool, for example:
+PHP's defaults (`upload_max_filesize = 2M`, `post_max_size = 8M`) reject photos larger than 2&nbsp;MB, and will reject essentially all video. Raise them in your php.ini or FPM pool, for example:
 
 ```text
-upload_max_filesize = 20M
-post_max_size = 25M
+upload_max_filesize = 100M
+post_max_size = 100M
 ```
 
-The shipped `snippets/lamb.conf` sets the matching NGINX limit (`client_max_body_size 25m;` — its default is only 1m). See [Media]({{ site.baseurl }}{% link media.md %}) for details.
+The shipped `snippets/lamb.conf` sets the matching NGINX limit (`client_max_body_size 100m;` — its default is only 1m). See [Media]({{ site.baseurl }}{% link media.md %}) for details.
 
 ```shell
 sudo chown $USER:www-data data -R

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -12,7 +12,7 @@ Any tags are automatically linked to tag archives.
 
 Select some text and paste a link over it to turn the selection into a markdown link, e.g. selecting `Lamb` and pasting `https://example.com` produces `[Lamb](https://example.com)`.
 
-Add images by dragging files onto the editor, or by pasting an image straight from the clipboard (for example a screenshot). Either way the image is uploaded and a markdown image link is inserted at the cursor. JPEG and PNG uploads are automatically converted to WebP to keep files small; GIF, WebP, and AVIF are stored as-is.
+Add images by dragging files onto the editor, or by pasting an image straight from the clipboard (for example a screenshot). Either way the image is uploaded and a markdown image link is inserted at the cursor. JPEG and PNG uploads are automatically converted to WebP to keep files small; GIF, WebP, and AVIF are stored as-is. Video files (`mp4`, `webm`, `mov`) can be dragged onto the editor the same way and are embedded as a playable video.
 
 Permalinks for statuses are in the form of `/status/<integer>`.
 
@@ -89,7 +89,7 @@ The following sections of the site are special:
 
 ## Related
 
-* [Media]({{ site.baseurl }}{% link media.md %}): Add images by drag-and-drop or paste; JPEG/PNG are converted to WebP.
+* [Media]({{ site.baseurl }}{% link media.md %}): Add images and video by drag-and-drop or paste; JPEG/PNG are converted to WebP, video is stored as-is.
 * [Drafts]({{ site.baseurl }}{% link drafts.md %}): Add `draft: true` to front-matter to save a post as a draft.
 * [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Add a future `created:` date to publish a post later.
 * [Social Embeds]({{ site.baseurl }}{% link social-embeds.md %}): A `summary:` in front-matter sets the description used in social preview cards.

--- a/docs/social-embeds.md
+++ b/docs/social-embeds.md
@@ -17,7 +17,9 @@ specific first:
 1. **The first image in the post.** If the post body embeds an image, that image
    becomes the card image and the Twitter card is upgraded to
    `summary_large_image` (a large, image-led preview). So sharing a photo or
-   screenshot post previews *that* image.
+   screenshot post previews *that* image. Video is not considered here — Lamb
+   does not extract a poster frame — so a post whose only media is a video
+   falls through to the next rule below.
 2. **A site-wide default you provide.** If the post has no image, Lamb looks for
    an `og-image.*` file in the web root (next to `index.php`) and uses it.
 3. **The built-in Lamb card.** If you haven't provided one, the shipped

--- a/src/LambDown.php
+++ b/src/LambDown.php
@@ -196,20 +196,72 @@ class LambDown extends Parsedown
      * Inject lazy-loading attributes on every inline image so post bodies
      * with embedded screenshots do not block first paint on the homepage.
      *
+     * Uploaded video files reuse the same `![alt](url)` Markdown syntax as
+     * images (dropped/uploaded via the same endpoint), so a src ending in a
+     * known video extension is rendered as an embedded `<video>` player
+     * instead of a broken `<img>`.
+     *
      * @param array<string, mixed> $Excerpt The inline excerpt to be parsed.
      *
-     * @return array<string, mixed>|null The parsed image element, or null when not an image.
+     * @return array<string, mixed>|null The parsed image or video element, or null when not an image.
      */
     protected function inlineImage($Excerpt)
     {
         $image = parent::inlineImage($Excerpt);
-        if (!is_array($image) || !isset($image['element']['attributes'])) {
+        if (!is_array($image) || !isset($image['element']['attributes']['src'])) {
             return $image;
         }
+
+        $src = $image['element']['attributes']['src'];
+        $ext = strtolower(pathinfo(parse_url($src, PHP_URL_PATH) ?? $src, PATHINFO_EXTENSION));
+
+        if (in_array($ext, VIDEO_UPLOAD_EXTENSIONS, true)) {
+            $image['element'] = $this->videoElement($image['element']);
+            return $image;
+        }
+
         $image['element']['attributes'] += [
             'loading'  => 'lazy',
             'decoding' => 'async',
         ];
         return $image;
+    }
+
+    /**
+     * Builds a `<video>` element from a parsed `<img>` element, reusing its
+     * attributes (dropping `alt`, which is meaningless on `<video>`).
+     *
+     * Parsedown's safe mode only auto-applies its src scheme allowlist to
+     * elements named `a`/`img` (see Parsedown::sanitiseElement()); renaming
+     * the element to `video` bypasses that check, so it is re-applied here
+     * explicitly via the inherited (protected) filterUnsafeUrlInAttribute().
+     * An explicit empty `text` forces a proper closing tag: `video` is not an
+     * HTML5 void element, so the self-closing markup Parsedown would
+     * otherwise emit for a childless element would leave the tag unclosed.
+     *
+     * @param array<string, mixed> $imgElement The `<img>` element from parent::inlineImage().
+     * @return array<string, mixed> The `<video>` element.
+     */
+    private function videoElement(array $imgElement): array
+    {
+        $attributes = $imgElement['attributes'];
+        unset($attributes['alt']);
+        $attributes += [
+            'controls'    => 'controls',
+            'preload'     => 'metadata',
+            'playsinline' => 'playsinline',
+        ];
+
+        $element = [
+            'name'       => 'video',
+            'attributes' => $attributes,
+            'text'       => '',
+        ];
+
+        if ($this->safeMode) {
+            $element = $this->filterUnsafeUrlInAttribute($element, 'src');
+        }
+
+        return $element;
     }
 }

--- a/src/constants.php
+++ b/src/constants.php
@@ -16,6 +16,8 @@ define('LOGIN_CSRF_COOKIE', 'lamb_login_csrf');
 define('IMAGE_FILES', 'imageFiles');
 // Image extensions accepted for upload. SVG is excluded: it can carry scripts.
 define('IMAGE_UPLOAD_EXTENSIONS', ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif']);
+// Video extensions accepted for upload; browsers decode these containers natively.
+define('VIDEO_UPLOAD_EXTENSIONS', ['mp4', 'webm', 'mov']);
 // Seconds before a single feed fetch is abandoned during /_cron ingestion.
 define('FEED_FETCH_TIMEOUT', 15);
 define('MINUTE_IN_SECONDS', 60);

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -74,11 +74,12 @@ function respond_upload(array $_args): void
 
 /**
  * Returns a safe, lower-cased file extension for an uploaded file, or null if the
- * extension is not an allowed image type.
+ * extension is not an allowed image or video type.
  *
  * Uploads land under the web root (src/assets/), so the extension is the line of
  * defence against writing executable files (e.g. .php). Only the allowlisted image
- * extensions are accepted; anything else (including extensionless names) is rejected.
+ * and video extensions are accepted; anything else (including extensionless names)
+ * is rejected.
  *
  * @param string $filename The client-supplied filename.
  * @return string|null The allowed lower-case extension, or null when not permitted.
@@ -86,7 +87,8 @@ function respond_upload(array $_args): void
 function safe_upload_extension(string $filename): ?string
 {
     $ext = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
-    if ($ext === '' || !in_array($ext, IMAGE_UPLOAD_EXTENSIONS, true)) {
+    $allowed = array_merge(IMAGE_UPLOAD_EXTENSIONS, VIDEO_UPLOAD_EXTENSIONS);
+    if ($ext === '' || !in_array($ext, $allowed, true)) {
         return null;
     }
 

--- a/tests/Unit/LambDownTest.php
+++ b/tests/Unit/LambDownTest.php
@@ -116,4 +116,58 @@ class LambDownTest extends TestCase
         $html = $this->parser->text("- [ ] read **the** docs");
         $this->assertStringContainsString('<strong>the</strong>', $html);
     }
+
+    public function testVideoExtensionRendersVideoTag(): void
+    {
+        $html = $this->parser->text('![clip](video.mp4)');
+        $this->assertStringContainsString('<video', $html);
+        $this->assertStringContainsString('controls="controls"', $html);
+        $this->assertStringContainsString('src="video.mp4"', $html);
+        $this->assertStringNotContainsString('<img', $html);
+    }
+
+    public function testVideoTagIsProperlyClosed(): void
+    {
+        // <video> is not an HTML5 void element; a self-closed "<video ... />"
+        // would leave the tag open in a browser and swallow following markup.
+        $html = $this->parser->text('![clip](video.mp4)');
+        $this->assertStringContainsString('</video>', $html);
+        $this->assertStringNotContainsString('/>', $html);
+    }
+
+    public function testWebmAndMovExtensionsRenderVideoTag(): void
+    {
+        $this->assertStringContainsString('<video', $this->parser->text('![clip](video.webm)'));
+        $this->assertStringContainsString('<video', $this->parser->text('![clip](video.mov)'));
+    }
+
+    public function testNonVideoExtensionStillRendersLazyImage(): void
+    {
+        $html = $this->parser->text('![photo](photo.png)');
+        $this->assertStringContainsString('<img', $html);
+        $this->assertStringContainsString('loading="lazy"', $html);
+        $this->assertStringNotContainsString('<video', $html);
+    }
+
+    public function testVideoSrcFiltersUnsafeUrlScheme(): void
+    {
+        // Parsedown's safe mode only auto-filters the src scheme for elements
+        // named "img"; renaming to "video" must not bypass that protection.
+        $html = $this->parser->text('![clip](javascript:evil.mp4)');
+        $this->assertStringContainsString('javascript%3Aevil.mp4', $html);
+    }
+
+    public function testVideoSrcWithQueryStringStillRendersVideoTag(): void
+    {
+        $html = $this->parser->text('![clip](https://cdn.example.com/clip.mp4?sig=abc123)');
+        $this->assertStringContainsString('<video', $html);
+        $this->assertStringContainsString('src="https://cdn.example.com/clip.mp4?sig=abc123"', $html);
+    }
+
+    public function testReferenceStyleVideoLinkRendersVideoTag(): void
+    {
+        $html = $this->parser->text("![clip][1]\n\n[1]: video.mp4");
+        $this->assertStringContainsString('<video', $html);
+        $this->assertStringContainsString('src="video.mp4"', $html);
+    }
 }

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -181,6 +181,21 @@ class UploadTest extends TestCase
         $this->assertSame('png', safe_upload_extension('evil.php.png'));
     }
 
+    public function testSafeUploadExtensionAllowsMp4(): void
+    {
+        $this->assertSame('mp4', safe_upload_extension('clip.mp4'));
+    }
+
+    public function testSafeUploadExtensionAllowsWebm(): void
+    {
+        $this->assertSame('webm', safe_upload_extension('clip.webm'));
+    }
+
+    public function testSafeUploadExtensionAllowsMov(): void
+    {
+        $this->assertSame('mov', safe_upload_extension('clip.mov'));
+    }
+
     // should_convert_to_webp — only re-encode raster formats that benefit and that
     // GD can losslessly round-trip (jpeg/png). webp/avif are already efficient; gif
     // may be animated (GD flattens to one frame), so it is passed through untouched.
@@ -225,6 +240,12 @@ class UploadTest extends TestCase
         // Installs without the gd extension must store the original bytes
         // instead of fataling on undefined GD functions.
         $this->assertFalse(should_convert_to_webp('jpg', gd_available: false));
+    }
+
+    public function testShouldNotConvertMp4(): void
+    {
+        // Video is never re-encoded; it is always stored as the original bytes.
+        $this->assertFalse(should_convert_to_webp('mp4'));
     }
 
     // convert_to_webp — GD-backed re-encode of an uploaded image into WebP

--- a/tests/js/upload-image.test.mjs
+++ b/tests/js/upload-image.test.mjs
@@ -62,6 +62,28 @@ test('handleFiles inserts the upload response at the cursor and fires input', as
   assert.ok(inputFired, 'an input event should be dispatched')
 })
 
+test('handleFiles posts a dropped video file the same way as an image', async () => {
+  // The drop handler forwards any dropped file with no client-side type
+  // filtering; a video is uploaded/inserted through the same path as an image.
+  const { window, document, api } = load('<!DOCTYPE html><body><textarea></textarea></body>')
+  const ta = document.querySelector('textarea')
+  ta.value = ''
+  ta.setSelectionRange(0, 0)
+
+  let posted
+  window.fetch = (url, opts) => {
+    posted = { url, opts }
+    return Promise.resolve({ json: () => Promise.resolve('![](/clip.mp4)') })
+  }
+
+  api.handleFiles([new window.File(['x'], 'clip.mp4', { type: 'video/mp4' })], ta)
+  await flush()
+
+  assert.equal(posted.url, '/upload')
+  assert.equal(posted.opts.body.get('imageFiles[]').name, 'clip.mp4')
+  assert.equal(ta.value, '![](/clip.mp4)')
+})
+
 test('handleFiles strips server alt text so the user sees empty [] to fill in', async () => {
   const { window, document, api } = load('<!DOCTYPE html><body><textarea></textarea></body>')
   const ta = document.querySelector('textarea')


### PR DESCRIPTION
## Summary

- The editor's drag-and-drop-to-upload flow already forwarded any dropped file with no client-side type filtering — only the server-side extension allowlist and the lack of a video render path blocked video. This widens the upload allowlist to accept `mp4`, `webm`, `mov` (stored as-is, no re-encoding) and teaches `LambDown` to render a video-extension `src` as an embedded `<video controls>` player instead of a broken `<img>`, reusing the existing `[alt](url)` Markdown syntax — no JS changes were needed for the drop path itself.
- Raises the PHP (`upload_max_filesize`/`post_max_size`) and NGINX (`client_max_body_size`) upload ceilings from 20–25MB to 100MB in the Docker images and shipped NGINX snippet — the old limits were sized for phone photos and would silently reject most real video clips (exceeding `post_max_size` empties `$_FILES` server-side, which the editor currently reports as a console-only error with no visible UI feedback).
- Docs updated: `docs/media.md` (new "Adding video" section + supported formats + size limits), `docs/social-embeds.md` (video-only posts fall back to the default card, no poster-frame extraction), `docs/post-types.md`, `docs/nginx.md`, `docs/docker.md`.

## Notes for reviewers

- Parsedown's safe mode only auto-applies its `src` scheme allowlist to elements named `a`/`img`; renaming to `video` bypasses that check, so `LambDown::videoElement()` re-applies it explicitly via the inherited `filterUnsafeUrlInAttribute()`. Covered by a `javascript:` scheme test.
- `video` is not an HTML5 void element, so the element is given an explicit empty `text` to force a proper `</video>` close tag rather than Parsedown's default self-closing markup for a childless element.
- This CI sandbox couldn't run `composer install` (GitHub API zip/dist downloads are rate-limited/blocked for this environment), so I verified the `LambDown`/`upload.php` logic with a standalone harness against the exact pinned Parsedown 1.8.0 source (extracted from git, not downloaded via the blocked API) rather than via `vendor/bin/codecept`. The JS suite (`pnpm test`) ran normally — all 33 tests pass, including the new video case. Please confirm `vendor/bin/codecept run Unit` passes in CI.

## Test plan

- [x] `pnpm test` — 33/33 pass, including new dropped-video regression test
- [x] Standalone harness against real Parsedown 1.8.0 source confirms: `<video>` rendering, proper closing tag, `mp4`/`webm`/`mov` all trigger it, non-video extensions unaffected, unsafe URL scheme neutralized, query-string URLs handled, reference-style links handled
- [ ] `vendor/bin/codecept run Unit` (please confirm in CI — blocked locally by sandbox network policy)
- [ ] `composer lint` / `composer analyse` (same blocker)
- [ ] Manual: drag an `.mp4` onto the editor, confirm it plays back on the published post


---
_Generated by [Claude Code](https://claude.ai/code/session_01E6LFvVJirNaRWEt7m6kEwd)_