### PR TITLE
Fix stored XSS via javascript: URI in feed source_url

### DIFF
--- a/src/post.php
+++ b/src/post.php
@@ -9,6 +9,7 @@ use SimplePie\Item;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
+use function Lamb\Http\is_valid_http_url;
 use function Lamb\parse_bean;
 use function Lamb\Route\is_reserved_route;
 
@@ -43,7 +44,13 @@ function populate_bean(string $text, Item|JsonFeedItem|null $feed_item = null, ?
             $bean->feeditem_uuid = md5($feed_name . $feed_item->get_id());
             $bean->feed_name = $feed_name;
         }
-        $bean->source_url = $feed_item->get_permalink();
+        // A feed item's permalink is attacker-influenced (any feed the site
+        // subscribes to can supply it) and is later rendered into an <a href>
+        // by Theme\link_source() — reject anything that isn't a well-formed
+        // http(s) URL so a `javascript:`/other-scheme permalink can't reach
+        // that attribute unescaped for scheme.
+        $permalink = (string) $feed_item->get_permalink();
+        $bean->source_url = is_valid_http_url($permalink) ? $permalink : null;
     }
 
     parse_bean($bean);

--- a/src/theme.php
+++ b/src/theme.php
@@ -15,6 +15,7 @@ use RedBeanPHP\R;
 use RuntimeException;
 
 use function Lamb\get_tags;
+use function Lamb\Http\is_valid_http_url;
 use function Lamb\Network\get_feeds;
 use function Lamb\permalink;
 use function Lamb\Post\body_has_tag;
@@ -336,6 +337,15 @@ function link_source(OODBBean $bean): string
     $feeds = get_feeds();
 
     $url = $bean->source_url ?? $feeds[$bean->feed_name] ?? '';
+
+    // escape() only encodes HTML metacharacters, not URL schemes: a
+    // `javascript:`-scheme URL passes through untouched into the href
+    // attribute. source_url is attacker-influenced (any subscribed feed's
+    // item permalink), so require a genuine http(s) URL before linking it,
+    // matching the scheme allowlist Parsedown's safe mode applies elsewhere.
+    if (!is_valid_http_url($url)) {
+        return sprintf('Via %s', escape($bean->feed_name));
+    }
 
     return sprintf('Via <a href="%s" title="View %s">%s</a>', escape($url), escape($bean->feed_name), escape($bean->feed_name));
 }

--- a/tests/Unit/PopulateBeanTest.php
+++ b/tests/Unit/PopulateBeanTest.php
@@ -232,6 +232,22 @@ class PopulateBeanTest extends TestCase
         $this->assertSame('https://example.com/article', $bean->source_url);
     }
 
+    public function testPopulateBeanRejectsNonHttpPermalinkScheme(): void
+    {
+        // A malicious/compromised feed's permalink is rendered into an <a
+        // href> by Theme\link_source() — a javascript: URI must never reach
+        // source_url (issue: stored XSS via feed attribution link).
+        $item = $this->createMock(SimplePieItem::class);
+        $item->method('get_date')->willReturn('2024-01-01 00:00:00');
+        $item->method('get_updated_date')->willReturn('2024-01-01 00:00:00');
+        $item->method('get_id')->willReturn('test-id-xss');
+        $item->method('get_permalink')->willReturn('javascript:alert(document.cookie)');
+
+        $bean = populate_bean("Feed content", $item, 'test-feed');
+
+        $this->assertNull($bean->source_url);
+    }
+
     private function makeFeedItem(string $id): SimplePieItem
     {
         $item = $this->createMock(SimplePieItem::class);

--- a/tests/Unit/ThemeBeanTest.php
+++ b/tests/Unit/ThemeBeanTest.php
@@ -401,4 +401,20 @@ class ThemeBeanTest extends TestCase
 
         $this->assertStringContainsString('https://example.com/feed.rss', $result);
     }
+
+    public function testLinkSourceRejectsJavascriptSchemeSourceUrl(): void
+    {
+        // Defense-in-depth: even if a non-http(s) source_url reaches this
+        // point (e.g. an old row from before populate_bean() validated it),
+        // link_source() must not emit it as an href.
+        $bean = R::dispense('post');
+        $bean->feed_name = 'TestFeed';
+        $bean->source_url = 'javascript:alert(document.cookie)';
+
+        $result = link_source($bean);
+
+        $this->assertStringNotContainsString('javascript:', $result);
+        $this->assertStringNotContainsString('<a ', $result);
+        $this->assertStringContainsString('TestFeed', $result);
+    }
 }


### PR DESCRIPTION
## Summary

`populate_bean()` (`src/post.php`) stores a feed item's permalink verbatim as `post.source_url`:

```php
$bean->source_url = $feed_item->get_permalink();
```

with no scheme/host validation at all — unlike every other URL the codebase trusts for fetching or linking, which goes through `is_valid_http_url()`.

`Theme\link_source()` (`src/theme.php`) then renders it into an attribution link shown on every post listing (home, tag pages, permalinks, across all three themes):

```php
return sprintf('Via <a href="%s" title="View %s">%s</a>', escape($url), ...);
```

`escape()` is `htmlspecialchars(..., ENT_QUOTES)` — it encodes `<`, `>`, `"`, `'`, but does nothing to the URL *scheme*. A feed item whose permalink is a `javascript:` URI passes through untouched into the `href` attribute.

**Exploit:** any RSS/Atom/JSON feed the site admin subscribes to (a third-party aggregator, planet-style feed, or a feed whose host is later compromised) can set an item's permalink to `javascript:...`. On the next `/_cron` ingestion run this is stored as `post.source_url` unmodified. When the admin (or any visitor) clicks the "Via `<FeedName>`" link on the resulting post, the `javascript:` URI executes in the site's origin — with the admin's ambient session, since `HttpOnly` only blocks script access to the cookie, not ambient same-origin requests. That's enough to drive authenticated actions (create/edit/delete posts, change settings, add a malicious feed for further exploitation).

Notably, the *same* permalink is also embedded in the post body as a Markdown citation link (`[$name]($url)` in `network/ingest.php`), and that path **is** safe — it's rendered through Parsedown with `setSafeMode(true)`, whose scheme allowlist neutralizes `javascript:`. `link_source()` builds its own HTML by hand and bypasses that pipeline entirely, so this is a gap in an otherwise careful design, not a systemic escaping problem.

## Fix

- `src/post.php`: `populate_bean()` now only stores `source_url` when it's a valid http(s) URL (`Lamb\Http\is_valid_http_url()`, the same gate used everywhere else a URL is trusted); anything else is stored as `null`.
- `src/theme.php`: `link_source()` additionally validates `source_url`/the fallback feed URL before linking it, falling back to a plain (non-linked) "Via `<feed>`" attribution otherwise — defense-in-depth for any row written before this fix, or any other future write path.

## Test plan

- [x] Added `testPopulateBeanRejectsNonHttpPermalinkScheme` (`tests/Unit/PopulateBeanTest.php`) — a `javascript:` permalink is never stored
- [x] Added `testLinkSourceRejectsJavascriptSchemeSourceUrl` (`tests/Unit/ThemeBeanTest.php`) — a `javascript:` `source_url` never reaches the rendered `href`
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_