### PR TITLE
Fix SSRF in WordPress importer image downloader

### DIFF
--- a/src/http.php
+++ b/src/http.php
@@ -179,6 +179,88 @@ function is_valid_http_url(string $url): bool
 }
 
 /**
+ * Whether an IP address is loopback, link-local, or a private/reserved range
+ * (RFC 1918, RFC 4193, the IPv4 link-local block that also covers the common
+ * cloud metadata address 169.254.169.254, etc.).
+ *
+ * @param string $ip
+ * @return bool
+ */
+function is_private_ip(string $ip): bool
+{
+    return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false;
+}
+
+/**
+ * Resolve a hostname to its IP addresses (A + AAAA records).
+ *
+ * Split out so {@see is_public_http_url} can be unit-tested with a fake
+ * resolver instead of depending on live DNS.
+ *
+ * @param string $host
+ * @return string[] Resolved IPs, or an empty array when resolution fails.
+ */
+function resolve_host_ips(string $host): array
+{
+    $records = @dns_get_record($host, DNS_A + DNS_AAAA);
+    if (is_array($records) && $records !== []) {
+        return array_values(array_filter(array_map(
+            fn($record) => $record['ip'] ?? $record['ipv6'] ?? null,
+            $records
+        )));
+    }
+
+    // dns_get_record() can be disabled/restricted in some environments;
+    // gethostbyname() is IPv4-only but covers that gap.
+    $ipv4 = @gethostbyname($host);
+    return $ipv4 !== false && $ipv4 !== $host ? [$ipv4] : [];
+}
+
+/**
+ * Whether a URL is safe to fetch: an absolute http(s) URL whose host resolves
+ * only to public, routable addresses.
+ *
+ * This closes an SSRF hole in {@see is_valid_http_url}, which only checks
+ * that a URL is well-formed http(s) — it accepts `http://127.0.0.1/`,
+ * `http://169.254.169.254/`, `http://10.0.0.1/`, etc. Anywhere a URL is
+ * attacker-influenced and this server will make a request to it on the
+ * attacker's behalf (webmention source verification, discovered webmention
+ * endpoints, feed fetches), the resolved destination — not just the URL's
+ * syntax — must be checked, since it's the destination that reaches internal
+ * services. Must be re-checked after every redirect hop for the same reason.
+ *
+ * @param string        $url
+ * @param callable|null $resolver fn(string $host): string[] — defaults to {@see resolve_host_ips}.
+ * @return bool
+ */
+function is_public_http_url(string $url, ?callable $resolver = null): bool
+{
+    if (!is_valid_http_url($url)) {
+        return false;
+    }
+
+    $host = (string) parse_url($url, PHP_URL_HOST);
+
+    if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+        return !is_private_ip($host);
+    }
+
+    $resolver ??= __NAMESPACE__ . '\\resolve_host_ips';
+    $ips = $resolver($host);
+    if ($ips === []) {
+        return false;
+    }
+
+    foreach ($ips as $ip) {
+        if (is_private_ip($ip)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
  * Extract the status code from an HTTP status line.
  *
  * Accepts status lines with or without a reason phrase ("HTTP/1.1 200 OK"
@@ -259,4 +341,101 @@ function fetch(string $url, array $opts = []): ?array
     $headers = $http_response_header;
 
     return ['status' => parse_status_line($headers[0] ?? ''), 'headers' => $headers, 'body' => $body];
+}
+
+/**
+ * Read the `Location` header from a response's raw header lines.
+ *
+ * @param string[] $headers
+ * @return string|null
+ */
+function response_location(array $headers): ?string
+{
+    foreach ($headers as $header) {
+        if (preg_match('/^location:\s*(.*)$/i', $header, $m)) {
+            return trim($m[1]);
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Resolve a possibly-relative redirect `Location` against the URL it came from.
+ *
+ * @param string $base
+ * @param string $location
+ * @return string
+ */
+function resolve_redirect_location(string $base, string $location): string
+{
+    if ($location === '' || parse_url($location, PHP_URL_SCHEME) !== null) {
+        return $location;
+    }
+
+    $scheme = parse_url($base, PHP_URL_SCHEME) ?: 'https';
+    $host = parse_url($base, PHP_URL_HOST) ?: '';
+    $port = parse_url($base, PHP_URL_PORT);
+    $authority = $scheme . '://' . $host . ($port ? ':' . $port : '');
+
+    if (str_starts_with($location, '//')) {
+        return $scheme . ':' . $location;
+    }
+    if (str_starts_with($location, '/')) {
+        return $authority . $location;
+    }
+
+    $path = parse_url($base, PHP_URL_PATH) ?: '/';
+    $dir = rtrim(substr($path, 0, strrpos($path, '/') + 1), '/');
+
+    return $authority . $dir . '/' . $location;
+}
+
+/**
+ * Fetch a URL like {@see fetch}, but only from public, non-internal addresses
+ * (see {@see is_public_http_url}), re-validating the destination on every
+ * redirect hop instead of trusting PHP's automatic `follow_location`.
+ *
+ * A remote server that responds fine on the first request but redirects to
+ * a loopback/private address is exactly the SSRF bypass this closes: without
+ * per-hop validation, `follow_location` would transparently fetch the
+ * internal address and only the (already-validated) first URL would ever be
+ * checked. Used for every URL that is attacker-influenced and fetched on the
+ * attacker's behalf (webmention source verification, discovered webmention
+ * endpoints, feed sources).
+ *
+ * @param string               $url
+ * @param array<string, mixed> $opts         Same as {@see fetch}; `follow_location`/`max_redirects` are ignored.
+ * @param int                  $max_redirects
+ * @param callable|null        $resolver     Passed through to {@see is_public_http_url}.
+ * @return array{status:int, headers:string[], body:string}|null Null when the URL (or any redirect hop) is unsafe or unreachable.
+ */
+function fetch_guarded(string $url, array $opts = [], int $max_redirects = 5, ?callable $resolver = null): ?array
+{
+    $opts['follow_location'] = 0;
+    $opts['max_redirects'] = null;
+
+    for ($hop = 0; $hop <= $max_redirects; $hop++) {
+        if (!is_public_http_url($url, $resolver)) {
+            return null;
+        }
+
+        $result = fetch($url, $opts);
+        if ($result === null) {
+            return null;
+        }
+
+        if ($result['status'] < 300 || $result['status'] >= 400) {
+            return $result;
+        }
+
+        $location = response_location($result['headers']);
+        if ($location === null) {
+            return $result;
+        }
+
+        $url = resolve_redirect_location($url, $location);
+    }
+
+    return null;
 }

--- a/src/http.php
+++ b/src/http.php
@@ -213,7 +213,7 @@ function resolve_host_ips(string $host): array
     // dns_get_record() can be disabled/restricted in some environments;
     // gethostbyname() is IPv4-only but covers that gap.
     $ipv4 = @gethostbyname($host);
-    return $ipv4 !== false && $ipv4 !== $host ? [$ipv4] : [];
+    return $ipv4 !== $host ? [$ipv4] : [];
 }
 
 /**

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -8,6 +8,8 @@ use JetBrains\PhpStorm\NoReturn;
 use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
 
+use function Lamb\Http\fetch_guarded;
+use function Lamb\Http\is_public_http_url;
 use function Lamb\Http\is_valid_http_url;
 use function Lamb\is_scheduled;
 use function Lamb\permalink;
@@ -206,7 +208,10 @@ function extract_meta(string $html): array
  */
 function fetch_source(string $url): ?string
 {
-    $result = \Lamb\Http\fetch($url, [
+    // $url is attacker-controlled (the `source` of an unauthenticated
+    // webmention POST): use the SSRF-safe fetcher, which rejects loopback/
+    // private/link-local destinations and re-checks every redirect hop.
+    $result = fetch_guarded($url, [
         'headers' => ['Accept: text/html, */*', 'User-Agent: Lamb-Webmention'],
         'timeout' => WEBMENTION_FETCH_TIMEOUT,
     ]);
@@ -538,9 +543,10 @@ function reconcile_resends_on_restore(int $post_id): int
  * @param callable|null $fetcher
  * @param callable|null $sender
  * @param int           $limit Maximum rows to process per run.
+ * @param callable|null $resolver Passed through to {@see is_public_http_url} for the discovered-endpoint SSRF check; injectable for testing.
  * @return array{sent:int, failed:int, skipped:int, cancelled:int}
  */
-function process_outbound(?callable $fetcher = null, ?callable $sender = null, int $limit = 20): array
+function process_outbound(?callable $fetcher = null, ?callable $sender = null, int $limit = 20, ?callable $resolver = null): array
 {
     $fetcher ??= __NAMESPACE__ . '\\fetch_target';
     $sender ??= __NAMESPACE__ . '\\send_webmention';
@@ -549,7 +555,7 @@ function process_outbound(?callable $fetcher = null, ?callable $sender = null, i
     $rows = R::find('webmentionoutbox', ' status = ? ORDER BY created ASC LIMIT ? ', ['pending', $limit]);
 
     foreach ($rows as $row) {
-        $outcome = process_outbound_row($row, $fetcher, $sender);
+        $outcome = process_outbound_row($row, $fetcher, $sender, $resolver);
         if ($outcome !== null) {
             $stats[$outcome]++;
         }
@@ -567,12 +573,13 @@ function process_outbound(?callable $fetcher = null, ?callable $sender = null, i
  * scheduled, so it is left pending and untouched (no attempt counted, no store)
  * until publication.
  *
- * @param OODBBean $row
- * @param callable $fetcher fn(string $url): ?array{headers: string[], body: string}
- * @param callable $sender  fn(string $endpoint, string $source, string $target): int
+ * @param OODBBean      $row
+ * @param callable      $fetcher  fn(string $url): ?array{headers: string[], body: string}
+ * @param callable      $sender   fn(string $endpoint, string $source, string $target): int
+ * @param callable|null $resolver Passed through to {@see is_public_http_url}; injectable for testing.
  * @return 'sent'|'failed'|'skipped'|'cancelled'|null Stat bucket name, or null when the row is deferred.
  */
-function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender): ?string
+function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender, ?callable $resolver = null): ?string
 {
     $post = R::load('post', (int) $row->post_id);
 
@@ -608,8 +615,11 @@ function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender
         ? discover_endpoint($fetched['body'] ?? '', $fetched['headers'] ?? [], $row->target)
         : null;
 
-    // A target may advertise any URL as its endpoint — only POST to http(s).
-    if ($endpoint !== null && !is_valid_http_url($endpoint)) {
+    // A target may advertise any URL as its endpoint, so this is just as
+    // attacker-influenced as the source in verify_and_store(): reject
+    // anything that isn't a public, non-internal http(s) destination before
+    // POSTing to it (SSRF via a malicious/compromised linked-to page).
+    if ($endpoint !== null && !is_public_http_url($endpoint, $resolver)) {
         $endpoint = null;
     }
 
@@ -640,7 +650,7 @@ function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender
  */
 function fetch_target(string $url): ?array
 {
-    $result = \Lamb\Http\fetch($url, [
+    $result = fetch_guarded($url, [
         'headers' => ['Accept: text/html, */*', 'User-Agent: Lamb-Webmention'],
         'timeout' => WEBMENTION_FETCH_TIMEOUT,
     ]);
@@ -669,10 +679,18 @@ function fetch_target(string $url): ?array
  */
 function send_webmention(string $endpoint, string $source, string $target): int
 {
-    return \Lamb\Http\post_form(
-        $endpoint,
-        ['source' => $source, 'target' => $target],
-        WEBMENTION_FETCH_TIMEOUT,
-        'Lamb-Webmention'
-    );
+    // Unlike Http\post_form(), fetch_guarded() re-validates the destination
+    // on every redirect hop — needed here because $endpoint came from the
+    // target page's own (attacker-influenced) endpoint discovery.
+    $result = fetch_guarded($endpoint, [
+        'method' => 'POST',
+        'headers' => [
+            'Content-Type: application/x-www-form-urlencoded',
+            'User-Agent: Lamb-Webmention',
+        ],
+        'content' => http_build_query(['source' => $source, 'target' => $target]),
+        'timeout' => WEBMENTION_FETCH_TIMEOUT,
+    ]);
+
+    return $result === null ? 0 : $result['status'];
 }

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -12,7 +12,7 @@ use RuntimeException;
 use SimpleXMLElement;
 use Symfony\Component\Yaml\Yaml;
 
-use function Lamb\Http\fetch;
+use function Lamb\Http\fetch_guarded;
 use function Lamb\Post\finalize_and_store_post;
 use function Lamb\Post\populate_bean;
 use function Lamb\Response\asset_url;
@@ -722,7 +722,12 @@ function default_image_downloader(string $url, string $sub_path): ?string
     if (!is_dir($dest_dir) && !mkdir($dest_dir, 0777, true) && !is_dir($dest_dir)) {
         return null;
     }
-    $response = fetch($url, ['max_bytes' => IMAGE_DOWNLOAD_MAX_BYTES]);
+    // $url is embedded in the WXR file being imported — an untrusted export
+    // an admin may have received from elsewhere — so it's just as
+    // attacker-influenced as a webmention source; use the same SSRF-safe
+    // fetcher (rejects loopback/private/link-local destinations and
+    // re-checks every redirect hop) rather than the unguarded fetch().
+    $response = fetch_guarded($url, ['max_bytes' => IMAGE_DOWNLOAD_MAX_BYTES]);
     if ($response === null || $response['body'] === '') {
         return null;
     }

--- a/tests/Unit/HttpFetchTest.php
+++ b/tests/Unit/HttpFetchTest.php
@@ -6,9 +6,13 @@ use PHPUnit\Framework\TestCase;
 
 use function Lamb\Http\build_http_context_options;
 use function Lamb\Http\fetch;
+use function Lamb\Http\fetch_guarded;
+use function Lamb\Http\is_private_ip;
+use function Lamb\Http\is_public_http_url;
 use function Lamb\Http\is_valid_http_url;
 use function Lamb\Http\parse_status_line;
 use function Lamb\Http\post_form;
+use function Lamb\Http\resolve_redirect_location;
 
 class HttpFetchTest extends TestCase
 {
@@ -126,5 +130,116 @@ class HttpFetchTest extends TestCase
     {
         $status = @post_form('file:///nonexistent/path/at/all', ['a' => 'b'], 1, 'Lamb-Test');
         $this->assertSame(0, $status);
+    }
+
+    // is_private_ip -----------------------------------------------------------
+
+    public function testIsPrivateIpDetectsLoopbackAndPrivateRanges(): void
+    {
+        $this->assertTrue(is_private_ip('127.0.0.1'));
+        $this->assertTrue(is_private_ip('10.0.0.1'));
+        $this->assertTrue(is_private_ip('172.16.0.1'));
+        $this->assertTrue(is_private_ip('192.168.1.1'));
+        // Link-local, including the common cloud metadata address.
+        $this->assertTrue(is_private_ip('169.254.169.254'));
+        $this->assertTrue(is_private_ip('::1'));
+    }
+
+    public function testIsPrivateIpFalseForPublicAddress(): void
+    {
+        $this->assertFalse(is_private_ip('93.184.216.34'));
+    }
+
+    // is_public_http_url --------------------------------------------------------
+
+    public function testIsPublicHttpUrlRejectsLiteralPrivateIp(): void
+    {
+        $this->assertFalse(is_public_http_url('http://127.0.0.1/'));
+        $this->assertFalse(is_public_http_url('http://169.254.169.254/latest/meta-data/'));
+        $this->assertFalse(is_public_http_url('http://[::1]/'));
+    }
+
+    public function testIsPublicHttpUrlAcceptsLiteralPublicIp(): void
+    {
+        $this->assertTrue(is_public_http_url('http://93.184.216.34/'));
+    }
+
+    public function testIsPublicHttpUrlRejectsMalformedUrl(): void
+    {
+        $this->assertFalse(is_public_http_url('not a url'));
+        $this->assertFalse(is_public_http_url('ftp://example.com/'));
+    }
+
+    public function testIsPublicHttpUrlUsesInjectedResolverForHostnames(): void
+    {
+        $resolver = fn (string $host) => $host === 'evil.example' ? ['127.0.0.1'] : ['93.184.216.34'];
+
+        $this->assertFalse(is_public_http_url('http://evil.example/', $resolver));
+        $this->assertTrue(is_public_http_url('http://good.example/', $resolver));
+    }
+
+    public function testIsPublicHttpUrlRejectsWhenResolutionFails(): void
+    {
+        $resolver = fn (string $host) => [];
+        $this->assertFalse(is_public_http_url('http://unresolvable.example/', $resolver));
+    }
+
+    public function testIsPublicHttpUrlRejectsWhenAnyResolvedIpIsPrivate(): void
+    {
+        // DNS rebinding / multi-record tricks: reject if *any* resolved address is private.
+        $resolver = fn (string $host) => ['93.184.216.34', '127.0.0.1'];
+        $this->assertFalse(is_public_http_url('http://mixed.example/', $resolver));
+    }
+
+    // resolve_redirect_location -------------------------------------------------
+
+    public function testResolveRedirectLocationPassesThroughAbsoluteUrl(): void
+    {
+        $this->assertSame(
+            'https://other.example/x',
+            resolve_redirect_location('https://example.com/a', 'https://other.example/x')
+        );
+    }
+
+    public function testResolveRedirectLocationResolvesRootRelativePath(): void
+    {
+        $this->assertSame(
+            'https://example.com/new',
+            resolve_redirect_location('https://example.com/a/b', '/new')
+        );
+    }
+
+    public function testResolveRedirectLocationResolvesProtocolRelative(): void
+    {
+        $this->assertSame(
+            'https://other.example/x',
+            resolve_redirect_location('https://example.com/a', '//other.example/x')
+        );
+    }
+
+    public function testResolveRedirectLocationResolvesRelativePathAgainstDirectory(): void
+    {
+        $this->assertSame(
+            'https://example.com/a/next',
+            resolve_redirect_location('https://example.com/a/b', 'next')
+        );
+    }
+
+    // fetch_guarded -------------------------------------------------------------
+
+    public function testFetchGuardedRejectsPrivateDestination(): void
+    {
+        $this->assertNull(fetch_guarded('http://127.0.0.1/secret'));
+    }
+
+    public function testFetchGuardedRejectsWhenResolvedHostIsPrivate(): void
+    {
+        $resolver = fn (string $host) => ['127.0.0.1'];
+        $this->assertNull(fetch_guarded('http://evil.example/', [], 5, $resolver));
+    }
+
+    public function testFetchGuardedRejectsMalformedUrl(): void
+    {
+        $this->assertNull(fetch_guarded('not a url'));
     }
 }

--- a/tests/Unit/WebmentionResendTest.php
+++ b/tests/Unit/WebmentionResendTest.php
@@ -55,6 +55,18 @@ class WebmentionResendTest extends TestCase
         R::store($post);
     }
 
+    /**
+     * A fake DNS resolver so tests using the example.com/example.org RFC 2606
+     * hostnames (not actually resolvable) pass the SSRF public-host check
+     * without a real network lookup.
+     *
+     * @return callable(string): string[]
+     */
+    private function publicResolver(): callable
+    {
+        return fn (string $host): array => ['93.184.216.34'];
+    }
+
     /** @return array{0: callable, 1: callable} */
     private function unreachableNetwork(): array
     {
@@ -101,7 +113,7 @@ class WebmentionResendTest extends TestCase
         $fetcher = fn (string $url) => ['headers' => ['<https://other.example/wm>; rel="webmention"'], 'body' => ''];
         $sender = fn (string $e, string $s, string $t): int => 202;
 
-        $result = process_outbound($fetcher, $sender);
+        $result = process_outbound($fetcher, $sender, 20, $this->publicResolver());
 
         $this->assertSame(1, $result['sent'], 'a deletion re-send must be sent, not cancelled by the deleted-source guard');
         $this->assertSame('sent', R::findOne('webmentionoutbox')->status);

--- a/tests/Unit/WebmentionSendTest.php
+++ b/tests/Unit/WebmentionSendTest.php
@@ -274,6 +274,18 @@ class WebmentionSendTest extends TestCase
     }
 
     /**
+     * A fake DNS resolver so tests using example.com/example.org/etc.
+     * hostnames (RFC 2606, not actually resolvable) pass the SSRF
+     * public-host check without a real network lookup.
+     *
+     * @return callable(string): string[]
+     */
+    private function publicResolver(): callable
+    {
+        return fn (string $host): array => ['93.184.216.34'];
+    }
+
+    /**
      * A fetcher/sender pair that fails the test if either is invoked.
      *
      * @return array{0: callable, 1: callable}
@@ -300,7 +312,7 @@ class WebmentionSendTest extends TestCase
             return 202;
         };
 
-        $result = process_outbound($fetcher, $sender);
+        $result = process_outbound($fetcher, $sender, 20, $this->publicResolver());
         $this->assertSame(1, $result['sent']);
         $this->assertSame('sent', R::findOne('webmentionoutbox')->status);
     }
@@ -338,7 +350,7 @@ class WebmentionSendTest extends TestCase
         $fetcher = fn (string $url) => ['headers' => ['<https://other.example/wm>; rel="webmention"'], 'body' => ''];
         $sender = fn (string $e, string $s, string $t): int => 400;
 
-        $result = process_outbound($fetcher, $sender);
+        $result = process_outbound($fetcher, $sender, 20, $this->publicResolver());
         $this->assertSame(1, $result['failed']);
         $this->assertSame('failed', R::findOne('webmentionoutbox')->status);
     }
@@ -410,7 +422,7 @@ class WebmentionSendTest extends TestCase
         $fetcher = fn (string $url) => ['headers' => ['<https://other.example/wm>; rel="webmention"'], 'body' => ''];
         $sender = fn (string $e, string $s, string $t): int => 202;
 
-        $result = process_outbound($fetcher, $sender);
+        $result = process_outbound($fetcher, $sender, 20, $this->publicResolver());
         $this->assertSame(1, $result['sent']);
         $this->assertSame('sent', R::findOne('webmentionoutbox')->status);
     }

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -9,6 +9,7 @@ use SimpleXMLElement;
 use function Lamb\Response\persist_image_bytes;
 use function Lamb\WordPress\asset_dir_for_date;
 use function Lamb\WordPress\build_post_body;
+use function Lamb\WordPress\default_image_downloader;
 use function Lamb\WordPress\extract_items;
 use function Lamb\WordPress\html_to_markdown;
 use function Lamb\WordPress\import_item;
@@ -941,5 +942,19 @@ XML;
         } finally {
             rmdir($dir);
         }
+    }
+
+    public function testDefaultImageDownloaderBlocksLoopbackDestination(): void
+    {
+        // Regression (SSRF): an image URL embedded in the WXR file being
+        // imported is just as attacker-influenced as a webmention source —
+        // a loopback/private/link-local destination must be rejected before
+        // any request is made, not just fetched and stored.
+        if (!defined('ROOT_DIR')) {
+            define('ROOT_DIR', sys_get_temp_dir() . '/lamb_wp_import_' . uniqid('', true));
+        }
+
+        $this->assertNull(default_image_downloader('http://127.0.0.1/evil.jpg', '2024/03'));
+        $this->assertNull(default_image_downloader('http://169.254.169.254/evil.png', '2024/03'));
     }
 }


### PR DESCRIPTION
## Summary

**Stacked on #508** (builds on it to reuse `Http\fetch_guarded()` — the diff will shrink to just this commit once #508 merges).

`default_image_downloader()` (`src/wordpress.php`), used by the WordPress WXR importer (`import-wordpress.php`, CLI-only), fetches every image URL harvested from the WXR file's post content (`<img src>`, `data-full-url`, `data-src`, or a "view full size" `<a href>` — see `rewrite_image_links_in_dom`) via:

```php
$response = fetch($url, ['max_bytes' => IMAGE_DOWNLOAD_MAX_BYTES]);
```

`Http\fetch()` follows up to 5 redirects by default with no destination validation — the only check anywhere in this path, `normalize_image_url()`, validates scheme only (http/https), never the resolved host/IP.

**Impact:** a WXR export is an untrusted input by nature — it's a file the admin received from somewhere else (a migration service, a shared/downloaded archive, a site they don't fully trust). Its embedded image URLs are just as attacker-influenced as a webmention `source`. A crafted or later-compromised image host can point directly at (or redirect to) `http://127.0.0.1:.../`, `http://169.254.169.254/...`, or any other internal address, and the importer will make that request before any content-type filtering kicks in. This requires the CLI import to actually be run against such a file (admin-invoked, not remotely triggerable), so it's rated Medium rather than the Medium-High of the unauthenticated webmention case in #508 — but it's a real, unguarded SSRF primitive with attacker-controlled destination and redirect-following.

## Fix

Switch to `fetch_guarded()` (added in #508), which rejects loopback/private/link-local destinations and re-validates the destination on every redirect hop.

## Test plan

- [x] Added `testDefaultImageDownloaderBlocksLoopbackDestination` (`tests/Unit/WordPressImportTest.php`) — a loopback and a link-local (cloud metadata) URL are both rejected
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_