### PR TITLE
Refactor: make the upload field reshaping testable

### DIFF
--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -28,12 +28,7 @@ function respond_upload(array $_args): void
     }
     Security\require_login();
 
-    $files = [];
-    foreach ($_FILES[IMAGE_FILES] as $name => $items) {
-        foreach ($items as $k => $value) {
-            $files[$k][$name] = $_FILES[IMAGE_FILES][$name][$k];
-        }
-    }
+    $files = normalize_uploaded_files($_FILES[IMAGE_FILES]);
 
     $out = '';
     foreach ($files as $f) {
@@ -74,6 +69,33 @@ function respond_upload(array $_args): void
 
     echo json_encode($out, JSON_THROW_ON_ERROR);
     die();
+}
+
+/**
+ * Turns PHP's attribute-major $_FILES entry into one array per uploaded file.
+ *
+ * PHP groups a multi-file field by attribute (`['name' => [...], 'tmp_name' => [...]]`);
+ * every caller wants it the other way round, one `['name' => …, 'tmp_name' => …, …]`
+ * per file. Extracted from respond_upload() so this reshaping — the part with all
+ * the index bookkeeping — is unit-testable, unlike the responder around it, which
+ * needs real $_FILES entries and dies on every exit path.
+ *
+ * A field posted without `[]` (attributes are scalars rather than arrays) yields
+ * the single file it describes.
+ *
+ * @param array<string, mixed> $field One $_FILES entry, e.g. $_FILES['imageFiles'].
+ * @return array<int, array<string, mixed>> One entry per uploaded file.
+ */
+function normalize_uploaded_files(array $field): array
+{
+    $files = [];
+    foreach ($field as $attribute => $values) {
+        foreach ((array) $values as $index => $value) {
+            $files[$index][$attribute] = $value;
+        }
+    }
+
+    return $files;
 }
 
 /**

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -8,6 +8,7 @@ use function Lamb\Response\asset_url;
 use function Lamb\Response\convert_to_webp;
 use function Lamb\Response\convert_to_webp_from_bytes;
 use function Lamb\Response\get_upload_dir;
+use function Lamb\Response\normalize_uploaded_files;
 use function Lamb\Response\safe_upload_extension;
 use function Lamb\Response\upload_subpath;
 use function Lamb\Response\scaled_dimensions;
@@ -53,6 +54,50 @@ class UploadTest extends TestCase
             }
         }
         rmdir($path);
+    }
+
+    // normalize_uploaded_files
+
+    public function testNormalizeUploadedFilesGroupsPerFieldArraysIntoOneEntryPerFile(): void
+    {
+        // The shape PHP builds for name="imageFiles[]": one array per attribute.
+        $field = [
+            'name'     => ['a.png', 'b.jpg'],
+            'type'     => ['image/png', 'image/jpeg'],
+            'tmp_name' => ['/tmp/php111', '/tmp/php222'],
+            'error'    => [UPLOAD_ERR_OK, UPLOAD_ERR_NO_FILE],
+            'size'     => [123, 456],
+        ];
+
+        $files = normalize_uploaded_files($field);
+
+        $this->assertCount(2, $files);
+        $this->assertSame('a.png', $files[0]['name']);
+        $this->assertSame('/tmp/php111', $files[0]['tmp_name']);
+        $this->assertSame(UPLOAD_ERR_OK, $files[0]['error']);
+        $this->assertSame('b.jpg', $files[1]['name']);
+        $this->assertSame(UPLOAD_ERR_NO_FILE, $files[1]['error']);
+    }
+
+    public function testNormalizeUploadedFilesReturnsEmptyForAnEmptyField(): void
+    {
+        $this->assertSame([], normalize_uploaded_files([]));
+    }
+
+    public function testNormalizeUploadedFilesHandlesASingleNonArrayUpload(): void
+    {
+        // The shape PHP builds for a plain name="imageFiles" (no brackets).
+        $field = [
+            'name'     => 'only.png',
+            'tmp_name' => '/tmp/php333',
+            'error'    => UPLOAD_ERR_OK,
+        ];
+
+        $files = normalize_uploaded_files($field);
+
+        $this->assertCount(1, $files);
+        $this->assertSame('only.png', $files[0]['name']);
+        $this->assertSame('/tmp/php333', $files[0]['tmp_name']);
     }
 
     // get_upload_dir


### PR DESCRIPTION
Part of a refactor sweep.

## What

`respond_upload()` opened with a nested loop that flips PHP's attribute-major `$_FILES` entry (`['name' => [...], 'tmp_name' => [...]]`) into one array per uploaded file. It indexed back into the superglobal (`$_FILES[IMAGE_FILES][$name][$k]`) rather than using the value already in hand, and it sat inside a responder no unit test can call — it needs real `$_FILES` entries and `die()`s on every exit path.

`normalize_uploaded_files($field)` now does the reshaping, and `respond_upload()` opens with a single call.

## Behaviour

Same result for the shape the client actually posts (`imageFiles[]`, so every attribute is an array).

One difference at the edge: a field posted **without** `[]` — scalar attributes — now yields the one file it describes, where the old loop iterated a string and silently produced nothing. `src/scripts/logged_in/upload-image.js` always appends `imageFiles[]`, so no real request shape changes; the helper is just no longer silently wrong if one ever did.

## Tests

`tests/Unit/UploadTest.php` gains three cases (multi-file grouping including per-file `error` codes, the empty field, and the scalar single-upload shape). Written red first.

Local: `phpcs` clean, `phpstan` (level 8) clean, `codecept run Unit` 1270 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfrzt37Uezf8hNjKpGmnR)_