### PR TITLE
Fix decompression-bomb DoS in image upload

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -18,6 +18,13 @@ define('IMAGE_FILES', 'imageFiles');
 define('IMAGE_UPLOAD_EXTENSIONS', ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif']);
 // Video extensions accepted for upload; browsers decode these containers natively.
 define('VIDEO_UPLOAD_EXTENSIONS', ['mp4', 'webm', 'mov']);
+// Upper bound on a source image's declared width*height before WebP conversion
+// decodes it. GD allocates the full pixel buffer as soon as it decodes an
+// image's header, before any of this app's own downscaling runs — a small
+// file can declare an enormous width/height ("decompression bomb") and force
+// a multi-gigabyte allocation. 40 megapixels comfortably covers any real
+// photo or screenshot while capping the worst case.
+define('MAX_UPLOAD_PIXELS', 40_000_000);
 // Seconds before a single feed fetch is abandoned during /_cron ingestion.
 define('FEED_FETCH_TIMEOUT', 15);
 define('MINUTE_IN_SECONDS', 60);

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -236,6 +236,16 @@ function convert_to_webp_from_bytes(string $bytes, string $dest_path, int $quali
         return false;
     }
 
+    // Reject an oversized declared width*height before decoding: a cheap
+    // header-only read via getimagesizefromstring(), ahead of the actual
+    // (memory-hungry) decode in imagecreatefromstring() below. A source that
+    // getimagesizefromstring() can't parse is left to imagecreatefromstring()
+    // itself, unchanged from prior behaviour.
+    $size = @getimagesizefromstring($bytes);
+    if (is_array($size) && $size[0] > 0 && $size[1] > 0 && $size[0] * $size[1] > MAX_UPLOAD_PIXELS) {
+        return false;
+    }
+
     $image = @imagecreatefromstring($bytes);
     if ($image === false) {
         return false;

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 use function Lamb\Response\asset_url;
 use function Lamb\Response\convert_to_webp;
+use function Lamb\Response\convert_to_webp_from_bytes;
 use function Lamb\Response\get_upload_dir;
 use function Lamb\Response\safe_upload_extension;
 use function Lamb\Response\upload_subpath;
@@ -294,6 +295,50 @@ class UploadTest extends TestCase
 
         $this->assertFalse(convert_to_webp($src, $dest));
         $this->assertFileDoesNotExist($dest);
+    }
+
+    public function testConvertRejectsDeclaredDimensionsOverPixelCap(): void
+    {
+        // Decompression-bomb guard: a PNG whose IHDR declares an enormous
+        // width/height forces GD to allocate the full pixel buffer as soon as
+        // imagecreatefromstring() decodes it — before this app's own
+        // downscaling ever runs. A tiny file with a huge *declared* size (no
+        // real pixel data needed) must be rejected via the header-only
+        // getimagesizefromstring() check, without ever reaching that decode.
+        $bytes = $this->makeFakePngHeader(20000, 20000);
+        $dest = $this->tempRootDir . '/bomb.webp';
+
+        $this->assertFalse(convert_to_webp_from_bytes($bytes, $dest));
+        $this->assertFileDoesNotExist($dest);
+    }
+
+    public function testConvertAllowsDeclaredDimensionsWithinPixelCap(): void
+    {
+        // A real, fully-formed image at a below-cap size still converts —
+        // the guard only rejects the declared size, not real uploads.
+        $src = $this->makePng(40, 30);
+        $dest = $this->tempRootDir . '/ok.webp';
+
+        $this->assertTrue(convert_to_webp_from_bytes((string) file_get_contents($src), $dest));
+        $this->assertFileExists($dest);
+    }
+
+    /**
+     * Builds a minimal well-formed PNG (correct signature, IHDR with valid
+     * CRC, IEND) declaring the given width/height — enough for
+     * getimagesizefromstring() to report those dimensions — with no real
+     * pixel data, so it never risks actually allocating a huge buffer even if
+     * the pixel-count guard under test were absent.
+     */
+    private function makeFakePngHeader(int $width, int $height): string
+    {
+        $signature = "\x89PNG\r\n\x1a\n";
+        // bit depth 8, color type 2 (truecolor), compression/filter/interlace 0.
+        $ihdrData = pack('NN', $width, $height) . pack('C5', 8, 2, 0, 0, 0);
+        $ihdrChunk = pack('N', strlen($ihdrData)) . 'IHDR' . $ihdrData . pack('N', crc32('IHDR' . $ihdrData));
+        $iendChunk = pack('N', 0) . 'IEND' . pack('N', crc32('IEND'));
+
+        return $signature . $ihdrChunk . $iendChunk;
     }
 
     // scaled_dimensions — downscale large uploads to a sane maximum edge


### PR DESCRIPTION
## Summary

`convert_to_webp_from_bytes()` (`src/response/upload.php`) — reached from all three upload paths (the web dropzone `respond_upload()`, Micropub create with an inline photo, and the Micropub media endpoint) — calls `imagecreatefromstring($bytes)` before this app's own downscaling logic (`scaled_dimensions()`) ever runs:

```php
$image = @imagecreatefromstring($bytes);   // decodes the full pixel buffer per declared width/height
...
[$new_width, $new_height] = scaled_dimensions(imagesx($image), imagesy($image), $max_dimension);   // downscaling happens *after*
```

GD allocates memory for the entire pixel buffer based on the image's **declared** width/height as soon as it decodes the header — the app's own downscale limit doesn't help, because it only runs after that allocation already happened. A small, well-under-the-upload-size-limit file whose header declares e.g. 30000×30000 pixels (minimal actual compressed data required) forces GD to attempt a multi-gigabyte allocation for a single request.

**Impact:** authenticated only (session or Micropub token with `create` scope — see #511 for a related gap in that check), but a single small upload can exhaust `memory_limit` (500 error) or, on a small self-hosted VPS with a generous/unbounded memory limit, degrade the whole box. Given this project explicitly targets small self-hosted instances, that's a real resource-exhaustion risk from routine authenticated use, not just a theoretical one.

## Fix

Reject an oversized declared `width * height` using `getimagesizefromstring()` — a cheap, header-only read that doesn't allocate a pixel buffer — before ever calling `imagecreatefromstring()`. The cap (`MAX_UPLOAD_PIXELS`, 40 megapixels) comfortably covers any real photo or screenshot. A source `getimagesizefromstring()` can't parse falls through to `imagecreatefromstring()` unchanged, preserving existing behavior for that case (it already fails safely there).

## Test plan

- [x] Added `testConvertRejectsDeclaredDimensionsOverPixelCap` — a hand-built, correctly-CRC'd PNG header declaring 20000×20000 pixels (no real pixel data, so the test itself never risks a large allocation) is rejected without reaching `imagecreatefromstring()`
- [x] Added `testConvertAllowsDeclaredDimensionsWithinPixelCap` — a normal below-cap image still converts (`tests/Unit/UploadTest.php`)
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_