### PR TITLE
Refactor: collapse duplicated feed-crawl status bookkeeping

### DIFF
--- a/src/network/json_feed.php
+++ b/src/network/json_feed.php
@@ -2,8 +2,6 @@
 
 namespace Lamb\Network;
 
-use RedBeanPHP\R;
-
 use function Lamb\Http\fetch_guarded;
 
 // FEED_FETCH_TIMEOUT is defined in constants.php
@@ -62,9 +60,7 @@ function parse_json_feed(string $json): ?array
  */
 function record_json_feed_crawl(string $name, string $url): array
 {
-    $status = feed_status_bean($name, $url);
-    $now    = (int) date('U');
-    $status->last_attempt = $now;
+    [$status, $now] = begin_crawl($name, $url);
 
     // A configured feed URL is admin-trusted, but nothing pins where it (or a
     // redirect from it) actually points — fetch_guarded() re-checks the
@@ -73,13 +69,9 @@ function record_json_feed_crawl(string $name, string $url): array
     $feed     = $response === null ? null : parse_json_feed($response['body']);
 
     if ($feed === null) {
-        $message = $response === null
+        return record_crawl_failure($status, $now, $response === null
             ? 'Feed fetch failed: no data returned.'
-            : 'Not a valid JSON Feed (missing jsonfeed.org version).';
-        $status->last_error    = $now;
-        $status->error_message = $message;
-        R::store($status);
-        return ['ok' => false, 'items' => 0, 'error' => $message];
+            : 'Not a valid JSON Feed (missing jsonfeed.org version).');
     }
 
     $watermark = (int) $status->last_success;
@@ -90,12 +82,7 @@ function record_json_feed_crawl(string $name, string $url): array
         }
     }
 
-    $status->last_success  = $now;
-    $status->item_count    = $items;
-    $status->error_message = '';
-    R::store($status);
-
-    return ['ok' => true, 'items' => $items, 'error' => null];
+    return record_crawl_success($status, $now, $items);
 }
 
 /**

--- a/src/network/sources.php
+++ b/src/network/sources.php
@@ -2,7 +2,6 @@
 
 namespace Lamb\Network;
 
-use RedBeanPHP\R;
 use SimplePie\File as SimplePieFile;
 use SimplePie\Item as SimplePieItem;
 use SimplePie\SimplePie;
@@ -122,9 +121,7 @@ function init_simplepie_feed(string $url): SimplePie
  */
 function record_feed_crawl(string $name, string $url, SimplePie $feed): array
 {
-    $status = feed_status_bean($name, $url);
-    $now    = (int)date('U');
-    $status->last_attempt = $now;
+    [$status, $now] = begin_crawl($name, $url);
 
     $error = $feed->error();
     if (is_array($error)) {
@@ -132,11 +129,7 @@ function record_feed_crawl(string $name, string $url, SimplePie $feed): array
     }
 
     if (!$feed->data || $error) {
-        $message = (string)($error ?: 'Feed fetch failed: no data returned.');
-        $status->last_error    = $now;
-        $status->error_message = $message;
-        R::store($status);
-        return ['ok' => false, 'items' => 0, 'error' => $message];
+        return record_crawl_failure($status, $now, (string)($error ?: 'Feed fetch failed: no data returned.'));
     }
 
     $watermark = (int)$status->last_success;
@@ -148,10 +141,5 @@ function record_feed_crawl(string $name, string $url, SimplePie $feed): array
         }
     }
 
-    $status->last_success  = $now;
-    $status->item_count    = $items;
-    $status->error_message = '';
-    R::store($status);
-
-    return ['ok' => true, 'items' => $items, 'error' => null];
+    return record_crawl_success($status, $now, $items);
 }

--- a/src/network/status.php
+++ b/src/network/status.php
@@ -38,6 +38,65 @@ function feed_status_bean(string $name, string $url): OODBBean
 }
 
 /**
+ * Opens a crawl: loads the feed's status bean and stamps the attempt timestamp.
+ *
+ * Every source type records an *attempt* before it fetches, so a feed that keeps
+ * failing is still rate-limited by /_cron's 30-minute per-feed window (that window
+ * is gated on `last_attempt`, not `last_success`). The bean is returned unsaved —
+ * record_crawl_success()/record_crawl_failure() persist it with the outcome.
+ *
+ * @param string $name Feed name from config.
+ * @param string $url  Feed URL from config.
+ * @return array{0: OODBBean, 1: int} The status bean and the attempt timestamp.
+ */
+function begin_crawl(string $name, string $url): array
+{
+    $status = feed_status_bean($name, $url);
+    $now    = (int)date('U');
+    $status->last_attempt = $now;
+
+    return [$status, $now];
+}
+
+/**
+ * Records a failed crawl: stamps the error without advancing the success watermark.
+ *
+ * Leaving `last_success` alone is what keeps a failed fetch from swallowing items —
+ * the next successful crawl still ingests everything newer than the last *success*.
+ *
+ * @param OODBBean $status  The status bean from begin_crawl().
+ * @param int      $now     The attempt timestamp from begin_crawl().
+ * @param string   $message The error to surface on the Logs tab.
+ * @return array{ok: bool, items: int, error: ?string}
+ */
+function record_crawl_failure(OODBBean $status, int $now, string $message): array
+{
+    $status->last_error    = $now;
+    $status->error_message = $message;
+    R::store($status);
+
+    return ['ok' => false, 'items' => 0, 'error' => $message];
+}
+
+/**
+ * Records a successful crawl: advances the watermark, counts items, clears any error.
+ *
+ * @param OODBBean $status The status bean from begin_crawl().
+ * @param int      $now    The attempt timestamp from begin_crawl().
+ * @param int      $items  Number of items created or updated this run.
+ * @return array{ok: bool, items: int, error: ?string}
+ */
+function record_crawl_success(OODBBean $status, int $now, int $items): array
+{
+    $status->last_success  = $now;
+    $status->item_count    = $items;
+    $status->error_message = '';
+    R::store($status);
+
+    return ['ok' => true, 'items' => $items, 'error' => null];
+}
+
+/**
  * Returns the persisted crawl status for every configured feed, in config order.
  *
  * Feeds with no stored health yet (never crawled) get a zeroed row so the Logs tab

--- a/tests/Unit/FeedStatusTest.php
+++ b/tests/Unit/FeedStatusTest.php
@@ -7,9 +7,12 @@ use RedBeanPHP\R;
 use SimplePie\Item as SimplePieItem;
 use SimplePie\SimplePie;
 
+use function Lamb\Network\begin_crawl;
 use function Lamb\Network\feed_status_bean;
 use function Lamb\Network\get_feed_statuses;
 use function Lamb\Network\prune_feed_status;
+use function Lamb\Network\record_crawl_failure;
+use function Lamb\Network\record_crawl_success;
 use function Lamb\Network\record_feed_crawl;
 
 class FeedStatusTest extends TestCase
@@ -175,6 +178,51 @@ class FeedStatusTest extends TestCase
         $result = record_feed_crawl('TestBlog', 'https://testblog.example.com/feed', $feed);
         $this->assertSame(0, $result['items']);
         $this->assertSame(0, R::count('post'));
+    }
+
+    // begin_crawl / record_crawl_failure / record_crawl_success
+
+    public function testBeginCrawlStampsAttemptWithoutTouchingSuccessWatermark(): void
+    {
+        $seed = feed_status_bean('TestBlog', 'https://testblog.example.com/feed');
+        $seed->last_success = 1700000000;
+        R::store($seed);
+
+        [$status, $now] = begin_crawl('TestBlog', 'https://testblog.example.com/feed');
+
+        $this->assertGreaterThan(0, $now);
+        $this->assertSame($now, (int)$status->last_attempt);
+        $this->assertSame(1700000000, (int)$status->last_success);
+    }
+
+    public function testRecordCrawlFailurePersistsMessageAndReturnsOutcome(): void
+    {
+        [$status, $now] = begin_crawl('TestBlog', 'https://testblog.example.com/feed');
+
+        $result = record_crawl_failure($status, $now, 'boom');
+
+        $this->assertSame(['ok' => false, 'items' => 0, 'error' => 'boom'], $result);
+        $reloaded = feed_status_bean('TestBlog', 'https://testblog.example.com/feed');
+        $this->assertSame('boom', (string)$reloaded->error_message);
+        $this->assertSame($now, (int)$reloaded->last_error);
+        $this->assertSame($now, (int)$reloaded->last_attempt);
+        $this->assertSame(0, (int)$reloaded->last_success);
+    }
+
+    public function testRecordCrawlSuccessAdvancesWatermarkAndClearsError(): void
+    {
+        $seed = feed_status_bean('TestBlog', 'https://testblog.example.com/feed');
+        $seed->error_message = 'old failure';
+        R::store($seed);
+
+        [$status, $now] = begin_crawl('TestBlog', 'https://testblog.example.com/feed');
+        $result = record_crawl_success($status, $now, 3);
+
+        $this->assertSame(['ok' => true, 'items' => 3, 'error' => null], $result);
+        $reloaded = feed_status_bean('TestBlog', 'https://testblog.example.com/feed');
+        $this->assertSame($now, (int)$reloaded->last_success);
+        $this->assertSame(3, (int)$reloaded->item_count);
+        $this->assertSame('', (string)$reloaded->error_message);
     }
 
     // get_feed_statuses


### PR DESCRIPTION
Part of a refactor sweep. Behaviour-preserving.

## What

`record_feed_crawl()` (SimplePie, `src/network/sources.php`) and `record_json_feed_crawl()` (JSON Feed, `src/network/json_feed.php`) carried duplicate copies of the `feedstatus` bookkeeping:

- stamp `last_attempt` before fetching,
- on failure record `last_error` + `error_message` **without** advancing the success watermark,
- on success advance `last_success`, store `item_count`, clear `error_message`.

The two copies had already drifted cosmetically, and a fix to one would silently miss the other.

## How

Three helpers now live in `src/network/status.php`, next to `feed_status_bean()`:

- `begin_crawl($name, $url): [OODBBean, int]` — loads the bean and stamps the attempt.
- `record_crawl_failure($status, $now, $message): array` — stores the error outcome.
- `record_crawl_success($status, $now, $items): array` — advances the watermark.

Each crawl recorder keeps only what is genuinely source-specific: SimplePie error normalisation on one side, guarded fetch + JSON Feed validation on the other. The now-unused `RedBeanPHP\R` imports are dropped from both files.

## Tests

`tests/Unit/FeedStatusTest.php` gains direct coverage of the three helpers (attempt stamping does not touch the watermark; failure persists the message and leaves `last_success` alone; success advances the watermark, counts items and clears the error). Written red first, then implemented.

Existing coverage of both crawl paths (`FeedStatusTest`, `JsonFeedTest`, `NetworkFeedTest`) is unchanged and still passes.

Local: `phpcs` clean, `phpstan` (level 8) clean, `codecept run Unit` 1270 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfrzt37Uezf8hNjKpGmnR)_