### PR TITLE
Fix /_cron watermark TOCTOU allowing concurrent execution

### DIFF
--- a/src/network.php
+++ b/src/network.php
@@ -21,6 +21,22 @@ use function Lamb\set_option;
 #[NoReturn] function process_feeds(): void
 {
     header('Content-Type: text/plain');
+
+    // /_cron is unauthenticated and meant to be hit by an external cron job
+    // (see docs/cron-scheduled-tasks.md), but nothing stops anyone from
+    // flooding it with concurrent requests. The rate-limit watermark below is
+    // only written after all work below completes, so without a lock, every
+    // request in such a burst reads the same stale watermark, passes the
+    // "too often" check, and proceeds in parallel — multiplying outbound
+    // feed/webmention HTTP calls and risking duplicate feed-item ingestion
+    // (no unique constraint on `feeditem_uuid`) and duplicate outbound
+    // webmention sends (no atomic claim on a queued row). Acquiring a
+    // non-blocking exclusive lock first serializes overlapping runs instead.
+    $lock = acquire_cron_lock();
+    if ($lock === null) {
+        die('Already running, try again later.');
+    }
+
     $feeds = get_feeds();
 
     $cron_last_updated = get_option('last_processed_date', 0);
@@ -81,6 +97,34 @@ use function Lamb\set_option;
 
     set_option($cron_last_updated, (int)date('U'));
     exit('Done');
+}
+
+/**
+ * Acquires an exclusive, non-blocking lock serializing /_cron runs.
+ *
+ * The returned handle must be kept referenced for the remainder of the
+ * request: the lock releases automatically once it (and the underlying file
+ * descriptor) is closed or the request ends, so an explicit unlock isn't
+ * needed as long as the caller never returns normally before then (every
+ * process_feeds() exit path terminates the request via die()/exit()).
+ *
+ * @param string $path Lock file path; created if absent.
+ * @return resource|null The open lock-file handle, or null when the lock is
+ *                        already held (another run is in progress) or the
+ *                        lock file itself couldn't be opened.
+ */
+function acquire_cron_lock(string $path = '../data/cron.lock')
+{
+    $handle = @fopen($path, 'c');
+    if ($handle === false) {
+        return null;
+    }
+    if (!flock($handle, LOCK_EX | LOCK_NB)) {
+        fclose($handle);
+        return null;
+    }
+
+    return $handle;
 }
 
 /**

--- a/tests/Unit/NetworkTest.php
+++ b/tests/Unit/NetworkTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SimplePie\Item as SimplePieItem;
 use RedBeanPHP\R;
 
+use function Lamb\Network\acquire_cron_lock;
 use function Lamb\Network\attributed_content;
 use function Lamb\Network\get_structured_content;
 use function Lamb\Network\purge_deleted_posts;
@@ -207,5 +208,66 @@ class NetworkTest extends TestCase
 
         $loaded = R::load('post', $liveId);
         $this->assertSame($liveId, $loaded->id);
+    }
+
+    // acquire_cron_lock — regression: /_cron's rate-limit watermark is only
+    // written after a full run completes, so without a mutual-exclusion lock,
+    // a burst of concurrent (unauthenticated) requests would all read the
+    // same stale watermark and run in parallel.
+
+    private function lockPath(): string
+    {
+        return sys_get_temp_dir() . '/lamb_cron_lock_test_' . uniqid('', true) . '.lock';
+    }
+
+    public function testAcquireCronLockSucceedsWhenUnlocked(): void
+    {
+        $path = $this->lockPath();
+        $handle = acquire_cron_lock($path);
+
+        $this->assertNotNull($handle);
+        $this->assertFileExists($path);
+
+        fclose($handle);
+        unlink($path);
+    }
+
+    public function testAcquireCronLockFailsWhileAlreadyHeld(): void
+    {
+        $path = $this->lockPath();
+        $first = acquire_cron_lock($path);
+        $this->assertNotNull($first, 'precondition: first acquisition must succeed');
+
+        $second = acquire_cron_lock($path);
+        $this->assertNull($second, 'a concurrent run must not acquire the lock while another holds it');
+
+        fclose($first);
+        unlink($path);
+    }
+
+    public function testAcquireCronLockSucceedsAfterPriorHolderReleases(): void
+    {
+        $path = $this->lockPath();
+        $first = acquire_cron_lock($path);
+        $this->assertNotNull($first);
+        fclose($first);
+
+        $second = acquire_cron_lock($path);
+        $this->assertNotNull($second, 'the lock must be acquirable again once released');
+
+        fclose($second);
+        unlink($path);
+    }
+
+    public function testAcquireCronLockCreatesLockFileWhenAbsent(): void
+    {
+        $path = $this->lockPath();
+        $this->assertFileDoesNotExist($path);
+
+        $handle = acquire_cron_lock($path);
+        $this->assertFileExists($path);
+
+        fclose($handle);
+        unlink($path);
     }
 }


### PR DESCRIPTION
## Summary

`/_cron` is unauthenticated by design (an external cron job hits it directly — see `docs/cron-scheduled-tasks.md`), rate-limited only by a `last_processed_date` watermark:

```php
$cron_last_updated = get_option('last_processed_date', 0);
if ((time() - $cron_last_updated->value) < MINUTE_IN_SECONDS) {
    die('Too often, try again later.');
}
// ... feed crawling, WebSub pings, webmention outbox drain ...
set_option($cron_last_updated, (int)date('U'));  // only written after everything above completes
```

The watermark is read once at the top and only written back after the *entire* run finishes. Flooding the endpoint with concurrent requests defeats the rate limit entirely: every request in a burst reads the same stale watermark, passes the check, and proceeds in parallel. Beyond the CPU/network amplification of running the whole pipeline N times from one cheap `GET`, this produces concrete duplicated side effects:

- **Duplicate feed-item ingestion**: `ingest_item()`'s dedup check (`R::findOne('post', 'feeditem_uuid = ?', ...)`) has no unique constraint backing it, so two overlapping crawls of the same feed can both pass the check before either has stored its post — a real duplicate-post data-integrity bug, visible on the site's own home page/feed.
- **Duplicate outbound webmention sends**: `process_outbound()`'s queue drain (`R::find('webmentionoutbox', "status = 'pending'", ...)`) has no atomic claim on a row before processing it, so two overlapping drains can both fetch-and-POST the same pending webmention — sending a duplicate notification to a third-party site's webmention endpoint, an externally-visible side effect on infrastructure the attacker doesn't control.

Both are attacker-triggerable at will, for free, since `/_cron` needs no authentication.

## Fix

Add `acquire_cron_lock()` — a non-blocking exclusive `flock()` on a lock file, acquired before the watermark is ever read and held for the duration of the run (released implicitly when the request ends, since every `process_feeds()` exit path terminates via `die()`/`exit()`). A concurrent request that can't acquire the lock exits immediately without touching the watermark or doing any work at all, closing the race at its root rather than patching each downstream duplication (feed ingestion, webmention drain) individually.

## Test plan

- [x] Added `acquire_cron_lock()` coverage (`tests/Unit/NetworkTest.php`): succeeds when unlocked, fails while another handle holds it, succeeds again once released, creates the lock file when absent
- [x] `vendor/bin/phpunit tests/Unit` — same pre-existing failures as on `main` (environment-only, e.g. missing `bin/upgrade` binary in this sandbox), no new failures
- [x] `vendor/bin/phpcs` clean on all changed files

Note: `process_feeds()`'s own success/failure paths aren't exercised end-to-end in the existing test suite (it's `#[NoReturn]`, ending in `die()`/`exit()`, and has no existing direct test) — coverage is at the `acquire_cron_lock()` level, the actual concurrency-prevention mechanism.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvsktnWYMD9oqHPwtbJk7d)_