### PR TITLE
Refactor: make the /_cron run loop's decisions and report lines testable

### DIFF
--- a/src/network.php
+++ b/src/network.php
@@ -18,6 +18,87 @@ use function Lamb\set_option;
 //
 // The `/_cron` route is registered centrally in Lamb\Route\register_app_routes().
 
+/**
+ * Whether a whole /_cron run may proceed.
+ *
+ * /_cron is unauthenticated and hit by an external scheduler, so runs are capped
+ * at one a minute. The watermark is only written once a run completes.
+ *
+ * @param int $last_run Unix timestamp of the last completed run (0 = never).
+ * @param int $now      Current Unix timestamp.
+ * @return bool
+ */
+function cron_run_due(int $last_run, int $now): bool
+{
+    return ($now - $last_run) >= MINUTE_IN_SECONDS;
+}
+
+/**
+ * Whether an individual feed is due another fetch.
+ *
+ * Gated on the last *attempt*, not the last success, so a failing feed is retried
+ * on schedule rather than locked out — and a healthy one is not re-fetched inside
+ * the 30-minute window.
+ *
+ * @param int $last_attempt Unix timestamp of the last fetch attempt (0 = never).
+ * @param int $now          Current Unix timestamp.
+ * @return bool
+ */
+function feed_fetch_due(int $last_attempt, int $now): bool
+{
+    return ($now - $last_attempt) >= MINUTE_IN_SECONDS * 30;
+}
+
+/**
+ * A maintenance report line, or '' when the count is zero.
+ *
+ * The cron output stays quiet about work that did not happen, so every
+ * maintenance step formats its line the same way.
+ *
+ * @param int    $count    How many rows the step touched.
+ * @param string $template A sprintf template taking the count (e.g. 'Purged %d post(s).').
+ * @return string The line including its newline, or ''.
+ */
+function count_line(int $count, string $template): string
+{
+    return $count > 0 ? sprintf($template, $count) . PHP_EOL : '';
+}
+
+/**
+ * The per-feed outcome line for the cron output.
+ *
+ * @param string $name   Feed name from config.
+ * @param array{ok: bool, items: int, error: ?string} $result As returned by crawl_feed().
+ * @return string The line including its newline.
+ */
+function crawl_line(string $name, array $result): string
+{
+    return $result['ok']
+        ? sprintf('OK: %s - %d item(s) ingested' . PHP_EOL, $name, $result['items'])
+        : sprintf('FAILED: %s - %s' . PHP_EOL, $name, $result['error']);
+}
+
+/**
+ * The outbound-webmention summary line, or '' when the queue was idle.
+ *
+ * @param array{sent: int, failed: int, skipped: int, cancelled: int} $sent As returned by process_outbound().
+ * @return string The line including its newline, or ''.
+ */
+function webmention_line(array $sent): string
+{
+    if (!$sent['sent'] && !$sent['failed'] && !$sent['skipped'] && !$sent['cancelled']) {
+        return '';
+    }
+
+    return sprintf(
+        'Webmentions sent: %d, failed: %d, skipped: %d, cancelled: %d' . PHP_EOL,
+        $sent['sent'],
+        $sent['failed'],
+        $sent['skipped'],
+        $sent['cancelled']
+    );
+}
+
 #[NoReturn] function process_feeds(): void
 {
     header('Content-Type: text/plain');
@@ -40,60 +121,31 @@ use function Lamb\set_option;
     $feeds = get_feeds();
 
     $cron_last_updated = get_option('last_processed_date', 0);
-    if ((time() - $cron_last_updated->value) < MINUTE_IN_SECONDS) {
+    if (!cron_run_due((int)$cron_last_updated->value, time())) {
         die('Too often, try again later.');
     }
 
-    $purged = purge_deleted_posts();
-    if ($purged > 0) {
-        echo("Purged $purged deleted post(s)." . PHP_EOL);
-    }
-
-    $pruned = prune_feed_status();
-    if ($pruned > 0) {
-        echo("Pruned $pruned stale feed status row(s)." . PHP_EOL);
-    }
-
-    $flattened = \Lamb\flatten_redirects();
-    if ($flattened > 0) {
-        echo("Flattened $flattened redirect(s)." . PHP_EOL);
-    }
+    echo count_line(purge_deleted_posts(), 'Purged %d deleted post(s).');
+    echo count_line(prune_feed_status(), 'Pruned %d stale feed status row(s).');
+    echo count_line(\Lamb\flatten_redirects(), 'Flattened %d redirect(s).');
 
     echo("Updating feeds..." . PHP_EOL);
     foreach ($feeds as $name => $url) {
         flush();
         $status = feed_status_bean($name, $url);
-        // The 30-minute fetch-frequency skip is gated on the last *attempt*, not the
-        // last success, so a failing feed is retried on schedule rather than locked
-        // out (and a healthy feed is not re-fetched within the window).
-        if ((time() - (int)$status->last_attempt) < MINUTE_IN_SECONDS * 30) {
+        if (!feed_fetch_due((int)$status->last_attempt, time())) {
             echo('Skipped ' . $url . PHP_EOL);
             continue;
         }
 
-        $result = crawl_feed($name, $url);
-        if ($result['ok']) {
-            printf("OK: %s - %d item(s) ingested" . PHP_EOL, $name, $result['items']);
-        } else {
-            printf("FAILED: %s - %s" . PHP_EOL, $name, $result['error']);
-        }
+        echo crawl_line($name, crawl_feed($name, $url));
     }
 
-    $published = \Lamb\Websub\ping_scheduled_publishes();
-    if ($published > 0) {
-        printf("WebSub: pinged hub for %d scheduled post(s) now published." . PHP_EOL, $published);
-    }
-
-    $sent = \Lamb\Webmention\process_outbound();
-    if ($sent['sent'] || $sent['failed'] || $sent['skipped'] || $sent['cancelled']) {
-        printf(
-            "Webmentions sent: %d, failed: %d, skipped: %d, cancelled: %d" . PHP_EOL,
-            $sent['sent'],
-            $sent['failed'],
-            $sent['skipped'],
-            $sent['cancelled']
-        );
-    }
+    echo count_line(
+        \Lamb\Websub\ping_scheduled_publishes(),
+        'WebSub: pinged hub for %d scheduled post(s) now published.'
+    );
+    echo webmention_line(\Lamb\Webmention\process_outbound());
 
     set_option($cron_last_updated, (int)date('U'));
     exit('Done');

--- a/tests/Unit/NetworkTest.php
+++ b/tests/Unit/NetworkTest.php
@@ -8,8 +8,13 @@ use RedBeanPHP\R;
 
 use function Lamb\Network\acquire_cron_lock;
 use function Lamb\Network\attributed_content;
+use function Lamb\Network\count_line;
+use function Lamb\Network\crawl_line;
+use function Lamb\Network\cron_run_due;
+use function Lamb\Network\feed_fetch_due;
 use function Lamb\Network\get_structured_content;
 use function Lamb\Network\purge_deleted_posts;
+use function Lamb\Network\webmention_line;
 
 class NetworkTest extends TestCase
 {
@@ -269,5 +274,87 @@ class NetworkTest extends TestCase
 
         fclose($handle);
         unlink($path);
+    }
+
+    // cron_run_due — the whole-run rate limit (1 minute)
+
+    public function testCronRunIsNotDueWithinAMinuteOfTheLastRun(): void
+    {
+        $now = 1_700_000_000;
+        $this->assertFalse(cron_run_due($now - 59, $now));
+    }
+
+    public function testCronRunIsDueAfterAFullMinute(): void
+    {
+        $now = 1_700_000_000;
+        $this->assertTrue(cron_run_due($now - MINUTE_IN_SECONDS, $now));
+    }
+
+    public function testCronRunIsDueWhenItHasNeverRun(): void
+    {
+        $this->assertTrue(cron_run_due(0, 1_700_000_000));
+    }
+
+    // feed_fetch_due — the per-feed rate limit (30 minutes)
+
+    public function testFeedFetchIsNotDueWithinThirtyMinutesOfTheLastAttempt(): void
+    {
+        $now = 1_700_000_000;
+        $this->assertFalse(feed_fetch_due($now - (29 * MINUTE_IN_SECONDS), $now));
+    }
+
+    public function testFeedFetchIsDueAfterThirtyMinutes(): void
+    {
+        $now = 1_700_000_000;
+        $this->assertTrue(feed_fetch_due($now - (30 * MINUTE_IN_SECONDS), $now));
+    }
+
+    public function testFeedFetchIsDueForAFeedNeverAttempted(): void
+    {
+        $this->assertTrue(feed_fetch_due(0, 1_700_000_000));
+    }
+
+    // count_line — maintenance summary lines are omitted when nothing happened
+
+    public function testCountLineIsEmptyForZero(): void
+    {
+        $this->assertSame('', count_line(0, 'Purged %d deleted post(s).'));
+    }
+
+    public function testCountLineFormatsAndTerminatesTheLine(): void
+    {
+        $this->assertSame('Purged 3 deleted post(s).' . PHP_EOL, count_line(3, 'Purged %d deleted post(s).'));
+    }
+
+    // crawl_line
+
+    public function testCrawlLineReportsIngestedCountOnSuccess(): void
+    {
+        $line = crawl_line('MyBlog', ['ok' => true, 'items' => 2, 'error' => null]);
+        $this->assertStringContainsString('OK: MyBlog', $line);
+        $this->assertStringContainsString('2 item(s)', $line);
+    }
+
+    public function testCrawlLineReportsTheErrorOnFailure(): void
+    {
+        $line = crawl_line('MyBlog', ['ok' => false, 'items' => 0, 'error' => 'could not resolve host']);
+        $this->assertStringContainsString('FAILED: MyBlog', $line);
+        $this->assertStringContainsString('could not resolve host', $line);
+    }
+
+    // webmention_line
+
+    public function testWebmentionLineIsEmptyWhenNothingHappened(): void
+    {
+        $this->assertSame('', webmention_line(['sent' => 0, 'failed' => 0, 'skipped' => 0, 'cancelled' => 0]));
+    }
+
+    public function testWebmentionLineReportsEveryCounter(): void
+    {
+        $line = webmention_line(['sent' => 1, 'failed' => 2, 'skipped' => 3, 'cancelled' => 4]);
+        $this->assertStringContainsString('sent: 1', $line);
+        $this->assertStringContainsString('failed: 2', $line);
+        $this->assertStringContainsString('skipped: 3', $line);
+        $this->assertStringContainsString('cancelled: 4', $line);
     }
 }


### PR DESCRIPTION
Part of a refactor sweep. Behaviour-preserving. This is the "make it testable" half of the sweep.

## Why

`process_feeds()` cannot be called from a unit test: it sets headers, echoes as it goes, and every exit path `die()`s. So everything it decided went untested — including **both rate limits**, which are the only thing between an unauthenticated `/_cron` and an unbounded burst of outbound feed/webmention fetches.

## How

Pull the decisions and the output formatting out as pure functions in `src/network.php`:

| Function | Responsibility |
|---|---|
| `cron_run_due($last_run, $now)` | the 1-minute whole-run limit |
| `feed_fetch_due($last_attempt, $now)` | the 30-minute per-feed limit |
| `count_line($count, $template)` | a maintenance line, or `''` when the count is zero |
| `crawl_line($name, $result)` | the per-feed `OK:`/`FAILED:` line |
| `webmention_line($sent)` | the outbound-queue summary, or `''` when idle |

`process_feeds()` becomes orchestration only: take the lock, ask whether the run is due, run each step, echo its line. The three maintenance steps each collapse from a five-line `if`/`echo` to one line, because "say nothing when nothing happened" now lives in `count_line()`.

## Behaviour

Unchanged, boundaries included: a run is due at exactly 60s and a feed at exactly 1800s, matching the previous `< MINUTE_IN_SECONDS` and `< MINUTE_IN_SECONDS * 30` skips. Same output text, same conditional lines.

## Tests

12 new cases in `tests/Unit/NetworkTest.php`, written red first — both rate limits (just inside, exactly at, and never-run), `count_line()`'s zero suppression and formatting, both `crawl_line()` branches, and `webmention_line()`'s idle case plus every counter. The rate-limit windows now have direct test coverage for the first time.

Local: `phpcs` clean, `phpstan` (level 8) clean, `codecept run Unit` 1279 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfrzt37Uezf8hNjKpGmnR)_