### PR TITLE
Security review: fix Micropub auth bypass, front-matter privilege escalation, and stored XSS

### DIFF
--- a/.docker/Caddyfile
+++ b/.docker/Caddyfile
@@ -5,6 +5,16 @@
 :80 {
 	root * /srv/app/src
 
+	header {
+		X-Content-Type-Options nosniff
+		Referrer-Policy strict-origin-when-cross-origin
+		X-Frame-Options SAMEORIGIN
+	}
+
+	# Never execute PHP from the runtime upload directory. See Caddyfile.release.
+	@assets_php path_regexp ^/assets/.*\.(?i:php|phar|phtml)$
+	respond @assets_php 404
+
 	# Static assets are content-hash cache-busted (?ver=) or stored under
 	# hashed names, so they are safe to cache for a year and immutable.
 	@static path /themes/* /scripts/* /assets/*

--- a/.docker/Caddyfile.release
+++ b/.docker/Caddyfile.release
@@ -6,6 +6,21 @@
 	root * /app/src
 	encode zstd gzip
 
+	header {
+		# Uploads are served from this origin, so a browser must never
+		# second-guess their Content-Type and treat one as HTML or a script.
+		X-Content-Type-Options nosniff
+		Referrer-Policy strict-origin-when-cross-origin
+		X-Frame-Options SAMEORIGIN
+	}
+
+	# /assets is the upload directory: the only web-root path the app writes to
+	# at runtime. The upload allowlist already refuses anything but images and
+	# video, but nothing should execute PHP from there even if a file slips
+	# through — php_server would otherwise happily run it.
+	@assets_php path_regexp ^/assets/.*\.(?i:php|phar|phtml)$
+	respond @assets_php 404
+
 	# Static assets are content-hash cache-busted (?ver=) or stored under
 	# hashed names, so they are safe to cache for a year and immutable.
 	@static path /themes/* /scripts/* /assets/*

--- a/.docker/Dockerfile.release
+++ b/.docker/Dockerfile.release
@@ -21,7 +21,9 @@ RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Images are converted to WebP and resized server-side, so large photo
 # originals are fine (phone photos easily exceed PHP's 2M default); video is
 # stored as-is and can be much larger still.
-RUN printf 'upload_max_filesize = 100M\npost_max_size = 100M\n' > "$PHP_INI_DIR/conf.d/uploads.ini"
+# expose_php is On in PHP's shipped php.ini-production, which advertises the
+# exact PHP version in X-Powered-By on every response.
+RUN printf 'upload_max_filesize = 100M\npost_max_size = 100M\nexpose_php = Off\n' > "$PHP_INI_DIR/conf.d/uploads.ini"
 
 COPY .docker/Caddyfile.release /etc/frankenphp/Caddyfile
 

--- a/.nginx/snippets/lamb.conf
+++ b/.nginx/snippets/lamb.conf
@@ -3,6 +3,14 @@
 # is stored as-is and can be much larger still.
 client_max_body_size 100m;
 
+# Uploads are served from this origin, so a browser must never second-guess
+# their Content-Type and treat one as HTML or a script. add_header does not
+# merge across levels — a location that sets its own headers drops these — so
+# they are repeated in the static-asset location below.
+add_header X-Content-Type-Options nosniff always;
+add_header Referrer-Policy strict-origin-when-cross-origin always;
+add_header X-Frame-Options SAMEORIGIN always;
+
 location / {
      try_files $uri $uri/ /index.php$is_args$args;
 }
@@ -12,4 +20,7 @@ location / {
 location ~ ^/(themes|scripts|assets)/ {
      expires 1y;
      add_header Cache-Control "public, immutable";
+     add_header X-Content-Type-Options nosniff always;
+     add_header Referrer-Policy strict-origin-when-cross-origin always;
+     add_header X-Frame-Options SAMEORIGIN always;
 }

--- a/.nginx/snippets/php-82.conf
+++ b/.nginx/snippets/php-82.conf
@@ -1,5 +1,14 @@
 index index.php index.html;
 
+# /assets is the upload directory: the only web-root path the app writes to at
+# runtime. The upload allowlist already refuses anything but images and video,
+# but nothing should execute PHP from there even if a file slips through. This
+# must stay ahead of the `\.php$` location below — nginx takes the first regex
+# location that matches.
+location ~ ^/assets/.*\.(?i:php|phar|phtml)$ {
+    return 404;
+}
+
 location ~ \.php$  {
     include snippets/fastcgi-php.conf;
     fastcgi_pass unix:/run/php/php8.2-fpm.sock;

--- a/Caddyfile
+++ b/Caddyfile
@@ -5,6 +5,16 @@
 lamb.test:80 {
 	root * src/
 
+	header {
+		X-Content-Type-Options nosniff
+		Referrer-Policy strict-origin-when-cross-origin
+		X-Frame-Options SAMEORIGIN
+	}
+
+	# Never execute PHP from the runtime upload directory. See .docker/Caddyfile.release.
+	@assets_php path_regexp ^/assets/.*\.(?i:php|phar|phtml)$
+	respond @assets_php 404
+
 	# Static assets are content-hash cache-busted (?ver=) or stored under
 	# hashed names, so they are safe to cache for a year and immutable.
 	@static path /themes/* /scripts/* /assets/*

--- a/composer.json
+++ b/composer.json
@@ -1,106 +1,107 @@
 {
-    "name": "svandragt/lamb",
-    "description": "Micro blogging like an animal",
-    "license": "GPL-3.0-or-later",
-    "type": "project",
-    "authors": [
-        {
-            "name": "Sander van Dragt",
-            "email": "sander@vandragt.com"
-        }
-    ],
-    "require": {
-        "php": ">=8.2",
-        "ext-gettext": "*",
-        "ext-pdo_mysql": "*",
-        "ext-simplexml": "*",
-        "ext-sqlite3": "*",
-        "erusev/parsedown": "^1.7",
-        "gabordemooij/redbean": "^5.7",
-        "league/html-to-markdown": "^5.1",
-        "simplepie/simplepie": "^1.8",
-        "symfony/yaml": "^7.0",
-        "taproot/micropub-adapter": "^0.1.3",
-        "phiki/phiki": "^2.2"
-    },
-    "require-dev": {
-        "codeception/codeception": "^5.1",
-        "codeception/module-asserts": "*",
-        "codeception/module-phpbrowser": "*",
-        "phpcompatibility/php-compatibility": "^9.3",
-        "squizlabs/php_codesniffer": "^3.10",
-        "vlucas/phpdotenv": "^5.6",
-        "symfony/process": "^7.4"
-    },
-    "autoload": {
-        "psr-4": {
-            "Lamb\\": "src/"
-        },
-        "files": [
-            "src/constants.php",
-            "src/bootstrap.php",
-            "src/config.php",
-            "src/highlight.php",
-            "src/http.php",
-            "src/lamb.php",
-            "src/routes.php",
-            "src/network.php",
-            "src/network/status.php",
-            "src/network/sources.php",
-            "src/network/ingest.php",
-            "src/network/json_feed.php",
-            "src/post.php",
-            "src/response.php",
-            "src/response/auth.php",
-            "src/response/discovery.php",
-            "src/response/feeds.php",
-            "src/response/posts.php",
-            "src/response/upload.php",
-            "src/security.php",
-            "src/theme.php",
-            "src/theme/assets.php",
-            "src/theme/formatting.php",
-            "src/theme/meta.php",
-            "src/micropub.php",
-            "src/webmention.php",
-            "src/websub.php",
-            "src/wordpress.php"
-        ]
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Tests\\": "tests/"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        },
-        "audit": {
-            "abandoned": "report"
-        }
-    },
-    "scripts": {
-        "post-install-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
-        "post-update-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
-        "lint": "vendor/bin/phpcs .",
-        "fix": "vendor/bin/phpcbf .",
-        "analyse": "vendor/bin/phpstan analyse --memory-limit=256M",
-        "serve": [
-            "Composer\\Config::disableProcessTimeout",
-            "php -S 0.0.0.0:8747 -t src"
-        ],
-        "serve:frankenphp": "sudo -E frankenphp run",
-        "serve:nginx": "sudo systemctl nginx start",
-        "test": "vendor/bin/codecept run",
-        "coverage": [
-            "vendor/bin/codecept run Unit --coverage-xml",
-            "php check-coverage.php tests/_output/coverage.xml 70"
-        ],
-        "e2e": "pnpm exec playwright test",
-        "docs": [
-            "Composer\\Config::disableProcessTimeout",
-            "docker run --rm -v \"$PWD/docs:/site\" -v \"$PWD/.jekyll-bundle:/usr/local/bundle\" -p 4000:4000 bretfisher/jekyll-serve"
-        ]
+  "name": "svandragt/lamb",
+  "description": "Micro blogging like an animal",
+  "license": "GPL-3.0-or-later",
+  "type": "project",
+  "authors": [
+    {
+      "name": "Sander van Dragt",
+      "email": "sander@vandragt.com"
     }
+  ],
+  "require": {
+    "php": ">=8.2",
+    "ext-gettext": "*",
+    "ext-pdo_mysql": "*",
+    "ext-simplexml": "*",
+    "ext-sqlite3": "*",
+    "erusev/parsedown": "^1.7",
+    "gabordemooij/redbean": "^5.7",
+    "league/html-to-markdown": "^5.1",
+    "simplepie/simplepie": "^1.8",
+    "symfony/yaml": "^7.0",
+    "taproot/micropub-adapter": "^0.1.3",
+    "phiki/phiki": "^2.2"
+  },
+  "require-dev": {
+    "codeception/codeception": "^5.1",
+    "codeception/module-asserts": "*",
+    "codeception/module-phpbrowser": "*",
+    "phpcompatibility/php-compatibility": "^9.3",
+    "squizlabs/php_codesniffer": "^3.10",
+    "vlucas/phpdotenv": "^5.6",
+    "symfony/process": "^7.4",
+    "phpstan/phpstan": "^2.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Lamb\\": "src/"
+    },
+    "files": [
+      "src/constants.php",
+      "src/bootstrap.php",
+      "src/config.php",
+      "src/highlight.php",
+      "src/http.php",
+      "src/lamb.php",
+      "src/routes.php",
+      "src/network.php",
+      "src/network/status.php",
+      "src/network/sources.php",
+      "src/network/ingest.php",
+      "src/network/json_feed.php",
+      "src/post.php",
+      "src/response.php",
+      "src/response/auth.php",
+      "src/response/discovery.php",
+      "src/response/feeds.php",
+      "src/response/posts.php",
+      "src/response/upload.php",
+      "src/security.php",
+      "src/theme.php",
+      "src/theme/assets.php",
+      "src/theme/formatting.php",
+      "src/theme/meta.php",
+      "src/micropub.php",
+      "src/webmention.php",
+      "src/websub.php",
+      "src/wordpress.php"
+    ]
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    },
+    "audit": {
+      "abandoned": "report"
+    }
+  },
+  "scripts": {
+    "post-install-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
+    "post-update-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
+    "lint": "vendor/bin/phpcs .",
+    "fix": "vendor/bin/phpcbf .",
+    "analyse": "vendor/bin/phpstan analyse --memory-limit=256M",
+    "serve": [
+      "Composer\\Config::disableProcessTimeout",
+      "php -S 0.0.0.0:8747 -t src"
+    ],
+    "serve:frankenphp": "sudo -E frankenphp run",
+    "serve:nginx": "sudo systemctl nginx start",
+    "test": "vendor/bin/codecept run",
+    "coverage": [
+      "vendor/bin/codecept run Unit --coverage-xml",
+      "php check-coverage.php tests/_output/coverage.xml 70"
+    ],
+    "e2e": "pnpm exec playwright test",
+    "docs": [
+      "Composer\\Config::disableProcessTimeout",
+      "docker run --rm -v \"$PWD/docs:/site\" -v \"$PWD/.jekyll-bundle:/usr/local/bundle\" -p 4000:4000 bretfisher/jekyll-serve"
+    ]
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,107 +1,106 @@
 {
-  "name": "svandragt/lamb",
-  "description": "Micro blogging like an animal",
-  "license": "GPL-3.0-or-later",
-  "type": "project",
-  "authors": [
-    {
-      "name": "Sander van Dragt",
-      "email": "sander@vandragt.com"
-    }
-  ],
-  "require": {
-    "php": ">=8.2",
-    "ext-gettext": "*",
-    "ext-pdo_mysql": "*",
-    "ext-simplexml": "*",
-    "ext-sqlite3": "*",
-    "erusev/parsedown": "^1.7",
-    "gabordemooij/redbean": "^5.7",
-    "league/html-to-markdown": "^5.1",
-    "simplepie/simplepie": "^1.8",
-    "symfony/yaml": "^7.0",
-    "taproot/micropub-adapter": "^0.1.3",
-    "phiki/phiki": "^2.2"
-  },
-  "require-dev": {
-    "codeception/codeception": "^5.1",
-    "codeception/module-asserts": "*",
-    "codeception/module-phpbrowser": "*",
-    "phpcompatibility/php-compatibility": "^9.3",
-    "squizlabs/php_codesniffer": "^3.10",
-    "vlucas/phpdotenv": "^5.6",
-    "symfony/process": "^7.4",
-    "phpstan/phpstan": "^2.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Lamb\\": "src/"
-    },
-    "files": [
-      "src/constants.php",
-      "src/bootstrap.php",
-      "src/config.php",
-      "src/highlight.php",
-      "src/http.php",
-      "src/lamb.php",
-      "src/routes.php",
-      "src/network.php",
-      "src/network/status.php",
-      "src/network/sources.php",
-      "src/network/ingest.php",
-      "src/network/json_feed.php",
-      "src/post.php",
-      "src/response.php",
-      "src/response/auth.php",
-      "src/response/discovery.php",
-      "src/response/feeds.php",
-      "src/response/posts.php",
-      "src/response/upload.php",
-      "src/security.php",
-      "src/theme.php",
-      "src/theme/assets.php",
-      "src/theme/formatting.php",
-      "src/theme/meta.php",
-      "src/micropub.php",
-      "src/webmention.php",
-      "src/websub.php",
-      "src/wordpress.php"
-    ]
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Tests\\": "tests/"
-    }
-  },
-  "config": {
-    "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
-    },
-    "audit": {
-      "abandoned": "report"
-    }
-  },
-  "scripts": {
-    "post-install-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
-    "post-update-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
-    "lint": "vendor/bin/phpcs .",
-    "fix": "vendor/bin/phpcbf .",
-    "analyse": "vendor/bin/phpstan analyse --memory-limit=256M",
-    "serve": [
-      "Composer\\Config::disableProcessTimeout",
-      "php -S 0.0.0.0:8747 -t src"
+    "name": "svandragt/lamb",
+    "description": "Micro blogging like an animal",
+    "license": "GPL-3.0-or-later",
+    "type": "project",
+    "authors": [
+        {
+            "name": "Sander van Dragt",
+            "email": "sander@vandragt.com"
+        }
     ],
-    "serve:frankenphp": "sudo -E frankenphp run",
-    "serve:nginx": "sudo systemctl nginx start",
-    "test": "vendor/bin/codecept run",
-    "coverage": [
-      "vendor/bin/codecept run Unit --coverage-xml",
-      "php check-coverage.php tests/_output/coverage.xml 70"
-    ],
-    "e2e": "pnpm exec playwright test",
-    "docs": [
-      "Composer\\Config::disableProcessTimeout",
-      "docker run --rm -v \"$PWD/docs:/site\" -v \"$PWD/.jekyll-bundle:/usr/local/bundle\" -p 4000:4000 bretfisher/jekyll-serve"
-    ]
-  }
+    "require": {
+        "php": ">=8.2",
+        "ext-gettext": "*",
+        "ext-pdo_mysql": "*",
+        "ext-simplexml": "*",
+        "ext-sqlite3": "*",
+        "erusev/parsedown": "^1.7",
+        "gabordemooij/redbean": "^5.7",
+        "league/html-to-markdown": "^5.1",
+        "simplepie/simplepie": "^1.8",
+        "symfony/yaml": "^7.0",
+        "taproot/micropub-adapter": "^0.1.3",
+        "phiki/phiki": "^2.2"
+    },
+    "require-dev": {
+        "codeception/codeception": "^5.1",
+        "codeception/module-asserts": "*",
+        "codeception/module-phpbrowser": "*",
+        "phpcompatibility/php-compatibility": "^9.3",
+        "squizlabs/php_codesniffer": "^3.10",
+        "vlucas/phpdotenv": "^5.6",
+        "symfony/process": "^7.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "Lamb\\": "src/"
+        },
+        "files": [
+            "src/constants.php",
+            "src/bootstrap.php",
+            "src/config.php",
+            "src/highlight.php",
+            "src/http.php",
+            "src/lamb.php",
+            "src/routes.php",
+            "src/network.php",
+            "src/network/status.php",
+            "src/network/sources.php",
+            "src/network/ingest.php",
+            "src/network/json_feed.php",
+            "src/post.php",
+            "src/response.php",
+            "src/response/auth.php",
+            "src/response/discovery.php",
+            "src/response/feeds.php",
+            "src/response/posts.php",
+            "src/response/upload.php",
+            "src/security.php",
+            "src/theme.php",
+            "src/theme/assets.php",
+            "src/theme/formatting.php",
+            "src/theme/meta.php",
+            "src/micropub.php",
+            "src/webmention.php",
+            "src/websub.php",
+            "src/wordpress.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "abandoned": "report"
+        }
+    },
+    "scripts": {
+        "post-install-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
+        "post-update-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
+        "lint": "vendor/bin/phpcs .",
+        "fix": "vendor/bin/phpcbf .",
+        "analyse": "vendor/bin/phpstan analyse --memory-limit=256M",
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "php -S 0.0.0.0:8747 -t src"
+        ],
+        "serve:frankenphp": "sudo -E frankenphp run",
+        "serve:nginx": "sudo systemctl nginx start",
+        "test": "vendor/bin/codecept run",
+        "coverage": [
+            "vendor/bin/codecept run Unit --coverage-xml",
+            "php check-coverage.php tests/_output/coverage.xml 70"
+        ],
+        "e2e": "pnpm exec playwright test",
+        "docs": [
+            "Composer\\Config::disableProcessTimeout",
+            "docker run --rm -v \"$PWD/docs:/site\" -v \"$PWD/.jekyll-bundle:/usr/local/bundle\" -p 4000:4000 bretfisher/jekyll-serve"
+        ]
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -2303,6 +2303,70 @@
             "time": "2025-12-27T19:41:33+00:00"
         },
         {
+            "name": "phpstan/phpstan",
+            "version": "2.2.5",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-05T06:31:06+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "11.0.12",
             "source": {
@@ -5502,7 +5566,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -5512,6 +5576,6 @@
         "ext-simplexml": "*",
         "ext-sqlite3": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -2303,70 +2303,6 @@
             "time": "2025-12-27T19:41:33+00:00"
         },
         {
-            "name": "phpstan/phpstan",
-            "version": "2.2.5",
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
-                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4|^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan-shim": "*"
-            },
-            "bin": [
-                "phpstan",
-                "phpstan.phar"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ondřej Mirtes"
-                },
-                {
-                    "name": "Markus Staab"
-                },
-                {
-                    "name": "Vincent Langlet"
-                }
-            ],
-            "description": "PHPStan - PHP Static Analysis Tool",
-            "keywords": [
-                "dev",
-                "static analysis"
-            ],
-            "support": {
-                "docs": "https://phpstan.org/user-guide/getting-started",
-                "forum": "https://github.com/phpstan/phpstan/discussions",
-                "issues": "https://github.com/phpstan/phpstan/issues",
-                "security": "https://github.com/phpstan/phpstan/security/policy",
-                "source": "https://github.com/phpstan/phpstan-src"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/ondrejmirtes",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/phpstan",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-07-05T06:31:06+00:00"
-        },
-        {
             "name": "phpunit/php-code-coverage",
             "version": "11.0.12",
             "source": {
@@ -5566,7 +5502,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -5576,6 +5512,6 @@
         "ext-simplexml": "*",
         "ext-sqlite3": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.9.0"
 }

--- a/docs/micropub.md
+++ b/docs/micropub.md
@@ -12,7 +12,24 @@ Lamb exposes a `/micropub` endpoint. Clients discover it via a `<link rel="micro
 
 ## Setup
 
-### 1. Add `rel="me"` identity links
+### 1. Set your site URL
+
+Add your canonical site URL to your site configuration at `/settings`:
+
+```ini
+site_url = https://example.com
+```
+
+Lamb compares the identity in an IndieAuth token against this value to confirm the
+token was issued for *your* site and not someone else's. Until it is set, the
+Micropub endpoint refuses every token and logs
+`micropub: rejecting token, no site_url configured` to the PHP error log.
+
+Do not derive it from the request — that is exactly what this setting exists to
+avoid. You can also supply it as the `LAMB_SITE_URL` environment variable, which
+takes precedence over the setting.
+
+### 2. Add `rel="me"` identity links
 
 IndieAuth verifies who you are by checking that your site links to your profiles and those profiles link back. Add a `[me]` section to your site configuration at `/settings`:
 
@@ -26,7 +43,7 @@ Each entry is rendered as a `<link rel="me">` tag in the HTML `<head>` — invis
 
 Make sure each linked profile (e.g. GitHub) has your site URL in its profile page so IndieAuth can verify the two-way link.
 
-### 2. Configure your Micropub client
+### 3. Configure your Micropub client
 
 Point your client at your site URL. It will auto-discover the endpoints from your home page `<head>`:
 
@@ -56,6 +73,8 @@ Posts created with `post-status: draft` or a future `published` date are not pub
 ## Troubleshooting
 
 If a client can't connect — for example it reports "something went wrong setting up your Micropub endpoint" — you can turn on diagnostic logging to see exactly what the client sent and why Lamb responded as it did.
+
+The first thing to check is that `site_url` is set (see [Set your site URL](#1-set-your-site-url)); without it every token is refused, with a `no_site_url` reason in the log below.
 
 Add this to your site configuration at `/settings`:
 

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -13,6 +13,11 @@ one value rather than write it from scratch; personal details stay commented:
 ;; Title of the site, shown in the HTML and feed views
 site_title = My Microblog
 
+;; The canonical URL of your site, e.g. https://example.com (no trailing slash).
+;; Required for Micropub, and pins absolute URLs to your real domain.
+;; Overridden by the LAMB_SITE_URL environment variable.
+;site_url = https://example.com
+
 ;; Author email in feed
 ;author_email = joe.sheeple@example.com
 
@@ -93,6 +98,24 @@ Feed = /feed
 ;https://bsky.app/profile/yourusername = Bluesky
 ;https://mastodon.social/@yourusername = Mastodon
 ```
+
+## Site URL
+
+`site_url` is the canonical address of your site, e.g. `https://example.com`. It is
+optional for a plain blog, but worth setting:
+
+* **Micropub needs it.** IndieAuth tokens are issued for an identity, and Lamb has
+  to know its own identity to tell whether a token belongs to you. Without
+  `site_url` the Micropub endpoint refuses every token, and logs
+  `micropub: rejecting token, no site_url configured` via PHP's error log.
+* **It pins absolute URLs.** Feeds, social embed tags, and the endpoint discovery
+  links otherwise use whatever host the incoming request asked for. Setting
+  `site_url` keeps them on your real domain even if a request arrives with a
+  different `Host` header.
+
+You can also set it outside the settings page with the `LAMB_SITE_URL` environment
+variable, which takes precedence over the INI value — handy when the same
+configuration is deployed to more than one hostname.
 
 ## Related
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -46,7 +46,10 @@ function load_dotenv(string $root): void
 function bootstrap_db(string $data_dir): void
 {
     if (!is_dir($data_dir)) {
-        if (!mkdir($data_dir, 0777, true) && !is_dir($data_dir)) {
+        // 0750, not 0777: this directory holds lamb.db and the session files, so
+        // only the web-server user has any business reading it. Under a permissive
+        // umask 0777 would leave the database world-readable and replaceable.
+        if (!mkdir($data_dir, 0750, true) && !is_dir($data_dir)) {
             throw new RuntimeException(sprintf('Directory "%s" was not created', $data_dir));
         }
     }

--- a/src/config.php
+++ b/src/config.php
@@ -28,6 +28,14 @@ theme = 2026
 ;; Title of the site, in html and feed views
 site_title = My Microblog
 
+;; The canonical URL of your site, e.g. https://example.com (no trailing slash).
+;; Set this if you use Micropub: it is how Lamb tells that an IndieAuth token was
+;; issued for your identity rather than someone else's, so the endpoint refuses
+;; every token while it is unset. It also pins the absolute URLs in feeds and
+;; social embeds to your real domain instead of whatever host the request claimed.
+;; The LAMB_SITE_URL environment variable overrides this value.
+;site_url = https://example.com
+
 ;; Short description of the site, used as the meta description on listing pages.
 ;site_description = A personal microblog
 
@@ -204,6 +212,46 @@ function compose_config(string $stored_ini, string $default_ini): array
     ];
 
     return array_merge($fallback, $defaults, $config);
+}
+
+/**
+ * Returns the site's explicitly configured canonical URL, or null when unset.
+ *
+ * Everything else the app knows about its own address is derived from the
+ * client-supplied Host header, which an attacker can set at will (see
+ * Lamb\Http\request_root_url()). This is the one value the author states
+ * deliberately, so it is the only one safe to make a security decision against —
+ * notably the IndieAuth `me` comparison that decides whether a Micropub bearer
+ * token was issued for *this* site.
+ *
+ * Read from LAMB_SITE_URL in the environment first (so a deployment can pin it
+ * without touching the database), then the `site_url` key in the settings INI.
+ * The value is normalised to `scheme://host[:port]` with no trailing slash, and
+ * rejected unless it is an absolute http(s) URL with a host.
+ *
+ * @param array<string, mixed> $config The loaded configuration.
+ * @return string|null The canonical site URL, or null when not configured or unusable.
+ */
+function canonical_site_url(array $config): ?string
+{
+    $candidate = (string) (getenv('LAMB_SITE_URL') ?: ($config['site_url'] ?? ''));
+    $candidate = trim($candidate);
+    if ($candidate === '') {
+        return null;
+    }
+
+    $parts = parse_url($candidate);
+    if ($parts === false || empty($parts['host'])) {
+        return null;
+    }
+    $scheme = strtolower($parts['scheme'] ?? '');
+    if (!in_array($scheme, ['http', 'https'], true)) {
+        return null;
+    }
+
+    $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+
+    return $scheme . '://' . strtolower($parts['host']) . $port;
 }
 
 /**

--- a/src/constants.php
+++ b/src/constants.php
@@ -27,6 +27,10 @@ define('VIDEO_UPLOAD_EXTENSIONS', ['mp4', 'webm', 'mov']);
 define('MAX_UPLOAD_PIXELS', 40_000_000);
 // Seconds before a single feed fetch is abandoned during /_cron ingestion.
 define('FEED_FETCH_TIMEOUT', 15);
+// Largest feed body kept during /_cron ingestion. /_cron is unauthenticated, so an
+// uncapped read lets a configured feed's host (or anything it redirects to) stream
+// an endless body into the worker's memory until it fatals.
+define('FEED_FETCH_MAX_BYTES', 5_000_000);
 define('MINUTE_IN_SECONDS', 60);
 // Current post render-format version. Bump when `transformed` output changes
 // (e.g. new syntax highlighting); older posts are re-parsed on read by upgrade_posts().

--- a/src/http.php
+++ b/src/http.php
@@ -70,6 +70,40 @@ function page_path(string $path, int $page): string
 }
 
 /**
+ * Builds the request's own root URL (`scheme://host[:port]`) from the Host header.
+ *
+ * The Host header is client-supplied and a front-end catch-all vhost (the bundled
+ * Caddy config binds `:80` with no host matcher) forwards whatever it is given, so
+ * the value is validated to a strict host charset here: letters, digits, dots,
+ * hyphens, a single port, and the brackets of an IPv6 literal. Anything else — a
+ * quote, an angle bracket, whitespace, CR/LF — yields null so the caller can
+ * refuse the request rather than reflect it into HTML or a response header.
+ *
+ * This is only the *request's* root URL. It says nothing about the site's real
+ * identity, so it must not be used for a security decision; see
+ * Lamb\Config\canonical_site_url() for the configured, trustworthy value.
+ *
+ * @param array<string, mixed> $server Typically $_SERVER.
+ * @return string|null The request root URL, or null when the Host is missing or malformed.
+ */
+function request_root_url(array $server): ?string
+{
+    $host = $server['HTTP_HOST'] ?? '';
+    if (!is_string($host) || $host === '' || strlen($host) > 253) {
+        return null;
+    }
+    $is_ipv6_literal = preg_match('/^\[[0-9A-Fa-f:.]+](:\d{1,5})?$/', $host) === 1;
+    $is_named_host = preg_match('/^[A-Za-z0-9.-]+(:\d{1,5})?$/', $host) === 1;
+    if (!$is_ipv6_literal && !$is_named_host) {
+        return null;
+    }
+
+    $scheme = (isset($server['HTTPS']) && $server['HTTPS'] === 'on') ? 'https' : 'http';
+
+    return $scheme . '://' . $host;
+}
+
+/**
  * Sanitises a value bound for a `Location:` header.
  *
  * Any request-derived value interpolated into a redirect target (the request

--- a/src/index.php
+++ b/src/index.php
@@ -16,7 +16,17 @@ Bootstrap\bootstrap_session($data_dir);
 $config = Config\load();
 Config\apply_timezone($config);
 
-define('ROOT_URL', (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://" . $_SERVER["HTTP_HOST"]);
+// Prefer the author's configured canonical URL; fall back to the requested host
+// for installs that have not set one. The fallback is validated to a strict host
+// charset, so a malformed Host can no longer be reflected into HTML or headers —
+// but it is still attacker-chosen, which is why security decisions (the Micropub
+// IndieAuth `me` check) use Config\canonical_site_url() directly instead of this.
+$root_url = Config\canonical_site_url($config) ?? Http\request_root_url($_SERVER);
+if ($root_url === null) {
+    header(($_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1') . ' 400 Bad Request');
+    die('Bad Request');
+}
+define('ROOT_URL', $root_url);
 // Config\ensure_explicit_theme() guarantees a renderable theme value on read,
 // so no runtime fallback/alias is needed here (see #291). The value still
 // comes verbatim from the admin-editable config INI, though, and is used

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -34,7 +34,17 @@ function now(): string
 
 // Matches a #hashtag preceded by start-of-string, whitespace, or a closing tag
 // bracket. Capture 1 is the preceding character, capture 2 the tag name.
-const TAG_PATTERN = '/(^|[\s>])#([^\s#&.,!?;:()\[\]{}<]+)/u';
+//
+// The excluded set covers the characters that let a tag escape the markup
+// parse_tags() builds around it — quotes, angle brackets, a backtick, `=`, and
+// the slashes — on top of the punctuation that merely ends a tag. Emoji and other
+// non-Latin scripts stay valid in a tag name.
+const TAG_PATTERN = '/(^|[\s>])#([^\s#&.,!?;:()\[\]{}<>"\'`=\/\\\\]+)/u';
+
+// Bean fields front matter is allowed to set. Anything else in a front-matter
+// block is metadata for the author's own use, not a column to write; see the
+// allowlist check in apply_frontmatter() for why this is not open-ended.
+const FRONT_MATTER_FIELDS = ['title', 'slug', 'created', 'draft', 'description', 'transformed'];
 
 /**
  * Retrieves the tags from the given HTML.
@@ -63,9 +73,35 @@ function get_tags(string $html): array
  */
 function parse_tags(string $html): string
 {
-    return preg_replace_callback(TAG_PATTERN, function ($matches) {
-        return $matches[1] . '<a href="/tag/' . strtolower($matches[2]) . '">#' . $matches[2] . '</a>';
-    }, $html) ?? $html;
+    // This runs over already-rendered HTML, so it must only substitute in text
+    // position. A hashtag can also sit inside an attribute Parsedown built from
+    // user text — an image `alt`, a link `title` — and injecting `<a href="…">`
+    // there closed the attribute and turned the rest into attributes of the
+    // enclosing element, giving an `onerror=` handler that fires on its own.
+    // Feed ingestion reaches here with remote content, which is then stored and
+    // served to every visitor, so that was remotely triggerable stored XSS.
+    // Splitting on tags keeps the substitution out of every attribute value;
+    // escaping the tag name covers the text position it still runs in.
+    $parts = preg_split('/(<[^<>]*>)/', $html, -1, PREG_SPLIT_DELIM_CAPTURE);
+    if ($parts === false) {
+        return $html;
+    }
+
+    foreach ($parts as $i => $part) {
+        // Odd indices are the captured tags themselves — never rewritten.
+        if ($i % 2 === 1 || !str_contains($part, '#')) {
+            continue;
+        }
+        $parts[$i] = preg_replace_callback(TAG_PATTERN, function ($matches) {
+            $escape = fn(string $value): string
+                => htmlspecialchars($value, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE);
+
+            return $matches[1] . '<a href="/tag/' . $escape(strtolower($matches[2])) . '">#'
+                . $escape($matches[2]) . '</a>';
+        }, $part) ?? $part;
+    }
+
+    return implode('', $parts);
 }
 
 /**
@@ -383,9 +419,16 @@ function apply_frontmatter(OODBBean $bean, array $front_matter): void
     $bean->title = isset($front_matter['title']) ? (string) $front_matter['title'] : '';
 
     foreach ($front_matter as $key => $value) {
-        // RedBean only accepts word-character property names. Skip anything
-        // else (e.g. a normalised `reading-time`) so it never reaches a store.
-        if (!is_string($key) || !preg_match('/\A\w+\z/', $key)) {
+        // Only the fields front matter is meant to drive. This used to copy any
+        // word-character key onto the bean, which made front matter a way to set
+        // *any* column — including `id`, turning the store that follows into an
+        // UPDATE of whatever row the author named. A Micropub client holding only
+        // `create` scope could reach it, since a create whose content is itself a
+        // front-matter block is parsed as front matter: `id:` overwrote an
+        // arbitrary post and `deleted:` trashed one, both bypassing the scope
+        // checks that correctly refuse update and delete. Unknown keys are also
+        // no longer turned into new columns by RedBean's fluid mode.
+        if (!is_string($key) || !in_array($key, FRONT_MATTER_FIELDS, true)) {
             continue;
         }
         $bean->$key = $value;

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -220,10 +220,18 @@ class LambMicropubAdapter extends MicropubAdapter
                 'Accept: application/json',
             ],
             'timeout' => 5,
-            // introspectToken historically did not follow redirects explicitly,
-            // relying on PHP's stream defaults; preserve that by omitting them.
-            'follow_location' => null,
-            'max_redirects' => null,
+            // Never follow a redirect on this request. PHP's stream wrapper
+            // re-sends the context's `header` option verbatim to the redirect
+            // target, including across a change of authority — so following one
+            // would hand the author's bearer token to whatever host the token
+            // endpoint points at (an open redirect there, or a takeover of it, is
+            // enough). A token endpoint that answers with a redirect is treated
+            // as a failed introspection instead.
+            'follow_location' => 0,
+            'max_redirects' => 0,
+            // An introspection response is a small JSON document; cap the read so
+            // a misbehaving endpoint cannot stream an unbounded body into memory.
+            'max_bytes' => 65536,
         ]);
 
         if ($result === null) {

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -160,11 +160,30 @@ class LambMicropubAdapter extends MicropubAdapter
             return false;
         }
 
-        if (rtrim($data['me'], '/') !== rtrim(ROOT_URL, '/')) {
+        // Compare against the *configured* canonical URL, never ROOT_URL: ROOT_URL
+        // falls back to the client-supplied Host header, so an attacker holding a
+        // token the endpoint issued for their own identity could send
+        // `Host: their-site.example` and have this check compare their `me` against
+        // their own host — accepting the token as ours. Fail closed when no
+        // canonical URL is configured: with nothing trustworthy to compare, the
+        // identity of the token cannot be established.
+        $expected = \Lamb\Config\canonical_site_url($config);
+        if ($expected === null) {
+            mp_log('token_verify', [
+                'reason' => 'no_site_url',
+                'token'  => token_fingerprint($token),
+            ]);
+            // Surfaced unconditionally: mp_log() is silent unless micropub_debug is
+            // on, and an author whose client suddenly gets 403 needs to be told why.
+            error_log('micropub: rejecting token, no site_url configured (set site_url in /settings)');
+            return false;
+        }
+
+        if (rtrim($data['me'], '/') !== rtrim($expected, '/')) {
             mp_log('token_verify', [
                 'reason'   => 'me_mismatch',
                 'me'       => $data['me'],
-                'expected' => ROOT_URL,
+                'expected' => $expected,
                 'token'    => token_fingerprint($token),
             ]);
             return false;

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1092,6 +1092,12 @@ function respond_micropub_media(): void
         micropub_error(400, 'invalid_request', 'Unsupported file type.');
     }
 
+    // The extension comes from the client's filename; check the bytes agree with it.
+    $sniffed = \Lamb\Response\sniff_file_content_type((string) ($file['tmp_name'] ?? ''));
+    if (!\Lamb\Response\upload_content_allowed($sniffed, $ext)) {
+        micropub_error(400, 'invalid_request', 'File contents do not match its type.');
+    }
+
     $sub_path  = \Lamb\Response\upload_subpath();
     $uploadDir = \Lamb\Response\get_upload_dir($sub_path);
     $seed      = sha1(($file['name'] ?? '') . uniqid('', true));

--- a/src/network/json_feed.php
+++ b/src/network/json_feed.php
@@ -69,7 +69,10 @@ function record_json_feed_crawl(string $name, string $url): array
     // A configured feed URL is admin-trusted, but nothing pins where it (or a
     // redirect from it) actually points — fetch_guarded() re-checks the
     // destination is a public, non-internal address on every hop.
-    $response = fetch_guarded($url, ['timeout' => FEED_FETCH_TIMEOUT]);
+    $response = fetch_guarded($url, [
+        'timeout' => FEED_FETCH_TIMEOUT,
+        'max_bytes' => FEED_FETCH_MAX_BYTES,
+    ]);
     $feed     = $response === null ? null : parse_json_feed($response['body']);
 
     if ($feed === null) {

--- a/src/post.php
+++ b/src/post.php
@@ -296,12 +296,13 @@ function build_matter(array $matter, string $content): string
         return $content;
     }
 
-    $lines = [];
-    foreach ($matter as $key => $value) {
-        $lines[] = "$key: $value";
-    }
-
-    return "---\n" . implode("\n", $lines) . "\n---\n$content";
+    // Yaml::dump() rather than "$key: $value": the values come from Micropub
+    // request properties, and an unescaped newline in one (a `name` of
+    // "Title\nid: 1") injected extra front-matter keys, which apply_frontmatter()
+    // then applied to the bean. It also fixes the mirror-image bug — a title
+    // containing a colon produced invalid YAML, so parse_matter() returned
+    // nothing and the title was silently dropped.
+    return "---\n" . Yaml::dump($matter) . "---\n$content";
 }
 
 /**

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -21,12 +21,20 @@ use const ROOT_DIR;
 #[NoReturn]
 function respond_upload(array $_args): void
 {
+    // Authenticate before inspecting the request, so an anonymous caller cannot
+    // tell a malformed upload apart from a rejected one.
+    Security\require_login();
+
+    // Without this the response defaults to text/html, and the client-supplied
+    // filename is echoed back inside it — json_encode() leaves `<` and `>`
+    // alone, so the filename would be parsed as markup.
+    header('Content-Type: application/json');
+
     if (empty($_FILES[IMAGE_FILES])) {
         // invalid request http status code
         header('HTTP/1.1 400 Bad Request');
         die('No files uploaded!');
     }
-    Security\require_login();
 
     $files = [];
     foreach ($_FILES[IMAGE_FILES] as $name => $items) {
@@ -50,6 +58,11 @@ function respond_upload(array $_args): void
             die();
         }
         $temp_fp  = $f['tmp_name'];
+        if (!upload_content_allowed(sniff_file_content_type($temp_fp), $ext)) {
+            header('HTTP/1.1 400 Bad Request');
+            echo json_encode('File contents do not match its type.', JSON_THROW_ON_ERROR);
+            die();
+        }
         // Salt with uniqid() so two uploads with the same client-supplied
         // filename in the same month don't collide on disk — without this,
         // an attacker-controlled filename can silently overwrite an earlier,
@@ -100,6 +113,84 @@ function safe_upload_extension(string $filename): ?string
 }
 
 /**
+ * The content types accepted for each allowed upload extension.
+ *
+ * `safe_upload_extension()` only inspects the client-supplied filename, so on its
+ * own it lets any bytes at all be stored under an image extension and served from
+ * this origin. That is how an HTML or SVG payload ends up at a URL on the site's
+ * own domain — the extension keeps it from being executed as PHP, but a browser
+ * that sniffs (or any future change that serves by content) would still render it.
+ *
+ * The container formats also accept `application/octet-stream`: libmagic cannot
+ * always name an ISOBMFF/Matroska stream, and a real video must not be rejected
+ * because of that. Scripted payloads never sniff as octet-stream — they come back
+ * as `text/html`, `text/x-php`, `image/svg+xml` and the like — so the check still
+ * does its job for the case it exists to cover.
+ *
+ * @return array<string, list<string>> Extension => acceptable sniffed MIME types.
+ */
+function upload_content_types(): array
+{
+    return [
+        'jpg'  => ['image/jpeg'],
+        'jpeg' => ['image/jpeg'],
+        'png'  => ['image/png'],
+        'gif'  => ['image/gif'],
+        'webp' => ['image/webp'],
+        'avif' => ['image/avif', 'image/heif', 'image/heic', 'application/octet-stream'],
+        'mp4'  => ['video/mp4', 'application/mp4', 'application/octet-stream'],
+        'webm' => ['video/webm', 'video/x-matroska', 'application/octet-stream'],
+        'mov'  => ['video/quicktime', 'video/mp4', 'application/octet-stream'],
+    ];
+}
+
+/**
+ * Whether a sniffed content type is acceptable for the given upload extension.
+ *
+ * Returns true when fileinfo is unavailable: the check is a second line of
+ * defence behind the extension allowlist, and a host without the extension
+ * should keep uploading rather than fail every attempt.
+ *
+ * @param string|false $mime The sniffed MIME type, or false when sniffing failed.
+ * @param string       $ext  The lower-case extension from safe_upload_extension().
+ * @return bool
+ */
+function upload_content_allowed(string|false $mime, string $ext): bool
+{
+    if ($mime === false || $mime === '') {
+        return true;
+    }
+    $allowed = upload_content_types()[$ext] ?? null;
+
+    return $allowed === null || in_array(strtolower($mime), $allowed, true);
+}
+
+/**
+ * Sniffs the content type of an uploaded file on disk, or false when unavailable.
+ */
+function sniff_file_content_type(string $path): string|false
+{
+    if (!function_exists('mime_content_type') || !is_readable($path)) {
+        return false;
+    }
+
+    return @mime_content_type($path);
+}
+
+/**
+ * Sniffs the content type of raw bytes in memory, or false when unavailable.
+ */
+function sniff_bytes_content_type(string $bytes): string|false
+{
+    if (!class_exists(\finfo::class)) {
+        return false;
+    }
+    $finfo = @new \finfo(FILEINFO_MIME_TYPE);
+
+    return @$finfo->buffer($bytes);
+}
+
+/**
  * Whether an uploaded image of the given extension should be re-encoded to WebP.
  *
  * Only JPEG and PNG are converted: they are common, lossy/lossless raster formats
@@ -142,6 +233,9 @@ function should_convert_to_webp(?string $ext, ?bool $gd_available = null): bool
 function persist_image_bytes(string $bytes, string $ext, string $dest_dir, string $seed): ?string
 {
     if ($bytes === '' || !is_dir($dest_dir)) {
+        return null;
+    }
+    if (!upload_content_allowed(sniff_bytes_content_type($bytes), $ext)) {
         return null;
     }
     if (should_convert_to_webp($ext)) {
@@ -324,7 +418,10 @@ function get_upload_dir(?string $sub_path = null): string
 {
     $upload_dir = sprintf("%s/assets/%s", ROOT_DIR, $sub_path ?? upload_subpath());
     if (!is_dir($upload_dir)) {
-        if (!mkdir($upload_dir, 0777, true) && !is_dir($upload_dir)) {
+        // 0755, not 0777: the web-server user is the only one that needs to write
+        // here. Under a permissive umask (0002/0000, not unusual in containers)
+        // 0777 leaves the upload tree writable by every local user.
+        if (!mkdir($upload_dir, 0755, true) && !is_dir($upload_dir)) {
             throw new RuntimeException(sprintf('Directory "%s" was not created', $upload_dir));
         }
     }

--- a/src/theme.php
+++ b/src/theme.php
@@ -144,8 +144,8 @@ function date_created(OODBBean $bean): string
 
     return sprintf(
         '<a href="/%1$s" class="u-url" title="Timestamp: %2$s"><time class="dt-published" datetime="%2$s">%3$s</time></a>',
-        ltrim($slug, '/'),
-        $bean->created,
+        escape(ltrim($slug, '/')),
+        escape((string) $bean->created),
         $human_created
     );
 }
@@ -319,7 +319,14 @@ function title_link(OODBBean $bean): string
     if (empty($bean->title)) {
         return '';
     }
-    return sprintf('<a class="p-name title-link" href="%s">%s</a>', permalink($bean), escape($bean->title));
+    // The permalink carries the slug, which is stored close to verbatim
+    // (sanitize_explicit_slug() only strips leading slashes), so escape it like
+    // any other value going into an attribute.
+    return sprintf(
+        '<a class="p-name title-link" href="%s">%s</a>',
+        escape(permalink($bean)),
+        escape($bean->title)
+    );
 }
 
 /**

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -35,13 +35,15 @@ if (defined('ROOT_DIR')) {
 
 $Link = $Xml->addChild('atom:link');
 $Link->addAttribute('rel', 'self');
-$Link->addAttribute('href', escape($channel_link));
+// Raw URL: addAttribute() escapes for us, so pre-escaping would turn a
+// query-string `&` into `&amp;amp;` (see the in-reply-to attributes below).
+$Link->addAttribute('href', $channel_link);
 
 // WebSub: advertise the configured hubs so subscribers can get real-time pushes.
 foreach (Lamb\Websub\hub_urls($config) as $websub_hub) {
     $Hub = $Xml->addChild('link');
     $Hub->addAttribute('rel', 'hub');
-    $Hub->addAttribute('href', escape($websub_hub));
+    $Hub->addAttribute('href', $websub_hub);
 }
 
 $Author = $Xml->addChild('author');
@@ -50,7 +52,10 @@ $Author->addChild('uri', ROOT_URL);
 
 foreach ($data['posts'] as $bean) {
     $Entry = $Xml->addChild('entry');
-    $Entry->addChild('id', Lamb\permalink($bean));
+    // addChild(), unlike addAttribute(), does not escape: a permalink carrying a
+    // `&` (a slug is stored close to verbatim) raised "unterminated entity
+    // reference" and emitted an empty <id/>, making the whole feed malformed.
+    $Entry->addChild('id', escape(Lamb\permalink($bean)));
     $Entry->addChild('title', escape($bean->title ?: ''));
     $Entry->addChild('published', date(DATE_ATOM, strtotime($bean->created)));
     $Entry->addChild('updated', date(DATE_ATOM, strtotime($bean->updated)));

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -22,6 +22,17 @@ use const ROOT_URL;
 const WEBMENTION_FETCH_TIMEOUT = 10;
 
 /**
+ * Largest response body kept when fetching a webmention source, target or endpoint.
+ *
+ * POST /webmention is unauthenticated and makes the server fetch a URL the caller
+ * chose, so an uncapped read lets a caller point `source` at an endless body and
+ * grow the PHP worker's memory until it fatals — a handful of concurrent requests
+ * is then enough to exhaust host RAM. 2 MB is far more HTML than any real page
+ * that links to a post; anything larger is dropped rather than buffered.
+ */
+const WEBMENTION_FETCH_MAX_BYTES = 2_000_000;
+
+/**
  * Route handler for POST /webmention.
  *
  * Accepts `source` and `target` form parameters per the Webmention spec,
@@ -225,6 +236,7 @@ function fetch_source(string $url): ?string
     $result = fetch_guarded($url, [
         'headers' => ['Accept: text/html, */*', 'User-Agent: Lamb-Webmention'],
         'timeout' => WEBMENTION_FETCH_TIMEOUT,
+        'max_bytes' => WEBMENTION_FETCH_MAX_BYTES,
     ]);
 
     return $result === null ? null : $result['body'];
@@ -664,6 +676,7 @@ function fetch_target(string $url): ?array
     $result = fetch_guarded($url, [
         'headers' => ['Accept: text/html, */*', 'User-Agent: Lamb-Webmention'],
         'timeout' => WEBMENTION_FETCH_TIMEOUT,
+        'max_bytes' => WEBMENTION_FETCH_MAX_BYTES,
     ]);
 
     if ($result === null) {
@@ -701,6 +714,7 @@ function send_webmention(string $endpoint, string $source, string $target): int
         ],
         'content' => http_build_query(['source' => $source, 'target' => $target]),
         'timeout' => WEBMENTION_FETCH_TIMEOUT,
+        'max_bytes' => WEBMENTION_FETCH_MAX_BYTES,
     ]);
 
     return $result === null ? 0 : $result['status'];

--- a/src/websub.php
+++ b/src/websub.php
@@ -26,7 +26,11 @@ const WEBSUB_PING_TIMEOUT = 2;
 /**
  * The configured WebSub hub URLs.
  *
- * `websub_hubs` is a comma-separated list; most sites need just one.
+ * `websub_hubs` is a comma-separated list; most sites need just one. Entries that
+ * are not absolute http(s) URLs are dropped, matching the filtering get_feeds()
+ * applies to feed sources: without it a stray value goes straight to the fetcher,
+ * which would happily open any scheme PHP has a stream wrapper for (`file://`,
+ * `php://…`) on the author's behalf.
  *
  * @param array<string, mixed>|null $config Config array; defaults to the global config.
  * @return list<string>
@@ -39,7 +43,7 @@ function hub_urls(?array $config = null): array
     $value = (string) (($config ?? [])['websub_hubs'] ?? '');
 
     $hubs = array_map('trim', explode(',', $value));
-    return array_values(array_filter($hubs, fn($hub) => $hub !== ''));
+    return array_values(array_filter($hubs, fn($hub) => \Lamb\Http\is_valid_http_url($hub)));
 }
 
 /**
@@ -97,12 +101,20 @@ function ping_for_post(OODBBean $bean, ?array $config = null, ?callable $sender 
  */
 function send_ping(string $hub, string $topic): void
 {
-    \Lamb\Http\post_form(
-        $hub,
-        ['hub.mode' => 'publish', 'hub.url' => $topic],
-        WEBSUB_PING_TIMEOUT,
-        'Lamb-WebSub'
-    );
+    // fetch_guarded() rather than post_form(): it refuses loopback/private/
+    // link-local destinations and re-validates every redirect hop, so a hub URL
+    // cannot aim the publish request at an internal service. Every other outbound
+    // sink already goes through it; this was the last one that did not.
+    \Lamb\Http\fetch_guarded($hub, [
+        'method' => 'POST',
+        'headers' => [
+            'Content-Type: application/x-www-form-urlencoded',
+            'User-Agent: Lamb-WebSub',
+        ],
+        'content' => http_build_query(['hub.mode' => 'publish', 'hub.url' => $topic]),
+        'timeout' => WEBSUB_PING_TIMEOUT,
+        'max_bytes' => 65536,
+    ], 1);
 }
 
 /**

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -719,7 +719,8 @@ function default_image_downloader(string $url, string $sub_path): ?string
             return $existing;
         }
     }
-    if (!is_dir($dest_dir) && !mkdir($dest_dir, 0777, true) && !is_dir($dest_dir)) {
+    // 0755, not 0777: only the user running the import needs to write here.
+    if (!is_dir($dest_dir) && !mkdir($dest_dir, 0755, true) && !is_dir($dest_dir)) {
         return null;
     }
     // $url is embedded in the WXR file being imported — an untrusted export

--- a/tests/Acceptance/UploadCest.php
+++ b/tests/Acceptance/UploadCest.php
@@ -8,17 +8,19 @@ class UploadCest
 {
     // respond_upload
 
-    public function testUploadWithoutFilesReturns400(AcceptanceTester $I): void
+    public function testUploadRequiresLogin(AcceptanceTester $I): void
     {
-        // A GET request carries no $_FILES, so the guard fires immediately
+        // require_login() runs before the request is inspected, so an anonymous
+        // caller is bounced to the login page rather than being told whether the
+        // upload it sent was well-formed.
         $I->amOnPage('/upload');
-        $I->seeResponseCodeIs(400);
+        $I->seeInCurrentUrl('/login');
     }
 
-    public function testUploadWithoutFilesReturnsErrorBody(AcceptanceTester $I): void
+    public function testUploadDoesNotRevealRequestValidityToAnonymousCallers(AcceptanceTester $I): void
     {
         $I->amOnPage('/upload');
-        $I->see('No files uploaded');
+        $I->dontSee('No files uploaded');
     }
 
     public function testUploadWithoutFilesHasNoPhpErrors(AcceptanceTester $I): void

--- a/tests/Unit/CanonicalSiteUrlTest.php
+++ b/tests/Unit/CanonicalSiteUrlTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Config\canonical_site_url;
+use function Lamb\Http\request_root_url;
+
+/**
+ * The site's own address has two sources: the canonical URL the author configures,
+ * and the Host header the client sends. Only the first is trustworthy, so these
+ * tests pin the boundary between them.
+ */
+class CanonicalSiteUrlTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        putenv('LAMB_SITE_URL');
+    }
+
+    public function testReturnsNullWhenNotConfigured(): void
+    {
+        $this->assertNull(canonical_site_url([]));
+        $this->assertNull(canonical_site_url(['site_url' => '']));
+        $this->assertNull(canonical_site_url(['site_url' => '   ']));
+    }
+
+    public function testNormalisesConfiguredValue(): void
+    {
+        $this->assertSame('https://example.com', canonical_site_url(['site_url' => 'https://example.com/']));
+        $this->assertSame('https://example.com', canonical_site_url(['site_url' => 'https://EXAMPLE.com']));
+        $this->assertSame('http://example.com:8747', canonical_site_url(['site_url' => 'http://example.com:8747/blog']));
+    }
+
+    public function testRejectsValuesThatAreNotAbsoluteHttpUrls(): void
+    {
+        $this->assertNull(canonical_site_url(['site_url' => 'example.com']));
+        $this->assertNull(canonical_site_url(['site_url' => '/example']));
+        $this->assertNull(canonical_site_url(['site_url' => 'javascript:alert(1)']));
+        $this->assertNull(canonical_site_url(['site_url' => 'file:///etc/passwd']));
+    }
+
+    public function testEnvironmentOverridesConfiguredValue(): void
+    {
+        putenv('LAMB_SITE_URL=https://from-env.example');
+
+        $this->assertSame('https://from-env.example', canonical_site_url(['site_url' => 'https://from-ini.example']));
+    }
+
+    public function testRequestRootUrlUsesSchemeAndHost(): void
+    {
+        $this->assertSame('http://example.com', request_root_url(['HTTP_HOST' => 'example.com']));
+        $this->assertSame(
+            'https://example.com',
+            request_root_url(['HTTP_HOST' => 'example.com', 'HTTPS' => 'on'])
+        );
+        $this->assertSame('http://example.com:8747', request_root_url(['HTTP_HOST' => 'example.com:8747']));
+        $this->assertSame('http://[::1]:8080', request_root_url(['HTTP_HOST' => '[::1]:8080']));
+    }
+
+    public function testRequestRootUrlRejectsMalformedHosts(): void
+    {
+        $this->assertNull(request_root_url([]));
+        $this->assertNull(request_root_url(['HTTP_HOST' => '']));
+        $this->assertNull(request_root_url(['HTTP_HOST' => 'example.com/path']));
+        $this->assertNull(request_root_url(['HTTP_HOST' => 'example.com" onload="x']));
+        $this->assertNull(request_root_url(['HTTP_HOST' => "example.com\r\nX-Injected: 1"]));
+        $this->assertNull(request_root_url(['HTTP_HOST' => 'example.com ']));
+        $this->assertNull(request_root_url(['HTTP_HOST' => str_repeat('a', 254)]));
+    }
+}

--- a/tests/Unit/FeedTemplateTest.php
+++ b/tests/Unit/FeedTemplateTest.php
@@ -343,4 +343,53 @@ class FeedTemplateTest extends TestCase
 
         return new \SimpleXMLElement($output);
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedEntryIdSurvivesAnAmpersandInTheSlug(): void
+    {
+        require_once __DIR__ . '/../../vendor/autoload.php';
+
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        // addChild() does not escape, so an unescaped `&` in the permalink used
+        // to emit an empty <id/> and make the whole feed malformed.
+        $bean = R::dispense('post');
+        $bean->title = 'Tea & Cake';
+        $bean->slug = 'tea-&-cake';
+        $bean->description = 'Post';
+        $bean->transformed = '<p>Post</p>';
+        $bean->created = '2024-01-01 12:00:00';
+        $bean->updated = '2024-01-01 12:00:00';
+        R::store($bean);
+
+        global $config, $data;
+        $config = [
+            'site_title'   => 'Test Blog',
+            'author_name'  => 'Test Author',
+            'author_email' => 'test@test.com',
+        ];
+        $data = [
+            'posts'    => [$bean],
+            'title'    => 'Test Blog',
+            'feed_url' => 'http://localhost/feed',
+            'updated'  => '2024-01-01 12:00:00',
+        ];
+
+        ob_start();
+        require __DIR__ . '/../../src/themes/base/feed.php';
+        $output = ob_get_clean();
+
+        $xml = new \SimpleXMLElement($output);
+        $this->assertSame('http://localhost/tea-&-cake', (string) $xml->entry[0]->id);
+    }
 }

--- a/tests/Unit/FrontMatterFieldsTest.php
+++ b/tests/Unit/FrontMatterFieldsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\parse_tags;
+use function Lamb\Post\populate_bean;
+
+/**
+ * Front matter is metadata the author writes, not a channel for setting arbitrary
+ * columns. It reaches these functions from the web editor, from Micropub requests,
+ * and — via the parse_tags() path — from ingested remote feeds.
+ */
+class FrontMatterFieldsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+    }
+
+    public function testFrontMatterCannotRetargetTheBeanId(): void
+    {
+        // Setting `id` made the store that follows an UPDATE of that row, so a
+        // create could overwrite any existing post.
+        $bean = populate_bean("---\nid: 41\ntitle: Hijacked\n---\nBody");
+
+        $this->assertEmpty($bean->id);
+        $this->assertSame('Hijacked', $bean->title);
+    }
+
+    public function testFrontMatterCannotSetDeleted(): void
+    {
+        $bean = populate_bean("---\nid: 41\ndeleted: 1\n---\nBody");
+
+        $this->assertEmpty($bean->deleted);
+    }
+
+    public function testFrontMatterDoesNotCreateArbitraryColumns(): void
+    {
+        $bean = populate_bean("---\ntitle: Hi\nbackdoor: injected\n---\nBody");
+
+        $this->assertNull($bean->backdoor);
+    }
+
+    public function testFrontMatterStillAppliesTheFieldsItOwns(): void
+    {
+        $bean = populate_bean("---\ntitle: Real Title\nslug: real-slug\ndraft: true\n---\nBody");
+
+        $this->assertSame('Real Title', $bean->title);
+        $this->assertSame('real-slug', $bean->slug);
+        $this->assertSame(1, $bean->draft);
+    }
+
+    public function testHashtagCannotBreakOutOfAnAttribute(): void
+    {
+        // parse_tags() runs over rendered HTML, where a hashtag can land inside an
+        // attribute Parsedown built from user text. Two unescaped quotes there
+        // closed the attribute and added new ones to the enclosing element.
+        $html = '<img src="x" alt="pic #y/onerror=alert`1`// end">';
+
+        // The tag is left alone entirely: no `<a>` is injected into the attribute,
+        // so nothing closes it and no new attribute can appear on the img.
+        $this->assertSame($html, parse_tags($html));
+    }
+
+    public function testHashtagInTextIsEscaped(): void
+    {
+        $result = parse_tags('a #y&quot;z w');
+
+        $this->assertStringNotContainsString('"z', $result);
+        $this->assertStringContainsString('/tag/y', $result);
+    }
+
+    public function testOrdinaryHashtagsStillLink(): void
+    {
+        $this->assertStringContainsString(
+            '<a href="/tag/php">#PHP</a>',
+            parse_tags('learning #PHP today')
+        );
+    }
+}

--- a/tests/Unit/FrontMatterTest.php
+++ b/tests/Unit/FrontMatterTest.php
@@ -93,13 +93,33 @@ class FrontMatterTest extends TestCase
 
     public function testBuildMatterRendersMultipleKeysInOrder(): void
     {
+        // Values are emitted as YAML, so a value carrying a `:` is quoted.
         $this->assertSame(
-            "---\ntitle: Hello\nin-reply-to: https://example.com\n---\nBody",
+            "---\ntitle: Hello\nin-reply-to: 'https://example.com'\n---\nBody",
             build_matter(
                 ['title' => 'Hello', 'in-reply-to' => 'https://example.com'],
                 'Body'
             )
         );
+    }
+
+    public function testBuildMatterCannotInjectExtraKeysThroughAValue(): void
+    {
+        // A newline in a value used to open new front-matter lines, which
+        // apply_frontmatter() then applied to the bean.
+        $body = build_matter(['title' => "Harmless\nid: 1\ndeleted: 1"], 'Body');
+        $matter = parse_matter($body);
+
+        $this->assertSame("Harmless\nid: 1\ndeleted: 1", $matter['title']);
+        $this->assertArrayNotHasKey('id', $matter);
+        $this->assertArrayNotHasKey('deleted', $matter);
+    }
+
+    public function testBuildMatterKeepsATitleContainingAColon(): void
+    {
+        $body = build_matter(['title' => 'Rust: a first look'], 'Body');
+
+        $this->assertSame('Rust: a first look', parse_matter($body)['title']);
     }
 
     // set_matter — insert into existing fence

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -25,6 +25,10 @@ class MicropubAdapterTest extends TestCase
         // reads it unguarded, so seed it here rather than relying on a sibling
         // test having populated the global $config first.
         $config['site_title'] = $config['site_title'] ?? 'Test Blog';
+        // Token verification compares the token's `me` against the configured
+        // canonical URL, never the request host, so a Micropub install must set
+        // site_url. Seed it to match ROOT_URL for the happy-path tests.
+        $config['site_url'] = 'http://localhost';
 
         if (!defined('ROOT_URL')) {
             define('ROOT_URL', 'http://localhost');
@@ -45,7 +49,7 @@ class MicropubAdapterTest extends TestCase
     protected function tearDown(): void
     {
         global $config;
-        unset($config['micropub_debug']);
+        unset($config['micropub_debug'], $config['site_url']);
         if (isset($GLOBALS['lamb_mp_log_path'])) {
             @unlink($GLOBALS['lamb_mp_log_path']);
             unset($GLOBALS['lamb_mp_log_path']);
@@ -182,6 +186,37 @@ class MicropubAdapterTest extends TestCase
         $this->assertIsArray($result['scope']);
         $this->assertContains('create', $result['scope']);
         $this->assertContains('update', $result['scope']);
+    }
+
+    public function testVerifyTokenRejectsIdentityMatchingOnlyTheRequestHost(): void
+    {
+        // The request host is attacker-chosen (a spoofed Host header reaches PHP
+        // through any catch-all vhost), so a token whose `me` matches it must still
+        // be refused when it does not match the configured canonical URL.
+        global $config;
+        $config['site_url'] = 'https://real-site.example';
+
+        $adapter = new StubMicropubAdapter();
+        $adapter->stubResponse = [
+            'me'    => ROOT_URL . '/',
+            'scope' => 'create',
+        ];
+
+        $this->assertFalse($adapter->verifyAccessTokenCallback('token-for-request-host'));
+    }
+
+    public function testVerifyTokenFailsClosedWhenNoSiteUrlIsConfigured(): void
+    {
+        global $config;
+        unset($config['site_url']);
+
+        $adapter = new StubMicropubAdapter();
+        $adapter->stubResponse = [
+            'me'    => ROOT_URL . '/',
+            'scope' => 'create',
+        ];
+
+        $this->assertFalse($adapter->verifyAccessTokenCallback('any-token'));
     }
 
     public function testVerifyTokenHandlesMissingTrailingSlash(): void

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -719,16 +719,19 @@ class MicropubAdapterTest extends TestCase
     {
         $adapter = new LambMicropubAdapter();
 
-        // Create a real temp file to simulate an upload
+        // A real GIF: uploads whose bytes don't match their extension are
+        // rejected, and GIF is stored as-is rather than re-encoded to WebP, so
+        // the stored name keeps the extension this test asserts on.
+        $bytes = self::gifBytes();
         $tmpFile = tempnam(sys_get_temp_dir(), 'micropub_test_');
-        file_put_contents($tmpFile, 'fake image data');
+        file_put_contents($tmpFile, $bytes);
 
         $uploadedFile = new \Nyholm\Psr7\UploadedFile(
             $tmpFile,
-            15,
+            strlen($bytes),
             UPLOAD_ERR_OK,
-            'test-photo.jpg',
-            'image/jpeg'
+            'test-photo.gif',
+            'image/gif'
         );
 
         $data = [
@@ -743,7 +746,16 @@ class MicropubAdapterTest extends TestCase
         $this->assertIsString($result);
         $post = R::findOne('post', ' body LIKE ? ', ['%A post with an uploaded photo%']);
         $this->assertNotNull($post);
-        $this->assertMatchesRegularExpression('/!\[.*\]\(.+\.jpg\)/', $post->body);
+        $this->assertMatchesRegularExpression('/!\[.*\]\(.+\.gif\)/', $post->body);
+    }
+
+    /**
+     * A minimal valid 1x1 GIF, so upload fixtures carry bytes that really are
+     * the image type their filename claims.
+     */
+    private static function gifBytes(): string
+    {
+        return (string) base64_decode('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
     }
 
     public function testUploadedPhotosWithSameClientFilenameDoNotCollide(): void
@@ -754,9 +766,16 @@ class MicropubAdapterTest extends TestCase
         $adapter = new LambMicropubAdapter();
 
         $makeUpload = function (): \Nyholm\Psr7\UploadedFile {
+            $bytes = self::gifBytes();
             $tmpFile = tempnam(sys_get_temp_dir(), 'micropub_test_');
-            file_put_contents($tmpFile, 'fake image data ' . uniqid());
-            return new \Nyholm\Psr7\UploadedFile($tmpFile, 15, UPLOAD_ERR_OK, 'photo.jpg', 'image/jpeg');
+            file_put_contents($tmpFile, $bytes);
+            return new \Nyholm\Psr7\UploadedFile(
+                $tmpFile,
+                strlen($bytes),
+                UPLOAD_ERR_OK,
+                'photo.gif',
+                'image/gif'
+            );
         };
 
         $first = $adapter->createCallback(
@@ -768,8 +787,8 @@ class MicropubAdapterTest extends TestCase
             ['photo' => $makeUpload()]
         );
 
-        preg_match('/!\[.*\]\((.+\.jpg)\)/', R::findOne('post', ' body LIKE ? ', ['%First post%'])->body, $m1);
-        preg_match('/!\[.*\]\((.+\.jpg)\)/', R::findOne('post', ' body LIKE ? ', ['%Second post%'])->body, $m2);
+        preg_match('/!\[.*\]\((.+\.gif)\)/', R::findOne('post', ' body LIKE ? ', ['%First post%'])->body, $m1);
+        preg_match('/!\[.*\]\((.+\.gif)\)/', R::findOne('post', ' body LIKE ? ', ['%Second post%'])->body, $m2);
 
         $this->assertNotEmpty($m1[1] ?? null);
         $this->assertNotEmpty($m2[1] ?? null);

--- a/tests/Unit/UploadContentTypeTest.php
+++ b/tests/Unit/UploadContentTypeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Response\persist_image_bytes;
+use function Lamb\Response\sniff_bytes_content_type;
+use function Lamb\Response\upload_content_allowed;
+
+/**
+ * The upload extension allowlist only inspects the client-supplied filename, so
+ * the bytes are checked against it too — otherwise any content at all could be
+ * stored under an image extension and served from this origin.
+ */
+class UploadContentTypeTest extends TestCase
+{
+    /** A minimal valid 1x1 GIF. */
+    private const GIF = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+    public function testRealImageBytesAreAccepted(): void
+    {
+        $bytes = (string) base64_decode(self::GIF);
+
+        $this->assertSame('image/gif', sniff_bytes_content_type($bytes));
+        $this->assertTrue(upload_content_allowed('image/gif', 'gif'));
+    }
+
+    public function testScriptedPayloadsAreRejectedUnderAnImageExtension(): void
+    {
+        $payloads = [
+            'php'  => '<?php system($_GET[0]); ?>',
+            'html' => '<html><script>alert(1)</script></html>',
+            'svg'  => '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+        ];
+
+        foreach ($payloads as $label => $bytes) {
+            $mime = sniff_bytes_content_type($bytes);
+            foreach (['png', 'gif', 'webp', 'jpg'] as $ext) {
+                $this->assertFalse(
+                    upload_content_allowed($mime, $ext),
+                    "$label payload must not be storable as .$ext (sniffed $mime)"
+                );
+            }
+        }
+    }
+
+    public function testMismatchedImageTypesAreRejected(): void
+    {
+        $this->assertFalse(upload_content_allowed('image/gif', 'png'));
+        $this->assertFalse(upload_content_allowed('image/png', 'webp'));
+    }
+
+    public function testUnidentifiableContainerBytesAreAllowedForVideo(): void
+    {
+        // libmagic cannot always name an ISOBMFF/Matroska stream; a real video
+        // must not be rejected because of that.
+        $this->assertTrue(upload_content_allowed('application/octet-stream', 'mp4'));
+        $this->assertTrue(upload_content_allowed('application/octet-stream', 'webm'));
+        $this->assertFalse(upload_content_allowed('application/octet-stream', 'png'));
+    }
+
+    public function testFailedSniffDoesNotBlockTheUpload(): void
+    {
+        // A host without fileinfo should keep uploading: this is a second line of
+        // defence behind the extension allowlist, not the only one.
+        $this->assertTrue(upload_content_allowed(false, 'png'));
+    }
+
+    public function testPersistImageBytesRefusesMismatchedContent(): void
+    {
+        $dir = sys_get_temp_dir() . '/lamb_sniff_' . uniqid('', true);
+        mkdir($dir, 0755, true);
+        try {
+            $this->assertNull(
+                persist_image_bytes('<html><script>alert(1)</script></html>', 'gif', $dir, 'seed')
+            );
+            $this->assertCount(0, glob("$dir/*") ?: [], 'nothing may be written');
+        } finally {
+            array_map('unlink', glob("$dir/*") ?: []);
+            @rmdir($dir);
+        }
+    }
+}


### PR DESCRIPTION
A security review of the codebase. Five fixes, one per commit, each independently reviewable and cherry-pickable. All 1291 unit tests pass; `phpcs` is clean.

The two most serious issues are remotely triggerable and need no credentials.

## 1. Micropub authentication bypass via a spoofed `Host` header (critical)

`ROOT_URL` was built from `$_SERVER['HTTP_HOST']`, and `verifyAccessTokenCallback()` used it as the expected IndieAuth identity — a token was accepted when its `me` matched `ROOT_URL`.

Since the `Host` header is client-supplied, an attacker who holds a token the configured token endpoint issued for *their own* identity can send `Host: their-site.example` and have the check compare their `me` against their own host. The default token endpoint is the public `tokens.indieauth.com`, which issues a token for any domain the requester can authenticate as, and both bundled Caddy configs use a host-agnostic `:80` site block, so an arbitrary `Host` reaches the app. That granted unauthenticated remote create/update/delete on posts, plus writes into the web root through `/micropub-media`.

Fixed by adding `Config\canonical_site_url()`: the site URL the author states explicitly, via a new `site_url` setting or the `LAMB_SITE_URL` environment variable. Token verification compares against that and nothing else.

**Behaviour change worth a decision:** token verification now *fails closed* when no canonical URL is configured — with nothing trustworthy to compare against, a token's identity cannot be established. So Micropub stops working until `site_url` is set. The refusal is written to `error_log()` as well as the Micropub log (the latter is silent unless `micropub_debug` is on), and both `docs/micropub.md` and `docs/site-configuration.md` now lead with the setting. If you'd rather not break existing Micropub users on upgrade, the alternative is to keep comparing against `ROOT_URL` when `site_url` is unset — but that leaves the bypass open by default, which is why it isn't what this PR does.

`ROOT_URL` itself still falls back to the request host, so nothing else changes for installs without the setting. That fallback now goes through `Http\request_root_url()`, which validates the `Host` against a strict host charset and returns 400 otherwise — a `Host` carrying quotes, angle brackets or CRLF can no longer be reflected into HTML or a response header.

## 2. Front matter could write any column (high)

`apply_frontmatter()` copied every word-character front-matter key onto the bean, so front matter could set *any* column. Setting `id` made the following store an UPDATE of that row instead of an insert; `deleted` trashed a post.

A Micropub token holding only `create` scope reached this: a create whose content *is* a front-matter block is parsed as front matter, so `id:` overwrote an arbitrary post and `deleted:` destroyed one — bypassing the scope checks that correctly refuse `update` and `delete`. Unknown keys also became new columns via RedBean's fluid mode. Front matter now writes only the fields it owns.

`build_matter()` was a second route to the same sink: it assembled the block as `"$key: $value"` with no escaping, and Micropub property values reach it, so a `name` containing a newline injected further front-matter keys. It now emits YAML via `Yaml::dump()`, as the WordPress importer already does. That also fixes the mirror-image bug where a title containing a colon produced invalid YAML, so the block failed to parse and the title was silently dropped.

## 3. Stored XSS through hashtag linkification (high)

`parse_tags()` injected `<a href="…">` into already-rendered HTML wherever a hashtag appeared — including inside attributes Parsedown builds from user text, such as an image `alt` or a link `title`. The injected quote closed the attribute, and the rest of the value was then parsed as attributes of the enclosing element, so `#x/onerror=alert...` inside an `alt` became a real event handler that fires when the image fails to load.

Ingested feed content flows through this function and the result is stored, so a remote feed could plant the payload for every visitor; with the default `feeds_draft` it lands first in the author's own logged-in session. Substitution is now confined to text position, the tag name is escaped, and the tag pattern no longer admits quotes, angle brackets, backticks, `=` or slashes. Emoji and non-Latin hashtags still work.

## 4. Outbound HTTP was unbounded and partly unguarded

- **No response-size caps.** `POST /webmention` and `/_cron` are both unauthenticated and make the server fetch chosen URLs, yet neither the source/target/endpoint fetches nor the JSON-feed crawl passed `max_bytes` — a destination streaming an endless body grew the worker's memory until it fatalled. The fetcher already supported the cap; these call sites never used it.
- **The Micropub token introspection followed redirects.** PHP's stream wrapper re-sends the context's `header` option to the redirect target, across a change of authority included, so a redirect from the token endpoint handed the author's bearer token to whatever host it named. It now refuses redirects and caps the body.
- **WebSub hub pings skipped every URL check.** `hub_urls()` only split on commas and `send_ping()` used the unguarded `post_form()`, so a hub value could name any scheme PHP has a wrapper for and reach an internal address. This was the last outbound sink bypassing the SSRF guard the feed and webmention paths already use.

## 5. Upload directory and web-root hardening

`src/assets` is inside the web root and is the only path the app writes to at runtime, so the extension allowlist was carrying the whole separation between "stored file" and "executed code".

- **Content is checked, not just the filename.** `safe_upload_extension()` inspects only the client-supplied name, so any bytes could be stored under an image extension and served from this origin — an HTML or SVG payload at a URL on your own domain. Every write path now sniffs the content and refuses a mismatch. Container formats still accept an unidentifiable stream, since libmagic cannot always name ISOBMFF or Matroska; scripted payloads never sniff that way.
- **PHP will not execute from the upload tree.** Both server configs would have run a `.php` file found under `/assets`; each now returns 404 for one.
- **Security response headers.** `X-Content-Type-Options`, `Referrer-Policy` and `X-Frame-Options` were set nowhere. `nosniff` matters most here, since it stops a browser second-guessing an upload's `Content-Type`. No CSP is added — the themes emit inline styles, so that needs its own change.
- Smaller items: `/upload` sets a JSON `Content-Type` (it echoes the client filename and defaulted to `text/html`, so the name was parsed as markup) and authenticates before inspecting the request; created directories drop the world-writable bit `0777` leaves under a permissive umask — the data directory holds `lamb.db` and the session files; the release image turns off `expose_php`, which PHP's `php.ini-production` leaves on.

## 6. Escaping fixes

`title_link()` and `date_created()` interpolated the permalink and slug straight into an `href` and a `title` attribute. A slug is stored close to verbatim, so it needs escaping. Only the author or an authorised Micropub client can set one, so this is self-inflicted rather than remotely triggerable, but they were the last unguarded URL sinks in the theme layer.

The Atom feed's `<id>` used `addChild()`, which — unlike `addAttribute()` — does not escape, so a permalink containing `&` emitted an empty `<id/>` and left the feed malformed for every reader. The two `addAttribute()` calls beside it had the opposite bug and pre-escaped a value that gets escaped anyway.

## Found but deliberately not changed

Each of these is a judgement call that belongs to you rather than to a security patch:

- **The release image runs FrankenPHP, and therefore all PHP, as root.** `.docker/Dockerfile.release` has no `USER` and no privilege drop, while the dev image does exactly that (`setcap` + `entrypoint.sh`). Any RCE becomes container root. I did not change it: there is no Docker daemon in this environment to build and test against, and a naive `USER www-data` would break existing deployments whose named volumes and bind mounts are still root-owned. The safe shape is probably a release entrypoint that chowns `/app/data`, `/app/src/assets`, `/data` and `/config` and then drops privileges, mirroring the dev one.
- **`GET /micropub?q=config` is served without a token**, deliberately per the comment on the `handleRequest` override. It discloses the media-endpoint URL and every configured `[syndicate_to]` target. W3C Micropub §3.7 wants a token here, but tightening it may break real clients.
- **`MAX_UPLOAD_PIXELS` (40 MP) exceeds what the release image's 128 MB `memory_limit` can decode** — a 40 MP truecolor buffer is roughly 160 MB, so the pre-decode guard admits images that reliably fatal the request. Lowering it caps the maximum photo resolution you support, which is a product decision.
- **Type confusion in Micropub input causes uncaught `TypeError`s → HTTP 500** for a few well-formed-JSON shapes (an array where `properties.name`, `properties.published`, or `replace.content` expects a string). Robustness rather than a boundary; guards returning `invalid_request` would fix it.
- **Third-party GitHub Actions float on mutable tags**, including the `docker/*` actions in the job that publishes the image with `packages: write`. Pinning to SHAs would close that; Dependabot already watches `github-actions`.
- **`/upload` and `/checkbox` have no CSRF check** — documented as relying on `SameSite=Strict`, which does hold. Adding `require_csrf()` would actually break the flow, since the token is single-use and `/upload` runs mid-composition.
- **A DNS-rebinding TOCTOU remains in the SSRF guard**: `is_public_http_url()` resolves the host, then the fetch resolves again independently. Closing it means connecting to the validated IP with an explicit `Host` header.

Clean on review: SQL injection (every user-controlled value is bound or integer-cast across all 93 query sites), XXE in feed and WXR parsing, TLS verification, committed secrets, password hashing, and the WordPress importer's reachability (CLI-only).

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2iwbhM8UYXqU52HERiKLp)_