### PR TITLE
Refactor: extract the slug-redirect and manual-redirect-warning helpers

### DIFF
--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -31,7 +31,6 @@ use function Lamb\Route\is_reserved_route;
  */
 function redirect_created(): void
 {
-    global $config;
     Security\require_login();
     Security\require_csrf();
     if ($_POST['submit'] !== SUBMIT_CREATE) {
@@ -50,17 +49,65 @@ function redirect_created(): void
         // Remove any existing redirect for this slug — the new post takes priority
         if (!empty($bean->slug)) {
             delete_redirect_for_slug($bean->slug);
-            $redirections = $config['redirections'] ?? [];
-            if (isset($redirections[$bean->slug])) {
-                $_SESSION['flash'][] = 'A manual redirect for <code>' . $bean->slug
-                    . '</code> still exists in Settings → [redirections]. You may want to remove it.';
-            }
+            warn_if_manual_redirect((string) $bean->slug);
         }
     } catch (SQL $e) {
         $_SESSION['flash'][] = 'Failed to save: ' . $e->getMessage();
     }
     notify_post_subscribers($bean);
     redirect_uri('/');
+}
+
+/**
+ * Flashes a warning when a slug a post just claimed is also listed under
+ * `[redirections]` in the INI config.
+ *
+ * The manual redirect wins over the post (it is checked first), so the post would
+ * be unreachable at its own URL without the author being told why. Both save paths
+ * (create and edit) check this, so the message lives in one place.
+ *
+ * @param string $slug The slug the post was saved with.
+ * @return void
+ */
+function warn_if_manual_redirect(string $slug): void
+{
+    global $config;
+
+    if ($slug === '') {
+        return;
+    }
+    if (!isset($config['redirections'][$slug])) {
+        return;
+    }
+
+    $_SESSION['flash'][] = 'A manual redirect for <code>' . $slug
+        . '</code> still exists in Settings → [redirections]. You may want to remove it.';
+}
+
+/**
+ * Records the 301 that keeps a renamed post's old URL working.
+ *
+ * Points $old_slug at $new_slug, first dropping any redirect that leads *away*
+ * from the new slug — a leftover from an earlier rename would otherwise bounce
+ * visitors of the new URL straight back out, or loop.
+ *
+ * The target is passed through sanitize_explicit_slug(): the same sanitiser runs
+ * when a slug is first read from front matter, but a slug that reached this point
+ * some other way must not be able to turn the stored redirect into a
+ * protocol-relative "//host/..." open redirect either.
+ *
+ * @param string $old_slug The slug the post used to live at.
+ * @param string $new_slug The slug it now lives at.
+ * @return void
+ */
+function store_slug_change_redirect(string $old_slug, string $new_slug): void
+{
+    delete_redirect_for_slug($new_slug);
+
+    $auto_redirect = R::dispense('redirect');
+    $auto_redirect->from_slug = $old_slug;
+    $auto_redirect->to_url    = '/' . sanitize_explicit_slug($new_slug);
+    R::store($auto_redirect);
 }
 
 /**
@@ -210,8 +257,6 @@ function restore_post(OODBBean $post): void
  */
 function redirect_edited(): void
 {
-    global $config;
-
     Security\require_login();
     Security\require_csrf();
     $validSubmits = [SUBMIT_EDIT];
@@ -257,25 +302,10 @@ function redirect_edited(): void
 
     $new_slug = $bean->slug;
     if (!empty($old_slug) && $old_slug !== $new_slug) {
-        // Remove any redirect pointing to the new slug to avoid redirect loops
-        delete_redirect_for_slug($new_slug);
-        // Store a redirect from the old slug to the new one. sanitize_explicit_slug()
-        // is also applied when a slug is first read from front matter, but a
-        // slug reaching this point some other way must not be able to turn
-        // this into a protocol-relative "//host/..." open redirect either.
-        $auto_redirect = R::dispense('redirect');
-        $auto_redirect->from_slug = $old_slug;
-        $auto_redirect->to_url = '/' . sanitize_explicit_slug($new_slug);
-        R::store($auto_redirect);
+        store_slug_change_redirect((string) $old_slug, (string) $new_slug);
     }
 
-    if (!empty($new_slug)) {
-        $redirections = $config['redirections'] ?? [];
-        if (isset($redirections[$new_slug])) {
-            $_SESSION['flash'][] = 'A manual redirect for <code>' . $new_slug
-                . '</code> still exists in Settings → [redirections]. You may want to remove it.';
-        }
-    }
+    warn_if_manual_redirect((string) $new_slug);
 
     notify_post_subscribers($bean);
 

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -12,6 +12,8 @@ use function Lamb\Response\redirect_created;
 use function Lamb\Response\redirect_edited;
 use function Lamb\Response\respond_edit;
 use function Lamb\Response\safe_referer_path;
+use function Lamb\Response\store_slug_change_redirect;
+use function Lamb\Response\warn_if_manual_redirect;
 
 class ResponsePostsTest extends TestCase
 {
@@ -57,6 +59,84 @@ class ResponsePostsTest extends TestCase
         $_SESSION = [];
         $_POST    = [];
         $_GET     = [];
+    }
+
+    // -------------------------------------------------------------------------
+    // warn_if_manual_redirect
+    // -------------------------------------------------------------------------
+
+    public function testWarnIfManualRedirectFlashesWhenConfigStillRedirectsTheSlug(): void
+    {
+        global $config;
+        $config['redirections'] = ['about' => 'https://example.com/elsewhere'];
+
+        warn_if_manual_redirect('about');
+
+        $this->assertCount(1, $_SESSION['flash'] ?? []);
+        $this->assertStringContainsString('about', $_SESSION['flash'][0]);
+        $this->assertStringContainsString('[redirections]', $_SESSION['flash'][0]);
+    }
+
+    public function testWarnIfManualRedirectStaysQuietForAnUnrelatedSlug(): void
+    {
+        global $config;
+        $config['redirections'] = ['about' => 'https://example.com/elsewhere'];
+
+        warn_if_manual_redirect('contact');
+
+        $this->assertSame([], $_SESSION['flash'] ?? []);
+    }
+
+    public function testWarnIfManualRedirectStaysQuietForAnEmptySlug(): void
+    {
+        global $config;
+        $config['redirections'] = ['' => 'https://example.com/elsewhere'];
+
+        warn_if_manual_redirect('');
+
+        $this->assertSame([], $_SESSION['flash'] ?? []);
+    }
+
+    // -------------------------------------------------------------------------
+    // store_slug_change_redirect
+    // -------------------------------------------------------------------------
+
+    public function testStoreSlugChangeRedirectPointsTheOldSlugAtTheNewOne(): void
+    {
+        R::exec('DELETE FROM redirect WHERE 1');
+
+        store_slug_change_redirect('old-slug', 'new-slug');
+
+        $redirect = R::findOne('redirect', ' from_slug = ? ', ['old-slug']);
+        $this->assertNotNull($redirect);
+        $this->assertSame('/new-slug', $redirect->to_url);
+    }
+
+    public function testStoreSlugChangeRedirectDropsAnyRedirectAwayFromTheNewSlug(): void
+    {
+        R::exec('DELETE FROM redirect WHERE 1');
+        // A stale redirect from an earlier rename would otherwise send visitors
+        // of the new slug straight back out again.
+        $stale = R::dispense('redirect');
+        $stale->from_slug = 'new-slug';
+        $stale->to_url    = '/somewhere-else';
+        R::store($stale);
+
+        store_slug_change_redirect('old-slug', 'new-slug');
+
+        $this->assertNull(R::findOne('redirect', ' from_slug = ? ', ['new-slug']));
+    }
+
+    public function testStoreSlugChangeRedirectSanitizesTheTarget(): void
+    {
+        R::exec('DELETE FROM redirect WHERE 1');
+
+        store_slug_change_redirect('old-slug', '/evil.example.com/phish');
+
+        $redirect = R::findOne('redirect', ' from_slug = ? ', ['old-slug']);
+        $this->assertNotNull($redirect);
+        // Must stay a local path — never a protocol-relative "//host/..." target.
+        $this->assertStringStartsNotWith('//', $redirect->to_url);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Part of a refactor sweep. Behaviour-preserving.

## What

Two things buried inside the post save handlers in `src/response/posts.php`:

**1. The `[redirections]` warning existed twice, verbatim.**

`redirect_created()` and `redirect_edited()` each built the same "A manual redirect for `<slug>` still exists in Settings → [redirections]" flash. A duplicated user-facing string drifts the moment someone rewords one copy. `warn_if_manual_redirect($slug)` now owns it, including the empty-slug guard that only one of the two copies had structurally.

**2. The slug-rename bookkeeping was inline and unreachable from tests.**

`redirect_edited()` dropped any redirect leading away from the new slug (loop prevention), then stored `old → /new` with the target passed through `sanitize_explicit_slug()` (no protocol-relative open redirect). Three statements with real security intent, sitting in a 70-line handler that no unit test can call — it terminates via `redirect_uri()`/`die()`. Now `store_slug_change_redirect($old, $new)`, which tests call directly.

Both handlers also drop their `global $config` now that the config read lives in the helper.

## Tests

New in `tests/Unit/ResponsePostsTest.php`, written red first:

- `warn_if_manual_redirect()`: flashes for a configured slug, stays quiet for an unrelated slug, stays quiet for an empty slug.
- `store_slug_change_redirect()`: points the old slug at the new one, deletes a stale redirect leading away from the new slug, and keeps the stored target a local path (not `//host/…`).

That last one is the first direct test of the open-redirect guard in this path — previously it was only reachable through a `die()`ing handler.

Local: `phpcs` clean, `phpstan` (level 8) clean, `codecept run Unit` 1273 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfrzt37Uezf8hNjKpGmnR)_