### PR TITLE
Fix Micropub source-query disclosure of draft/trashed/scheduled content

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -586,6 +586,29 @@ function is_viewable(OODBBean $post): bool
 }
 
 /**
+ * Returns true for a post an anonymous visitor may see: not draft, not
+ * deleted, and not scheduled for the future. The in-memory counterpart to
+ * visible_clause() (the SQL allow-list for listings), for callers that
+ * already have a loaded bean.
+ *
+ * Deliberately has no logged-in exception, unlike is_viewable(): it's for
+ * request paths where the caller's identity isn't the site's own logged-in
+ * session (an inbound webmention POST, /_cron) — a session cookie that
+ * happens to be present must not leak a hidden post's existence to whichever
+ * party is actually making the request.
+ *
+ * @param OODBBean $post The post to inspect (an unsaved/missing bean has id 0).
+ * @return bool
+ */
+function is_publicly_visible(OODBBean $post): bool
+{
+    if (empty($post->id) || $post->deleted == 1 || $post->draft == 1) {
+        return false;
+    }
+    return !is_scheduled($post);
+}
+
+/**
  * Returns true when the supplied preview token grants access to an
  * unpublished post's permalink.
  *

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -13,6 +13,7 @@ use Taproot\Micropub\MicropubAdapter;
 
 use function Lamb\add_body_tags;
 use function Lamb\get_tags;
+use function Lamb\is_publicly_visible;
 use function Lamb\is_scheduled;
 use function Lamb\notify_post_subscribers;
 use function Lamb\parse_bean;
@@ -39,6 +40,21 @@ class LambMicropubAdapter extends MicropubAdapter
         $bean = $this->findPostByUrl($url);
         if ($bean === null) {
             return false;
+        }
+
+        // Unlike create/update/delete, a source query has no scope of its own —
+        // any token that merely verifies for this site would otherwise get
+        // full read access to every draft/scheduled/trashed post's content
+        // (sequential /status/<id> ids make this trivial to enumerate). A
+        // publicly-visible post's content is already public, so any valid
+        // token may read it; a hidden one requires 'update' scope (the same
+        // trust level needed to edit it) and otherwise looks exactly like a
+        // nonexistent post, so this can't be used as an existence oracle either.
+        if (!is_publicly_visible($bean)) {
+            $scope = $this->user['scope'] ?? [];
+            if ($this->user !== null && !in_array('update', $scope)) {
+                return false;
+            }
         }
 
         $props = $this->beanToMf2Properties($bean);
@@ -381,7 +397,11 @@ class LambMicropubAdapter extends MicropubAdapter
     public function updateCallback(string $url, array $actions)
     {
         $bean = $this->findPostByUrl($url);
-        if ($bean === null) {
+        // A soft-deleted post is meant to stay immutable until explicitly
+        // restored via the delete-scoped undeleteCallback(); treating it the
+        // same as "no such post" here also means this can't be used to tell
+        // a trashed post's id apart from a nonexistent one.
+        if ($bean === null || (int) $bean->deleted === 1) {
             return 'invalid_request';
         }
 

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -113,7 +113,15 @@ function verify_and_store(string $source, string $target, ?callable $fetcher = n
  * Resolve a target URL to the id of the Lamb post it points at.
  *
  * Returns null when the host is not ours, the path is not a recognised post
- * URL, or no matching post exists.
+ * URL, no matching post exists, or the matching post isn't publicly visible
+ * (a draft, a scheduled post, or a trashed one). The visibility check uses
+ * is_publicly_visible(), not is_viewable(): POST /webmention is unauthenticated
+ * and driven by whichever remote party sends the request, not by the site's
+ * own logged-in session, so a hidden post must 404 here exactly as it does
+ * for an anonymous permalink visit — otherwise an attacker could use the
+ * differing responses to enumerate draft/scheduled/trashed post ids that
+ * don't otherwise exist as far as an anonymous visitor can tell, and attach
+ * an unmoderated mention to a post before it's ever published.
  *
  * @param string $target
  * @return int|null
@@ -128,8 +136,11 @@ function target_post_id(string $target): ?int
 
     $path = parse_url($target, PHP_URL_PATH) ?: '';
     $bean = \Lamb\find_post_by_path($path);
+    if ($bean === null || !\Lamb\is_publicly_visible($bean)) {
+        return null;
+    }
 
-    return $bean !== null ? (int) $bean->id : null;
+    return (int) $bean->id;
 }
 
 /**

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
 use Lamb\Micropub\LambMicropubAdapter;
 use Tests\Support\StubMicropubAdapter;
@@ -550,6 +551,98 @@ class MicropubAdapterTest extends TestCase
         $this->assertArrayNotHasKey('category', $result['properties']);
     }
 
+    // --- sourceQueryCallback visibility (regression: content disclosure) ---
+    // A source query has no scope of its own, unlike create/update/delete —
+    // without a visibility check, ANY valid token could read the full
+    // content of any draft/scheduled/trashed post, not merely learn it
+    // exists (sequential /status/<id> ids make this trivial to enumerate).
+
+    private function makeHiddenPost(array $fields): OODBBean
+    {
+        $bean = R::dispense('post');
+        $bean->body = $fields['body'] ?? 'Hidden content';
+        $bean->slug = '';
+        $bean->created = $fields['created'] ?? date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        $bean->draft = $fields['draft'] ?? 0;
+        $bean->deleted = $fields['deleted'] ?? 0;
+        R::store($bean);
+        return $bean;
+    }
+
+    public function testSourceQueryReturnsFalseForDraftWithoutUpdateScope(): void
+    {
+        $bean = $this->makeHiddenPost(['draft' => 1]);
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = ['me' => ROOT_URL . '/', 'scope' => ['create']];
+
+        $result = $adapter->sourceQueryCallback(ROOT_URL . '/status/' . $bean->id);
+        $this->assertFalse($result, 'a create-only token must not read a draft\'s content via source query');
+    }
+
+    public function testSourceQueryReturnsContentForDraftWithUpdateScope(): void
+    {
+        $bean = $this->makeHiddenPost(['draft' => 1, 'body' => 'Draft-only content']);
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = ['me' => ROOT_URL . '/', 'scope' => ['update']];
+
+        $result = $adapter->sourceQueryCallback(ROOT_URL . '/status/' . $bean->id);
+        $this->assertIsArray($result);
+        $this->assertStringContainsString('Draft-only content', $result['properties']['content'][0]);
+    }
+
+    public function testSourceQueryReturnsFalseForScheduledWithoutUpdateScope(): void
+    {
+        $bean = $this->makeHiddenPost(['created' => date('Y-m-d H:i:s', strtotime('+1 day'))]);
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = ['me' => ROOT_URL . '/', 'scope' => ['create']];
+
+        $result = $adapter->sourceQueryCallback(ROOT_URL . '/status/' . $bean->id);
+        $this->assertFalse($result);
+    }
+
+    public function testSourceQueryReturnsFalseForTrashedWithoutUpdateScope(): void
+    {
+        $bean = $this->makeHiddenPost(['deleted' => 1]);
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = ['me' => ROOT_URL . '/', 'scope' => ['create']];
+
+        $result = $adapter->sourceQueryCallback(ROOT_URL . '/status/' . $bean->id);
+        $this->assertFalse($result);
+    }
+
+    public function testSourceQueryReturnsContentForTrashedWithUpdateScope(): void
+    {
+        // update scope may still see a trashed post's source (e.g. to decide
+        // whether to restore it via the separately delete-scoped undelete).
+        $bean = $this->makeHiddenPost(['deleted' => 1, 'body' => 'Trashed content']);
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = ['me' => ROOT_URL . '/', 'scope' => ['update']];
+
+        $result = $adapter->sourceQueryCallback(ROOT_URL . '/status/' . $bean->id);
+        $this->assertIsArray($result);
+        $this->assertStringContainsString('Trashed content', $result['properties']['content'][0]);
+    }
+
+    public function testSourceQueryReturnsContentForPublishedPostRegardlessOfScope(): void
+    {
+        // A published post's content is already public — any valid token
+        // may read it, matching pre-fix behaviour for the common case.
+        $bean = $this->makeHiddenPost(['body' => 'Published content']);
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = ['me' => ROOT_URL . '/', 'scope' => []];
+
+        $result = $adapter->sourceQueryCallback(ROOT_URL . '/status/' . $bean->id);
+        $this->assertIsArray($result);
+        $this->assertStringContainsString('Published content', $result['properties']['content'][0]);
+    }
+
     public function testCreateCallbackPublishedSetsCreatedDate(): void
     {
         $adapter = new LambMicropubAdapter();
@@ -747,6 +840,34 @@ class MicropubAdapterTest extends TestCase
         $adapter = new LambMicropubAdapter();
         $result = $adapter->updateCallback(ROOT_URL . '/status/999999', ['replace' => ['content' => ['new']]]);
         $this->assertSame('invalid_request', $result);
+    }
+
+    public function testUpdateCallbackReturnsInvalidRequestForTrashedPost(): void
+    {
+        // Regression: a soft-deleted post is meant to stay immutable until
+        // restored via the (delete-scoped) undeleteCallback() — an
+        // update-scoped token must not be able to silently rewrite trashed
+        // content while it stays hidden, and the response must be
+        // indistinguishable from "no such post".
+        $bean = R::dispense('post');
+        $bean->body = 'Trashed content must not change';
+        $bean->slug = '';
+        $bean->deleted = 1;
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = ['me' => ROOT_URL . '/', 'scope' => ['update']];
+
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['replace' => ['content' => ['Attempted overwrite']]]
+        );
+
+        $this->assertSame('invalid_request', $result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('Trashed content must not change', $updated->body);
     }
 
     public function testUpdateCallbackReplaceContentUpdatesBody(): void

--- a/tests/Unit/PostVisibilityTest.php
+++ b/tests/Unit/PostVisibilityTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\is_publicly_visible;
 use function Lamb\is_viewable;
 use function Lamb\Response\respond_post;
 use function Lamb\Response\respond_status;
@@ -96,6 +97,43 @@ class PostVisibilityTest extends TestCase
     {
         $bean = R::load('post', 999999);
         $this->assertFalse(is_viewable($bean));
+    }
+
+    // ---- is_publicly_visible() predicate -----------------------------------
+    // Unlike is_viewable(), has no logged-in exception: used by request paths
+    // (webmention receiving) where a session cookie isn't the caller's own.
+
+    public function testPubliclyVisiblePostIsVisible(): void
+    {
+        $bean = $this->makePost([]);
+        $this->assertTrue(is_publicly_visible($bean));
+    }
+
+    public function testDeletedPostIsNeverPubliclyVisibleEvenWhenLoggedIn(): void
+    {
+        $bean = $this->makePost(['deleted' => 1]);
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertFalse(is_publicly_visible($bean));
+    }
+
+    public function testDraftIsNeverPubliclyVisibleEvenWhenLoggedIn(): void
+    {
+        $bean = $this->makePost(['draft' => 1]);
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertFalse(is_publicly_visible($bean), 'a logged-in session must not affect this predicate');
+    }
+
+    public function testScheduledIsNeverPubliclyVisibleEvenWhenLoggedIn(): void
+    {
+        $bean = $this->makePost(['created' => date('Y-m-d H:i:s', time() + 86400)]);
+        $_SESSION[SESSION_LOGIN] = true;
+        $this->assertFalse(is_publicly_visible($bean));
+    }
+
+    public function testMissingPostIsNotPubliclyVisible(): void
+    {
+        $bean = R::load('post', 999999);
+        $this->assertFalse(is_publicly_visible($bean));
     }
 
     // ---- respond_status (/status/<id>) ------------------------------------

--- a/tests/Unit/WebmentionTest.php
+++ b/tests/Unit/WebmentionTest.php
@@ -69,6 +69,42 @@ class WebmentionTest extends TestCase
         $this->assertNull(target_post_id(ROOT_URL . '/status/999999'));
     }
 
+    public function testTargetPostIdRejectsDraftPost(): void
+    {
+        // Regression: an unauthenticated webmention POST must not be able to
+        // tell a draft apart from a nonexistent post — both must resolve to
+        // null, matching how an anonymous permalink visit 404s on a draft.
+        $id = $this->makePost();
+        $bean = R::load('post', $id);
+        $bean->draft = 1;
+        R::store($bean);
+
+        $this->assertNull(target_post_id(ROOT_URL . '/status/' . $id));
+    }
+
+    public function testTargetPostIdRejectsScheduledPost(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Hello world';
+        $bean->transformed = '<p>Hello world</p>';
+        $bean->created = date('Y-m-d H:i:s', strtotime('+1 day'));
+        $bean->updated = '2026-01-01 00:00:00';
+        $bean->version = 1;
+        $id = (int) R::store($bean);
+
+        $this->assertNull(target_post_id(ROOT_URL . '/status/' . $id));
+    }
+
+    public function testTargetPostIdRejectsTrashedPost(): void
+    {
+        $id = $this->makePost();
+        $bean = R::load('post', $id);
+        $bean->deleted = 1;
+        R::store($bean);
+
+        $this->assertNull(target_post_id(ROOT_URL . '/status/' . $id));
+    }
+
     // source_mentions_target ------------------------------------------------
 
     public function testSourceMentionsTargetMatchesHref(): void
@@ -129,6 +165,24 @@ class WebmentionTest extends TestCase
         $this->assertSame($target, $wm->target);
         $this->assertSame($id, (int) $wm->post_id);
         $this->assertNotEmpty($wm->verified_at);
+    }
+
+    public function testVerifyRejectsMentionOnDraftPostEvenWhenSourceLinksIt(): void
+    {
+        // Regression: a webmention must not be attachable to a draft before
+        // it's ever published, and the response must be indistinguishable
+        // from "no such post" (both 400 "target is not a valid post").
+        $id = $this->makePost();
+        $bean = R::load('post', $id);
+        $bean->draft = 1;
+        R::store($bean);
+
+        $target = ROOT_URL . '/status/' . $id;
+        $html = '<a href="' . $target . '">re</a>';
+
+        $res = verify_and_store('https://other.example/reply', $target, fn () => $html);
+        $this->assertSame(400, $res['status']);
+        $this->assertSame(0, R::count('webmention'));
     }
 
     public function testVerifyDeduplicatesOnRepeat(): void


### PR DESCRIPTION
## Summary

**Stacked on #514** (builds on it to reuse `Lamb\is_publicly_visible()` — the diff will shrink to just this commit once #514 merges).

Every scope-gated Micropub action in this codebase checks the verified token's scope before acting — `createCallback()` requires `create`, `updateCallback()`/`deleteCallback()`/`undeleteCallback()` require `update`/`delete`. `sourceQueryCallback()` (`GET /micropub?q=source&url=...`) had **no scope check at all**, and — unlike the sibling `target_post_id()` bug already fixed for webmentions — **no visibility check either**:

```php
public function sourceQueryCallback(string $url, ?array $properties = null)
{
    $bean = $this->findPostByUrl($url);   // find_post_by_path() — no draft/deleted/scheduled filter
    if ($bean === null) {
        return false;
    }
    $props = $this->beanToMf2Properties($bean);   // full title/body/tags/syndication, unconditionally
    ...
}
```

**Impact:** any bearer token that verifies for the site (`verifyAccessTokenCallback()` only checks the token's `me` matches `ROOT_URL` — there's no "read" scope anywhere in this codebase to check against) gets full read access to **any post's complete content** via `q=source` — not merely learn it exists, but its actual title, body, tags, and syndication targets — including drafts, soft-deleted, and future-scheduled posts. Since `/status/<id>` ids are sequential auto-increment, a client the owner has ever authorized for any purpose (even one granted only `create` scope, e.g. a "post a quick note" app) can enumerate `/status/1`, `/status/2`, … and harvest every unpublished/trashed post's full content. This is more severe than the previously-fixed webmention existence oracle: it discloses actual content, not just existence, and — because it has no scope check — it's reachable by any authorized client regardless of what the owner intended to grant it.

A related, narrower gap: `updateCallback()` had no check against a soft-deleted post either, so an `update`-scoped token could silently rewrite a trashed post's content while it stayed hidden — bypassing the trust boundary #517 (delete/undelete scope) established specifically for touching trashed posts.

## Fix

- `sourceQueryCallback()`: a publicly-visible post's content is already public, so any valid token may still read it (unchanged behavior for the common case). A hidden post (draft/scheduled/trashed) now requires `update` scope — the trust level already needed to edit it — and otherwise returns `false`, indistinguishable from a nonexistent post, closing the existence-oracle side channel too.
- `updateCallback()`: a soft-deleted post is now treated as "no such post" (`invalid_request`), matching the immutability `undeleteCallback()`'s scope gate already implies, and incidentally closing the same existence-oracle gap for trashed posts on this action.

## Test plan

- [x] Added draft/scheduled/trashed × with/without-`update`-scope coverage for `sourceQueryCallback()`, plus confirming a published post stays readable by any token (`tests/Unit/MicropubAdapterTest.php`)
- [x] Added `testUpdateCallbackReturnsInvalidRequestForTrashedPost` — asserts both the `invalid_request` response and that the post's body is actually unchanged
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_