### PR TITLE
Refactor: share the webmention HTTP request options

### DIFF
--- a/src/webmention.php
+++ b/src/webmention.php
@@ -212,6 +212,31 @@ function extract_meta(string $html): array
 }
 
 /**
+ * The fetch_guarded() options every webmention HTTP call shares.
+ *
+ * Receiving (fetching a source), sending discovery (fetching a target) and the
+ * send itself all identify themselves as Lamb-Webmention and use the same
+ * timeout, so a remote site sees one consistent client and one place changes it.
+ *
+ * @param array<string, mixed> $extra Per-call options; `headers` are appended to
+ *                                    the shared ones, anything else overrides.
+ * @return array<string, mixed>
+ */
+function request_options(array $extra = []): array
+{
+    $headers = array_merge(
+        ['Accept: text/html, */*', 'User-Agent: Lamb-Webmention'],
+        $extra['headers'] ?? []
+    );
+    unset($extra['headers']);
+
+    return array_merge(
+        ['headers' => $headers, 'timeout' => WEBMENTION_FETCH_TIMEOUT],
+        $extra
+    );
+}
+
+/**
  * Fetch the raw HTML of a webmention source page.
  *
  * @param string $url
@@ -222,10 +247,7 @@ function fetch_source(string $url): ?string
     // $url is attacker-controlled (the `source` of an unauthenticated
     // webmention POST): use the SSRF-safe fetcher, which rejects loopback/
     // private/link-local destinations and re-checks every redirect hop.
-    $result = fetch_guarded($url, [
-        'headers' => ['Accept: text/html, */*', 'User-Agent: Lamb-Webmention'],
-        'timeout' => WEBMENTION_FETCH_TIMEOUT,
-    ]);
+    $result = fetch_guarded($url, request_options());
 
     return $result === null ? null : $result['body'];
 }
@@ -661,10 +683,7 @@ function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender
  */
 function fetch_target(string $url): ?array
 {
-    $result = fetch_guarded($url, [
-        'headers' => ['Accept: text/html, */*', 'User-Agent: Lamb-Webmention'],
-        'timeout' => WEBMENTION_FETCH_TIMEOUT,
-    ]);
+    $result = fetch_guarded($url, request_options());
 
     if ($result === null) {
         return null;
@@ -693,15 +712,11 @@ function send_webmention(string $endpoint, string $source, string $target): int
     // Unlike Http\post_form(), fetch_guarded() re-validates the destination
     // on every redirect hop — needed here because $endpoint came from the
     // target page's own (attacker-influenced) endpoint discovery.
-    $result = fetch_guarded($endpoint, [
-        'method' => 'POST',
-        'headers' => [
-            'Content-Type: application/x-www-form-urlencoded',
-            'User-Agent: Lamb-Webmention',
-        ],
+    $result = fetch_guarded($endpoint, request_options([
+        'method'  => 'POST',
+        'headers' => ['Content-Type: application/x-www-form-urlencoded'],
         'content' => http_build_query(['source' => $source, 'target' => $target]),
-        'timeout' => WEBMENTION_FETCH_TIMEOUT,
-    ]);
+    ]));
 
     return $result === null ? 0 : $result['status'];
 }

--- a/tests/Unit/WebmentionTest.php
+++ b/tests/Unit/WebmentionTest.php
@@ -9,9 +9,12 @@ use function Lamb\Webmention\discover_endpoint;
 use function Lamb\Webmention\extract_meta;
 use function Lamb\Webmention\is_external_http_url;
 use function Lamb\Webmention\source_mentions_target;
+use function Lamb\Webmention\request_options;
 use function Lamb\Webmention\target_post_id;
 use function Lamb\Webmention\verify_and_store;
 use function Lamb\Webmention\webmentions_for_post;
+
+use const Lamb\Webmention\WEBMENTION_FETCH_TIMEOUT;
 
 class WebmentionTest extends TestCase
 {
@@ -339,5 +342,32 @@ class WebmentionTest extends TestCase
             'https://example.com/post'
         );
         $this->assertNull($endpoint);
+    }
+
+    // request_options — every webmention HTTP call identifies itself the same way
+
+    public function testRequestOptionsCarriesTheWebmentionUserAgentAndTimeout(): void
+    {
+        $options = request_options();
+
+        $this->assertContains('User-Agent: Lamb-Webmention', $options['headers']);
+        $this->assertContains('Accept: text/html, */*', $options['headers']);
+        $this->assertSame(WEBMENTION_FETCH_TIMEOUT, $options['timeout']);
+    }
+
+    public function testRequestOptionsMergesExtraOptionsForASendingRequest(): void
+    {
+        $options = request_options([
+            'method'  => 'POST',
+            'headers' => ['Content-Type: application/x-www-form-urlencoded'],
+            'content' => 'source=a&target=b',
+        ]);
+
+        $this->assertSame('POST', $options['method']);
+        $this->assertSame('source=a&target=b', $options['content']);
+        // Caller headers are added, not swapped in: the User-Agent survives.
+        $this->assertContains('User-Agent: Lamb-Webmention', $options['headers']);
+        $this->assertContains('Content-Type: application/x-www-form-urlencoded', $options['headers']);
+        $this->assertSame(WEBMENTION_FETCH_TIMEOUT, $options['timeout']);
     }
 }


### PR DESCRIPTION
Part of a refactor sweep. Last item in the sweep.

## What

Three functions in `src/webmention.php` each spelled out their own `fetch_guarded()` options:

- `fetch_source()` — receiving: fetch the claimed source page
- `fetch_target()` — sending: fetch the target for endpoint discovery
- `send_webmention()` — sending: POST to the discovered endpoint

Between them the `Lamb-Webmention` User-Agent and `WEBMENTION_FETCH_TIMEOUT` appeared three times, and `Accept: text/html, */*` twice. Changing how Lamb identifies itself to remote sites meant finding all three.

## How

`request_options($extra)` holds the shared base and merges per-call options. Caller `headers` are **appended** to the shared ones rather than replacing them, so the send's `Content-Type` is added without silently dropping the User-Agent.

## One deliberate difference

The outbound POST now also carries `Accept: text/html, */*`, which it previously omitted. `send_webmention()` reads only the status code off that response, so this cannot change what Lamb does with the reply. The alternative was keeping `Accept` out of the shared base and repeating it in both GET callers — this seemed the worse trade.

## Tests

`tests/Unit/WebmentionTest.php` gains two cases: the base options carry the User-Agent, Accept and timeout; and a sending call's extra options merge in with the User-Agent intact. Written red first.

Local: `phpcs` clean, `phpstan` (level 8) clean, `codecept run Unit` 1269 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKfrzt37Uezf8hNjKpGmnR)_