### PR TITLE
Refactor: deduplicate the Micropub scope gates

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -50,11 +50,8 @@ class LambMicropubAdapter extends MicropubAdapter
         // token may read it; a hidden one requires 'update' scope (the same
         // trust level needed to edit it) and otherwise looks exactly like a
         // nonexistent post, so this can't be used as an existence oracle either.
-        if (!is_publicly_visible($bean)) {
-            $scope = $this->user['scope'] ?? [];
-            if ($this->user !== null && !in_array('update', $scope)) {
-                return false;
-            }
+        if (!is_publicly_visible($bean) && $this->lacksScope('update')) {
+            return false;
         }
 
         $props = $this->beanToMf2Properties($bean);
@@ -260,6 +257,40 @@ class LambMicropubAdapter extends MicropubAdapter
     }
 
     /**
+     * The insufficient_scope response for an action the token may not perform,
+     * or null when it may proceed.
+     *
+     * The gate every scope-checked callback shares, so all four ask the same
+     * question and name their own scope in the challenge. A request with no token
+     * at all ($this->user === null) is not gated here: the callbacks are also
+     * reached from the logged-in web paths, whose authorisation happened earlier.
+     *
+     * @param string $scope The scope this action requires (e.g. 'create', 'delete').
+     * @return Response|null
+     */
+    private function scopeRejection(string $scope): ?Response
+    {
+        return $this->lacksScope($scope) ? $this->insufficientScopeResponse($scope) : null;
+    }
+
+    /**
+     * Whether the request carries a token that does *not* grant $scope.
+     *
+     * False for an untokened request, so the callbacks stay usable from the
+     * logged-in web paths (see scopeRejection()). Kept separate from
+     * scopeRejection() for the one gate that answers with something other than
+     * an insufficient_scope response: a source query for a hidden post hides it
+     * instead (returns false), rather than confirming it exists.
+     *
+     * @param string $scope The scope being demanded.
+     * @return bool
+     */
+    private function lacksScope(string $scope): bool
+    {
+        return $this->user !== null && !in_array($scope, $this->user['scope'] ?? [], true);
+    }
+
+    /**
      * Handle a micropub create request.
      *
      * @param array<string, mixed> $data  Normalised microformats2 data.
@@ -268,9 +299,9 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     public function createCallback(array $data, array $uploadedFiles = [])
     {
-        $scope = $this->user['scope'] ?? [];
-        if ($this->user !== null && !in_array('create', $scope)) {
-            return $this->insufficientScopeResponse('create');
+        $rejection = $this->scopeRejection('create');
+        if ($rejection !== null) {
+            return $rejection;
         }
 
         $props = $data['properties'] ?? [];
@@ -355,9 +386,9 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     public function deleteCallback(string $url)
     {
-        $scope = $this->user['scope'] ?? [];
-        if ($this->user !== null && !in_array('delete', $scope)) {
-            return $this->insufficientScopeResponse('delete');
+        $rejection = $this->scopeRejection('delete');
+        if ($rejection !== null) {
+            return $rejection;
         }
 
         $bean = $this->findPostByUrl($url);
@@ -383,9 +414,9 @@ class LambMicropubAdapter extends MicropubAdapter
         // Gated on 'delete' scope, not a separate 'undelete' one: undelete is
         // the reversal of the same destructive action, and this codebase
         // doesn't otherwise define a distinct scope for it.
-        $scope = $this->user['scope'] ?? [];
-        if ($this->user !== null && !in_array('delete', $scope)) {
-            return $this->insufficientScopeResponse('delete');
+        $rejection = $this->scopeRejection('delete');
+        if ($rejection !== null) {
+            return $rejection;
         }
 
         $bean = $this->findPostByUrl($url);
@@ -418,9 +449,9 @@ class LambMicropubAdapter extends MicropubAdapter
             return 'invalid_request';
         }
 
-        $scope = $this->user['scope'] ?? [];
-        if ($this->user !== null && !in_array('update', $scope)) {
-            return $this->insufficientScopeResponse('update');
+        $rejection = $this->scopeRejection('update');
+        if ($rejection !== null) {
+            return $rejection;
         }
 
         foreach ($actions['replace'] ?? [] as $property => $values) {

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -1228,6 +1228,74 @@ class MicropubAdapterTest extends TestCase
         $this->assertEquals(1, $updated->deleted, 'the post must still be deleted');
     }
 
+    // --- scope gating across the callbacks ---
+
+    /**
+     * Stores a post and returns an adapter whose token carries only 'read' —
+     * a real scope, but never the one a scope-gated callback asks for.
+     *
+     * @return array{0: LambMicropubAdapter, 1: string} The adapter and the post URL.
+     */
+    private function readOnlyTokenFor(string $body, bool $deleted = false): array
+    {
+        $bean = R::dispense('post');
+        $bean->body    = $body;
+        $bean->slug    = '';
+        $bean->deleted = $deleted ? 1 : null;
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = ['me' => ROOT_URL . '/', 'scope' => ['read']];
+
+        return [$adapter, ROOT_URL . '/status/' . $bean->id];
+    }
+
+    private function assertChallengeNamesScope(mixed $result, string $scope): void
+    {
+        $this->assertInstanceOf(\Psr\Http\Message\ResponseInterface::class, $result);
+        $this->assertSame(403, $result->getStatusCode());
+        $this->assertStringContainsString(
+            'scope="' . $scope . '"',
+            $result->getHeaderLine('www-authenticate')
+        );
+    }
+
+    public function testDeleteChallengeNamesTheDeleteScope(): void
+    {
+        [$adapter, $url] = $this->readOnlyTokenFor('Not deletable by a read token');
+        $this->assertChallengeNamesScope($adapter->deleteCallback($url), 'delete');
+    }
+
+    public function testUndeleteChallengeNamesTheDeleteScope(): void
+    {
+        [$adapter, $url] = $this->readOnlyTokenFor('Not restorable by a read token', deleted: true);
+        $this->assertChallengeNamesScope($adapter->undeleteCallback($url), 'delete');
+    }
+
+    public function testUpdateChallengeNamesTheUpdateScope(): void
+    {
+        [$adapter, $url] = $this->readOnlyTokenFor('Not editable by a read token');
+        $result = $adapter->updateCallback($url, ['replace' => ['content' => ['nope']]]);
+        $this->assertChallengeNamesScope($result, 'update');
+    }
+
+    public function testScopeGatedCallbackAllowsAnUnauthenticatedCall(): void
+    {
+        // No token at all (the logged-in web paths): the scope gate must not
+        // fire, otherwise every non-Micropub caller would 403.
+        $bean = R::dispense('post');
+        $bean->body    = 'Deletable without a token';
+        $bean->slug    = '';
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $this->assertTrue($adapter->deleteCallback(ROOT_URL . '/status/' . $bean->id));
+    }
+
     // --- beanToMf2Properties (via sourceQueryCallback) ---
 
     public function testSourceQueryReturnsNamePropertyForTitledPost(): void


### PR DESCRIPTION
Part of a refactor sweep. Behaviour-preserving.

## What

Five callbacks in `src/micropub.php` asked the same question with five copies of the same two lines — read `$this->user['scope']`, reject when a token is present but lacks the required scope:

| Callback | Scope | On rejection |
|---|---|---|
| `createCallback` | `create` | `insufficient_scope` (403) |
| `deleteCallback` | `delete` | `insufficient_scope` (403) |
| `undeleteCallback` | `delete` | `insufficient_scope` (403) |
| `updateCallback` | `update` | `insufficient_scope` (403) |
| `sourceQueryCallback` (hidden post) | `update` | `false` — hide, don't confirm existence |

Five copies of an authorisation check is exactly where a future gate gets added with the wrong scope name, or missed entirely (`deleteCallback` had no check at all until #517).

## How

Two private helpers:

- `lacksScope($scope)` — the predicate. `false` for an untokened request, so the callbacks remain usable from the logged-in web paths whose authorisation happened earlier.
- `scopeRejection($scope)` — the `insufficient_scope` `Response`, or `null` to proceed. Used by the four Response-returning gates.

`sourceQueryCallback()` calls `lacksScope()` directly, keeping its deliberate hide-rather-than-403 answer (#518).

## Behaviour

Identical, with one narrowing worth naming: the copies used a loose `in_array()`; the helper compares strictly, matching the existing `has_micropub_scope()`. Introspected scopes are always strings (`explode(' ', …)`), so the outcome is the same — it just no longer leans on loose comparison.

## Tests

`tests/Unit/MicropubAdapterTest.php` gains three tests pinning that each gate names **its own** scope in the `WWW-Authenticate` challenge (delete → `scope="delete"`, undelete → `scope="delete"`, update → `scope="update"`) — the wiring a bad extraction would break — plus one that an untokened call is not gated. They were written and passing against the pre-refactor code, then re-run after.

Existing scope regression tests (#511, #517, #518) unchanged and still green.

Local: `phpcs` clean, `phpstan` (level 8) clean, `codecept run Unit` 1271 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfrzt37Uezf8hNjKpGmnR)_