### PR TITLE
Fix draft/scheduled/trashed post existence oracle via webmention target

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -586,6 +586,29 @@ function is_viewable(OODBBean $post): bool
 }
 
 /**
+ * Returns true for a post an anonymous visitor may see: not draft, not
+ * deleted, and not scheduled for the future. The in-memory counterpart to
+ * visible_clause() (the SQL allow-list for listings), for callers that
+ * already have a loaded bean.
+ *
+ * Deliberately has no logged-in exception, unlike is_viewable(): it's for
+ * request paths where the caller's identity isn't the site's own logged-in
+ * session (an inbound webmention POST, /_cron) — a session cookie that
+ * happens to be present must not leak a hidden post's existence to whichever
+ * party is actually making the request.
+ *
+ * @param OODBBean $post The post to inspect (an unsaved/missing bean has id 0).
+ * @return bool
+ */
+function is_publicly_visible(OODBBean $post): bool
+{
+    if (empty($post->id) || $post->deleted == 1 || $post->draft == 1) {
+        return false;
+    }
+    return !is_scheduled($post);
+}
+
+/**
  * Returns true when the supplied preview token grants access to an
  * unpublished post's permalink.
  *

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -113,7 +113,15 @@ function verify_and_store(string $source, string $target, ?callable $fetcher = n
  * Resolve a target URL to the id of the Lamb post it points at.
  *
  * Returns null when the host is not ours, the path is not a recognised post
- * URL, or no matching post exists.
+ * URL, no matching post exists, or the matching post isn't publicly visible
+ * (a draft, a scheduled post, or a trashed one). The visibility check uses
+ * is_publicly_visible(), not is_viewable(): POST /webmention is unauthenticated
+ * and driven by whichever remote party sends the request, not by the site's
+ * own logged-in session, so a hidden post must 404 here exactly as it does
+ * for an anonymous permalink visit — otherwise an attacker could use the
+ * differing responses to enumerate draft/scheduled/trashed post ids that
+ * don't otherwise exist as far as an anonymous visitor can tell, and attach
+ * an unmoderated mention to a post before it's ever published.
  *
  * @param string $target
  * @return int|null
@@ -128,8 +136,11 @@ function target_post_id(string $target): ?int
 
     $path = parse_url($target, PHP_URL_PATH) ?: '';
     $bean = \Lamb\find_post_by_path($path);
+    if ($bean === null || !\Lamb\is_publicly_visible($bean)) {
+        return null;
+    }
 
-    return $bean !== null ? (int) $bean->id : null;
+    return (int) $bean->id;
 }
 
 /**

--- a/tests/Unit/PostVisibilityTest.php
+++ b/tests/Unit/PostVisibilityTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\is_publicly_visible;
 use function Lamb\is_viewable;
 use function Lamb\Response\respond_post;
 use function Lamb\Response\respond_status;
@@ -96,6 +97,43 @@ class PostVisibilityTest extends TestCase
     {
         $bean = R::load('post', 999999);
         $this->assertFalse(is_viewable($bean));
+    }
+
+    // ---- is_publicly_visible() predicate -----------------------------------
+    // Unlike is_viewable(), has no logged-in exception: used by request paths
+    // (webmention receiving) where a session cookie isn't the caller's own.
+
+    public function testPubliclyVisiblePostIsVisible(): void
+    {
+        $bean = $this->makePost([]);
+        $this->assertTrue(is_publicly_visible($bean));
+    }
+
+    public function testDeletedPostIsNeverPubliclyVisibleEvenWhenLoggedIn(): void
+    {
+        $bean = $this->makePost(['deleted' => 1]);
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertFalse(is_publicly_visible($bean));
+    }
+
+    public function testDraftIsNeverPubliclyVisibleEvenWhenLoggedIn(): void
+    {
+        $bean = $this->makePost(['draft' => 1]);
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertFalse(is_publicly_visible($bean), 'a logged-in session must not affect this predicate');
+    }
+
+    public function testScheduledIsNeverPubliclyVisibleEvenWhenLoggedIn(): void
+    {
+        $bean = $this->makePost(['created' => date('Y-m-d H:i:s', time() + 86400)]);
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertFalse(is_publicly_visible($bean));
+    }
+
+    public function testMissingPostIsNotPubliclyVisible(): void
+    {
+        $bean = R::load('post', 999999);
+        $this->assertFalse(is_publicly_visible($bean));
     }
 
     // ---- respond_status (/status/<id>) ------------------------------------

--- a/tests/Unit/WebmentionTest.php
+++ b/tests/Unit/WebmentionTest.php
@@ -69,6 +69,42 @@ class WebmentionTest extends TestCase
         $this->assertNull(target_post_id(ROOT_URL . '/status/999999'));
     }
 
+    public function testTargetPostIdRejectsDraftPost(): void
+    {
+        // Regression: an unauthenticated webmention POST must not be able to
+        // tell a draft apart from a nonexistent post — both must resolve to
+        // null, matching how an anonymous permalink visit 404s on a draft.
+        $id = $this->makePost();
+        $bean = R::load('post', $id);
+        $bean->draft = 1;
+        R::store($bean);
+
+        $this->assertNull(target_post_id(ROOT_URL . '/status/' . $id));
+    }
+
+    public function testTargetPostIdRejectsScheduledPost(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Hello world';
+        $bean->transformed = '<p>Hello world</p>';
+        $bean->created = date('Y-m-d H:i:s', strtotime('+1 day'));
+        $bean->updated = '2026-01-01 00:00:00';
+        $bean->version = 1;
+        $id = (int) R::store($bean);
+
+        $this->assertNull(target_post_id(ROOT_URL . '/status/' . $id));
+    }
+
+    public function testTargetPostIdRejectsTrashedPost(): void
+    {
+        $id = $this->makePost();
+        $bean = R::load('post', $id);
+        $bean->deleted = 1;
+        R::store($bean);
+
+        $this->assertNull(target_post_id(ROOT_URL . '/status/' . $id));
+    }
+
     // source_mentions_target ------------------------------------------------
 
     public function testSourceMentionsTargetMatchesHref(): void
@@ -129,6 +165,24 @@ class WebmentionTest extends TestCase
         $this->assertSame($target, $wm->target);
         $this->assertSame($id, (int) $wm->post_id);
         $this->assertNotEmpty($wm->verified_at);
+    }
+
+    public function testVerifyRejectsMentionOnDraftPostEvenWhenSourceLinksIt(): void
+    {
+        // Regression: a webmention must not be attachable to a draft before
+        // it's ever published, and the response must be indistinguishable
+        // from "no such post" (both 400 "target is not a valid post").
+        $id = $this->makePost();
+        $bean = R::load('post', $id);
+        $bean->draft = 1;
+        R::store($bean);
+
+        $target = ROOT_URL . '/status/' . $id;
+        $html = '<a href="' . $target . '">re</a>';
+
+        $res = verify_and_store('https://other.example/reply', $target, fn () => $html);
+        $this->assertSame(400, $res['status']);
+        $this->assertSame(0, R::count('webmention'));
     }
 
     public function testVerifyDeduplicatesOnRepeat(): void


### PR DESCRIPTION
## Summary

Every public-facing post lookup in this codebase deliberately gates through `is_viewable()` or `visible_clause()` — direct permalinks, feeds, search, tag pages. `target_post_id()` (`src/webmention.php`), which resolves a webmention's `target` URL to a post id, was the one exception: it loaded the post unconditionally, with no visibility check at all.

```php
function target_post_id(string $target): ?int
{
    ...
    $bean = \Lamb\find_post_by_path($path);
    return $bean !== null ? (int) $bean->id : null;   // no draft/scheduled/deleted check
}
```

`POST /webmention` is unauthenticated (`respond_webmention()`). `verify_and_store()` produces two distinguishable 400 responses depending on whether a target id/slug resolves to a real row at all:

- `target=<real but hidden post>` → `"source does not link to target"` (post exists, mention just wasn't verified)
- `target=<nonexistent id>` → `"target is not a valid post on this site"` (no such row)

By diffing those, an unauthenticated caller can enumerate which `/status/<id>` values or slugs correspond to a real **draft, scheduled, or trashed** post — even though that same id 404s everywhere else in the app for an anonymous visitor. That undermines the "an unpublished post doesn't exist as far as an anonymous visitor can tell" guarantee the rest of the codebase maintains carefully (`visible_clause()`'s own docblock references a prior bug where scheduled posts leaked into related posts, showing this is an actively-maintained invariant).

It's also not just an oracle: because a verified mention has no moderation gate (`webmentions_for_post()` only filters on `verified_at IS NOT NULL`, not on any pending/approved status), an attacker can pre-attach a fabricated mention — with author/content scraped from their own page — to a draft or scheduled post before the author ever publishes it. That mention renders on the post's `_webmentions` partial the moment the post goes public, with no review step.

## Fix

Add `is_publicly_visible()` (`src/lamb.php`) — the in-memory counterpart to `visible_clause()` for callers that already have a loaded bean — and use it in `target_post_id()`.

This is deliberately **not** `is_viewable()`, which trusts a logged-in session as a preview exception. That's the wrong check here: `/webmention` (and `/_cron`, which processes the outbound queue) isn't driven by the site's own session — a cookie that happens to be present shouldn't affect what a remote, unauthenticated party can infer. `process_outbound_row()` already documents exactly this rationale for the same reason ("This deliberately does not use `is_viewable()`... a logged-in author hitting `/_cron` must not leak drafts") — `is_publicly_visible()` makes that same principle reusable and applies it consistently to the receiving side too.

## Test plan

- [x] Added `is_publicly_visible()` coverage (`tests/Unit/PostVisibilityTest.php`): published/deleted/draft/scheduled/missing, including confirming a logged-in session does **not** change the result (unlike `is_viewable()`)
- [x] Added `testTargetPostIdRejectsDraftPost`/`RejectsScheduledPost`/`RejectsTrashedPost` and `testVerifyRejectsMentionOnDraftPostEvenWhenSourceLinksIt` (`tests/Unit/WebmentionTest.php`)
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_