### PR TITLE
Refactor: extract the shared pagination window arithmetic

### DIFF
--- a/src/response.php
+++ b/src/response.php
@@ -105,6 +105,35 @@ function build_exclude_slugs_clause(array $slugs): ?array
 }
 
 /**
+ * Clamps a requested page against the available range and returns the row window.
+ *
+ * The one place the page arithmetic lives: both pagination paths (in-memory array
+ * and DB query) need the same clamp-then-offset, and build_pagination_meta() needs
+ * the same page count to derive prev/next from.
+ *
+ * A non-positive $per_page is treated as 1 rather than dividing by zero: it comes
+ * from `posts_per_page` in the INI config, which nothing validates, so `= 0` would
+ * otherwise fatal every listing page.
+ *
+ * @param int $total_posts Total number of matching posts.
+ * @param int $page        Requested page (1-based).
+ * @param int $per_page    Items per page.
+ * @return array{page: int, offset: int, total_pages: int}
+ */
+function pagination_window(int $total_posts, int $page, int $per_page): array
+{
+    $per_page    = max(1, $per_page);
+    $total_pages = $total_posts > 0 ? (int)ceil($total_posts / $per_page) : 1;
+    $page        = min($page, $total_pages);
+
+    return [
+        'page'        => $page,
+        'offset'      => ($page - 1) * $per_page,
+        'total_pages' => $total_pages,
+    ];
+}
+
+/**
  * Builds the pagination metadata array from pre-computed values.
  *
  * @param int $page         Current page number (1-based).
@@ -115,7 +144,7 @@ function build_exclude_slugs_clause(array $slugs): ?array
  */
 function build_pagination_meta(int $page, int $per_page, int $total_posts, int $offset): array
 {
-    $total_pages = $total_posts > 0 ? (int)ceil($total_posts / $per_page) : 1;
+    $total_pages = pagination_window($total_posts, $page, $per_page)['total_pages'];
     return [
         'current'     => $page,
         'per_page'    => $per_page,
@@ -237,9 +266,7 @@ function upgrade_posts(array $posts): void
 function paginate_array(array $values, int $page, int $per_page): array
 {
     $total_posts = count($values);
-    $total_pages = $total_posts > 0 ? (int)ceil($total_posts / $per_page) : 1;
-    $page   = min($page, $total_pages);
-    $offset = ($page - 1) * $per_page;
+    ['page' => $page, 'offset' => $offset] = pagination_window($total_posts, $page, $per_page);
 
     return [
         'items'      => array_slice($values, $offset, $per_page),
@@ -262,9 +289,7 @@ function paginate_db(string $bean_type, string $order_by_clause, ?string $where_
 {
     $total_posts = !empty($where_sql) ? R::count($bean_type, $where_sql, $params) : R::count($bean_type);
 
-    $total_pages = $total_posts > 0 ? (int)ceil($total_posts / $per_page) : 1;
-    $page   = min($page, $total_pages);
-    $offset = ($page - 1) * $per_page;
+    ['page' => $page, 'offset' => $offset] = pagination_window($total_posts, $page, $per_page);
 
     if (!empty($where_sql)) {
         // When params are provided, use R::find with param binding and append offset/limit
@@ -302,6 +327,9 @@ function paginate_posts(mixed $source, string $order_by_clause = 'created DESC',
         global $config;
         $per_page = (int)($config['posts_per_page'] ?? 10);
     }
+    // Clamped here as well as in pagination_window() so the page count, the row
+    // offset and the SQL LIMIT all agree on the same size (see that helper).
+    $per_page = max(1, $per_page);
 
     // Explicit $page avoids the superglobal; fall back to $_GET only when not provided.
     $page = $page ?? max(1, (int)($_GET['page'] ?? 1));

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -9,6 +9,7 @@ use function Lamb\Response\build_pagination_meta;
 use function Lamb\Response\get_cookie_options;
 use function Lamb\Response\get_feed_updated_date;
 use function Lamb\Response\paginate_posts;
+use function Lamb\Response\pagination_window;
 use function Lamb\Response\upgrade_posts;
 
 class ResponseTest extends TestCase
@@ -80,6 +81,40 @@ class ResponseTest extends TestCase
         $slugs = ['about', 'contact'];
         $result = build_exclude_slugs_clause($slugs);
         $this->assertSame($slugs, $result['params']);
+    }
+
+    // pagination_window
+
+    public function testPaginationWindowComputesOffsetForRequestedPage()
+    {
+        $window = pagination_window(25, 3, 10);
+        $this->assertSame(3, $window['page']);
+        $this->assertSame(20, $window['offset']);
+        $this->assertSame(3, $window['total_pages']);
+    }
+
+    public function testPaginationWindowClampsPageBeyondTheLastOne()
+    {
+        $window = pagination_window(25, 99, 10);
+        $this->assertSame(3, $window['page']);
+        $this->assertSame(20, $window['offset']);
+    }
+
+    public function testPaginationWindowIsSinglePageWhenThereAreNoPosts()
+    {
+        $window = pagination_window(0, 4, 10);
+        $this->assertSame(1, $window['page']);
+        $this->assertSame(0, $window['offset']);
+        $this->assertSame(1, $window['total_pages']);
+    }
+
+    public function testPaginationWindowTreatsNonPositivePerPageAsOne()
+    {
+        // posts_per_page = 0 in the INI config would otherwise divide by zero.
+        $window = pagination_window(3, 2, 0);
+        $this->assertSame(2, $window['page']);
+        $this->assertSame(1, $window['offset']);
+        $this->assertSame(3, $window['total_pages']);
     }
 
     // build_pagination_meta


### PR DESCRIPTION
Part of a refactor sweep.

## What

The page arithmetic in `src/response.php` existed in three places:

- `paginate_array()` — page count, clamp, offset
- `paginate_db()` — the same three lines
- `build_pagination_meta()` — a third copy of the page-count half, to derive `prev_page`/`next_page`

## How

`pagination_window($total_posts, $page, $per_page)` returns `{page, offset, total_pages}` and is now the single owner of that calculation. All three callers use it.

## One behavioural change (called out deliberately)

`pagination_window()` treats a non-positive `$per_page` as `1` instead of dividing by zero. `posts_per_page` is read straight from the INI config and nothing validates it, so a site that sets `posts_per_page = 0` at `/settings` currently gets a `DivisionByZeroError` on every listing page. `paginate_posts()` clamps its resolved value the same way, so the page count, the row offset and the SQL `LIMIT` all agree on one page size.

Everything else is identical: same clamping, same offsets, same metadata shape.

## Tests

`tests/Unit/ResponseTest.php` gains four `pagination_window()` cases (offset for a requested page, clamping past the last page, the empty-collection single page, and the non-positive `per_page` guard). Written red first.

Local: `phpcs` clean, `phpstan` (level 8) clean, `codecept run Unit` 1271 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfrzt37Uezf8hNjKpGmnR)_