### PR TITLE
Add Known CMS importer, extract shared Lamb\Import module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,8 @@
       "src/config.php",
       "src/highlight.php",
       "src/http.php",
+      "src/import.php",
+      "src/known.php",
       "src/lamb.php",
       "src/routes.php",
       "src/network.php",

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,7 @@ Devtools / local environments / sandbox:
 * [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %})
 * [Drafts]({{ site.baseurl }}{% link drafts.md %})
 * [Feeds]({{ site.baseurl }}{% link feeds.md %})
+* [Known import]({{ site.baseurl }}{% link known-import.md %})
 * [Media]({{ site.baseurl }}{% link media.md %})
 * [Menu Items]({{ site.baseurl }}{% link menu-items.md %})
 * [Micropub]({{ site.baseurl }}{% link micropub.md %})

--- a/docs/known-import.md
+++ b/docs/known-import.md
@@ -1,0 +1,53 @@
+---
+title: Known import
+---
+
+# Importing from Known
+
+Lamb ships a CLI script that reads a [Known CMS](https://withknown.com) RSS export and feeds each published item through Lamb's existing post-creation pipeline. The importer is fully offline — no credentials, no API access — and re-running it is safe.
+
+## What you get
+
+- Every published item in the export is imported. Known's RSS export is a partial WXR veneer: post content lives in `<description>` (not `<content:encoded>`), there's no `<wp:post_name>`, and the only date field is `<pubDate>` — so a post's `created` and `updated` timestamps are always identical.
+- HTML post bodies are sanitised (`<script>`, `<style>`, `<iframe>` and `on*` event attributes are stripped) and converted to Markdown, same as the WordPress importer.
+- **Known-specific cleanups.** Hidden link-preview markup (`unfurl-block` and its children) is removed entirely; every wrapper `<div>` is then unwrapped — Known's own structural divs (`e-content`, `entry-content`, `known-bookmark`, `photo-view`) as well as legacy authored divs carried over from earlier platforms, since a div surviving conversion would render as visibly escaped HTML; inline `<a class="p-category" rel="tag">#tag</a>` anchors (which point at the old, now-dead tag archive) are replaced with plain `#tag` text so the hashtag survives without a dead link; and photo posts' `<a data-gallery>` wrapper around the image is unwrapped to a bare `<img>`.
+- **Status detection.** ~45% of a typical Known export is title-less "status update" posts, where Known synthesised a title from the post body. These are detected two ways — the title ends in `...`, or the body carries a microformats2 `p-name` class — and are imported as native, titleless Lamb status posts (permalink `/status/<id>`) rather than pinning the synthetic title. Posts with a real title keep it, and pin the `<link>` path leaf as their slug via front matter.
+- **Bookmarks.** Items whose `<link>` points at an offsite page (not the export's own host) are bookmarks. A markdown link line — `[title](url)` — is prepended to the body, mirroring how Known rendered them, and the title is kept in front matter (unlike status posts).
+- **Tags.** Known's `<category>#tag</category>` elements become inline `#hashtags` at the end of the body, same as WordPress categories/tags. Leading `#`, case and duplicates are normalised away, and any tag already present as an inline hashtag in the converted body (case-insensitively) is dropped rather than duplicated — Known posts often carry the same tag both ways. Known's structural tags are not imported at all: `#status` just marks a titleless status update (which Lamb models as a post without a title) and `#uncategorized` means no category.
+- Every image referenced in the body is downloaded into `src/assets/YYYY/MM/` (using the post's own creation date), re-encoded to WebP and scaled down to the upload pipeline's max edge ([details](media.md)), and the body links are rewritten to point at the local copies — the same image pipeline the WordPress importer uses. `<enclosure>` elements are ignored: they always duplicate an image already inline in the body.
+- Imported posts are **silent**: the importer calls the low-level save pipeline directly, so no outbound webmentions or WebSub hub pings are emitted. The content already exists somewhere else.
+
+## Exporting from Known
+
+In Known, go to **Site Configuration → Import/Export**, and export an **RSS** feed of your content.
+
+## Running the importer
+
+From the project root:
+
+```bash
+# Preview what would be imported without writing anything
+php import-known.php /path/to/export.rss --dry-run
+
+# Run it for real
+php import-known.php /path/to/export.rss
+```
+
+The script prints one line per item (`imported:` or `would import:`) plus a final summary with the totals (created, existed, skipped). An item that was already imported in a previous run is recognised by its `feeditem_uuid` (md5 of `'known-' + guid`) and left alone.
+
+## After the import
+
+The importer writes directly to the same database your site uses, so the posts are visible immediately. There is no separate review queue.
+
+A few things worth checking manually:
+
+- **Slugs and redirects.** Titled posts keep the slug from their original `<link>` path leaf, written into front matter as `slug:`. Status posts (synthetic-title detection above) get no `slug:`/`title:` front matter and fall through to their `/status/<id>` permalink instead. Either way, an automatic 301 redirect is created from **both** the old on-host `<link>` path (e.g. `/2020/old-slug`) and the old `<guid>` path (`/view/<hash>`) to the new local URL, so old links and any bookmarks to the `guid` permalink keep working.
+- **Bookmarks.** The bookmarked page's title and URL appear as a markdown link line at the top of the post body — edit it if you'd rather present it differently.
+- **Media.** Run a quick `git status` on `src/assets/` to see what was downloaded.
+
+## Related
+
+- [WordPress import](wordpress-import.md) — the sibling importer this one shares its image-download and Markdown-conversion pipeline with.
+- [Cross-posting](cross-posting.md) — outbound syndication, the opposite direction.
+- [Feeds](feeds.md) — how Lamb publishes content for other readers to ingest.
+- [Media](media.md) — how uploaded images are stored and converted.

--- a/docs/wordpress-import.md
+++ b/docs/wordpress-import.md
@@ -46,6 +46,7 @@ A few things worth checking manually:
 
 ## Related
 
+- [Known import](known-import.md) — the sibling importer this one shares its image-download and Markdown-conversion pipeline with.
 - [Cross-posting](cross-posting.md) — outbound syndication, the opposite direction.
 - [Feeds](feeds.md) — how Lamb publishes content for other readers to ingest.
 - [Media](media.md) — how uploaded images are stored and converted.

--- a/import-known.php
+++ b/import-known.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Known CMS importer — CLI script.
+ *
+ * Parses a Known RSS export (Site Configuration → Import/Export → RSS) and
+ * feeds each published item through Lamb's existing post-creation pipeline.
+ * Known's export is a partial WXR veneer: content lives in <description>
+ * rather than <content:encoded>, there is no <wp:post_name> (the slug comes
+ * from the <link> path leaf instead), and dates only carry <pubDate>.
+ * Idempotent: re-running an import never recreates a row (dedup by
+ * md5('known-' . guid) on the feeditem_uuid column).
+ *
+ *   php import-known.php path/to/export.rss [--dry-run]
+ *
+ * --dry-run     Parse and convert every item but write nothing to the DB
+ *               or filesystem. Use this first to surface parsing errors.
+ *
+ * The script intentionally does NOT emit outbound webmentions or WebSub
+ * pings — imported posts are pre-existing content, not new publications.
+ */
+
+namespace Lamb;
+
+use Lamb\Import;
+use Lamb\Known;
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "import-known.php must be run from the command line.\n");
+    exit(1);
+}
+
+define('ROOT_DIR', __DIR__ . '/src');
+require __DIR__ . '/vendor/autoload.php';
+
+[$path, $dry_run] = Import\parse_import_args($argv);
+if ($path === null) {
+    fwrite(STDERR, "Usage: php import-known.php <export.rss> [--dry-run]\n");
+    exit(1);
+}
+
+if (!is_readable($path)) {
+    fwrite(STDERR, "Cannot read export.rss file: $path\n");
+    exit(1);
+}
+
+$data_dir = getenv('LAMB_DATA_DIR') ?: __DIR__ . '/data';
+Bootstrap\bootstrap_db($data_dir);
+
+global $config;
+$config = Config\load();
+Config\apply_timezone($config);
+
+$rss = Import\parse_rss_file($path);
+$items = Known\extract_items($rss);
+
+Import\run_import(
+    $items,
+    Known\skip_reason(...),
+    static fn(array $item): string => Known\known_uuid((string) $item['guid']),
+    Known\import_item(...),
+    $dry_run,
+);

--- a/import-wordpress.php
+++ b/import-wordpress.php
@@ -20,15 +20,18 @@
 
 namespace Lamb;
 
+use Lamb\Import;
 use Lamb\WordPress;
-use RedBeanPHP\R;
 
 if (PHP_SAPI !== 'cli') {
     fwrite(STDERR, "import-wordpress.php must be run from the command line.\n");
     exit(1);
 }
 
-[$path, $dry_run] = parse_import_args($argv);
+define('ROOT_DIR', __DIR__ . '/src');
+require __DIR__ . '/vendor/autoload.php';
+
+[$path, $dry_run] = Import\parse_import_args($argv);
 if ($path === null) {
     fwrite(STDERR, "Usage: php import-wordpress.php <wxr.xml> [--dry-run]\n");
     exit(1);
@@ -38,9 +41,6 @@ if (!is_readable($path)) {
     fwrite(STDERR, "Cannot read WXR file: $path\n");
     exit(1);
 }
-
-define('ROOT_DIR', __DIR__ . '/src');
-require __DIR__ . '/vendor/autoload.php';
 
 $data_dir = getenv('LAMB_DATA_DIR') ?: __DIR__ . '/data';
 Bootstrap\bootstrap_db($data_dir);
@@ -52,72 +52,10 @@ Config\apply_timezone($config);
 $rss = WordPress\parse_wxr_file($path);
 $items = WordPress\extract_items($rss);
 
-$downloader = $dry_run
-    ? static fn(): ?string => null
-    : 'Lamb\\WordPress\\default_image_downloader';
-
-$created = 0;
-$existed = 0;
-$skipped = 0;
-/** @var array<string, int> $skip_reasons */
-$skip_reasons = [];
-$total = count($items);
-
-foreach ($items as $i => $item) {
-    $reason = WordPress\skip_reason($item);
-    if ($reason !== null) {
-        $skipped++;
-        $skip_reasons[$reason] = ($skip_reasons[$reason] ?? 0) + 1;
-        continue;
-    }
-    $uuid = WordPress\wordpress_uuid((string) $item['guid']);
-    if (R::findOne('post', ' feeditem_uuid = ? ', [$uuid])) {
-        $existed++;
-        continue;
-    }
-
-    $bean = WordPress\import_item($item, $downloader, $dry_run);
-    if ($bean === null) {
-        $skipped++;
-        $skip_reasons['conversion failed'] = ($skip_reasons['conversion failed'] ?? 0) + 1;
-        echo "[" . ($i + 1) . "/$total] skipped (conversion failed): "
-            . trim((string) $item['title']) . "\n";
-        continue;
-    }
-    $created++;
-    $verb = $dry_run ? 'would import' : 'imported';
-    echo "[" . ($i + 1) . "/$total] $verb: " . trim((string) $item['title']) . "\n";
-}
-
-$prefix = $dry_run ? '[dry-run] ' : '';
-echo "\n{$prefix}Done. created=$created existed=$existed skipped=$skipped total=$total\n";
-if ($skip_reasons) {
-    arsort($skip_reasons);
-    echo "Skipped breakdown:\n";
-    foreach ($skip_reasons as $reason => $count) {
-        echo "  $count\t$reason\n";
-    }
-}
-
-/**
- * Parses argv into [path, dry_run]. Returns [null, false] when the path is
- * missing.
- *
- * @param array<int,string> $argv
- * @return array{0: ?string, 1: bool}
- */
-function parse_import_args(array $argv): array
-{
-    $path = null;
-    $dry_run = false;
-    foreach (array_slice($argv, 1) as $arg) {
-        if ($arg === '--dry-run') {
-            $dry_run = true;
-        } elseif ($arg === '--help' || $arg === '-h') {
-            return [null, false];
-        } elseif ($path === null) {
-            $path = $arg;
-        }
-    }
-    return [$path, $dry_run];
-}
+Import\run_import(
+    $items,
+    WordPress\skip_reason(...),
+    static fn(array $item): string => WordPress\wordpress_uuid((string) $item['guid']),
+    WordPress\import_item(...),
+    $dry_run,
+);

--- a/src/import.php
+++ b/src/import.php
@@ -1,0 +1,822 @@
+<?php
+
+namespace Lamb\Import;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use League\HTMLToMarkdown\HtmlConverter;
+use RedBeanPHP\R;
+use RuntimeException;
+use SimpleXMLElement;
+use Symfony\Component\Yaml\Yaml;
+
+use function Lamb\Http\fetch;
+use function Lamb\Response\asset_url;
+
+/**
+ * Stable dedup key for an imported feed item. Mirrors the feed-ingest
+ * convention (`feeditem_uuid = md5($feed_name . $id)`), so re-running an
+ * import never recreates a row. Called with a per-CMS prefix ('wordpress-',
+ * 'known-', …) so dedup identity can never collide across importers.
+ */
+function import_uuid(string $prefix, string $guid): string
+{
+    return md5($prefix . $guid);
+}
+
+/**
+ * Loads an RSS/WXR XML string into a SimpleXMLElement.
+ */
+function parse_rss_string(string $xml): SimpleXMLElement
+{
+    $previous = libxml_use_internal_errors(true);
+    $rss = simplexml_load_string($xml);
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+    if ($rss === false) {
+        throw new RuntimeException('Could not parse RSS XML.');
+    }
+    return $rss;
+}
+
+/**
+ * Loads an RSS/WXR XML file from disk.
+ */
+function parse_rss_file(string $path): SimpleXMLElement
+{
+    $xml = @file_get_contents($path);
+    if ($xml === false) {
+        throw new RuntimeException("Could not read RSS file: $path");
+    }
+    return parse_rss_string($xml);
+}
+
+/**
+ * Resolves an RFC822 `pubDate` (the only date field Known's RSS export
+ * carries) to a local `Y-m-d H:i:s` string. Extracted from wxr_local_datetime's
+ * final fallback so both importers share one RFC822 parse path.
+ */
+function local_datetime_from_rfc822(string $pub_date): string
+{
+    if ($pub_date !== '') {
+        $ts = strtotime($pub_date);
+        if ($ts !== false) {
+            return date('Y-m-d H:i:s', $ts);
+        }
+    }
+    return '';
+}
+
+/**
+ * Removes executable / styling tags and any `on*` event-handler attributes.
+ *
+ * Imported body HTML is untrusted enough to warrant a defensive scrub before
+ * it touches the Markdown converter. Tag removal is done at DOM level so
+ * nested markup doesn't break the strip; event-handler attributes are walked
+ * off every element regardless of case.
+ */
+function sanitize_html(string $html): string
+{
+    if (trim($html) === '') {
+        return '';
+    }
+    $dom = load_html_fragment($html);
+    sanitize_html_in_dom($dom);
+    return dump_html_fragment($dom);
+}
+
+/**
+ * In-place sanitisation pass: removes script/style/iframe nodes and any
+ * `on*` event-handler attributes from every element. Extracted so {@see
+ * prepare_imported_html} can chain it onto the same DOM as the image rewrite
+ * pass, avoiding a parse/serialise round-trip between the two stages.
+ */
+function sanitize_html_in_dom(DOMDocument $dom): void
+{
+    $xpath = new DOMXPath($dom);
+
+    $strip = $xpath->query('//script | //style | //iframe') ?: [];
+    foreach ($strip as $node) {
+        if ($node instanceof \DOMNode) {
+            $node->parentNode?->removeChild($node);
+        }
+    }
+
+    $elements = $xpath->query('//*') ?: [];
+    foreach ($elements as $el) {
+        if (!$el instanceof DOMElement) {
+            continue;
+        }
+        $remove = [];
+        foreach ($el->attributes as $attr) {
+            if (stripos($attr->nodeName, 'on') === 0) {
+                $remove[] = $attr->nodeName;
+            }
+        }
+        foreach ($remove as $name) {
+            $el->removeAttribute($name);
+        }
+    }
+}
+
+/**
+ * Converts the already-sanitised HTML body to Markdown.
+ *
+ * The HtmlConverter is configured to keep unknown HTML so a malformed snippet
+ * doesn't silently disappear; hard_break = true preserves <br> as a visible
+ * line break in source.
+ *
+ * @param list<string> $unwrap_class_prefixes Div/section class prefixes (in
+ *                     addition to figure/figcaption/cite/span) to loop-unwrap
+ *                     before conversion — e.g. WordPress's `wp-block-` blocks.
+ */
+function html_to_markdown(string $html, array $unwrap_class_prefixes = []): string
+{
+    $placeholders = [];
+    $html = normalize_html($html, $placeholders, $unwrap_class_prefixes);
+    $converter = new HtmlConverter([
+        'header_style'    => 'atx',
+        'strip_tags'      => false,
+        'remove_nodes'    => '',
+        'hard_break'      => true,
+        'use_autolinks'   => true,
+        'preserve_comments' => false,
+    ]);
+    $markdown = strtr(trim($converter->convert($html)), $placeholders);
+    $markdown = html_entity_decode($markdown, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    return separate_images_from_following_text($markdown);
+}
+
+function separate_images_from_following_text(string $markdown): string
+{
+    return preg_replace('/(!\[[^\]]*]\([^)]+\))(?=\S)/', "$1\n\n", $markdown) ?? $markdown;
+}
+
+/**
+ * Normalises imported editor HTML before Markdown conversion.
+ *
+ * The Markdown converter preserves unknown HTML by design. CMS exports often
+ * contain presentational block wrappers, tables and video tags that would
+ * otherwise survive into Lamb's safe Markdown renderer as visible escaped tags.
+ *
+ * @param array<string, string> $placeholders
+ * @param list<string> $unwrap_class_prefixes Div/section class prefixes (in
+ *                     addition to figure/figcaption/cite/span) to loop-unwrap.
+ *                     An empty list unwraps only figure/figcaption/cite/span.
+ */
+function normalize_html(string $html, array &$placeholders = [], array $unwrap_class_prefixes = []): string
+{
+    if (trim($html) === '') {
+        return '';
+    }
+
+    $dom = load_html_fragment($html);
+    $xpath = new DOMXPath($dom);
+
+    $tables = $xpath->query('//table') ?: [];
+    foreach ($tables as $table) {
+        if (!$table instanceof DOMElement || $table->parentNode === null) {
+            continue;
+        }
+        $key = 'LAMBTABLEPLACEHOLDER' . count($placeholders);
+        $placeholders[$key] = markdown_table($table, $unwrap_class_prefixes);
+        $table->parentNode->replaceChild($dom->createTextNode("\n\n$key\n\n"), $table);
+    }
+
+    $videos = $xpath->query('//video[@src]') ?: [];
+    foreach ($videos as $video) {
+        if (!$video instanceof DOMElement || $video->parentNode === null) {
+            continue;
+        }
+        $src = $video->getAttribute('src');
+        $link = $dom->createElement('a');
+        $link->setAttribute('href', $src);
+        $link->appendChild($dom->createTextNode($src));
+        $p = $dom->createElement('p');
+        $p->appendChild($link);
+        $video->parentNode->replaceChild($p, $video);
+    }
+
+    $class_condition = '';
+    foreach ($unwrap_class_prefixes as $prefix) {
+        $class_condition .= ' or contains(concat(" ", normalize-space(@class), " "), " ' . $prefix . '")';
+    }
+
+    do {
+        $changed = false;
+        $wrappers = $xpath->query(
+            '//*[self::figure or self::figcaption or self::cite or self::span'
+            . ' or ((self::div or self::section)'
+            . ' and (false()' . $class_condition . '))]'
+        ) ?: [];
+        foreach ($wrappers as $wrapper) {
+            if (!$wrapper instanceof DOMElement || $wrapper->parentNode === null) {
+                continue;
+            }
+            unwrap_element($dom, $wrapper, in_array($wrapper->tagName, ['div', 'section', 'figure', 'figcaption'], true));
+            $changed = true;
+        }
+    } while ($changed);
+
+    return dump_html_fragment($dom);
+}
+
+function unwrap_element(DOMDocument $dom, DOMElement $element, bool $block): void
+{
+    $parent = $element->parentNode;
+    if ($parent === null) {
+        return;
+    }
+    if ($block) {
+        $parent->insertBefore($dom->createTextNode("\n\n"), $element);
+    }
+    while ($element->firstChild !== null) {
+        $parent->insertBefore($element->firstChild, $element);
+    }
+    if ($block) {
+        $parent->insertBefore($dom->createTextNode("\n\n"), $element);
+    }
+    $parent->removeChild($element);
+}
+
+/**
+ * @param list<string> $unwrap_class_prefixes Threaded through to the nested
+ *                     html_to_markdown() call for each cell so table cells
+ *                     containing CMS-specific block wrappers unwrap correctly.
+ */
+function markdown_table(DOMElement $table, array $unwrap_class_prefixes = []): string
+{
+    $doc = $table->ownerDocument;
+    if ($doc === null) {
+        return '';
+    }
+    $xpath = new DOMXPath($doc);
+    $rows = [];
+    foreach ($xpath->query('.//tr', $table) ?: [] as $tr) {
+        if (!$tr instanceof DOMElement) {
+            continue;
+        }
+        $cells = [];
+        foreach ($xpath->query('./th|./td', $tr) ?: [] as $cell) {
+            if (!$cell instanceof DOMElement) {
+                continue;
+            }
+            $cells[] = markdown_table_cell($cell, $unwrap_class_prefixes);
+        }
+        if ($cells !== []) {
+            $rows[] = ['cells' => $cells];
+        }
+    }
+    if ($rows === []) {
+        return '';
+    }
+
+    $columnCount = max(array_map(static fn(array $row): int => count($row['cells']), $rows));
+    $lines = [];
+    $first = array_shift($rows);
+    $lines[] = markdown_table_row($first['cells'], $columnCount);
+    $lines[] = markdown_table_row(array_fill(0, $columnCount, '---'), $columnCount);
+    foreach ($rows as $row) {
+        $lines[] = markdown_table_row($row['cells'], $columnCount);
+    }
+
+    return "\n\n" . implode("\n", $lines) . "\n\n";
+}
+
+/**
+ * @param list<string> $unwrap_class_prefixes
+ */
+function markdown_table_cell(DOMElement $cell, array $unwrap_class_prefixes = []): string
+{
+    $doc = $cell->ownerDocument;
+    if ($doc === null) {
+        return '';
+    }
+    $html = '';
+    foreach ($cell->childNodes as $child) {
+        $html .= $doc->saveHTML($child);
+    }
+    $markdown = html_to_markdown($html, $unwrap_class_prefixes);
+    $markdown = preg_replace('/\s+/', ' ', $markdown) ?? $markdown;
+    return str_replace('|', '\\|', trim($markdown));
+}
+
+/**
+ * @param list<string> $cells
+ */
+function markdown_table_row(array $cells, int $columnCount): string
+{
+    $cells = array_pad($cells, $columnCount, '');
+    return '| ' . implode(' | ', $cells) . ' |';
+}
+
+/**
+ * Renders a post body with a YAML front-matter block (title, slug) and inline
+ * #hashtags.
+ *
+ * Tags are appended to the body as #hashtag tokens because Lamb's tag index
+ * scans the body for `#tag` rather than reading a separate column.
+ *
+ * An explicit `slug:` line — sourced from the CMS's own permalink leaf — pins
+ * the post's URL to its original permalink. parse_matter() only derives a
+ * slug from the title when none is set, so the imported slug survives the
+ * normal save pipeline. finalize_slug() still suffixes `-id` on a reserved-
+ * route or collision, so a duplicate imported slug can't override an existing
+ * post.
+ *
+ * @param list<string> $tags
+ */
+function build_post_body(string $title, string $markdown_body, array $tags, string $slug = ''): string
+{
+    $title = trim($title);
+    $slug = trim($slug);
+    $tagLine = '';
+    if ($tags !== []) {
+        $tagLine = "\n\n" . implode(' ', array_map(static fn(string $t): string => '#' . $t, $tags));
+    }
+
+    $body = trim($markdown_body) . $tagLine . "\n";
+
+    $front = [];
+    if ($title !== '') {
+        $front['title'] = $title;
+    }
+    if ($slug !== '') {
+        $front['slug'] = $slug;
+    }
+    if ($front === []) {
+        return $body;
+    }
+    $matter = rtrim(Yaml::dump($front), "\n");
+    return "---\n" . $matter . "\n---\n\n" . $body;
+}
+
+/**
+ * Returns the YYYY/MM subpath under src/assets/ for a post's created date.
+ * Falls back to the current month when the date can't be parsed.
+ */
+function asset_dir_for_date(string $created): string
+{
+    $ts = $created ? strtotime($created) : false;
+    if ($ts === false) {
+        $ts = time();
+    }
+    return date('Y/m', $ts);
+}
+
+/**
+ * Walks an HTML fragment and downloads every referenced image:
+ *  - `<img>` elements: prefers `data-full-url` (WordPress gallery blocks put
+ *    the original full-resolution URL there and a smaller `…-473x1024.jpg`
+ *    variant in `src`; pulling the full original lets convert_to_webp() do the
+ *    1600px resize from a higher-quality source). Falls back to `src`, then to
+ *    `data-src` for lazy-loaded markup.
+ *  - `<a>` elements whose `href` points at an image extension: thumbnails
+ *    wrapped in "view full size" links would otherwise leave dead off-site
+ *    links in the body once the source site is decommissioned.
+ *
+ * Protocol-relative URLs (`//host/path.jpg`) are treated as `https://`.
+ * Multi-resolution `srcset`/`sizes` attributes are stripped once we have a
+ * local copy — the WebP we wrote is already the canonical single-resolution
+ * image. data-* URL hints are also dropped on success so stale absolute URLs
+ * pointing at the old host don't leak back in. Failed downloads, data: URIs
+ * and relative URLs are left untouched.
+ *
+ * @param callable(string,string):?string $downloader  ($url, $sub_path) → saved filename or null.
+ */
+function rewrite_image_links(string $html, string $created, callable $downloader): string
+{
+    if (trim($html) === '') {
+        return '';
+    }
+    $dom = load_html_fragment($html);
+    rewrite_image_links_in_dom($dom, $created, $downloader);
+    return dump_html_fragment($dom);
+}
+
+/**
+ * In-place version of {@see rewrite_image_links}, chained on the same DOM as
+ * {@see sanitize_html_in_dom} from {@see prepare_imported_html} so the two
+ * passes don't each parse and serialise the body separately.
+ *
+ * @param callable(string,string):?string $downloader  ($url, $sub_path) → saved filename or null.
+ */
+function rewrite_image_links_in_dom(DOMDocument $dom, string $created, callable $downloader): void
+{
+    $xpath = new DOMXPath($dom);
+    $sub_path = asset_dir_for_date($created);
+
+    unwrap_picture_elements($dom, $xpath);
+
+    $imgs = $xpath->query('//img[@src or @data-src or @data-full-url]') ?: [];
+    foreach ($imgs as $img) {
+        if (!$img instanceof DOMElement) {
+            continue;
+        }
+        $src = pick_image_url($img);
+        $url = normalize_image_url($src);
+        if ($url === null) {
+            continue;
+        }
+        $filename = $downloader($url, $sub_path);
+        if (!is_string($filename) || $filename === '') {
+            continue;
+        }
+        $img->setAttribute('src', asset_url($sub_path, $filename));
+        foreach (['srcset', 'sizes', 'data-src', 'data-full-url', 'data-link', 'data-orig-file'] as $stale) {
+            $img->removeAttribute($stale);
+        }
+    }
+
+    $anchors = $xpath->query('//a[@href]') ?: [];
+    foreach ($anchors as $a) {
+        if (!$a instanceof DOMElement) {
+            continue;
+        }
+        $href = $a->getAttribute('href');
+        if (!href_looks_like_image($href)) {
+            continue;
+        }
+        $url = normalize_image_url($href);
+        if ($url === null) {
+            continue;
+        }
+        $filename = $downloader($url, $sub_path);
+        if (!is_string($filename) || $filename === '') {
+            continue;
+        }
+        $a->setAttribute('href', asset_url($sub_path, $filename));
+    }
+}
+
+/**
+ * Replaces every `<picture>` in the document with its descendant `<img>`
+ * fallback (or a synthesised `<img>` derived from the first `<source srcset>`
+ * URL when there is no `<img>` child).
+ *
+ * `<picture>` doesn't survive the Markdown converter — unknown HTML is kept
+ * verbatim, so the post body would otherwise display raw `<source>` tags. The
+ * downstream image walk only knows about `<img>`, and `<source>` URLs in
+ * srcset would leak the old host into the body. Unwrapping here means the
+ * single canonical `<img>` flows through the normal rewrite path.
+ */
+function unwrap_picture_elements(DOMDocument $dom, DOMXPath $xpath): void
+{
+    $pictures = $xpath->query('//picture') ?: [];
+    foreach ($pictures as $picture) {
+        if (!$picture instanceof DOMElement || $picture->parentNode === null) {
+            continue;
+        }
+        $img = first_descendant_img($xpath, $picture)
+            ?? synthesise_img_from_source($xpath, $picture, $dom);
+        if ($img === null) {
+            $picture->parentNode->removeChild($picture);
+            continue;
+        }
+        // Detach the img from wherever it lives inside the picture before
+        // splicing the picture out — otherwise the `replaceChild` below
+        // disposes the still-attached node along with the rest of the tree.
+        $img->parentNode?->removeChild($img);
+        $picture->parentNode->replaceChild($img, $picture);
+    }
+}
+
+function first_descendant_img(DOMXPath $xpath, DOMElement $picture): ?DOMElement
+{
+    $found = $xpath->query('.//img', $picture);
+    if ($found === false) {
+        return null;
+    }
+    foreach ($found as $node) {
+        if ($node instanceof DOMElement) {
+            return $node;
+        }
+    }
+    return null;
+}
+
+function synthesise_img_from_source(DOMXPath $xpath, DOMElement $picture, DOMDocument $dom): ?DOMElement
+{
+    $sources = $xpath->query('.//source[@srcset]', $picture);
+    if ($sources === false) {
+        return null;
+    }
+    foreach ($sources as $source) {
+        if (!$source instanceof DOMElement) {
+            continue;
+        }
+        $first = first_srcset_url($source->getAttribute('srcset'));
+        if ($first === null) {
+            continue;
+        }
+        $img = $dom->createElement('img');
+        $img->setAttribute('src', $first);
+        return $img;
+    }
+    return null;
+}
+
+/**
+ * Pulls the first URL out of an HTML5 `srcset` attribute. The grammar is
+ * comma-separated entries of "URL [descriptor]"; we only need the URL of the
+ * first entry, with everything after the first whitespace dropped.
+ */
+function first_srcset_url(string $srcset): ?string
+{
+    $first = trim(explode(',', $srcset, 2)[0]);
+    if ($first === '') {
+        return null;
+    }
+    $parts = preg_split('/\s+/', $first, 2);
+    $url = $parts === false ? '' : $parts[0];
+    return $url === '' ? null : $url;
+}
+
+/**
+ * Picks the best source URL for an `<img>` element: full-res variant first,
+ * then the regular `src`, then lazy-load `data-src`.
+ */
+function pick_image_url(DOMElement $img): string
+{
+    foreach (['data-full-url', 'src', 'data-src'] as $attr) {
+        $value = trim($img->getAttribute($attr));
+        if ($value !== '') {
+            return $value;
+        }
+    }
+    return '';
+}
+
+/**
+ * Normalises a candidate image URL to an absolute http(s) form, or returns
+ * null when it isn't fetchable (data: URI, relative path, empty, etc.).
+ * Protocol-relative `//host/path` URLs are promoted to https.
+ */
+function normalize_image_url(string $url): ?string
+{
+    $url = trim($url);
+    if ($url === '') {
+        return null;
+    }
+    if (str_starts_with($url, '//')) {
+        return 'https:' . $url;
+    }
+    $scheme = parse_url($url, PHP_URL_SCHEME);
+    if (!is_string($scheme) || !in_array(strtolower($scheme), ['http', 'https'], true)) {
+        return null;
+    }
+    return $url;
+}
+
+/**
+ * Whether an anchor href appears to point at an image — used to decide if a
+ * "view full size" link should also be downloaded. Conservative: only known
+ * upload-pipeline extensions are accepted, query strings and fragments are
+ * tolerated.
+ */
+function href_looks_like_image(string $href): bool
+{
+    $path = parse_url($href, PHP_URL_PATH);
+    if (!is_string($path) || $path === '') {
+        return false;
+    }
+    $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+    return $ext !== '' && in_array($ext, IMAGE_UPLOAD_EXTENSIONS, true);
+}
+
+/**
+ * Cap for how many bytes a single image download is allowed to consume.
+ * A misbehaving server returning a multi-GB body with image/* Content-Type
+ * would otherwise OOM the importer; truncated reads fail the WebP decode
+ * cleanly, which is the right outcome.
+ */
+const IMAGE_DOWNLOAD_MAX_BYTES = 20_000_000;
+
+/**
+ * Default downloader used by the CLI scripts: fetches $url over HTTP and
+ * writes it under ROOT_DIR/assets/$sub_path with a content-hash filename.
+ * JPEG/PNG are re-encoded to WebP via the shared persistence helper. Returns
+ * the filename relative to the subdirectory, or null on any failure.
+ *
+ * Idempotent: when the destination file already exists from an earlier post in
+ * the same month — or from a previous interrupted run — the existing filename
+ * is returned without re-fetching. The seed is sha1($url), so the same URL
+ * always maps to the same on-disk name.
+ */
+function default_image_downloader(string $url, string $sub_path): ?string
+{
+    if (!defined('ROOT_DIR')) {
+        return null;
+    }
+    $path = parse_url($url, PHP_URL_PATH) ?: '';
+    $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+    if ($ext === '' || !in_array($ext, IMAGE_UPLOAD_EXTENSIONS, true)) {
+        return null;
+    }
+    $dest_dir = ROOT_DIR . '/assets/' . $sub_path;
+    $seed = sha1($url);
+    foreach (["$seed.webp", "$seed.$ext"] as $existing) {
+        if (is_file("$dest_dir/$existing")) {
+            return $existing;
+        }
+    }
+    if (!is_dir($dest_dir) && !mkdir($dest_dir, 0777, true) && !is_dir($dest_dir)) {
+        return null;
+    }
+    $response = fetch($url, ['max_bytes' => IMAGE_DOWNLOAD_MAX_BYTES]);
+    if ($response === null || $response['body'] === '') {
+        return null;
+    }
+    if ($response['status'] < 200 || $response['status'] >= 300) {
+        return null;
+    }
+    if (!response_is_image($response['headers'])) {
+        return null;
+    }
+    return \Lamb\Response\persist_image_bytes($response['body'], $ext, $dest_dir, $seed);
+}
+
+/**
+ * Scans raw HTTP response headers (as returned by Lamb\Http\fetch) for an
+ * image/* Content-Type. Lets the downloader reject 200-OK HTML error pages,
+ * CDN block pages, or login-required HTML returned for unauthenticated asset
+ * URLs — situations the URL extension and status code alone don't catch.
+ *
+ * @param string[] $headers Raw response header lines.
+ */
+function response_is_image(array $headers): bool
+{
+    foreach ($headers as $header) {
+        if (preg_match('/^content-type\s*:\s*image\//i', $header)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Bundles the sanitise + image-rewrite passes (and an optional CMS-specific
+ * DOM pass in between) onto a single DOM. Used by each importer's
+ * `import_item()` to halve the parse/serialise work versus calling the two
+ * public string functions back to back, and to remove a layer of round-trip
+ * artifacts (entity normalisation, attribute reordering) between the stages.
+ *
+ * @param callable(string,string):?string $downloader ($url, $sub_path) → saved filename or null.
+ * @param ?callable(DOMDocument):void     $dom_pass    Optional CMS-specific DOM
+ *                     surgery run after sanitisation and before the image
+ *                     rewrite (e.g. Known's unfurl-block removal).
+ */
+function prepare_imported_html(string $html, string $created, callable $downloader, ?callable $dom_pass = null): string
+{
+    if (trim($html) === '') {
+        return '';
+    }
+    $dom = load_html_fragment($html);
+    sanitize_html_in_dom($dom);
+    if ($dom_pass !== null) {
+        $dom_pass($dom);
+    }
+    rewrite_image_links_in_dom($dom, $created, $downloader);
+    return dump_html_fragment($dom);
+}
+
+/**
+ * Stores an automatic redirect from an imported source URL path to a local
+ * Lamb path. Importers only create redirects for old paths that do not
+ * naturally match Lamb's freshly minted permalink.
+ */
+function store_redirect(string $from, string $to): void
+{
+    $redirect = R::findOneOrDispense('redirect', ' from_slug = ? ', [$from]);
+    $redirect->from_slug = $from;
+    $redirect->to_url = $to;
+    R::store($redirect);
+}
+
+/**
+ * Parses argv into [path, dry_run]. Returns [null, false] when the path is
+ * missing.
+ *
+ * @param array<int,string> $argv
+ * @return array{0: ?string, 1: bool}
+ */
+function parse_import_args(array $argv): array
+{
+    $path = null;
+    $dry_run = false;
+    foreach (array_slice($argv, 1) as $arg) {
+        if ($arg === '--dry-run') {
+            $dry_run = true;
+        } elseif ($arg === '--help' || $arg === '-h') {
+            return [null, false];
+        } elseif ($path === null) {
+            $path = $arg;
+        }
+    }
+    return [$path, $dry_run];
+}
+
+/**
+ * Shared CLI import loop: walks $items, skips out-of-scope ones (tallying a
+ * skip-reason breakdown), dedups already-imported items by uuid, imports the
+ * rest through $import, and prints a per-item progress line plus a final
+ * summary. Used by both import-wordpress.php and import-known.php so the two
+ * scripts' output stays byte-identical in shape.
+ *
+ * @param list<array<string, mixed>>      $items      Items from extract_items().
+ * @param callable(array<string,mixed>):?string $skip_reason Explains why an item is out of scope, or null.
+ * @param callable(array<string,mixed>):string  $uuid       Computes the item's dedup uuid.
+ * @param callable(array<string,mixed>,callable,bool):?\RedBeanPHP\OODBBean $import Imports a single item.
+ */
+function run_import(array $items, callable $skip_reason, callable $uuid, callable $import, bool $dry_run): void
+{
+    $downloader = $dry_run
+        ? static fn(): ?string => null
+        : 'Lamb\\Import\\default_image_downloader';
+
+    $created = 0;
+    $existed = 0;
+    $skipped = 0;
+    /** @var array<string, int> $skip_reasons */
+    $skip_reasons = [];
+    $total = count($items);
+
+    foreach ($items as $i => $item) {
+        $reason = $skip_reason($item);
+        if ($reason !== null) {
+            $skipped++;
+            $skip_reasons[$reason] = ($skip_reasons[$reason] ?? 0) + 1;
+            continue;
+        }
+        $item_uuid = $uuid($item);
+        if (R::findOne('post', ' feeditem_uuid = ? ', [$item_uuid])) {
+            $existed++;
+            continue;
+        }
+
+        $bean = $import($item, $downloader, $dry_run);
+        if ($bean === null) {
+            $skipped++;
+            $skip_reasons['conversion failed'] = ($skip_reasons['conversion failed'] ?? 0) + 1;
+            echo "[" . ($i + 1) . "/$total] skipped (conversion failed): "
+                . trim((string) $item['title']) . "\n";
+            continue;
+        }
+        $created++;
+        $verb = $dry_run ? 'would import' : 'imported';
+        echo "[" . ($i + 1) . "/$total] $verb: " . trim((string) $item['title']) . "\n";
+    }
+
+    $prefix = $dry_run ? '[dry-run] ' : '';
+    echo "\n{$prefix}Done. created=$created existed=$existed skipped=$skipped total=$total\n";
+    if ($skip_reasons) {
+        arsort($skip_reasons);
+        echo "Skipped breakdown:\n";
+        foreach ($skip_reasons as $reason => $count) {
+            echo "  $count\t$reason\n";
+        }
+    }
+}
+
+/**
+ * Loads an HTML fragment into DOMDocument with UTF-8 preserved.
+ *
+ * Wraps the input in a full <!doctype html><html><body> tree rather than using
+ * LIBXML_HTML_NOIMPLIED, because libxml's handling of top-level fragment
+ * elements changed between 2.9 and 2.12: the older NOIMPLIED + sibling-div
+ * trick lost the wrapper on the newer parser and the round-trip collapsed to
+ * just the meta hint. The full wrap parses identically on every libxml
+ * version we support. The `<?xml encoding="utf-8" ?>` processing instruction
+ * forces UTF-8; without it loadHTML defaults to ISO-8859-1 and mangles
+ * multibyte input.
+ */
+function load_html_fragment(string $html): DOMDocument
+{
+    $dom = new DOMDocument();
+    $previous = libxml_use_internal_errors(true);
+    $dom->loadHTML(
+        '<?xml encoding="utf-8" ?><!DOCTYPE html><html><body>' . $html . '</body></html>'
+    );
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+    return $dom;
+}
+
+/**
+ * Renders the contents of the synthesised <body> back out as an HTML fragment.
+ * The original input lives as body's direct children, so we serialise each in
+ * order and skip the wrapper.
+ */
+function dump_html_fragment(DOMDocument $dom): string
+{
+    $body = $dom->getElementsByTagName('body')->item(0);
+    if (!$body instanceof DOMElement) {
+        return trim((string) $dom->saveHTML());
+    }
+    $out = '';
+    foreach ($body->childNodes as $child) {
+        $out .= $dom->saveHTML($child);
+    }
+    return $out;
+}

--- a/src/known.php
+++ b/src/known.php
@@ -1,0 +1,391 @@
+<?php
+
+namespace Lamb\Known;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use RedBeanPHP\OODBBean;
+use RedBeanPHP\R;
+use SimpleXMLElement;
+
+use function Lamb\Import\build_post_body;
+use function Lamb\Import\html_to_markdown;
+use function Lamb\Import\import_uuid;
+use function Lamb\Import\local_datetime_from_rfc822;
+use function Lamb\Import\prepare_imported_html;
+use function Lamb\Import\store_redirect;
+use function Lamb\Import\unwrap_element;
+use function Lamb\Post\body_has_tag;
+use function Lamb\Post\finalize_and_store_post;
+use function Lamb\Post\populate_bean;
+
+// Known's RSS export borrows two fields from the WordPress WXR namespace
+// (wp:post_type, wp:status) without adopting the rest of WXR. Known has its
+// own copy of the namespace URI so this file never depends on Lamb\WordPress.
+const WP_NS = 'http://wordpress.org/export/1.2/';
+
+// Known tags that describe the post's shape rather than its subject, dropped
+// on import: 'status' marks a titleless status update (Lamb models that as a
+// post without a title, not a tag) and 'uncategorized' means no category at
+// all.
+const STRUCTURAL_TAGS = ['status', 'uncategorized'];
+
+/**
+ * Whether a tag is one of Known's structural tags ({@see STRUCTURAL_TAGS}).
+ * Accepts raw tag text as it appears in the export — with or without the
+ * leading `#`, in any case.
+ */
+function is_structural_tag(string $tag): bool
+{
+    $tag = strtolower(trim(ltrim(trim($tag), '#')));
+    return in_array($tag, STRUCTURAL_TAGS, true);
+}
+
+/**
+ * Strips standalone structural hashtags (`#status`, `#uncategorized`) from
+ * converted Markdown.
+ *
+ * Runs on the final text form rather than the DOM because the hashtags reach
+ * it by several routes: authors typed them inline (Known's inline tagging),
+ * repair_known_content() surfaces them out of the malformed tag-line
+ * paragraph, and a handful of source-damaged posts only reveal them after
+ * html_to_markdown()'s entity decoding. Lamb's tag index scans the body for
+ * `#tag` tokens, so any survivor would re-import the tag through the back
+ * door.
+ */
+function strip_structural_hashtags(string $markdown): string
+{
+    $pattern = '/[ \t]?(?<![\w#])#(?:' . implode('|', STRUCTURAL_TAGS) . ')\b/i';
+    return preg_replace($pattern, '', $markdown) ?? $markdown;
+}
+
+/**
+ * Stable dedup key for a Known post. Mirrors the feed-ingest convention
+ * (`feeditem_uuid = md5($feed_name . $id)`), so re-running an import never
+ * recreates a row.
+ */
+function known_uuid(string $guid): string
+{
+    return import_uuid('known-', $guid);
+}
+
+/**
+ * Repairs Known's malformed trailing tag-line paragraph.
+ *
+ * Known appends the post's tags as a `<p>` of plain `#hashtag` text and
+ * `p-category` anchors, but its RSS export double-escapes that paragraph's
+ * own `<p>`/`</p>` (they arrive as `&lt;p&gt;` entities). Left alone, the
+ * entities decode into literal `<p>` text in the converted Markdown body.
+ * Un-escaping is limited to exactly this shape — an escaped `<p>` wrapping
+ * nothing but hashtags and tag anchors — so genuinely escaped markup that an
+ * author wrote about (or that Known damaged elsewhere in old posts) is
+ * passed through untouched.
+ */
+function repair_known_content(string $html): string
+{
+    $pattern = '/&lt;p&gt;\s*((?:#[\w-]+\s*|<a\b[^>]*class="[^"]*p-category[^"]*"[^>]*>.*?<\/a>\s*)+)&lt;\/p&gt;/is';
+    return preg_replace($pattern, '<p>$1</p>', $html) ?? $html;
+}
+
+/**
+ * Extracts every <item> from the channel as a normalised assoc array.
+ *
+ * Known's RSS export is a partial WXR veneer: content lives in <description>
+ * (no content:encoded), there's no <wp:post_name>, so the slug has to come
+ * from the <link> path leaf — but only when <link> is on the same host as
+ * the channel's own <link> (the other 25/445 items in the source export are
+ * bookmarks whose <link> points at the bookmarked page itself). Tags appear
+ * as plain `<category>#tag</category>` elements (no domain/nicename
+ * attributes). Dates are RFC822 `<pubDate>` only, so created and updated are
+ * always identical.
+ *
+ * @return list<array{
+ *   title:string, guid:string, link:string, content:string,
+ *   post_type:string, status:string, created:string, updated:string,
+ *   tags:list<string>, slug:string, bookmark_url:string,
+ *   title_is_synthetic:bool
+ * }>
+ */
+function extract_items(SimpleXMLElement $rss): array
+{
+    $channel_host = strtolower(
+        (string) (parse_url(trim((string) ($rss->channel->link ?? '')), PHP_URL_HOST) ?: '')
+    );
+
+    $items = [];
+    foreach ($rss->channel->item ?? [] as $item) {
+        $wp = $item->children(WP_NS);
+
+        $title = trim((string) ($item->title ?? ''));
+        $link = trim((string) ($item->link ?? ''));
+        $content = repair_known_content((string) ($item->description ?? ''));
+        $created = local_datetime_from_rfc822(trim((string) ($item->pubDate ?? '')));
+
+        $link_host = strtolower((string) (parse_url($link, PHP_URL_HOST) ?: ''));
+        $on_host = $link_host !== '' && $link_host === $channel_host;
+
+        $slug = '';
+        $bookmark_url = '';
+        if ($on_host) {
+            $path = parse_url($link, PHP_URL_PATH);
+            if (is_string($path) && trim($path, '/') !== '') {
+                $segments = explode('/', trim($path, '/'));
+                $slug = (string) end($segments);
+            }
+        } else {
+            $bookmark_url = $link;
+        }
+
+        $tags = [];
+        foreach ($item->category ?? [] as $cat) {
+            $tag = trim((string) $cat);
+            if (str_starts_with($tag, '#')) {
+                $tag = substr($tag, 1);
+            }
+            $tag = strtolower(trim($tag));
+            if ($tag !== '' && !is_structural_tag($tag)) {
+                $tags[] = $tag;
+            }
+        }
+
+        $title_is_synthetic = str_ends_with(rtrim($title), '...')
+            || (bool) preg_match('/class="[^"]*\bp-name\b/', $content);
+
+        $items[] = [
+            'title'              => $title,
+            'guid'               => trim((string) ($item->guid ?? '')),
+            'link'               => $link,
+            'content'            => $content,
+            'post_type'          => trim((string) ($wp->post_type ?? '')),
+            'status'             => trim((string) ($wp->status ?? '')),
+            'created'            => $created,
+            'updated'            => $created,
+            'tags'               => array_values(array_unique($tags)),
+            'slug'               => $slug,
+            'bookmark_url'       => $bookmark_url,
+            'title_is_synthetic' => $title_is_synthetic,
+        ];
+    }
+    return $items;
+}
+
+/**
+ * First-pass scope: published posts only. The real export has zero items
+ * outside this scope, but the check is kept for defensiveness (and parity
+ * with the WordPress importer) should a future export carry drafts.
+ *
+ * @param array<string, mixed> $item
+ */
+function should_import(array $item): bool
+{
+    return skip_reason($item) === null;
+}
+
+/**
+ * Explains why an item falls outside import scope, or null when it should be
+ * imported. Single source of truth for should_import(); the importer uses the
+ * reason string to break down its skipped tally.
+ *
+ * @param array<string, mixed> $item
+ */
+function skip_reason(array $item): ?string
+{
+    $type   = (string) ($item['post_type'] ?? '');
+    $status = (string) ($item['status'] ?? '');
+    if ($type !== 'post') {
+        return "unsupported post_type '" . ($type === '' ? '(none)' : $type) . "'";
+    }
+    if ($status !== 'publish') {
+        return "non-published status '" . ($status === '' ? '(none)' : $status) . "'";
+    }
+    return null;
+}
+
+/**
+ * Known-specific DOM surgery, run as the `$dom_pass` callback inside
+ * {@see \Lamb\Import\prepare_imported_html} (after sanitisation, before the
+ * image rewrite):
+ *
+ *  - `div.unfurl-block` (Known's hidden link-preview UI, including its
+ *    nested `unfurl`/`unfurl-edit` children) is removed entirely.
+ *  - `a.p-category[rel=tag]` anchors (pointing at the dead old host's tag
+ *    archive) are replaced with a plain text node of their own text, so the
+ *    inline `#tag` survives as ordinary body text instead of a dead link.
+ *    Structural-tag anchors ({@see STRUCTURAL_TAGS}) are removed outright
+ *    instead; their plain-text form is handled later, in
+ *    {@see strip_structural_hashtags} on the converted Markdown.
+ *  - `a[data-gallery]` anchors (Known's photo-post wrapper around the image)
+ *    are unwrapped to a bare `<img>`.
+ *  - Every remaining div is loop-unwrapped. This covers Known's own
+ *    structural wrappers (`e-content`, `entry-content`, `known-bookmark`,
+ *    `photo-view`, which can nest each other) and any legacy authored divs
+ *    carried over from earlier platforms (bare `<div>`s, Windows Live
+ *    Writer wrappers, …). A div holds no meaning in Markdown, and one that
+ *    survives conversion renders as visibly escaped HTML in Lamb's safe
+ *    renderer — unwrapping to paragraph breaks is strictly better. The
+ *    unfurl-block removal above runs first, so junk subtrees are gone
+ *    before this pass keeps their content.
+ */
+function normalize_known_html_in_dom(DOMDocument $dom): void
+{
+    $xpath = new DOMXPath($dom);
+
+    $unfurls = $xpath->query(
+        '//div[contains(concat(" ", normalize-space(@class), " "), " unfurl-block ")]'
+    ) ?: [];
+    foreach ($unfurls as $node) {
+        if ($node instanceof DOMElement && $node->parentNode !== null) {
+            $node->parentNode->removeChild($node);
+        }
+    }
+
+    $tag_anchors = $xpath->query(
+        '//a[@rel="tag" and contains(concat(" ", normalize-space(@class), " "), " p-category ")]'
+    ) ?: [];
+    foreach ($tag_anchors as $a) {
+        if (!$a instanceof DOMElement || $a->parentNode === null) {
+            continue;
+        }
+        // Structural tags are dropped outright — leaving them as text would
+        // put e.g. `#status` back into Lamb's body-scanning tag index.
+        if (is_structural_tag($a->textContent)) {
+            $a->parentNode->removeChild($a);
+            continue;
+        }
+        $a->parentNode->replaceChild($dom->createTextNode($a->textContent), $a);
+    }
+
+
+    $gallery_anchors = $xpath->query('//a[@data-gallery]') ?: [];
+    foreach ($gallery_anchors as $a) {
+        if ($a instanceof DOMElement) {
+            unwrap_element($dom, $a, false);
+        }
+    }
+
+    do {
+        $changed = false;
+        $wrappers = $xpath->query('//div') ?: [];
+        foreach ($wrappers as $wrapper) {
+            if (!$wrapper instanceof DOMElement || $wrapper->parentNode === null) {
+                continue;
+            }
+            unwrap_element($dom, $wrapper, true);
+            $changed = true;
+        }
+    } while ($changed);
+}
+
+/**
+ * Runs a single Known RSS item through the standard post pipeline.
+ *
+ * Returns null when the item is out of scope. When an item with the same
+ * `known_uuid()` already exists the existing bean is returned untouched —
+ * re-running an import is therefore safe and idempotent.
+ *
+ * Synthetic-title items (Known-generated status updates — title ends `...`
+ * or the body carries microformats2 `p-name`) are imported titleless, so
+ * they fall through to Lamb's native `/status/<id>` permalink instead of
+ * pinning a Known-derived slug. Bookmark items (an offsite `<link>`) get a
+ * `[title](url)` markdown line prepended to the body, mirroring how Known
+ * rendered them. Extracted `<category>` tags already present as inline
+ * hashtags in the converted body (case-insensitively) are dropped so they
+ * aren't duplicated.
+ *
+ * No outbound webmentions or WebSub pings are emitted: the call path stops at
+ * finalize_and_store_post(), which never invokes notify_post_subscribers().
+ *
+ * @param array<string, mixed>            $item       Item from extract_items().
+ * @param callable(string,string):?string $downloader Image downloader.
+ */
+function import_item(array $item, callable $downloader, bool $dry_run = false): ?OODBBean
+{
+    if (!should_import($item)) {
+        return null;
+    }
+
+    $uuid = known_uuid((string) $item['guid']);
+    $existing = R::findOne('post', ' feeditem_uuid = ? ', [$uuid]);
+    if ($existing) {
+        return $existing;
+    }
+
+    $body_html = (string) ($item['content'] ?? '');
+    $prepared = $body_html === ''
+        ? ''
+        : prepare_imported_html(
+            $body_html,
+            (string) $item['created'],
+            $downloader,
+            normalize_known_html_in_dom(...),
+        );
+    $markdown = strip_structural_hashtags(html_to_markdown($prepared));
+
+    $extracted_tags = array_values(array_map(static fn($t): string => (string) $t, (array) ($item['tags'] ?? [])));
+    $tags = array_values(array_filter(
+        $extracted_tags,
+        static fn(string $tag): bool => !body_has_tag($tag, $markdown)
+    ));
+
+    $title_is_synthetic = (bool) ($item['title_is_synthetic'] ?? false);
+    $title = $title_is_synthetic ? '' : (string) ($item['title'] ?? '');
+    $slug = $title_is_synthetic ? '' : (string) ($item['slug'] ?? '');
+
+    $bookmark_url = trim((string) ($item['bookmark_url'] ?? ''));
+    if ($bookmark_url !== '') {
+        $markdown = '[' . (string) $item['title'] . '](' . $bookmark_url . ')' . "\n\n" . $markdown;
+    }
+
+    $body = build_post_body($title, $markdown, $tags, $slug);
+
+    $bean = populate_bean($body);
+    if (!empty($item['created'])) {
+        $bean->created = (string) $item['created'];
+    }
+    if (!empty($item['updated'])) {
+        $bean->updated = (string) $item['updated'];
+    }
+    $bean->feeditem_uuid = $uuid;
+    $bean->feed_name = 'known';
+
+    if ($dry_run) {
+        return $bean;
+    }
+
+    finalize_and_store_post($bean);
+    store_source_redirects($item, $bean);
+    return $bean;
+}
+
+/**
+ * Stores automatic redirects from an imported Known item's old URLs to its
+ * new local Lamb path: the on-host `<link>` path (`2020/<slug>`, skipped for
+ * offsite bookmarks and when it already equals the new path) and the `<guid>`
+ * path (`view/<hash>`) — Known's own permalinks resolved either way.
+ *
+ * @param array<string, mixed> $item
+ */
+function store_source_redirects(array $item, OODBBean $bean): void
+{
+    $to = $bean->slug ? '/' . $bean->slug : '/status/' . $bean->id;
+
+    $bookmark_url = trim((string) ($item['bookmark_url'] ?? ''));
+    if ($bookmark_url === '') {
+        $link_path = parse_url((string) ($item['link'] ?? ''), PHP_URL_PATH);
+        if (is_string($link_path) && $link_path !== '') {
+            $from = trim($link_path, '/');
+            if ($from !== '' && $from !== ltrim($to, '/')) {
+                store_redirect($from, $to);
+            }
+        }
+    }
+
+    $guid_path = parse_url((string) ($item['guid'] ?? ''), PHP_URL_PATH);
+    if (is_string($guid_path) && $guid_path !== '') {
+        $from = trim($guid_path, '/');
+        if ($from !== '') {
+            store_redirect($from, $to);
+        }
+    }
+}

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -2,20 +2,19 @@
 
 namespace Lamb\WordPress;
 
-use DOMDocument;
-use DOMElement;
-use DOMXPath;
-use League\HTMLToMarkdown\HtmlConverter;
 use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
-use RuntimeException;
 use SimpleXMLElement;
-use Symfony\Component\Yaml\Yaml;
 
-use function Lamb\Http\fetch;
+use function Lamb\Import\build_post_body;
+use function Lamb\Import\html_to_markdown as import_html_to_markdown;
+use function Lamb\Import\import_uuid;
+use function Lamb\Import\parse_rss_file;
+use function Lamb\Import\parse_rss_string;
+use function Lamb\Import\prepare_imported_html;
+use function Lamb\Import\store_redirect;
 use function Lamb\Post\finalize_and_store_post;
 use function Lamb\Post\populate_bean;
-use function Lamb\Response\asset_url;
 
 const WXR_NS = 'http://wordpress.org/export/1.2/';
 const CONTENT_NS = 'http://purl.org/rss/1.0/modules/content/';
@@ -27,7 +26,7 @@ const CONTENT_NS = 'http://purl.org/rss/1.0/modules/content/';
  */
 function wordpress_uuid(string $guid): string
 {
-    return md5('wordpress-' . $guid);
+    return import_uuid('wordpress-', $guid);
 }
 
 /**
@@ -35,14 +34,7 @@ function wordpress_uuid(string $guid): string
  */
 function parse_wxr_string(string $xml): SimpleXMLElement
 {
-    $previous = libxml_use_internal_errors(true);
-    $rss = simplexml_load_string($xml);
-    libxml_clear_errors();
-    libxml_use_internal_errors($previous);
-    if ($rss === false) {
-        throw new RuntimeException('Could not parse WXR XML.');
-    }
-    return $rss;
+    return parse_rss_string($xml);
 }
 
 /**
@@ -50,11 +42,7 @@ function parse_wxr_string(string $xml): SimpleXMLElement
  */
 function parse_wxr_file(string $path): SimpleXMLElement
 {
-    $xml = @file_get_contents($path);
-    if ($xml === false) {
-        throw new RuntimeException("Could not read WXR file: $path");
-    }
-    return parse_wxr_string($xml);
+    return parse_rss_file($path);
 }
 
 /**
@@ -187,590 +175,15 @@ function skip_reason(array $item): ?string
 }
 
 /**
- * Removes executable / styling tags and any `on*` event-handler attributes.
+ * Converts the already-sanitised WordPress HTML body to Markdown.
  *
- * WP body HTML is untrusted enough to warrant a defensive scrub before it
- * touches the Markdown converter. Tag removal is done at DOM level so nested
- * markup doesn't break the strip; event-handler attributes are walked off
- * every element regardless of case.
- */
-function sanitize_html(string $html): string
-{
-    if (trim($html) === '') {
-        return '';
-    }
-    $dom = load_html_fragment($html);
-    sanitize_html_in_dom($dom);
-    return dump_html_fragment($dom);
-}
-
-/**
- * In-place sanitisation pass: removes script/style/iframe nodes and any
- * `on*` event-handler attributes from every element. Extracted so {@see
- * import_item} can chain it onto the same DOM as {@see rewrite_image_links_in_dom},
- * avoiding a parse/serialise round-trip between the two stages.
- */
-function sanitize_html_in_dom(DOMDocument $dom): void
-{
-    $xpath = new DOMXPath($dom);
-
-    $strip = $xpath->query('//script | //style | //iframe') ?: [];
-    foreach ($strip as $node) {
-        if ($node instanceof \DOMNode) {
-            $node->parentNode?->removeChild($node);
-        }
-    }
-
-    $elements = $xpath->query('//*') ?: [];
-    foreach ($elements as $el) {
-        if (!$el instanceof DOMElement) {
-            continue;
-        }
-        $remove = [];
-        foreach ($el->attributes as $attr) {
-            if (stripos($attr->nodeName, 'on') === 0) {
-                $remove[] = $attr->nodeName;
-            }
-        }
-        foreach ($remove as $name) {
-            $el->removeAttribute($name);
-        }
-    }
-}
-
-/**
- * Converts the already-sanitised HTML body to Markdown.
- *
- * The HtmlConverter is configured to keep unknown HTML so a malformed snippet
- * doesn't silently disappear; hard_break = true preserves <br> as a visible
- * line break in source.
+ * Delegates to the shared converter with the `wp-block-` unwrap prefix, so
+ * WordPress's block-editor wrapper divs/sections (`wp-block-buttons`,
+ * `wp-block-image`, …) are unwrapped the same way they always have been.
  */
 function html_to_markdown(string $html): string
 {
-    $placeholders = [];
-    $html = normalize_wordpress_html($html, $placeholders);
-    $converter = new HtmlConverter([
-        'header_style'    => 'atx',
-        'strip_tags'      => false,
-        'remove_nodes'    => '',
-        'hard_break'      => true,
-        'use_autolinks'   => true,
-        'preserve_comments' => false,
-    ]);
-    $markdown = strtr(trim($converter->convert($html)), $placeholders);
-    $markdown = html_entity_decode($markdown, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-    return separate_images_from_following_text($markdown);
-}
-
-function separate_images_from_following_text(string $markdown): string
-{
-    return preg_replace('/(!\[[^\]]*]\([^)]+\))(?=\S)/', "$1\n\n", $markdown) ?? $markdown;
-}
-
-/**
- * Normalises WordPress editor HTML before Markdown conversion.
- *
- * The Markdown converter preserves unknown HTML by design. WordPress exports
- * often contain presentational block wrappers, tables and video tags that would
- * otherwise survive into Lamb's safe Markdown renderer as visible escaped tags.
- */
-/**
- * @param array<string, string> $placeholders
- */
-function normalize_wordpress_html(string $html, array &$placeholders = []): string
-{
-    if (trim($html) === '') {
-        return '';
-    }
-
-    $dom = load_html_fragment($html);
-    $xpath = new DOMXPath($dom);
-
-    $tables = $xpath->query('//table') ?: [];
-    foreach ($tables as $table) {
-        if (!$table instanceof DOMElement || $table->parentNode === null) {
-            continue;
-        }
-        $key = 'LAMBTABLEPLACEHOLDER' . count($placeholders);
-        $placeholders[$key] = markdown_table($table);
-        $table->parentNode->replaceChild($dom->createTextNode("\n\n$key\n\n"), $table);
-    }
-
-    $videos = $xpath->query('//video[@src]') ?: [];
-    foreach ($videos as $video) {
-        if (!$video instanceof DOMElement || $video->parentNode === null) {
-            continue;
-        }
-        $src = $video->getAttribute('src');
-        $link = $dom->createElement('a');
-        $link->setAttribute('href', $src);
-        $link->appendChild($dom->createTextNode($src));
-        $p = $dom->createElement('p');
-        $p->appendChild($link);
-        $video->parentNode->replaceChild($p, $video);
-    }
-
-    do {
-        $changed = false;
-        $wrappers = $xpath->query(
-            '//*[self::figure or self::figcaption or self::cite or self::span'
-            . ' or ((self::div or self::section)'
-            . ' and contains(concat(" ", normalize-space(@class), " "), " wp-block-"))]'
-        ) ?: [];
-        foreach ($wrappers as $wrapper) {
-            if (!$wrapper instanceof DOMElement || $wrapper->parentNode === null) {
-                continue;
-            }
-            unwrap_element($dom, $wrapper, in_array($wrapper->tagName, ['div', 'section', 'figure', 'figcaption'], true));
-            $changed = true;
-        }
-    } while ($changed);
-
-    return dump_html_fragment($dom);
-}
-
-function unwrap_element(DOMDocument $dom, DOMElement $element, bool $block): void
-{
-    $parent = $element->parentNode;
-    if ($parent === null) {
-        return;
-    }
-    if ($block) {
-        $parent->insertBefore($dom->createTextNode("\n\n"), $element);
-    }
-    while ($element->firstChild !== null) {
-        $parent->insertBefore($element->firstChild, $element);
-    }
-    if ($block) {
-        $parent->insertBefore($dom->createTextNode("\n\n"), $element);
-    }
-    $parent->removeChild($element);
-}
-
-function markdown_table(DOMElement $table): string
-{
-    $doc = $table->ownerDocument;
-    if ($doc === null) {
-        return '';
-    }
-    $xpath = new DOMXPath($doc);
-    $rows = [];
-    foreach ($xpath->query('.//tr', $table) ?: [] as $tr) {
-        if (!$tr instanceof DOMElement) {
-            continue;
-        }
-        $cells = [];
-        foreach ($xpath->query('./th|./td', $tr) ?: [] as $cell) {
-            if (!$cell instanceof DOMElement) {
-                continue;
-            }
-            $cells[] = markdown_table_cell($cell);
-        }
-        if ($cells !== []) {
-            $rows[] = ['cells' => $cells];
-        }
-    }
-    if ($rows === []) {
-        return '';
-    }
-
-    $columnCount = max(array_map(static fn(array $row): int => count($row['cells']), $rows));
-    $lines = [];
-    $first = array_shift($rows);
-    $lines[] = markdown_table_row($first['cells'], $columnCount);
-    $lines[] = markdown_table_row(array_fill(0, $columnCount, '---'), $columnCount);
-    foreach ($rows as $row) {
-        $lines[] = markdown_table_row($row['cells'], $columnCount);
-    }
-
-    return "\n\n" . implode("\n", $lines) . "\n\n";
-}
-
-function markdown_table_cell(DOMElement $cell): string
-{
-    $doc = $cell->ownerDocument;
-    if ($doc === null) {
-        return '';
-    }
-    $html = '';
-    foreach ($cell->childNodes as $child) {
-        $html .= $doc->saveHTML($child);
-    }
-    $markdown = html_to_markdown($html);
-    $markdown = preg_replace('/\s+/', ' ', $markdown) ?? $markdown;
-    return str_replace('|', '\\|', trim($markdown));
-}
-
-/**
- * @param list<string> $cells
- */
-function markdown_table_row(array $cells, int $columnCount): string
-{
-    $cells = array_pad($cells, $columnCount, '');
-    return '| ' . implode(' | ', $cells) . ' |';
-}
-
-/**
- * Renders a post body with a YAML front-matter block (title, slug) and inline
- * #hashtags.
- *
- * Tags are appended to the body as #hashtag tokens because Lamb's tag index
- * scans the body for `#tag` rather than reading a separate column.
- *
- * An explicit `slug:` line — sourced from the WP `<wp:post_name>` — pins the
- * post's URL to its original WordPress permalink leaf. parse_matter() only
- * derives a slug from the title when none is set, so the WP slug survives the
- * normal save pipeline. finalize_slug() still suffixes `-id` on a reserved-
- * route or collision, so a duplicate WP slug can't override an existing post.
- *
- * @param list<string> $tags
- */
-function build_post_body(string $title, string $markdown_body, array $tags, string $slug = ''): string
-{
-    $title = trim($title);
-    $slug = trim($slug);
-    $tagLine = '';
-    if ($tags !== []) {
-        $tagLine = "\n\n" . implode(' ', array_map(static fn(string $t): string => '#' . $t, $tags));
-    }
-
-    $body = trim($markdown_body) . $tagLine . "\n";
-
-    $front = [];
-    if ($title !== '') {
-        $front['title'] = $title;
-    }
-    if ($slug !== '') {
-        $front['slug'] = $slug;
-    }
-    if ($front === []) {
-        return $body;
-    }
-    $matter = rtrim(Yaml::dump($front), "\n");
-    return "---\n" . $matter . "\n---\n\n" . $body;
-}
-
-/**
- * Returns the YYYY/MM subpath under src/assets/ for a post's created date.
- * Falls back to the current month when the date can't be parsed.
- */
-function asset_dir_for_date(string $created): string
-{
-    $ts = $created ? strtotime($created) : false;
-    if ($ts === false) {
-        $ts = time();
-    }
-    return date('Y/m', $ts);
-}
-
-/**
- * Walks an HTML fragment and downloads every referenced image:
- *  - `<img>` elements: prefers `data-full-url` (WordPress gallery blocks put
- *    the original full-resolution URL there and a smaller `…-473x1024.jpg`
- *    variant in `src`; pulling the full original lets convert_to_webp() do the
- *    1600px resize from a higher-quality source). Falls back to `src`, then to
- *    `data-src` for lazy-loaded markup.
- *  - `<a>` elements whose `href` points at an image extension: thumbnails
- *    wrapped in "view full size" links would otherwise leave dead off-site
- *    links in the body once the WP site is decommissioned.
- *
- * Protocol-relative URLs (`//host/path.jpg`) are treated as `https://`.
- * Multi-resolution `srcset`/`sizes` attributes are stripped once we have a
- * local copy — the WebP we wrote is already the canonical single-resolution
- * image. data-* URL hints are also dropped on success so stale absolute URLs
- * pointing at the old host don't leak back in. Failed downloads, data: URIs
- * and relative URLs are left untouched.
- *
- * @param callable(string,string):?string $downloader  ($url, $sub_path) → saved filename or null.
- */
-function rewrite_image_links(string $html, string $created, callable $downloader): string
-{
-    if (trim($html) === '') {
-        return '';
-    }
-    $dom = load_html_fragment($html);
-    rewrite_image_links_in_dom($dom, $created, $downloader);
-    return dump_html_fragment($dom);
-}
-
-/**
- * In-place version of {@see rewrite_image_links}, chained on the same DOM as
- * {@see sanitize_html_in_dom} from {@see import_item} so the two passes don't
- * each parse and serialise the body separately.
- *
- * @param callable(string,string):?string $downloader  ($url, $sub_path) → saved filename or null.
- */
-function rewrite_image_links_in_dom(DOMDocument $dom, string $created, callable $downloader): void
-{
-    $xpath = new DOMXPath($dom);
-    $sub_path = asset_dir_for_date($created);
-
-    unwrap_picture_elements($dom, $xpath);
-
-    $imgs = $xpath->query('//img[@src or @data-src or @data-full-url]') ?: [];
-    foreach ($imgs as $img) {
-        if (!$img instanceof DOMElement) {
-            continue;
-        }
-        $src = pick_image_url($img);
-        $url = normalize_image_url($src);
-        if ($url === null) {
-            continue;
-        }
-        $filename = $downloader($url, $sub_path);
-        if (!is_string($filename) || $filename === '') {
-            continue;
-        }
-        $img->setAttribute('src', asset_url($sub_path, $filename));
-        foreach (['srcset', 'sizes', 'data-src', 'data-full-url', 'data-link', 'data-orig-file'] as $stale) {
-            $img->removeAttribute($stale);
-        }
-    }
-
-    $anchors = $xpath->query('//a[@href]') ?: [];
-    foreach ($anchors as $a) {
-        if (!$a instanceof DOMElement) {
-            continue;
-        }
-        $href = $a->getAttribute('href');
-        if (!href_looks_like_image($href)) {
-            continue;
-        }
-        $url = normalize_image_url($href);
-        if ($url === null) {
-            continue;
-        }
-        $filename = $downloader($url, $sub_path);
-        if (!is_string($filename) || $filename === '') {
-            continue;
-        }
-        $a->setAttribute('href', asset_url($sub_path, $filename));
-    }
-}
-
-/**
- * Replaces every `<picture>` in the document with its descendant `<img>`
- * fallback (or a synthesised `<img>` derived from the first `<source srcset>`
- * URL when there is no `<img>` child).
- *
- * `<picture>` doesn't survive the Markdown converter — unknown HTML is kept
- * verbatim, so the post body would otherwise display raw `<source>` tags. The
- * downstream image walk only knows about `<img>`, and `<source>` URLs in
- * srcset would leak the old WP host into the body. Unwrapping here means the
- * single canonical `<img>` flows through the normal rewrite path.
- */
-function unwrap_picture_elements(DOMDocument $dom, DOMXPath $xpath): void
-{
-    $pictures = $xpath->query('//picture') ?: [];
-    foreach ($pictures as $picture) {
-        if (!$picture instanceof DOMElement || $picture->parentNode === null) {
-            continue;
-        }
-        $img = first_descendant_img($xpath, $picture)
-            ?? synthesise_img_from_source($xpath, $picture, $dom);
-        if ($img === null) {
-            $picture->parentNode->removeChild($picture);
-            continue;
-        }
-        // Detach the img from wherever it lives inside the picture before
-        // splicing the picture out — otherwise the `replaceChild` below
-        // disposes the still-attached node along with the rest of the tree.
-        $img->parentNode?->removeChild($img);
-        $picture->parentNode->replaceChild($img, $picture);
-    }
-}
-
-function first_descendant_img(DOMXPath $xpath, DOMElement $picture): ?DOMElement
-{
-    $found = $xpath->query('.//img', $picture);
-    if ($found === false) {
-        return null;
-    }
-    foreach ($found as $node) {
-        if ($node instanceof DOMElement) {
-            return $node;
-        }
-    }
-    return null;
-}
-
-function synthesise_img_from_source(DOMXPath $xpath, DOMElement $picture, DOMDocument $dom): ?DOMElement
-{
-    $sources = $xpath->query('.//source[@srcset]', $picture);
-    if ($sources === false) {
-        return null;
-    }
-    foreach ($sources as $source) {
-        if (!$source instanceof DOMElement) {
-            continue;
-        }
-        $first = first_srcset_url($source->getAttribute('srcset'));
-        if ($first === null) {
-            continue;
-        }
-        $img = $dom->createElement('img');
-        $img->setAttribute('src', $first);
-        return $img;
-    }
-    return null;
-}
-
-/**
- * Pulls the first URL out of an HTML5 `srcset` attribute. The grammar is
- * comma-separated entries of "URL [descriptor]"; we only need the URL of the
- * first entry, with everything after the first whitespace dropped.
- */
-function first_srcset_url(string $srcset): ?string
-{
-    $first = trim(explode(',', $srcset, 2)[0]);
-    if ($first === '') {
-        return null;
-    }
-    $parts = preg_split('/\s+/', $first, 2);
-    $url = $parts === false ? '' : $parts[0];
-    return $url === '' ? null : $url;
-}
-
-/**
- * Picks the best source URL for an `<img>` element: full-res variant first,
- * then the regular `src`, then lazy-load `data-src`.
- */
-function pick_image_url(DOMElement $img): string
-{
-    foreach (['data-full-url', 'src', 'data-src'] as $attr) {
-        $value = trim($img->getAttribute($attr));
-        if ($value !== '') {
-            return $value;
-        }
-    }
-    return '';
-}
-
-/**
- * Normalises a candidate image URL to an absolute http(s) form, or returns
- * null when it isn't fetchable (data: URI, relative path, empty, etc.).
- * Protocol-relative `//host/path` URLs are promoted to https.
- */
-function normalize_image_url(string $url): ?string
-{
-    $url = trim($url);
-    if ($url === '') {
-        return null;
-    }
-    if (str_starts_with($url, '//')) {
-        return 'https:' . $url;
-    }
-    $scheme = parse_url($url, PHP_URL_SCHEME);
-    if (!is_string($scheme) || !in_array(strtolower($scheme), ['http', 'https'], true)) {
-        return null;
-    }
-    return $url;
-}
-
-/**
- * Whether an anchor href appears to point at an image — used to decide if a
- * "view full size" link should also be downloaded. Conservative: only known
- * upload-pipeline extensions are accepted, query strings and fragments are
- * tolerated.
- */
-function href_looks_like_image(string $href): bool
-{
-    $path = parse_url($href, PHP_URL_PATH);
-    if (!is_string($path) || $path === '') {
-        return false;
-    }
-    $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-    return $ext !== '' && in_array($ext, IMAGE_UPLOAD_EXTENSIONS, true);
-}
-
-/**
- * Cap for how many bytes a single image download is allowed to consume.
- * A misbehaving server returning a multi-GB body with image/* Content-Type
- * would otherwise OOM the importer; truncated reads fail the WebP decode
- * cleanly, which is the right outcome.
- */
-const IMAGE_DOWNLOAD_MAX_BYTES = 20_000_000;
-
-/**
- * Default downloader used by the CLI script: fetches $url over HTTP and writes
- * it under ROOT_DIR/assets/$sub_path with a content-hash filename. JPEG/PNG
- * are re-encoded to WebP via the shared persistence helper. Returns the
- * filename relative to the subdirectory, or null on any failure.
- *
- * Idempotent: when the destination file already exists from an earlier post in
- * the same month — or from a previous interrupted run — the existing filename
- * is returned without re-fetching. The seed is sha1($url), so the same URL
- * always maps to the same on-disk name.
- */
-function default_image_downloader(string $url, string $sub_path): ?string
-{
-    if (!defined('ROOT_DIR')) {
-        return null;
-    }
-    $path = parse_url($url, PHP_URL_PATH) ?: '';
-    $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-    if ($ext === '' || !in_array($ext, IMAGE_UPLOAD_EXTENSIONS, true)) {
-        return null;
-    }
-    $dest_dir = ROOT_DIR . '/assets/' . $sub_path;
-    $seed = sha1($url);
-    foreach (["$seed.webp", "$seed.$ext"] as $existing) {
-        if (is_file("$dest_dir/$existing")) {
-            return $existing;
-        }
-    }
-    if (!is_dir($dest_dir) && !mkdir($dest_dir, 0777, true) && !is_dir($dest_dir)) {
-        return null;
-    }
-    $response = fetch($url, ['max_bytes' => IMAGE_DOWNLOAD_MAX_BYTES]);
-    if ($response === null || $response['body'] === '') {
-        return null;
-    }
-    if ($response['status'] < 200 || $response['status'] >= 300) {
-        return null;
-    }
-    if (!response_is_image($response['headers'])) {
-        return null;
-    }
-    return \Lamb\Response\persist_image_bytes($response['body'], $ext, $dest_dir, $seed);
-}
-
-/**
- * Scans raw HTTP response headers (as returned by Lamb\Http\fetch) for an
- * image/* Content-Type. Lets the downloader reject 200-OK HTML error pages,
- * CDN block pages, or login-required HTML returned for unauthenticated asset
- * URLs — situations the URL extension and status code alone don't catch.
- *
- * @param string[] $headers Raw response header lines.
- */
-function response_is_image(array $headers): bool
-{
-    foreach ($headers as $header) {
-        if (preg_match('/^content-type\s*:\s*image\//i', $header)) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/**
- * Bundles the sanitise + image-rewrite passes onto a single DOM. Used by
- * {@see import_item} to halve the parse/serialise work versus calling the two
- * public string functions back to back, and to remove a layer of round-trip
- * artifacts (entity normalisation, attribute reordering) between the two
- * stages.
- *
- * @param callable(string,string):?string $downloader  ($url, $sub_path) → saved filename or null.
- */
-function prepare_imported_html(string $html, string $created, callable $downloader): string
-{
-    if (trim($html) === '') {
-        return '';
-    }
-    $dom = load_html_fragment($html);
-    sanitize_html_in_dom($dom);
-    rewrite_image_links_in_dom($dom, $created, $downloader);
-    return dump_html_fragment($dom);
+    return import_html_to_markdown($html, ['wp-block-']);
 }
 
 /**
@@ -800,8 +213,8 @@ function import_item(array $item, callable $downloader, bool $dry_run = false): 
 
     // Sanitize and image-rewrite share one DOM so the body is parsed and
     // serialised once for these two passes (a third parse happens inside
-    // html_to_markdown for normalize_wordpress_html, which has to stay on its
-    // own DOM because of its placeholder-string substitution dance).
+    // html_to_markdown for normalize_html, which has to stay on its own DOM
+    // because of its placeholder-string substitution dance).
     $body_html = (string) ($item['content'] ?? '');
     $prepared = $body_html === ''
         ? ''
@@ -874,50 +287,5 @@ function store_source_redirect(array $item, OODBBean $bean): void
         return;
     }
 
-    $redirect = R::findOneOrDispense('redirect', ' from_slug = ? ', [$from]);
-    $redirect->from_slug = $from;
-    $redirect->to_url = $to;
-    R::store($redirect);
-}
-
-/**
- * Loads an HTML fragment into DOMDocument with UTF-8 preserved.
- *
- * Wraps the input in a full <!doctype html><html><body> tree rather than using
- * LIBXML_HTML_NOIMPLIED, because libxml's handling of top-level fragment
- * elements changed between 2.9 and 2.12: the older NOIMPLIED + sibling-div
- * trick lost the wrapper on the newer parser and the round-trip collapsed to
- * just the meta hint. The full wrap parses identically on every libxml
- * version we support. The `<?xml encoding="utf-8" ?>` processing instruction
- * forces UTF-8; without it loadHTML defaults to ISO-8859-1 and mangles
- * multibyte input.
- */
-function load_html_fragment(string $html): DOMDocument
-{
-    $dom = new DOMDocument();
-    $previous = libxml_use_internal_errors(true);
-    $dom->loadHTML(
-        '<?xml encoding="utf-8" ?><!DOCTYPE html><html><body>' . $html . '</body></html>'
-    );
-    libxml_clear_errors();
-    libxml_use_internal_errors($previous);
-    return $dom;
-}
-
-/**
- * Renders the contents of the synthesised <body> back out as an HTML fragment.
- * The original input lives as body's direct children, so we serialise each in
- * order and skip the wrapper.
- */
-function dump_html_fragment(DOMDocument $dom): string
-{
-    $body = $dom->getElementsByTagName('body')->item(0);
-    if (!$body instanceof DOMElement) {
-        return trim((string) $dom->saveHTML());
-    }
-    $out = '';
-    foreach ($body->childNodes as $child) {
-        $out .= $dom->saveHTML($child);
-    }
-    return $out;
+    store_redirect($from, $to);
 }

--- a/tests/Unit/KnownImportTest.php
+++ b/tests/Unit/KnownImportTest.php
@@ -1,0 +1,555 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+use SimpleXMLElement;
+
+use function Lamb\Import\html_to_markdown;
+use function Lamb\Import\parse_rss_string;
+use function Lamb\Import\prepare_imported_html;
+use function Lamb\Known\extract_items;
+use function Lamb\Known\import_item;
+use function Lamb\Known\known_uuid;
+use function Lamb\Known\normalize_known_html_in_dom;
+use function Lamb\Known\should_import;
+use function Lamb\Known\skip_reason;
+use function Lamb\Known\strip_structural_hashtags;
+use function Lamb\Post\split_frontmatter;
+
+/**
+ * Covers parsing, Known-specific DOM normalisation, body assembly and
+ * idempotent import for the Known CMS importer. Outbound webmentions/WebSub
+ * pings are NOT triggered because import_item() uses the low-level pipeline
+ * (populate_bean → finalize_and_store_post) which never calls
+ * notify_post_subscribers().
+ *
+ * The fixture below is minimised from the real ~445-item /home/sander/Downloads/export.rss
+ * export: a photo post (data-gallery anchor + img + duplicate enclosure), a
+ * bookmark (offsite link + unfurl-block + inline p-category anchor matching a
+ * <category>), a synthetic-title status update (both the `...`-title and
+ * `p-name` detection signals at once), a titled article whose inline hashtag
+ * duplicates its <category> tag in a different case, and one non-published
+ * item to exercise the skip path.
+ */
+class KnownImportTest extends TestCase
+{
+    private const SAMPLE_RSS = <<<'XML'
+<?xml version="1.0"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:wp="http://wordpress.org/export/1.2/">
+<channel>
+    <title>Example Notes</title>
+    <link>https://example.test/</link>
+    <item>
+        <title>Turn that frown upside down</title>
+        <link>https://example.test/2020/turn-that-frown-upside-down</link>
+        <guid>https://known.example/view/aaaa1111</guid>
+        <pubDate>Tue, 26 May 2020 12:48:16 +0000</pubDate>
+        <wp:post_type>post</wp:post_type>
+        <wp:status>publish</wp:status>
+        <dc:creator>Author</dc:creator>
+        <description><![CDATA[
+<div class="e-content entry-content" data-num-pics="1">
+    <div class="photo-view">
+        <a href="https://example.test/2020/turn-that-frown-upside-down" data-gallery="Turn that frown upside down"><img
+            src="https://example.test/file/aaaa1111/photo.png" class="u-photo"
+            alt="Turn that frown upside down"/></a>
+    </div>
+    <p>People recognise faces.</p>
+</div>
+]]></description>
+        <enclosure url="https://example.test/file/aaaa1111/photo.png" type="image/png" length="123"/>
+    </item>
+    <item>
+        <title>Fancy Zoom Calls - Example.ca</title>
+        <link>http://external.example/archives/fancy-zoom-calls</link>
+        <guid>https://known.example/view/bbbb2222</guid>
+        <pubDate>Wed, 06 May 2020 07:04:42 +0000</pubDate>
+        <wp:post_type>post</wp:post_type>
+        <wp:status>publish</wp:status>
+        <dc:creator>Author</dc:creator>
+        <description><![CDATA[<div class="known-bookmark">
+    <div class="e-content"><p>I love reading about these <a href="https://example.test/tag/remoteworking" class="p-category" rel="tag">#remoteworking</a> setups</p></div></div>
+<div class="unfurl-block" data-parent-object="bbbb2222">
+    <div class="unfurl col-md-12" style="display:none;" data-url="http://external.example/archives/fancy-zoom-calls"></div>
+    <div class="unfurl-edit pull-right small" style="display:none;">
+        <a href="#" class="refresh" title="Refresh preview">refresh</a>
+        <a href="#" class="delete" title="Remove preview">delete</a>
+    </div>
+</div>
+]]></description>
+        <category>#remoteworking</category>
+    </item>
+    <item>
+        <title>If you send email using `noreply@` then ...</title>
+        <link>https://example.test/2020/if-you-send-email-using-noreply-then</link>
+        <guid>https://known.example/view/cccc3333</guid>
+        <pubDate>Thu, 21 May 2020 08:35:53 +0000</pubDate>
+        <wp:post_type>post</wp:post_type>
+        <wp:status>publish</wp:status>
+        <dc:creator>Author</dc:creator>
+        <description><![CDATA[<p class="p-name e-content entry-content">If you send email using `noreply@` then think about why you're not having a human contact.&lt;p&gt;#status <a href="https://example.test/tag/status" class="p-category" rel="tag">#status</a>&lt;/p&gt;</p>
+]]></description>
+        <category>#status</category>
+        <category>#Uncategorized</category>
+    </item>
+    <item>
+        <title>Cuttlefish are amazing</title>
+        <link>https://example.test/2019/cuttlefish-are-amazing</link>
+        <guid>https://known.example/view/dddd4444</guid>
+        <pubDate>Sun, 04 Aug 2019 11:33:55 +0000</pubDate>
+        <wp:post_type>post</wp:post_type>
+        <wp:status>publish</wp:status>
+        <dc:creator>Author</dc:creator>
+        <description><![CDATA[
+<div class="e-content entry-content">
+<p>Look at this <a href="https://example.test/tag/Cuttlefish" class="p-category" rel="tag">#cuttlefish</a> go.</p>
+</div>
+]]></description>
+        <category>#Cuttlefish</category>
+        <category>#cuttlefish</category>
+    </item>
+    <item>
+        <title>Draft thought</title>
+        <link>https://example.test/2021/draft-thought</link>
+        <guid>https://known.example/view/eeee5555</guid>
+        <pubDate>Fri, 01 Jan 2021 00:00:00 +0000</pubDate>
+        <wp:post_type>post</wp:post_type>
+        <wp:status>draft</wp:status>
+        <dc:creator>Author</dc:creator>
+        <description><![CDATA[<p>Not published yet.</p>]]></description>
+    </item>
+</channel>
+</rss>
+XML;
+
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        global $config;
+        $config = $config ?? [];
+
+        // pubDate carries an explicit +0000 offset, so pinning to UTC makes
+        // the resulting local timestamps deterministic regardless of host TZ.
+        date_default_timezone_set('UTC');
+    }
+
+    private function sampleItems(): array
+    {
+        return extract_items(parse_rss_string(self::SAMPLE_RSS));
+    }
+
+    public function testKnownUuidIsStableForSameGuid(): void
+    {
+        $guid = 'https://known.example/view/aaaa1111';
+        $this->assertSame(md5('known-' . $guid), known_uuid($guid));
+    }
+
+    public function testParseRssStringReturnsRssElement(): void
+    {
+        $rss = parse_rss_string(self::SAMPLE_RSS);
+        $this->assertInstanceOf(SimpleXMLElement::class, $rss);
+        $this->assertSame('rss', $rss->getName());
+    }
+
+    public function testExtractItemsReturnsAllChannelItems(): void
+    {
+        $items = $this->sampleItems();
+        $this->assertCount(5, $items);
+        $this->assertSame('Turn that frown upside down', $items[0]['title']);
+        $this->assertSame('post', $items[0]['post_type']);
+        $this->assertSame('publish', $items[0]['status']);
+    }
+
+    public function testExtractItemsSetsCreatedEqualToUpdatedFromPubDate(): void
+    {
+        $items = $this->sampleItems();
+        $this->assertSame('2020-05-26 12:48:16', $items[0]['created']);
+        $this->assertSame($items[0]['created'], $items[0]['updated']);
+    }
+
+    public function testExtractItemsStripsHashLowercasesAndDedupesTags(): void
+    {
+        $items = $this->sampleItems();
+        // Two <category> tags differing only in case ("#Cuttlefish",
+        // "#cuttlefish") must collapse into a single lowercase 'cuttlefish'.
+        $this->assertSame(['cuttlefish'], $items[3]['tags']);
+    }
+
+    public function testExtractItemsDropsStructuralTags(): void
+    {
+        // 'status' marks a titleless status update (Lamb models that as a
+        // post shape, not a tag) and 'uncategorized' means no category —
+        // neither carries meaning worth importing, in any case variant.
+        $items = $this->sampleItems();
+        $this->assertSame([], $items[2]['tags']);
+    }
+
+    public function testExtractItemsReadsSlugFromOnHostLinkLeaf(): void
+    {
+        $items = $this->sampleItems();
+        $this->assertSame('turn-that-frown-upside-down', $items[0]['slug']);
+        $this->assertSame('cuttlefish-are-amazing', $items[3]['slug']);
+    }
+
+    public function testExtractItemsLeavesSlugEmptyAndSetsBookmarkUrlForOffsiteLink(): void
+    {
+        $items = $this->sampleItems();
+        $this->assertSame('', $items[1]['slug']);
+        $this->assertSame('http://external.example/archives/fancy-zoom-calls', $items[1]['bookmark_url']);
+    }
+
+    public function testExtractItemsLeavesBookmarkUrlEmptyForOnHostLinks(): void
+    {
+        $items = $this->sampleItems();
+        $this->assertSame('', $items[0]['bookmark_url']);
+        $this->assertSame('', $items[3]['bookmark_url']);
+    }
+
+    public function testExtractItemsDetectsSyntheticTitleFromEllipsisAndPName(): void
+    {
+        $items = $this->sampleItems();
+        $this->assertTrue($items[2]['title_is_synthetic']);
+    }
+
+    public function testExtractItemsDoesNotFlagRealTitlesAsSynthetic(): void
+    {
+        $items = $this->sampleItems();
+        $this->assertFalse($items[0]['title_is_synthetic']);
+        $this->assertFalse($items[3]['title_is_synthetic']);
+    }
+
+    public function testExtractItemsDetectsSyntheticTitleFromEllipsisOnly(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0"?>
+<rss version="2.0" xmlns:wp="http://wordpress.org/export/1.2/">
+<channel>
+    <link>https://example.test/</link>
+    <item>
+        <title>Tweet: so tempted to start a truth correction ac...</title>
+        <link>https://example.test/2015/tweet-so-tempted</link>
+        <guid>https://known.example/view/ffff6666</guid>
+        <pubDate>Sun, 25 Jan 2015 13:11:09 +0000</pubDate>
+        <wp:post_type>post</wp:post_type>
+        <wp:status>publish</wp:status>
+        <description><![CDATA[<div class="e-content entry-content"><p>So tempted to start a truth correction account.</p></div>]]></description>
+    </item>
+</channel>
+</rss>
+XML;
+        $items = extract_items(parse_rss_string($xml));
+        $this->assertTrue($items[0]['title_is_synthetic']);
+    }
+
+    public function testExtractItemsDetectsSyntheticTitleFromPNameOnly(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0"?>
+<rss version="2.0" xmlns:wp="http://wordpress.org/export/1.2/">
+<channel>
+    <link>https://example.test/</link>
+    <item>
+        <title>Thinking whether to renew http://example.org</title>
+        <link>https://example.test/2020/thinking-whether-to-renew</link>
+        <guid>https://known.example/view/gggg7777</guid>
+        <pubDate>Thu, 16 Jan 2020 11:40:00 +0000</pubDate>
+        <wp:post_type>post</wp:post_type>
+        <wp:status>publish</wp:status>
+        <description><![CDATA[<p class="p-name e-content entry-content">Thinking whether to renew <a href="http://example.org">http://example.org</a></p>]]></description>
+    </item>
+</channel>
+</rss>
+XML;
+        $items = extract_items(parse_rss_string($xml));
+        $this->assertTrue($items[0]['title_is_synthetic']);
+    }
+
+    public function testShouldImportRejectsNonPublishedStatus(): void
+    {
+        $items = $this->sampleItems();
+        $this->assertTrue(should_import($items[0]));
+        $this->assertFalse(should_import($items[4]));
+        $this->assertStringContainsString("non-published status 'draft'", (string) skip_reason($items[4]));
+    }
+
+    public function testNormalizeKnownHtmlRemovesUnfurlBlockEntirely(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+        $prepared = prepare_imported_html(
+            $items[1]['content'],
+            $items[1]['created'],
+            $downloader,
+            normalize_known_html_in_dom(...),
+        );
+        $markdown = html_to_markdown($prepared);
+
+        $this->assertStringNotContainsString('unfurl', $markdown);
+        $this->assertStringNotContainsString('refresh', $markdown);
+        $this->assertStringNotContainsString('<div', $markdown);
+    }
+
+    public function testNormalizeKnownHtmlReplacesCategoryAnchorWithPlainTagText(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+        $prepared = prepare_imported_html(
+            $items[1]['content'],
+            $items[1]['created'],
+            $downloader,
+            normalize_known_html_in_dom(...),
+        );
+        $markdown = html_to_markdown($prepared);
+
+        $this->assertStringContainsString('#remoteworking', $markdown);
+        $this->assertStringNotContainsString('example.test/tag', $markdown);
+        $this->assertStringNotContainsString('[#remoteworking]', $markdown);
+    }
+
+    public function testNormalizeKnownHtmlUnwrapsGalleryAnchorAndImageIsDownloaded(): void
+    {
+        $items = $this->sampleItems();
+        $downloaded = [];
+        $downloader = function (string $url) use (&$downloaded): ?string {
+            $downloaded[] = $url;
+            return 'photo123.png';
+        };
+        $prepared = prepare_imported_html(
+            $items[0]['content'],
+            $items[0]['created'],
+            $downloader,
+            normalize_known_html_in_dom(...),
+        );
+        $markdown = html_to_markdown($prepared);
+
+        $this->assertSame(['https://example.test/file/aaaa1111/photo.png'], $downloaded);
+        $this->assertStringContainsString('/assets/2020/05/photo123.png', $markdown);
+        $this->assertStringNotContainsString('example.test', $markdown);
+        $this->assertStringNotContainsString('[![', $markdown); // not still wrapped in a link
+        $this->assertStringNotContainsString('<div', $markdown);
+    }
+
+    public function testNormalizeKnownHtmlRemovesStructuralTagAnchorsAndText(): void
+    {
+        // The fixture mirrors Known's malformed trailing tag line: an escaped
+        // `&lt;p&gt;` wrapping the tag as plain '#status' text plus its
+        // p-category anchor. Neither form may survive — Lamb's tag index
+        // scans the body, so leftover text alone would re-import the tag
+        // through the back door — and the escaped paragraph itself must not
+        // decode into literal '<p>' text.
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+        $prepared = prepare_imported_html(
+            $items[2]['content'],
+            $items[2]['created'],
+            $downloader,
+            normalize_known_html_in_dom(...),
+        );
+        $markdown = strip_structural_hashtags(html_to_markdown($prepared));
+
+        $this->assertStringNotContainsString('#status', $markdown);
+        $this->assertStringNotContainsString('<p>', $markdown);
+        $this->assertStringContainsString('human contact', $markdown);
+    }
+
+    public function testImportItemBodyCarriesNoStructuralTags(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $bean = import_item($items[2], $downloader, true);
+
+        $this->assertNotNull($bean);
+        $body = strtolower((string) $bean->body);
+        $this->assertStringNotContainsString('#status', $body);
+        $this->assertStringNotContainsString('#uncategorized', $body);
+    }
+
+    public function testNormalizeKnownHtmlUnwrapsLegacyAuthoredDivs(): void
+    {
+        // Posts migrated into Known from earlier platforms carry authored
+        // wrapper divs (bare <div>, Windows Live Writer markup) that Known's
+        // own class list doesn't cover. Any div surviving conversion renders
+        // as visibly escaped HTML in Lamb's safe renderer, so the DOM pass
+        // unwraps every remaining div.
+        $html = '<div class="e-content entry-content">'
+            . '<div class="wlWriterSmartContent" style="margin:0px;"><div>'
+            . '<p>Legacy paragraph.</p>'
+            . '</div></div></div>';
+        $downloader = fn(): ?string => null;
+        $prepared = prepare_imported_html(
+            $html,
+            '2009-01-01 00:00:00',
+            $downloader,
+            normalize_known_html_in_dom(...),
+        );
+        $markdown = html_to_markdown($prepared);
+
+        $this->assertStringContainsString('Legacy paragraph.', $markdown);
+        $this->assertStringNotContainsString('<div', $markdown);
+        $this->assertStringNotContainsString('wlWriterSmartContent', $markdown);
+    }
+
+    public function testImportItemDedupesExtractedTagAgainstInlineHashtagCaseInsensitively(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $bean = import_item($items[3], $downloader, true);
+
+        $this->assertNotNull($bean);
+        // The extracted '#Cuttlefish'/'#cuttlefish' category tags must not be
+        // appended a second time — the inline "#cuttlefish" already covers it.
+        $this->assertSame(1, substr_count(strtolower((string) $bean->body), '#cuttlefish'));
+    }
+
+    public function testImportItemCreatesPostWithKnownUuidFeedNameAndDates(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $bean = import_item($items[0], $downloader, false);
+
+        $this->assertNotNull($bean);
+        $this->assertNotEmpty($bean->id);
+        $this->assertSame(known_uuid('https://known.example/view/aaaa1111'), $bean->feeditem_uuid);
+        $this->assertSame('known', $bean->feed_name);
+        $this->assertSame('2020-05-26 12:48:16', $bean->created);
+    }
+
+    public function testImportItemPinsTitleAndSlugForTitledPost(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $bean = import_item($items[0], $downloader, false);
+
+        $this->assertNotNull($bean);
+        $this->assertSame('turn-that-frown-upside-down', (string) $bean->slug);
+        $this->assertStringContainsString("title: 'Turn that frown upside down'", (string) $bean->body);
+    }
+
+    public function testImportItemLeavesTitleAndSlugEmptyForSyntheticStatusPost(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $bean = import_item($items[2], $downloader, false);
+
+        $this->assertNotNull($bean);
+        $this->assertSame('', (string) $bean->slug);
+        $this->assertStringNotContainsString('title:', (string) $bean->body);
+        $this->assertStringNotContainsString('slug:', (string) $bean->body);
+    }
+
+    public function testImportItemPrependsBookmarkLinkLineToBody(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $bean = import_item($items[1], $downloader, false);
+
+        $this->assertNotNull($bean);
+        // Bookmarks keep their title in front matter.
+        $this->assertStringContainsString("title: 'Fancy Zoom Calls - Example.ca'", (string) $bean->body);
+        [, $content] = split_frontmatter((string) $bean->body);
+        $this->assertStringStartsWith(
+            '[Fancy Zoom Calls - Example.ca](http://external.example/archives/fancy-zoom-calls)',
+            ltrim($content)
+        );
+    }
+
+    public function testImportItemStoresRedirectsForBothLinkPathAndGuidPath(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $bean = import_item($items[0], $downloader, false);
+        $this->assertNotNull($bean);
+
+        $linkRedirect = R::findOne('redirect', ' from_slug = ? ', ['2020/turn-that-frown-upside-down']);
+        $guidRedirect = R::findOne('redirect', ' from_slug = ? ', ['view/aaaa1111']);
+
+        $this->assertNotNull($linkRedirect);
+        $this->assertNotNull($guidRedirect);
+        $this->assertSame('/' . $bean->slug, (string) $linkRedirect->to_url);
+        $this->assertSame('/' . $bean->slug, (string) $guidRedirect->to_url);
+    }
+
+    public function testImportItemIsIdempotentByUuid(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $first = import_item($items[0], $downloader, false);
+        $second = import_item($items[0], $downloader, false);
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertSame($first->id, $second->id);
+        $this->assertCount(1, R::findAll('post'));
+    }
+
+    public function testImportItemDryRunStoresNothing(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $bean = import_item($items[0], $downloader, true);
+
+        $this->assertNotNull($bean);
+        $this->assertEmpty($bean->id);
+        $this->assertCount(0, R::findAll('post'));
+        $this->assertCount(0, R::findAll('redirect'));
+    }
+
+    public function testImportItemSkipsNonPublishedItems(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $bean = import_item($items[4], $downloader, false);
+
+        $this->assertNull($bean);
+        $this->assertCount(0, R::findAll('post'));
+    }
+
+    public function testAuthenticLocalExportDryRunsWhenPresent(): void
+    {
+        if (!class_exists(\League\HTMLToMarkdown\HtmlConverter::class)) {
+            $this->markTestSkipped('league/html-to-markdown is not installed');
+        }
+
+        $paths = glob(dirname(__DIR__, 2) . '/tmp/*.rss') ?: [];
+        $path = $paths[0] ?? null;
+        if ($path === null || !is_readable($path)) {
+            $this->markTestSkipped('Local authentic Known export is not present.');
+        }
+
+        $rss = parse_rss_string((string) file_get_contents($path));
+        $items = extract_items($rss);
+
+        $importable = array_values(array_filter($items, should_import(...)));
+        $this->assertCount(445, $items);
+        $this->assertCount(445, $importable);
+
+        $downloader = fn(): ?string => null;
+        foreach ($importable as $item) {
+            $this->assertNotSame('', trim((string) $item['guid']));
+            $this->assertNotSame('', trim((string) $item['created']));
+            $bean = import_item($item, $downloader, true);
+            $this->assertNotNull($bean);
+            $this->assertEmpty($bean->id);
+            $this->assertNotSame('', trim((string) $bean->body));
+        }
+
+        $this->assertCount(0, R::findAll('post'));
+    }
+}

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -6,17 +6,17 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 use SimpleXMLElement;
 
+use function Lamb\Import\asset_dir_for_date;
+use function Lamb\Import\build_post_body;
+use function Lamb\Import\response_is_image;
+use function Lamb\Import\rewrite_image_links;
+use function Lamb\Import\sanitize_html;
 use function Lamb\Response\persist_image_bytes;
-use function Lamb\WordPress\asset_dir_for_date;
-use function Lamb\WordPress\build_post_body;
 use function Lamb\WordPress\extract_items;
 use function Lamb\WordPress\html_to_markdown;
 use function Lamb\WordPress\import_item;
 use function Lamb\WordPress\parse_wxr_file;
 use function Lamb\WordPress\parse_wxr_string;
-use function Lamb\WordPress\response_is_image;
-use function Lamb\WordPress\rewrite_image_links;
-use function Lamb\WordPress\sanitize_html;
 use function Lamb\WordPress\should_import;
 use function Lamb\WordPress\wordpress_uuid;
 


### PR DESCRIPTION
## Summary

Adds a second import type for [Known CMS](https://github.com/idno/idno) RSS exports with parity to the existing WordPress importer, and extracts the CMS-agnostic ~700 lines of `src/wordpress.php` into a new shared `Lamb\Import` module (`src/import.php`) that both importers build on.

### Known importer (`import-known.php` + `src/known.php`)

- Content from `<description>`, dates from `<pubDate>`, slug from the on-host `<link>` path leaf; idempotent dedup via `md5('known-' . guid)`.
- Synthetic-title status updates (title ends `...` or body carries microformats2 `p-name`) import as native titleless Lamb statuses at `/status/<id>`.
- Bookmarks (offsite `<link>`) get a `[title](url)` markdown line prepended, mirroring Known's rendering.
- Automatic redirects from both the old `/YYYY/slug` path and the `/view/<hash>` guid path to the new permalink.
- Known markup cleanup: `unfurl-block` link-preview junk removed, tag anchors flattened to plain `#tag` text, photo gallery anchors and all wrapper divs unwrapped, Known's double-escaped trailing tag-line paragraph repaired.
- Structural tags (`#status`, `#uncategorized`) are not imported in any of their forms.

### Refactor safety

- WordPress importer dry-run output is byte-identical before and after the extraction (verified against a real 175-item WXR export).
- All 33 pre-existing WordPress import tests pass unchanged; 30 new Known tests added.

## Test plan

- `vendor/bin/codecept run Unit` — 1237 tests green
- `composer lint` / `composer analyse` — clean
- Full scratch-DB import of a real 445-item Known export, run twice: 445 created / 0 duplicated, 244 titled posts + 201 statuses, 865 redirects, zero markup or structural-tag residue

🤖 Generated with [Claude Code](https://claude.com/claude-code)