### PR TITLE
Fix open redirect via slug-based auto-redirect

### DIFF
--- a/src/post.php
+++ b/src/post.php
@@ -146,11 +146,36 @@ function parse_matter(string $body): array
 
     $matter = normalize_matter_keys($matter);
 
+    if (isset($matter['slug'])) {
+        $matter['slug'] = sanitize_explicit_slug((string) $matter['slug']);
+    }
+
     if (isset($matter['title']) && !isset($matter['slug'])) {
         $matter['slug'] = slugify($matter['title']);
     }
 
     return $matter;
+}
+
+/**
+ * Strips leading slashes/backslashes from an explicit front-matter `slug:`
+ * value.
+ *
+ * An explicit slug (unlike a title-derived one, which goes through
+ * slugify()) is stored verbatim and later feeds an automatic redirect's
+ * `to_url` on a subsequent slug change (`'/' . $slug`, in redirect_edited()).
+ * A slug beginning with `/` (or `\`, which some browsers normalise to `/` in
+ * a URL) would make that concatenation a protocol-relative `//host/...` (or
+ * `/\host/...`) URL — an open redirect off the site. Stripped rather than
+ * rejected outright so a legitimate custom slug that merely has redundant
+ * leading slashes still saves.
+ *
+ * @param string $slug
+ * @return string
+ */
+function sanitize_explicit_slug(string $slug): string
+{
+    return ltrim($slug, "/\\");
 }
 
 /**

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -17,6 +17,7 @@ use function Lamb\parse_bean;
 use function Lamb\Post\finalize_and_store_post;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\populate_bean;
+use function Lamb\Post\sanitize_explicit_slug;
 use function Lamb\Post\toggle_checkbox;
 use function Lamb\Route\is_reserved_route;
 
@@ -258,10 +259,13 @@ function redirect_edited(): void
     if (!empty($old_slug) && $old_slug !== $new_slug) {
         // Remove any redirect pointing to the new slug to avoid redirect loops
         delete_redirect_for_slug($new_slug);
-        // Store a redirect from the old slug to the new one
+        // Store a redirect from the old slug to the new one. sanitize_explicit_slug()
+        // is also applied when a slug is first read from front matter, but a
+        // slug reaching this point some other way must not be able to turn
+        // this into a protocol-relative "//host/..." open redirect either.
         $auto_redirect = R::dispense('redirect');
         $auto_redirect->from_slug = $old_slug;
-        $auto_redirect->to_url = '/' . $new_slug;
+        $auto_redirect->to_url = '/' . sanitize_explicit_slug($new_slug);
         R::store($auto_redirect);
     }
 

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -9,6 +9,7 @@ use function Lamb\Post\body_has_tag;
 use function Lamb\Post\get_tag_search_conditions;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\posts_by_tag;
+use function Lamb\Post\sanitize_explicit_slug;
 use function Lamb\Post\slugify;
 use function Lamb\render_body;
 
@@ -194,6 +195,48 @@ class PostTest extends TestCase
         $body = "---\ntitle: My Post Title\nslug: custom-slug\n---\nContent.";
         $result = parse_matter($body);
         $this->assertSame('custom-slug', $result['slug']);
+    }
+
+    // parse_matter / sanitize_explicit_slug — an explicit slug must never be
+    // able to turn a later automatic redirect's `to_url` (built as
+    // '/' . $slug in redirect_edited()) into a protocol-relative
+    // "//host/..." (or "/\host/...") open redirect.
+
+    public function testParseMatterStripsLeadingSlashFromExplicitSlug()
+    {
+        $body = "---\nslug: /evil.example.com\n---\nContent.";
+        $result = parse_matter($body);
+        $this->assertSame('evil.example.com', $result['slug']);
+    }
+
+    public function testParseMatterStripsLeadingSlashesFromExplicitSlug()
+    {
+        $body = "---\nslug: //evil.example.com\n---\nContent.";
+        $result = parse_matter($body);
+        $this->assertSame('evil.example.com', $result['slug']);
+    }
+
+    public function testParseMatterStripsLeadingBackslashFromExplicitSlug()
+    {
+        $body = "---\nslug: \\evil.example.com\n---\nContent.";
+        $result = parse_matter($body);
+        $this->assertSame('evil.example.com', $result['slug']);
+    }
+
+    public function testParseMatterLeavesOrdinarySlugUnchanged()
+    {
+        $body = "---\nslug: my-normal-slug\n---\nContent.";
+        $result = parse_matter($body);
+        $this->assertSame('my-normal-slug', $result['slug']);
+    }
+
+    public function testSanitizeExplicitSlugStripsLeadingSlashesAndBackslashes()
+    {
+        $this->assertSame('evil.com', sanitize_explicit_slug('/evil.com'));
+        $this->assertSame('evil.com', sanitize_explicit_slug('//evil.com'));
+        $this->assertSame('evil.com', sanitize_explicit_slug('/\\evil.com'));
+        $this->assertSame('evil.com', sanitize_explicit_slug('\\evil.com'));
+        $this->assertSame('normal-slug', sanitize_explicit_slug('normal-slug'));
     }
 
     // parse_matter — front matter is a *leading* fence only


### PR DESCRIPTION
## Summary

An explicit front-matter `slug:` value is stored **verbatim** — unlike a title-derived one, which goes through `slugify()`:

```php
// src/post.php, parse_matter()
if (isset($matter['title']) && !isset($matter['slug'])) {
    $matter['slug'] = slugify($matter['title']);   // only when slug is absent
}
```

`redirect_edited()` (`src/response/posts.php`) creates an automatic redirect row whenever a saved post's slug changes:

```php
$auto_redirect->to_url = '/' . $new_slug;   // no validation of $new_slug's shape
```

A slug beginning with `/` — or `\`, which some browsers normalise to a second `/` inside a URL — turns that concatenation into a protocol-relative `//host/...` (or `/\host/...`) URL. `find_redirect()`/`index.php` send it straight to a `301 Location:` header with only CR/LF stripping (`Http\sanitize_location()`), no same-origin check (that check, `local_redirect_target()`, exists elsewhere in this codebase for the `/login` redirect — proving the team is already aware of this exact bug class, just not applied here).

**Exploit scenario:** the author edits a post's front matter to `slug: /evil.example.com` and saves. `redirect_edited()` stores `from_slug = <old slug>`, `to_url = '//evil.example.com'`. Any subsequent visitor to the post's *old* permalink gets a silent `301` that browsers resolve to `https://evil.example.com` — phishing via a trusted, possibly-bookmarked/indexed URL, or laundering the site's link reputation. Since Micropub's create flow can embed its own front matter (an empty-`properties` create request stores the raw content text as the post body verbatim), a client holding only a scoped `create` token can plant such a slug at post-creation time too, one edit away (by the unaware site owner) from becoming a live redirect.

I deliberately did **not** touch `find_redirect()`/the redirect-serving code in `index.php`: the `[redirections]` config setting intentionally supports absolute external URLs as a first-class admin feature (`str_starts_with($dest, 'http')`), so a blanket same-origin check there would break that. The bug is specifically that an *automatically-created* redirect (from an edited slug the admin didn't knowingly turn into a full URL) can become external without the admin ever intending it.

## Fix

- `src/post.php`: add `sanitize_explicit_slug()`, applied in `parse_matter()` — the single YAML-parsing entry point shared by the web editor, Micropub create/update, feed re-parsing, and the WordPress importer (which embeds its own slug into front matter via `build_post_body()`) — so a slug can never start with `/` or `\` the moment it's read.
- `src/response/posts.php`: apply the same sanitizer again where `redirect_edited()` builds `to_url`, as defense-in-depth against any other path that might set `$bean->slug` directly.

## Test plan

- [x] Added `sanitize_explicit_slug()` coverage plus `parse_matter()` regression tests for `/evil.example.com`, `//evil.example.com`, `\evil.example.com`, and an ordinary slug left unchanged (`tests/Unit/PostTest.php`)
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

Note: `redirect_edited()`'s success path itself isn't exercised end-to-end in the existing test suite (it ends in a `die()`-based redirect, and existing tests for it deliberately only cover early-return branches) — coverage is at the `parse_matter()`/`sanitize_explicit_slug()` level, matching that established convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_