### PR TITLE
Fix predictable upload filenames causing silent overwrite

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -557,7 +557,11 @@ class LambMicropubAdapter extends MicropubAdapter
             }
             $sub_path  = \Lamb\Response\upload_subpath();
             $uploadDir = \Lamb\Response\get_upload_dir($sub_path);
-            $seed      = sha1($file->getClientFilename() ?? uniqid('', true));
+            // Always salt with uniqid(), not only when the client filename is
+            // absent — otherwise two uploads sharing a client filename in the
+            // same month collide and the later one silently overwrites the
+            // earlier, already-published one on disk.
+            $seed      = sha1(($file->getClientFilename() ?? '') . uniqid('', true));
 
             $filename = \Lamb\Response\persist_image_bytes(
                 (string) $file->getStream(),

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -50,7 +50,11 @@ function respond_upload(array $_args): void
             die();
         }
         $temp_fp  = $f['tmp_name'];
-        $seed     = sha1($f['name']);
+        // Salt with uniqid() so two uploads with the same client-supplied
+        // filename in the same month don't collide on disk — without this,
+        // an attacker-controlled filename can silently overwrite an earlier,
+        // already-published upload at the same path.
+        $seed     = sha1($f['name'] . uniqid('', true));
         $sub_path = upload_subpath();
         $dir      = get_upload_dir($sub_path);
 

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -616,6 +616,36 @@ class MicropubAdapterTest extends TestCase
         $this->assertMatchesRegularExpression('/!\[.*\]\(.+\.jpg\)/', $post->body);
     }
 
+    public function testUploadedPhotosWithSameClientFilenameDoNotCollide(): void
+    {
+        // Regression: the on-disk filename was sha1(client filename) with no
+        // salt, so two uploads sharing a client filename in the same month
+        // silently overwrote each other.
+        $adapter = new LambMicropubAdapter();
+
+        $makeUpload = function (): \Nyholm\Psr7\UploadedFile {
+            $tmpFile = tempnam(sys_get_temp_dir(), 'micropub_test_');
+            file_put_contents($tmpFile, 'fake image data ' . uniqid());
+            return new \Nyholm\Psr7\UploadedFile($tmpFile, 15, UPLOAD_ERR_OK, 'photo.jpg', 'image/jpeg');
+        };
+
+        $first = $adapter->createCallback(
+            ['type' => ['h-entry'], 'properties' => ['content' => ['First post']]],
+            ['photo' => $makeUpload()]
+        );
+        $second = $adapter->createCallback(
+            ['type' => ['h-entry'], 'properties' => ['content' => ['Second post']]],
+            ['photo' => $makeUpload()]
+        );
+
+        preg_match('/!\[.*\]\((.+\.jpg)\)/', R::findOne('post', ' body LIKE ? ', ['%First post%'])->body, $m1);
+        preg_match('/!\[.*\]\((.+\.jpg)\)/', R::findOne('post', ' body LIKE ? ', ['%Second post%'])->body, $m2);
+
+        $this->assertNotEmpty($m1[1] ?? null);
+        $this->assertNotEmpty($m2[1] ?? null);
+        $this->assertNotSame($m1[1], $m2[1], 'uploads with the same client filename must not collide on disk');
+    }
+
     public function testCreateCallbackWithDraftPostStatusSavesAsDraft(): void
     {
         $adapter = new LambMicropubAdapter();


### PR DESCRIPTION
## Summary

The on-disk name for an uploaded image is `{seed}.{ext}` under `src/assets/{Y}/{m}/` (`get_upload_dir()`/`upload_subpath()` in `src/response/upload.php`). Two of the three upload paths derive `$seed` **solely** from the client-supplied filename, with no random component:

- `src/response/upload.php:53` (`respond_upload()`, the web dropzone upload): `$seed = sha1($f['name']);`
- `src/micropub.php:560` (`saveUploadedPhotos()`, Micropub create with an inline photo): `$seed = sha1($file->getClientFilename() ?? uniqid('', true));` — only salts when the client filename is *absent*.

Compare the third, correct sibling: `respond_micropub_media()` (`src/micropub.php:1003`) — `$seed = sha1(($file['name'] ?? '') . uniqid('', true));` — always salts.

**Impact:** the client filename is fully attacker/user-controlled (e.g. `photo.jpg`). Any later upload in the same UTC month that is *also* named `photo.jpg` computes the identical seed and **silently overwrites** the earlier file at the same path — retroactively changing the image embedded in an older, already-published (and possibly syndicated/cached-elsewhere) post, without touching that post's own database row at all. This requires authentication (a logged-in session, or a Micropub token with `create` scope), so it's a content-integrity/defacement issue rather than an auth bypass — but it's concrete and trivially reproducible (just upload two files named the same thing).

## Fix

Salt both seeds with `uniqid()`, matching the media endpoint's existing pattern, so two uploads never collide regardless of client filename.

## Test plan

- [x] Added `testUploadedPhotosWithSameClientFilenameDoNotCollide` (`tests/Unit/MicropubAdapterTest.php`) — two Micropub-create uploads sharing a client filename resolve to different stored URLs
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_