### PR TITLE
Workshop git-mcp tunnel, undici pin, ignore db backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.db
+*.db.bak*
 /tests/Support/Data/sessions/
 /.docker/*.env
 /data/cache/

--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -3,7 +3,16 @@ base: ubuntu@24.04
 sdks:
     - name: node          # Node.js 24 (store SDK) — mirrors devbox nodejs@24
     - name: claude-code    # agent tooling
+      plugs:
+        git-mcp:
+          interface: tunnel
+          endpoint: 127.0.0.1:3015
     - name: project-lamb   # in-project SDK: PHP toolchain + project bootstrap
+    - name: system
+      slots:
+        git-mcp-host:
+          interface: tunnel
+          endpoint: 127.0.0.1:3015
 
 actions:
   # Print the URL to reach the dev server from the host.

--- a/.workshop/lamb/sdk.yaml
+++ b/.workshop/lamb/sdk.yaml
@@ -1,5 +1,1 @@
 name: lamb
-hooks:
-  - setup-base
-  - setup-project
-  - check-health

--- a/devbox.lock
+++ b/devbox.lock
@@ -7,7 +7,6 @@
     },
     "nodejs@24": {
       "last_modified": "2025-12-29T16:45:58Z",
-      "plugin_version": "0.0.3",
       "resolved": "github:NixOS/nixpkgs/346dd96ad74dc4457a9db9de4f4f57dab2e5731d#nodejs_24",
       "source": "devbox-search",
       "version": "24.12.0",
@@ -268,7 +267,6 @@
     },
     "php@8.2": {
       "last_modified": "2024-03-22T11:26:23Z",
-      "plugin_version": "0.0.3",
       "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#php",
       "source": "devbox-search",
       "version": "8.2.17",
@@ -401,7 +399,6 @@
     },
     "ruby@3.3": {
       "last_modified": "2026-01-23T17:20:52Z",
-      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#ruby",
       "source": "devbox-search",
       "version": "3.3.10",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "@types/node": "^26.0.1",
     "jsdom": "^29.1.1"
   },
+  "pnpm": {
+    "overrides": {
+      "undici": "^7.28.0"
+    }
+  },
   "scripts": {
     "screenshot": "pnpm exec node scripts/screenshot.mjs",
     "test": "node --test \"tests/js/**/*.test.mjs\""


### PR DESCRIPTION
- Add git-mcp tunnel (plug + host slot on 127.0.0.1:3015) to the Workshop dev env; drop the sdk.yaml hooks list
- Pin undici to ^7.28.0 via pnpm override; devbox.lock plugin_version churn
- Ignore local `*.db.bak*` files so `data/` stops showing as untracked

Unit tests pass (1196 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)