### PR TITLE
Refactor: share the public-posts clause and the listing assembly

### DIFF
--- a/src/response.php
+++ b/src/response.php
@@ -105,6 +105,33 @@ function build_exclude_slugs_clause(array $slugs): ?array
 }
 
 /**
+ * The WHERE clause selecting posts that belong in a public listing: publicly
+ * visible (published, not trashed, not future-dated) and not pinned as a menu
+ * item — menu posts are pages reachable from the nav, so they are kept out of
+ * the chronological stream and the feeds.
+ *
+ * Owned in one place so the homepage and the feeds can't drift apart on what
+ * "public" means; both used to assemble the two clauses inline, in opposite
+ * orders.
+ *
+ * @return array{sql: string, params: array<int, mixed>}
+ */
+function public_posts_clause(): array
+{
+    $visible = \Lamb\visible_clause();
+    $sql     = $visible['sql'];
+    $params  = $visible['params'];
+
+    $exclude = build_exclude_slugs_clause(\Lamb\Config\get_menu_slugs());
+    if ($exclude !== null) {
+        $sql   .= ' AND ' . $exclude['sql'];
+        $params = array_merge($params, $exclude['params']);
+    }
+
+    return ['sql' => $sql, 'params' => $params];
+}
+
+/**
  * Builds the pagination metadata array from pre-computed values.
  *
  * @param int $page         Current page number (1-based).

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -29,21 +29,33 @@ function respond_home(): array
         redirect_created();
     }
 
-    $data['title'] = $config['site_title'] ?? '';
+    $public = public_posts_clause();
 
-    $visible = \Lamb\visible_clause();
-    $where_sql = $visible['sql'];
-    $where_params = $visible['params'];
-    $clause = build_exclude_slugs_clause(Config\get_menu_slugs());
-    if ($clause !== null) {
-        $where_sql .= ' AND ' . $clause['sql'];
-        $where_params = array_merge($where_params, $clause['params']);
-    }
-    $paginated = paginate_posts('post', 'created DESC', $where_sql, $where_params);
-    $data['posts'] = $paginated['items'];
-    $data['pagination'] = $paginated['pagination'];
+    return listing_data($config['site_title'] ?? '', 'created DESC', $public['sql'], $public['params']);
+}
 
-    return $data;
+/**
+ * Assembles the view data for a paginated post listing.
+ *
+ * The shared tail of every listing route (home, drafts, trash, scheduled): run the
+ * query through paginate_posts() and hand the template its three keys. Callers own
+ * the query and any authentication they need — this only assembles the result.
+ *
+ * @param string $title           Page title for the template.
+ * @param string $order_by_clause SQL ORDER BY expression (without the keyword).
+ * @param string $where_sql       WHERE clause selecting the posts to list.
+ * @param array<int, mixed> $params Bound parameters for the WHERE clause.
+ * @return array{title: string, posts: array<int, mixed>, pagination: array<string, mixed>}
+ */
+function listing_data(string $title, string $order_by_clause, string $where_sql, array $params = []): array
+{
+    $paginated = paginate_posts('post', $order_by_clause, $where_sql, $params);
+
+    return [
+        'title'      => $title,
+        'posts'      => $paginated['items'],
+        'pagination' => $paginated['pagination'],
+    ];
 }
 
 /**
@@ -55,12 +67,7 @@ function respond_drafts(): array
 {
     Security\require_login();
 
-    $data['title'] = 'Drafts';
-    $paginated = paginate_posts('post', 'created DESC', SQL_IS_DRAFT);
-    $data['posts'] = $paginated['items'];
-    $data['pagination'] = $paginated['pagination'];
-
-    return $data;
+    return listing_data('Drafts', 'created DESC', SQL_IS_DRAFT);
 }
 
 /**
@@ -72,12 +79,7 @@ function respond_trash(): array
 {
     Security\require_login();
 
-    $data['title'] = 'Trash';
-    $paginated = paginate_posts('post', 'deleted_at DESC', SQL_IS_DELETED);
-    $data['posts'] = $paginated['items'];
-    $data['pagination'] = $paginated['pagination'];
-
-    return $data;
+    return listing_data('Trash', 'deleted_at DESC', SQL_IS_DELETED);
 }
 
 /**
@@ -109,12 +111,7 @@ function respond_scheduled(): array
 {
     Security\require_login();
 
-    $data['title'] = 'Scheduled';
-    $paginated = paginate_posts('post', 'created ASC', SQL_IS_SCHEDULED, [\Lamb\now()]);
-    $data['posts'] = $paginated['items'];
-    $data['pagination'] = $paginated['pagination'];
-
-    return $data;
+    return listing_data('Scheduled', 'created ASC', SQL_IS_SCHEDULED, [\Lamb\now()]);
 }
 
 /**
@@ -162,21 +159,8 @@ function get_feed_data(): array
 {
     global $config;
 
-    $visible = \Lamb\visible_clause();
-    $clause = build_exclude_slugs_clause(Config\get_menu_slugs());
-    if ($clause !== null) {
-        $posts = R::find(
-            'post',
-            $clause['sql'] . ' AND' . $visible['sql'] . 'ORDER BY updated DESC LIMIT 20',
-            array_merge($clause['params'], $visible['params'])
-        );
-    } else {
-        $posts = R::find(
-            'post',
-            $visible['sql'] . 'ORDER BY updated DESC LIMIT 20',
-            $visible['params']
-        );
-    }
+    $public = public_posts_clause();
+    $posts  = R::find('post', $public['sql'] . ' ORDER BY updated DESC LIMIT 20', $public['params']);
 
     $first_post = reset($posts);
     return [

--- a/tests/Unit/ResponseHandlersTest.php
+++ b/tests/Unit/ResponseHandlersTest.php
@@ -8,6 +8,7 @@ use RedBeanPHP\R;
 use function Lamb\Bootstrap\ensure_post_columns;
 use function Lamb\Response\count_drafts;
 use function Lamb\Response\count_trash;
+use function Lamb\Response\listing_data;
 use function Lamb\Response\respond_404;
 use function Lamb\Response\respond_drafts;
 use function Lamb\Response\respond_home;
@@ -19,6 +20,9 @@ use function Lamb\Response\respond_tag;
 use function Lamb\Response\respond_trash;
 use function Lamb\Response\restore_post;
 use function Lamb\Response\soft_delete_post;
+
+use const Lamb\SQL_IS_DRAFT;
+use const Lamb\SQL_IS_SCHEDULED;
 
 class ResponseHandlersTest extends TestCase
 {
@@ -637,6 +641,43 @@ class ResponseHandlersTest extends TestCase
         $ids = array_map(fn($p) => $p->id, $result['posts']);
         $this->assertContains($deleted->id, $ids);
         $this->assertNotContains($live->id, $ids);
+    }
+
+    // listing_data
+
+    public function testListingDataReturnsTitlePostsAndPagination(): void
+    {
+        $post = R::dispense('post');
+        $post->body    = 'A draft';
+        $post->draft   = 1;
+        $post->created = date('Y-m-d H:i:s');
+        $post->updated = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $data = listing_data('Drafts', 'created DESC', SQL_IS_DRAFT);
+
+        $this->assertSame('Drafts', $data['title']);
+        $this->assertSame([$post->id], array_values(array_map(fn($p) => $p->id, $data['posts'])));
+        $this->assertSame(1, $data['pagination']['total_posts']);
+    }
+
+    public function testListingDataBindsSuppliedParameters(): void
+    {
+        $future = R::dispense('post');
+        $future->body    = 'Scheduled';
+        $future->created = date('Y-m-d H:i:s', time() + 3600);
+        $future->updated = date('Y-m-d H:i:s');
+        R::store($future);
+
+        $past = R::dispense('post');
+        $past->body    = 'Published';
+        $past->created = date('Y-m-d H:i:s', time() - 3600);
+        $past->updated = date('Y-m-d H:i:s');
+        R::store($past);
+
+        $data = listing_data('Scheduled', 'created ASC', SQL_IS_SCHEDULED, [\Lamb\now()]);
+
+        $this->assertSame([$future->id], array_values(array_map(fn($p) => $p->id, $data['posts'])));
     }
 
     // count_drafts / count_trash

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -9,6 +9,7 @@ use function Lamb\Response\build_pagination_meta;
 use function Lamb\Response\get_cookie_options;
 use function Lamb\Response\get_feed_updated_date;
 use function Lamb\Response\paginate_posts;
+use function Lamb\Response\public_posts_clause;
 use function Lamb\Response\upgrade_posts;
 
 class ResponseTest extends TestCase
@@ -80,6 +81,35 @@ class ResponseTest extends TestCase
         $slugs = ['about', 'contact'];
         $result = build_exclude_slugs_clause($slugs);
         $this->assertSame($slugs, $result['params']);
+    }
+
+    // public_posts_clause
+
+    public function testPublicPostsClauseFiltersDraftsDeletedAndScheduled()
+    {
+        global $config;
+        $config = ['menu_items' => []];
+
+        $clause = public_posts_clause();
+
+        $this->assertStringContainsString('draft', $clause['sql']);
+        $this->assertStringContainsString('deleted', $clause['sql']);
+        $this->assertStringContainsString('created', $clause['sql']);
+        $this->assertStringNotContainsString('slug NOT IN', $clause['sql']);
+    }
+
+    public function testPublicPostsClauseExcludesMenuItemSlugs()
+    {
+        global $config;
+        $config = ['menu_items' => ['About' => 'about', 'Contact' => '/contact']];
+
+        $clause = public_posts_clause();
+
+        $this->assertStringContainsString('slug NOT IN', $clause['sql']);
+        // Params must line up with the placeholders: the visibility clause's
+        // "created > ?" comes first, then the excluded slugs in order.
+        $this->assertSame(substr_count($clause['sql'], '?'), count($clause['params']));
+        $this->assertSame(['about', 'contact'], array_slice($clause['params'], 1));
     }
 
     // build_pagination_meta


### PR DESCRIPTION
Part of a refactor sweep. Behaviour-preserving.

## What

Two duplications in the listing routes (`src/response/feeds.php`):

**1. "Which posts are public?" was defined twice, differently.**

`respond_home()` appended the menu-slug exclusion after the visibility clause; `get_feed_data()` prepended it *and* kept a second `R::find()` branch for the "no menu items configured" case. Same result, two spellings — and two places to edit when the definition of public changes.

`public_posts_clause()` (in `src/response.php`, next to `build_exclude_slugs_clause()`) now owns it and returns one `{sql, params}` pair. The feed's duplicated query branch disappears.

**2. Every listing route hand-copied the same three keys.**

`respond_home()`, `respond_drafts()`, `respond_trash()` and `respond_scheduled()` each called `paginate_posts()` and then assigned `title`/`posts`/`pagination` into `$data`. That tail is now `listing_data($title, $order_by, $where_sql, $params)`.

`Security\require_login()` stays in the route handlers rather than moving into the helper — authentication should be visible at the route, not a side effect of assembling data.

## Behaviour

Same posts, ordering, pagination and template keys. The only difference is the generated feed SQL's clause order (`AND` commutes, and bound params follow their placeholders).

## Tests

- `tests/Unit/ResponseTest.php`: `public_posts_clause()` filters drafts/deleted/scheduled, excludes configured menu slugs, and keeps params aligned with placeholders.
- `tests/Unit/ResponseHandlersTest.php`: `listing_data()` returns title/posts/pagination and binds supplied parameters.
- Existing `respond_home`/`respond_drafts`/`respond_trash`/feed tests cover the rewired call sites unchanged.

Local: `phpcs` clean, `phpstan` (level 8) clean, `codecept run Unit` 1271 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfrzt37Uezf8hNjKpGmnR)_