### PR TITLE
Fix missing scope check on Micropub delete/undelete

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -339,6 +339,11 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     public function deleteCallback(string $url)
     {
+        $scope = $this->user['scope'] ?? [];
+        if ($this->user !== null && !in_array('delete', $scope)) {
+            return $this->insufficientScopeResponse('delete');
+        }
+
         $bean = $this->findPostByUrl($url);
         if ($bean === null) {
             return 'invalid_request';
@@ -359,6 +364,14 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     public function undeleteCallback(string $url)
     {
+        // Gated on 'delete' scope, not a separate 'undelete' one: undelete is
+        // the reversal of the same destructive action, and this codebase
+        // doesn't otherwise define a distinct scope for it.
+        $scope = $this->user['scope'] ?? [];
+        if ($this->user !== null && !in_array('delete', $scope)) {
+            return $this->insufficientScopeResponse('delete');
+        }
+
         $bean = $this->findPostByUrl($url);
         if ($bean === null) {
             return 'invalid_request';

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -1000,6 +1000,32 @@ class MicropubAdapterTest extends TestCase
         $this->assertSame('invalid_request', $result);
     }
 
+    public function testDeleteCallbackReturnsInsufficientScopeWhenTokenLacksDeleteScope(): void
+    {
+        // Regression: deleteCallback() previously had no scope check at all,
+        // so any valid token — regardless of granted scope — could delete
+        // arbitrary posts.
+        $bean = R::dispense('post');
+        $bean->body = 'Should survive an unscoped delete attempt';
+        $bean->slug = '';
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = ['me' => ROOT_URL . '/', 'scope' => ['create']];
+
+        $result = $adapter->deleteCallback(ROOT_URL . '/status/' . $bean->id);
+
+        $this->assertInstanceOf(\Psr\Http\Message\ResponseInterface::class, $result);
+        $this->assertSame(403, $result->getStatusCode());
+        $body = json_decode((string) $result->getBody(), true);
+        $this->assertSame('insufficient_scope', $body['error']);
+
+        $updated = R::load('post', $bean->id);
+        $this->assertEmpty($updated->deleted, 'the post must not have been deleted');
+    }
+
     // --- undeleteCallback ---
 
     public function testUndeleteCallbackClearsDeletedFlag(): void
@@ -1025,6 +1051,28 @@ class MicropubAdapterTest extends TestCase
         $adapter = new LambMicropubAdapter();
         $result = $adapter->undeleteCallback(ROOT_URL . '/status/999999');
         $this->assertSame('invalid_request', $result);
+    }
+
+    public function testUndeleteCallbackReturnsInsufficientScopeWhenTokenLacksDeleteScope(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Should stay deleted against an unscoped undelete attempt';
+        $bean->slug = '';
+        $bean->deleted = 1;
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = ['me' => ROOT_URL . '/', 'scope' => ['create']];
+
+        $result = $adapter->undeleteCallback(ROOT_URL . '/status/' . $bean->id);
+
+        $this->assertInstanceOf(\Psr\Http\Message\ResponseInterface::class, $result);
+        $this->assertSame(403, $result->getStatusCode());
+
+        $updated = R::load('post', $bean->id);
+        $this->assertEquals(1, $updated->deleted, 'the post must still be deleted');
     }
 
     // --- beanToMf2Properties (via sourceQueryCallback) ---


### PR DESCRIPTION
## Summary

`Taproot\MicropubAdapter` never enforces OAuth scope itself — that's left entirely to each implementing callback. This codebase's `createCallback()` and `updateCallback()` do it correctly (require `create`/`update` scope respectively), but `deleteCallback()` and `undeleteCallback()` had **no scope check at all**:

```php
public function deleteCallback(string $url)
{
    $bean = $this->findPostByUrl($url);
    if ($bean === null) {
        return 'invalid_request';
    }
    \Lamb\Response\soft_delete_post($bean);   // no scope check before this
    return true;
}
```

**Impact:** any bearer token that verifies for the site (`verifyAccessTokenCallback()` only checks the token's `me` matches `ROOT_URL`), regardless of what scope it was actually granted, could soft-delete or restore **arbitrary posts**. A third-party Micropub client authorized only for `create` — e.g. a client that just posts notes on the owner's behalf — could delete or undelete any post on the site. This is a more destructive gap than the same missing-scope pattern already found on the media endpoint (draft PR #511): deleting content is a stronger action than uploading a file.

## Fix

Add the same scope check `createCallback()`/`updateCallback()` already use — `in_array('delete', $scope)` — to both `deleteCallback()` and `undeleteCallback()`, returning the same RFC 6750 `insufficient_scope` 403 + challenge on failure. `undeleteCallback()` is gated on the same `delete` scope rather than a separate `undelete` one: it's the reversal of the same destructive action, and this codebase doesn't otherwise define a distinct scope for it.

## Test plan

- [x] Added `testDeleteCallbackReturnsInsufficientScopeWhenTokenLacksDeleteScope` / `testUndeleteCallbackReturnsInsufficientScopeWhenTokenLacksDeleteScope` (`tests/Unit/MicropubAdapterTest.php`) — both assert the 403 response *and* that the post's `deleted` state is actually unchanged
- [x] Existing `deleteCallback`/`undeleteCallback` tests (which don't set `$adapter->user`, so `$this->user` stays `null`) continue to pass unchanged — matching the same `$this->user !== null` guard `createCallback()`/`updateCallback()` already use for the same reason
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_