### PR TITLE
Fix missing scope check on Micropub media endpoint

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -795,6 +795,22 @@ function mp_log(string $event, array $context = []): void
  * @param string|null $scope       Scope the action requires (insufficient_scope only).
  * @param string|null $description Human-readable error description.
  */
+/**
+ * Whether a verified access-token user carries a given Micropub scope.
+ *
+ * Shared by every scope-gated Micropub action (post creation/update, and the
+ * media endpoint) so a token issued without the scope an action needs is
+ * rejected consistently.
+ *
+ * @param array{me?: mixed, scope?: list<string>}|false $user The result of verifyAccessTokenCallback().
+ * @param string                                         $scope Required scope (e.g. 'create').
+ * @return bool
+ */
+function has_micropub_scope(array|false $user, string $scope): bool
+{
+    return is_array($user) && in_array($scope, $user['scope'] ?? [], true);
+}
+
 function bearer_challenge(?string $error = null, ?string $scope = null, ?string $description = null): string
 {
     $params = [];
@@ -981,6 +997,20 @@ function respond_micropub_media(): void
             'unauthorized',
             'Invalid or expired token.',
             bearer_challenge('invalid_token', null, 'The access token is invalid or expired.')
+        );
+    }
+
+    // The base MicropubAdapter never enforces scope itself — it's left to the
+    // implementing callbacks, and createCallback()/updateCallback() both do
+    // (requiring 'create'/'update'). This endpoint is reached independently
+    // of those callbacks, so without its own check here a token issued with
+    // any scope at all (e.g. 'update'-only) could still upload files.
+    if (!has_micropub_scope($user, 'create')) {
+        micropub_error(
+            403,
+            'insufficient_scope',
+            'Your access token does not grant the scope required for this action.',
+            bearer_challenge('insufficient_scope', 'create')
         );
     }
 

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -7,6 +7,8 @@ use RedBeanPHP\R;
 use Lamb\Micropub\LambMicropubAdapter;
 use Tests\Support\StubMicropubAdapter;
 
+use function Lamb\Micropub\has_micropub_scope;
+
 class MicropubAdapterTest extends TestCase
 {
     protected function setUp(): void
@@ -1254,5 +1256,32 @@ class MicropubAdapterTest extends TestCase
         $post = R::findOne('post', ' body LIKE ? ', ['%syndicated-to%']);
         $this->assertNotNull($post, 'syndicated-to must survive a content update');
         $this->assertSame('https://bsky.app/profile/me', $post->syndicated_to);
+    }
+
+    // --- has_micropub_scope ---
+
+    public function testHasMicropubScopeTrueWhenScopePresent(): void
+    {
+        $user = ['me' => ROOT_URL . '/', 'scope' => ['create', 'update']];
+        $this->assertTrue(has_micropub_scope($user, 'create'));
+    }
+
+    public function testHasMicropubScopeFalseWhenScopeAbsent(): void
+    {
+        // Regression: the Micropub media endpoint accepted any valid token
+        // regardless of scope, unlike createCallback()/updateCallback().
+        $user = ['me' => ROOT_URL . '/', 'scope' => ['update']];
+        $this->assertFalse(has_micropub_scope($user, 'create'));
+    }
+
+    public function testHasMicropubScopeFalseWhenNoScopeKey(): void
+    {
+        $user = ['me' => ROOT_URL . '/'];
+        $this->assertFalse(has_micropub_scope($user, 'create'));
+    }
+
+    public function testHasMicropubScopeFalseForFailedToken(): void
+    {
+        $this->assertFalse(has_micropub_scope(false, 'create'));
     }
 }


### PR DESCRIPTION
## Summary

`Taproot\MicropubAdapter` (the base class `LambMicropubAdapter` extends) never enforces OAuth scope itself — that's left entirely to the implementing callbacks. This codebase's own `createCallback()` and `updateCallback()` do it correctly:

```php
// createCallback()
$scope = $this->user['scope'] ?? [];
if ($this->user !== null && !in_array('create', $scope)) {
    return $this->insufficientScopeResponse('create');
}
```

`respond_micropub_media()` (`src/micropub.php`), the standalone Micropub media-upload route, is reached independently of those callbacks — and only checked that the bearer token introspected to the site's own `me`:

```php
$user = $adapter->verifyAccessTokenCallback($token);
if (!$user) { ... 401 ... }
// (no scope check — straight into $_FILES['file'] handling)
```

**Impact:** if the site owner authorizes a third-party Micropub client with a narrower-scoped token (e.g. `update`-only, or an identity-only token some IndieAuth flows issue), that token — despite never being granted `create`/media privileges — can still `POST` directly to `/micropub-media` with a `file` field and successfully store it, returning `201 Location: <url>`. That breaks least-privilege: a compromised or otherwise-untrusted "read/update-only" integration can use the site as file storage (subject to the existing extension allowlist).

## Fix

Add `has_micropub_scope()`, a small shared predicate mirroring the check `createCallback()`/`updateCallback()` already perform, and require `create` scope in `respond_micropub_media()` before accepting an upload — returning the same RFC 6750 `insufficient_scope` 403 + `WWW-Authenticate` challenge the class callbacks use.

## Test plan

- [x] Added `testHasMicropubScopeFalseWhenScopeAbsent` (regression for this bug) plus coverage for present/missing-key/failed-token cases (`tests/Unit/MicropubAdapterTest.php`)
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

Note: `respond_micropub_media()` itself isn't unit-tested end-to-end (it writes headers/exits directly, like `respond_webmention()` elsewhere in this codebase) — `has_micropub_scope()` is factored out specifically so the scope logic it uses is directly testable, matching how `verify_and_store()` is tested separately from its `respond_webmention()` wrapper.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_