### PR TITLE
Normalize config and front matter types to prevent fatals

### DIFF
--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -99,6 +99,39 @@ Feed = /feed
 ;https://mastodon.social/@yourusername = Mastodon
 ```
 
+## Values and sections
+
+Every setting is one of two shapes, and the difference is a pair of brackets:
+
+* A **single value**, written `key = value` — `site_title`, `theme`,
+  `posts_per_page`, `timezone` and the rest of the keys above the first
+  `[section]` header.
+* A **section** of `label = value` entries under a `[name]` header —
+  `[menu_items]`, `[footer_items]`, `[feeds]`, `[preconnect]`, `[me]`,
+  `[redirections]` and `[syndicate_to]`.
+
+Getting the shape wrong is easy to do and easy to miss, because the file is
+still valid INI either way:
+
+```
+[site_title]          ;; wrong: a section where a single value belongs
+feeds = https://…     ;; wrong: a single value where the [feeds] section belongs
+
+[menu_items]
+Home = /
+Home = /start         ;; wrong: a repeated label makes the entry a list
+```
+
+Lamb ignores a setting written in the wrong shape and uses the default instead,
+so a slip cannot take the site down — and it tells you which ones it ignored
+when you save, alongside the "Settings saved successfully" message. If a
+setting you changed appears to have no effect, that message is the first place
+to look.
+
+Note that everything after a `[section]` header belongs to that section until
+the next one. A single-value setting written below a section header becomes an
+entry in it, so keep them all at the top of the file.
+
 ## Site URL
 
 `site_url` is the canonical address of your site, e.g. `https://example.com`. It is

--- a/src/config.php
+++ b/src/config.php
@@ -157,7 +157,13 @@ function ensure_explicit_theme(string $ini_text, string $default_theme = 'base')
         return "theme = {$default_theme}\n\n" . $ini_text;
     }
 
-    $current = trim((string) $parsed['theme']);
+    // A `[theme]` header rather than a `theme = ...` line parses to an array;
+    // casting that to a string warns and yields the literal "Array", which
+    // looked like a real theme name and stopped the migration here. Treat any
+    // non-scalar as unusable — there is no `theme =` line for the rewrite below
+    // to find, so the text is returned unchanged and normalize_config() drops
+    // the key, leaving index.php to fall back to the base theme.
+    $current = is_scalar($parsed['theme']) ? trim((string) $parsed['theme']) : '';
     if ($current === '' || $current === 'default') {
         return (string) preg_replace(
             '/^(\h*theme\h*=).*$/mi',
@@ -194,8 +200,8 @@ function load(): array
  */
 function compose_config(string $stored_ini, string $default_ini): array
 {
-    $config = parse_ini_safe($stored_ini);
     $defaults = parse_ini_safe($default_ini);
+    $config = normalize_config(parse_ini_safe($stored_ini), $defaults);
 
     // Theme is intentionally not defaulted here. An install without an explicit
     // theme is migrated per-install on read (see ensure_explicit_theme /
@@ -212,6 +218,126 @@ function compose_config(string $stored_ini, string $default_ini): array
     ];
 
     return array_merge($fallback, $defaults, $config);
+}
+
+/**
+ * The config keys written as `[section]` blocks of `label = value` entries.
+ *
+ * Everything else is a single-value setting. This is the shape schema
+ * normalize_config() and shape_warnings() work from. It is spelled out rather
+ * than inferred from the seeded defaults because the defaults keep the
+ * personal-identity and opt-in settings (`author_name`, `site_description`,
+ * `404_fallback`, …) commented out, so they are absent from the parsed
+ * defaults and inference could not tell they are scalars.
+ */
+const CONFIG_SECTIONS = [
+    'menu_items',
+    'footer_items',
+    'feeds',
+    'preconnect',
+    'me',
+    'redirections',
+    'syndicate_to',
+];
+
+/**
+ * Returns true when the named config key holds a section rather than a value.
+ *
+ * The seeded defaults are consulted as well as CONFIG_SECTIONS, so a section
+ * added to get_default_ini_text() is classified correctly even if this list is
+ * not updated with it.
+ *
+ * @param string $key The config key.
+ * @param array<string, mixed> $defaults The parsed seeded defaults.
+ * @return bool
+ */
+function is_config_section(string $key, array $defaults): bool
+{
+    return in_array($key, CONFIG_SECTIONS, true) || is_array($defaults[$key] ?? null);
+}
+
+/**
+ * Coerces the parsed INI into the shapes its readers assume.
+ *
+ * `parse_ini_string()` is called with sections enabled, so the author picks
+ * each key's PHP type by how they write it, and the two spellings are only one
+ * bracket apart:
+ *
+ *   [site_title]        a scalar setting arrives as an array
+ *   feeds = <url>       a section arrives as a string
+ *   Home[] = /          a section entry arrives as a nested array
+ *
+ * None of the ~50 consumers expect the other shape. Most of them fatal on it —
+ * `escape()`, `wrap_title()` and `str_starts_with()` all take a `string`, so a
+ * `[site_title]` header 500s every HTML page, including `/settings`, which is
+ * the page the author would use to undo it. The quieter cases are worse: a
+ * wrongly-shaped `feeds_draft` made `filter_var()` return false and silently
+ * published third-party feed items that should have been held for review, and a
+ * wrongly-shaped `posts_per_page` cast to 1.
+ *
+ * Rather than guard 50 call sites, normalise once here, on the way out of the
+ * parser. The seeded defaults declare each documented key's shape, so they are
+ * also the schema: a key the defaults hold as an array is a section, anything
+ * else is a scalar setting. A value of the wrong shape is dropped, which in
+ * compose_config() means the seeded default applies — the same
+ * fall-back-to-something-renderable stance parse_ini_safe() takes for INI that
+ * does not parse at all. Keys the defaults do not mention (the author's own)
+ * keep their value when scalar and are filtered to scalars when not.
+ *
+ * @param array<string, mixed> $config   The parsed stored config.
+ * @param array<string, mixed> $defaults The parsed seeded defaults, used as the shape schema.
+ * @return array<string, mixed> The config with every value in its expected shape.
+ */
+function normalize_config(array $config, array $defaults): array
+{
+    $normalized = [];
+
+    foreach ($config as $key => $value) {
+        if (is_config_section((string) $key, $defaults)) {
+            $normalized[$key] = normalize_config_section($value);
+            continue;
+        }
+
+        if (is_array($value)) {
+            // A single-value setting written as a section, or a section the
+            // author invented that nothing reads. Neither has a meaning to any
+            // consumer, so drop it and let the default stand.
+            continue;
+        }
+
+        $normalized[$key] = (string) $value;
+    }
+
+    return $normalized;
+}
+
+/**
+ * Reduces a config section to the `label => string` map its readers iterate.
+ *
+ * A section is only ever consumed as flat label/value pairs — menu links, feed
+ * URLs, redirect targets, rel="me" links. A repeated key (`Home[] = /`) nests
+ * an array under the label, which then reaches `str_starts_with()` or
+ * `escape()` as an array and throws; there is no sensible single value to
+ * recover from it, so the entry is dropped and its siblings still render.
+ *
+ * @param mixed $section The raw parsed section value.
+ * @return array<string, string> The section as flat label/value pairs.
+ */
+function normalize_config_section(mixed $section): array
+{
+    if (!is_array($section)) {
+        return [];
+    }
+
+    $normalized = [];
+    foreach ($section as $label => $value) {
+        if (!is_scalar($value)) {
+            continue;
+        }
+        $normalized[(string) $label] = (string) $value;
+    }
+
+    return $normalized;
 }
 
 /**
@@ -372,6 +498,57 @@ function validate_ini(string $ini_text): array
     } finally {
         restore_error_handler();
     }
+}
+
+/**
+ * Describes the settings normalize_config() will ignore, in the author's terms.
+ *
+ * The normalisation is deliberately quiet at render time — a wrongly-shaped
+ * value falls back to its default rather than taking the site down. But quiet
+ * at *save* time would mean typing a setting, being told "Settings saved
+ * successfully", and watching it have no effect with nothing to explain why.
+ * This is the "communicate failure" half: the settings handler flashes these
+ * alongside the success message.
+ *
+ * Only shape is reported. Whether a value is a usable timezone, URL or theme
+ * name is each reader's business and each already has its own fallback.
+ *
+ * @param string $ini_text The raw INI text as the author submitted it.
+ * @return list<string> Human-readable warnings, empty when every value fits.
+ */
+function shape_warnings(string $ini_text): array
+{
+    $defaults = parse_ini_safe(get_default_ini_text());
+    $warnings = [];
+
+    foreach (parse_ini_safe($ini_text) as $key => $value) {
+        $expects_section = is_config_section((string) $key, $defaults);
+
+        if ($expects_section && !is_array($value)) {
+            $warnings[] = "`{$key}` is a list of entries: write it as a `[{$key}]` section. "
+                . 'The single value was ignored.';
+            continue;
+        }
+
+        if (!$expects_section && is_array($value)) {
+            $warnings[] = "`{$key}` takes one value: write it as `{$key} = ...`, not a "
+                . "`[{$key}]` section. The section was ignored.";
+            continue;
+        }
+
+        if (!is_array($value)) {
+            continue;
+        }
+
+        foreach ($value as $label => $entry) {
+            if (!is_scalar($entry)) {
+                $warnings[] = "`{$label}` appears more than once in `[{$key}]`, "
+                    . 'which makes it a list. The entry was ignored.';
+            }
+        }
+    }
+
+    return $warnings;
 }
 
 /**

--- a/src/index.php
+++ b/src/index.php
@@ -36,7 +36,11 @@ define('ROOT_URL', $root_url);
 // reason) keeps it to a safe filename charset, closing both a path-traversal
 // primitive and a site-wide stored-XSS surface a stray HTML-breaking
 // character in `theme = ...` would otherwise open up.
-define("THEME", Theme\sanitize_filename((string) $config['theme']));
+// `?? 'base'` is not the old runtime fallback returning: ensure_explicit_theme()
+// still guarantees a `theme` line exists. It covers the one case that line
+// cannot be trusted — a `[theme]` section header, which normalize_config()
+// drops because an array cannot name a theme directory.
+define("THEME", Theme\sanitize_filename((string) ($config['theme'] ?? 'base')));
 define("THEME_DIR", ROOT_DIR . '/themes/' . THEME . '/');
 define("THEME_URL", 'themes/' . THEME . '/');
 

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -16,6 +16,7 @@ use RedBeanPHP\R;
 use RedBeanPHP\RedException\SQL;
 
 use function Lamb\Post\consume_leading_heading;
+use function Lamb\Post\matter_string;
 use function Lamb\Post\normalize_frontmatter_fence;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\set_matter;
@@ -363,10 +364,10 @@ function highlight_and_link(string $markdown): string
  * Normalises the reply target from front matter into a single string.
  *
  * Reads the `in-reply-to` key (parse_matter() has already canonicalised the
- * `in_reply_to` spelling onto it), collapsing a YAML list to its first entry.
- * The key is removed from the passed-by-reference front matter so the
- * hyphenated key is never written as an invalid column by the blind copy in
- * apply_frontmatter().
+ * `in_reply_to` spelling onto it and collapsed a YAML list to its first entry
+ * via matter_string()). The key is removed from the passed-by-reference front
+ * matter so the hyphenated key is never written as an invalid column by the
+ * blind copy in apply_frontmatter().
  *
  * @param array<int|string, mixed> $front_matter The parsed front matter, modified in place.
  * @return string The normalised reply target, or '' when absent.
@@ -375,13 +376,10 @@ function highlight_and_link(string $markdown): string
  */
 function normalize_in_reply_to(array &$front_matter): string
 {
-    $in_reply_to = $front_matter['in-reply-to'] ?? null;
+    $in_reply_to = matter_string($front_matter['in-reply-to'] ?? null);
     unset($front_matter['in-reply-to']);
-    if (is_array($in_reply_to)) {
-        $in_reply_to = $in_reply_to[0] ?? null;
-    }
 
-    return is_string($in_reply_to) ? trim($in_reply_to) : '';
+    return $in_reply_to !== null ? trim($in_reply_to) : '';
 }
 
 /**
@@ -408,15 +406,16 @@ function apply_frontmatter(OODBBean $bean, array $front_matter): void
     $bean->in_reply_to = normalize_in_reply_to($front_matter);
 
     // Normalise syndication record. Hyphenated key can't map via the loop below.
-    $bean->syndicated_to = isset($front_matter['syndicated-to'])
-        ? (string) $front_matter['syndicated-to']
-        : '';
+    $bean->syndicated_to = matter_string($front_matter['syndicated-to'] ?? null) ?? '';
 
     // Reset the title to empty when it is absent from front matter, so removing
     // the `title:` line (or all front matter) on an edit clears a previously
     // stored title. The additive loop below only ever sets keys that are
-    // present, so without this an old title would survive every save.
-    $bean->title = isset($front_matter['title']) ? (string) $front_matter['title'] : '';
+    // present, so without this an old title would survive every save. The key
+    // is consumed here (as in_reply_to is) so the loop cannot put the raw,
+    // uncoerced value back on the bean two lines later.
+    $bean->title = matter_string($front_matter['title'] ?? null) ?? '';
+    unset($front_matter['title']);
 
     foreach ($front_matter as $key => $value) {
         // Only the fields front matter is meant to drive. This used to copy any
@@ -429,6 +428,15 @@ function apply_frontmatter(OODBBean $bean, array $front_matter): void
         // checks that correctly refuse update and delete. Unknown keys are also
         // no longer turned into new columns by RedBean's fluid mode.
         if (!is_string($key) || !in_array($key, FRONT_MATTER_FIELDS, true)) {
+            continue;
+        }
+        // RedBean refuses an array or object as a property value ("Invalid Bean
+        // value"), and the refusal surfaces at R::store() — past every catch
+        // block, which only handles SQL errors — as a 500 with the post lost.
+        // A YAML list or map here has nothing to say about a scalar column, so
+        // leave the existing value in place and let the per-field normalisation
+        // that follows (apply_scheduling, the draft flag) settle it.
+        if (!is_scalar($value)) {
             continue;
         }
         $bean->$key = $value;
@@ -462,7 +470,12 @@ function apply_frontmatter(OODBBean $bean, array $front_matter): void
  */
 function apply_scheduling(OODBBean $bean, array $front_matter, mixed $previous_created): void
 {
-    if (!isset($front_matter['created'])) {
+    // array_key_exists(), not isset(): a bare `created:` line parses to null,
+    // which isset() reports as absent. The copy loop in apply_frontmatter()
+    // sees the key either way, so an isset() check here skipped the repair and
+    // left the column NULL — a post with no date at all, listed publicly and
+    // dated "now" by the feeds.
+    if (!array_key_exists('created', $front_matter)) {
         return;
     }
 

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -15,6 +15,7 @@ use function Lamb\add_body_tags;
 use function Lamb\get_tags;
 use function Lamb\is_publicly_visible;
 use function Lamb\is_scheduled;
+use function Lamb\normalize_datetime;
 use function Lamb\notify_post_subscribers;
 use function Lamb\parse_bean;
 use function Lamb\permalink;
@@ -22,6 +23,7 @@ use function Lamb\remove_body_tags;
 use function Lamb\strip_trailing_body_tags;
 use function Lamb\Post\build_matter;
 use function Lamb\Post\finalize_and_store_post;
+use function Lamb\Post\matter_string;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\populate_bean;
 use function Lamb\Post\split_frontmatter;
@@ -352,9 +354,14 @@ class LambMicropubAdapter extends MicropubAdapter
             $bean->transformed = $this->sanitizeHtml($content);
         }
 
-        $published = $props['published'][0] ?? null;
-        if ($published) {
-            $bean->created = date('Y-m-d H:i:s', strtotime($published));
+        // normalize_datetime() rather than strtotime(): it accepts the same
+        // shapes front matter does and returns null instead of false, so a
+        // non-string `published` no longer TypeErrors and an unparseable one no
+        // longer silently backdates the post to 1970 (strtotime() returns false,
+        // which date() reads as the epoch).
+        $published = normalize_datetime($props['published'][0] ?? null);
+        if ($published !== null) {
+            $bean->created = $published;
         }
 
         $postStatus = $props['post-status'][0] ?? null;
@@ -582,9 +589,13 @@ class LambMicropubAdapter extends MicropubAdapter
     {
         $currentBody  = $bean->body ?? '';
         $matter       = parse_matter($currentBody);
-        $title        = $matter['title'] ?? null;
-        $replyTo      = $matter['in-reply-to'] ?? null;
-        $syndicatedTo = $matter['syndicated-to'] ?? null;
+        // matter_string(), not a bare read: parse_matter() normalises these
+        // keys, but the ?string parameters below turn any survivor into a fatal
+        // TypeError, and an update is the one Micropub call that re-reads front
+        // matter the author wrote by hand.
+        $title        = matter_string($matter['title'] ?? null);
+        $replyTo      = matter_string($matter['in-reply-to'] ?? null);
+        $syndicatedTo = matter_string($matter['syndicated-to'] ?? null);
 
         $tags       = get_tags($currentBody);
         $hashtagStr = empty($tags) ? '' : ' ' . implode(' ', array_map(fn($t) => '#' . $t, $tags));
@@ -704,8 +715,13 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     private function buildBody(array $props, string $content): string
     {
-        $title = $props['name'][0] ?? null;
-        $replyTo = $props['in-reply-to'][0] ?? null;
+        // Microformats properties are arrays of values, and a value is not
+        // necessarily a string: `in-reply-to` is legitimately an embedded
+        // h-cite object, and a client is free to send a nested array for
+        // `name`. Both reached the ?string parameters of assembleFrontMatter()
+        // as arrays and 500ed the create.
+        $title = matter_string($props['name'][0] ?? null);
+        $replyTo = matter_string($props['in-reply-to'][0] ?? null);
 
         $photos = $this->buildPhotos($props['photo'] ?? []);
         if ($photos !== '') {
@@ -722,7 +738,13 @@ class LambMicropubAdapter extends MicropubAdapter
             $content = $content . "\n\n" . $extra;
         }
 
-        $syndicateTo  = array_filter(array_values((array) ($props['mp-syndicate-to'] ?? [])));
+        // Filter to scalars before imploding: a nested array here produced an
+        // "Array to string conversion" warning and stored the literal "Array"
+        // as the syndication target.
+        $syndicateTo  = array_filter(
+            array_map(matter_string(...), array_values((array) ($props['mp-syndicate-to'] ?? []))),
+            fn(?string $uid) => $uid !== null && $uid !== ''
+        );
         $syndicatedTo = !empty($syndicateTo) ? implode(' ', $syndicateTo) : null;
 
         return build_matter(

--- a/src/network/ingest.php
+++ b/src/network/ingest.php
@@ -7,6 +7,7 @@ use RedBeanPHP\R;
 use RedBeanPHP\RedException\SQL;
 use SimplePie\Item as SimplePieItem;
 
+use function Lamb\Post\build_matter;
 use function Lamb\Post\finalize_and_store_post;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\populate_bean;
@@ -100,13 +101,13 @@ function get_structured_content(SimplePieItem|JsonFeedItem $item, string $name):
     $contents = attributed_content($item, $name);
     $title = sanitize_feed_title($item->get_title() ?? '');
     if (!empty($title)) {
-        $contents = <<<MATTER
----
-title: {$title}
----
-
-{$contents}
-MATTER;
+        // build_matter() (i.e. Yaml::dump) rather than interpolating the title
+        // into a heredoc. Interpolation let the remote feed choose the YAML
+        // *type* of its own title: `[a, b]` arrived as a list and `2024-01-02`
+        // as a date object, neither of which is a string, and the ingest run
+        // died on the first such item. Dumping quotes the scalar so a title is
+        // always read back as the text the feed sent.
+        $contents = build_matter(['title' => $title], "\n" . $contents);
     }
     return $contents;
 }
@@ -117,11 +118,15 @@ MATTER;
  * Front matter is delimited by `---` and parsed as YAML, so an untrusted title
  * containing newlines could inject extra keys (e.g. `slug`, `created`) and a `---`
  * sequence could close the block early. Whitespace is collapsed to single spaces,
- * any run of three or more hyphens is shortened, the result is length-capped, and
- * slashes/quotes are escaped (preserving the existing front-matter format).
+ * any run of three or more hyphens is shortened, and the result is length-capped.
+ *
+ * Quoting and escaping are no longer done here: get_structured_content() now
+ * renders the block with Yaml::dump(), which quotes the scalar correctly for
+ * whatever it contains. The previous addslashes() left a literal backslash in
+ * front of every apostrophe in the stored title.
  *
  * @param string $title The raw feed item title.
- * @return string A single-line, length-capped, escaped title safe for front matter.
+ * @return string A single-line, length-capped title safe for front matter.
  */
 function sanitize_feed_title(string $title): string
 {
@@ -132,7 +137,7 @@ function sanitize_feed_title(string $title): string
         $title = rtrim(mb_substr($title, 0, 200));
     }
 
-    return addslashes($title);
+    return $title;
 }
 
 /**

--- a/src/post.php
+++ b/src/post.php
@@ -152,13 +152,101 @@ function parse_matter(string $body): array
     }
 
     $matter = normalize_matter_keys($matter);
+    $matter = normalize_matter_values($matter);
 
+    // normalize_matter_values() has already made both of these a string when
+    // present; the casts keep the static analyser's `mixed` narrowing happy.
     if (isset($matter['slug'])) {
         $matter['slug'] = sanitize_explicit_slug((string) $matter['slug']);
     }
 
     if (isset($matter['title']) && !isset($matter['slug'])) {
-        $matter['slug'] = slugify($matter['title']);
+        $matter['slug'] = slugify((string) $matter['title']);
+    }
+
+    return $matter;
+}
+
+/**
+ * The front-matter keys the rest of the codebase reads as plain text.
+ *
+ * These are the values normalize_matter_values() coerces to a string (or drops
+ * as absent). Keys outside this list — `created`, `draft` — carry their own
+ * type handling downstream and are left as YAML parsed them.
+ */
+const MATTER_TEXT_KEYS = ['title', 'slug', 'summary', 'description', 'in-reply-to', 'syndicated-to'];
+
+/**
+ * Coerces a front-matter value to the string its readers assume, or null when
+ * it has no faithful textual form.
+ *
+ * YAML is a typed format and the author picks the type by how they write the
+ * line: `title: [a, b]` is a list, `title: 2024-01-02` is a date object (front
+ * matter is parsed with PARSE_DATETIME), `title: yes` is a boolean. Everything
+ * downstream — slugify(), the `(string)` casts in apply_frontmatter(), the
+ * `?string` parameters in the Micropub adapter — expects a string, and PHP 8
+ * turns that mismatch into a fatal rather than a warning, so one mistyped line
+ * took down the whole save. Where it did not, an array cast to the literal
+ * string "Array" and was stored as the post's title or slug.
+ *
+ * The coercion:
+ *  - strings, integers and floats become their textual form;
+ *  - a list collapses to its first entry — the shape `in-reply-to` already
+ *    accepted, generalised, so `title: [a, b]` reads as `a`;
+ *  - dates are formatted back to the wall-clock text the author typed;
+ *  - a map, a nested list, a boolean or null have no faithful text (neither
+ *    "1" nor "true" is what `title: yes` meant), so they are reported as
+ *    absent and the caller's own fallback applies.
+ *
+ * @param mixed $value The raw front-matter value.
+ * @return string|null The value as text, or null when it has none.
+ */
+function matter_string(mixed $value): ?string
+{
+    if (is_array($value)) {
+        // One level only: the first entry of a list of lists is still not text.
+        $value = array_is_list($value) ? ($value[0] ?? null) : null;
+    }
+    if (is_string($value)) {
+        return $value;
+    }
+    if (is_int($value) || is_float($value)) {
+        return (string) $value;
+    }
+    if ($value instanceof \DateTimeInterface) {
+        // A bare `2024-01-02` parses to midnight; render it back without the
+        // time the author never typed.
+        return $value->format($value->format('H:i:s') === '00:00:00' ? 'Y-m-d' : 'Y-m-d H:i:s');
+    }
+
+    return null;
+}
+
+/**
+ * Normalises the textual front-matter values to strings before they are matched.
+ *
+ * The companion to normalize_matter_keys(): that one canonicalises how a key is
+ * spelled, this one canonicalises what its value is. Running both inside
+ * parse_matter() makes it the single place the rest of the codebase has to
+ * trust — every consumer of MATTER_TEXT_KEYS gets a string or nothing, and a
+ * key whose value has no textual form is removed so `isset()` reports it as
+ * absent rather than handing on an array.
+ *
+ * @param array<int|string, mixed> $matter The parsed front matter.
+ * @return array<int|string, mixed> The front matter with textual values coerced.
+ */
+function normalize_matter_values(array $matter): array
+{
+    foreach (MATTER_TEXT_KEYS as $key) {
+        if (!array_key_exists($key, $matter)) {
+            continue;
+        }
+        $text = matter_string($matter[$key]);
+        if ($text === null) {
+            unset($matter[$key]);
+            continue;
+        }
+        $matter[$key] = $text;
     }
 
     return $matter;

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -330,6 +330,13 @@ function respond_settings(): array
         if ($validation['valid']) {
             Config\save_ini_text($submitted_ini);
             $_SESSION['flash'][] = "Settings saved successfully.";
+            // Syntactically valid INI can still hold a setting in the wrong
+            // shape — a `[site_title]` section, a `feeds = <url>` line. Those
+            // are ignored on read so they cannot break the site; say so here,
+            // or the author is left with a setting that saved and did nothing.
+            foreach (Config\shape_warnings($submitted_ini) as $warning) {
+                $_SESSION['flash'][] = $warning;
+            }
             redirect_uri('/settings');
         } else {
             $_SESSION['flash'][] = "Invalid INI syntax. Your changes were not saved.";

--- a/src/theme.php
+++ b/src/theme.php
@@ -373,7 +373,12 @@ function syndication_links(OODBBean $bean): string
     $targets = $config['syndicate_to'] ?? [];
     $links = [];
     foreach (preg_split('/\s+/', trim($raw)) ?: [] as $uid) {
-        if ($uid === '') {
+        // Same reasoning as link_source() above: escape() encodes HTML
+        // metacharacters, not URL schemes, so a `javascript:` target passed
+        // straight into the href. syndicated_to is not author-only — a Micropub
+        // client holding just `create` scope sets it via mp-syndicate-to — so
+        // require a real http(s) URL before linking it.
+        if ($uid === '' || !is_valid_http_url($uid)) {
             continue;
         }
         $name = $targets[$uid] ?? (parse_url($uid, PHP_URL_HOST) ?: $uid);

--- a/tests/Unit/ConfigTypesTest.php
+++ b/tests/Unit/ConfigTypesTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Config\compose_config;
+use function Lamb\Config\get_default_ini_text;
+use function Lamb\Config\get_menu_slugs;
+use function Lamb\Config\normalize_config;
+use function Lamb\Config\shape_warnings;
+
+/**
+ * The settings INI is parsed with sections enabled, so the author decides each
+ * key's PHP type by how they write it: a `[site_title]` header makes a scalar
+ * setting an array, `feeds = <url>` makes a section a string, and `Home[] = /`
+ * nests an array inside a section. Consumers assume the documented shape and
+ * PHP 8 turns the mismatch into a fatal — on a page that is also how the author
+ * would undo the mistake.
+ *
+ * These tests pin the normalisation that keeps a wrongly-shaped value from
+ * reaching a consumer at all.
+ */
+class ConfigTypesTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function withConfig(string $ini): array
+    {
+        return compose_config($ini, get_default_ini_text());
+    }
+
+    // normalize_config() — scalar settings
+
+    public function testScalarSettingWrittenAsSectionIsDropped(): void
+    {
+        // `[site_title]` rather than `site_title = ...`. An array here reached
+        // escape()/wrap_title() and fatally TypeError'd every HTML page.
+        $config = normalize_config(['site_title' => ['foo' => 'bar']], ['site_title' => 'Default']);
+
+        $this->assertArrayNotHasKey('site_title', $config);
+    }
+
+    public function testDroppedScalarSettingFallsBackToTheSeededDefault(): void
+    {
+        $config = $this->withConfig("[site_title]\nfoo = bar\n");
+
+        $this->assertSame('My Microblog', $config['site_title']);
+    }
+
+    public function testScalarSettingKeepsItsStringValue(): void
+    {
+        $config = normalize_config(['site_title' => 'Mine'], ['site_title' => 'Default']);
+
+        $this->assertSame('Mine', $config['site_title']);
+    }
+
+    public function testUnknownScalarKeyIsKept(): void
+    {
+        $config = normalize_config(['custom' => 'value'], []);
+
+        $this->assertSame('value', $config['custom']);
+    }
+
+    public function testUnknownArrayKeyIsDropped(): void
+    {
+        // Nothing reads it and it is not a documented section, so it cannot be
+        // handed on as an array.
+        $config = normalize_config(['custom' => ['a' => 'b']], []);
+
+        $this->assertArrayNotHasKey('custom', $config);
+    }
+
+    /**
+     * The seeded INI keeps the personal-identity and opt-in settings commented
+     * out, so they are absent from the parsed defaults. Inferring "scalar
+     * setting" from the defaults alone therefore missed exactly these keys, and
+     * `[author_name]` still reached escape() in the Atom feed as an array.
+     *
+     * @dataProvider commentedOutScalarKeyProvider
+     */
+    public function testScalarSettingCommentedOutInTheDefaultsIsStillNormalised(string $key): void
+    {
+        $config = $this->withConfig("[{$key}]\nx = y\n");
+
+        $this->assertFalse(is_array($config[$key] ?? null), "$key must not stay an array");
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function commentedOutScalarKeyProvider(): array
+    {
+        return [
+            'author_name'      => ['author_name'],
+            'author_email'     => ['author_email'],
+            'site_description' => ['site_description'],
+            'site_url'         => ['site_url'],
+            '404_fallback'     => ['404_fallback'],
+            'websub_hubs'      => ['websub_hubs'],
+            'micropub_debug'   => ['micropub_debug'],
+        ];
+    }
+
+    public function testShapeWarningsNamesAScalarCommentedOutInTheDefaults(): void
+    {
+        $warnings = shape_warnings("[author_name]\nx = y\n");
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('author_name', $warnings[0]);
+    }
+
+    // normalize_config() — sections
+
+    public function testSectionWrittenAsScalarIsDropped(): void
+    {
+        // `feeds = https://example.com/rss` instead of a `[feeds]` section.
+        $config = normalize_config(['feeds' => 'https://example.com/rss'], ['feeds' => []]);
+
+        $this->assertSame([], $config['feeds']);
+    }
+
+    public function testSectionDropsNestedArrayEntries(): void
+    {
+        // `Home[] = /` inside `[menu_items]` nests an array under the label.
+        $config = normalize_config(
+            ['menu_items' => ['Home' => ['/'], 'About' => '/about']],
+            ['menu_items' => []]
+        );
+
+        $this->assertSame(['About' => '/about'], $config['menu_items']);
+    }
+
+    public function testSectionValuesAreStrings(): void
+    {
+        $config = normalize_config(['menu_items' => ['Home' => 1]], ['menu_items' => []]);
+
+        $this->assertSame(['Home' => '1'], $config['menu_items']);
+    }
+
+    // The consumers that used to fatal
+
+    public function testMenuSlugsSurviveASectionWrittenAsAScalar(): void
+    {
+        global $config;
+        $original = $config;
+        $config = $this->withConfig("menu_items = /about\n");
+
+        // foreach over a string warned and produced nothing.
+        $this->assertIsArray(get_menu_slugs());
+
+        $config = $original;
+    }
+
+    public function testMenuSlugsSurviveANestedMenuEntry(): void
+    {
+        global $config;
+        $original = $config;
+        $config = $this->withConfig("[menu_items]\nHome[] = /x\n");
+
+        // str_starts_with() on an array is a TypeError, and this runs on every
+        // listing page and feed.
+        $this->assertSame([], get_menu_slugs());
+
+        $config = $original;
+    }
+
+    public function testFeedsDraftFailsClosedWhenWronglyShaped(): void
+    {
+        // filter_var(array, FILTER_VALIDATE_BOOLEAN) is false, which silently
+        // flipped the default from "hold feed items for review" to "publish
+        // them immediately".
+        $config = $this->withConfig("[feeds_draft]\nx = y\n");
+
+        $this->assertTrue(filter_var($config['feeds_draft'], FILTER_VALIDATE_BOOLEAN));
+    }
+
+    public function testPostsPerPageFallsBackToTheDefaultWhenWronglyShaped(): void
+    {
+        // (int) on a non-empty array is 1 — with no diagnostic — which
+        // paginated the whole site one post at a time.
+        $config = $this->withConfig("posts_per_page[] = 10\n");
+
+        $this->assertSame(10, (int) $config['posts_per_page']);
+    }
+
+    public function testThemeIsAlwaysAStringOrAbsent(): void
+    {
+        $config = $this->withConfig("[theme]\nx = y\n");
+
+        // index.php casts this to a string to build a filesystem path.
+        $this->assertFalse(is_array($config['theme'] ?? null));
+    }
+
+    public function testRedirectionsWrittenAsAScalarCannotRedirectSlugZero(): void
+    {
+        // isset() on a string is false for a non-numeric offset but true for
+        // "0", so requesting /0 read a single character out of the value.
+        $config = $this->withConfig("redirections = https://evil.example\n");
+
+        $this->assertSame([], $config['redirections']);
+    }
+
+    // shape_warnings() — the author has to be told what was ignored
+
+    public function testShapeWarningsIsEmptyForTheSeededDefaults(): void
+    {
+        $this->assertSame([], shape_warnings(get_default_ini_text()));
+    }
+
+    public function testShapeWarningsNamesAScalarWrittenAsASection(): void
+    {
+        $warnings = shape_warnings("[site_title]\nfoo = bar\n");
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('site_title', $warnings[0]);
+        $this->assertStringContainsString('ignored', $warnings[0]);
+    }
+
+    public function testShapeWarningsNamesASectionWrittenAsAScalar(): void
+    {
+        $warnings = shape_warnings("feeds = https://example.com/rss\n");
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('[feeds]', $warnings[0]);
+    }
+
+    public function testShapeWarningsNamesARepeatedSectionKey(): void
+    {
+        $warnings = shape_warnings("[menu_items]\nHome[] = /\n");
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('menu_items', $warnings[0]);
+        $this->assertStringContainsString('Home', $warnings[0]);
+    }
+
+    public function testShapeWarningsIsEmptyForUnparseableIni(): void
+    {
+        // validate_ini() already rejects this with a syntax error; there is
+        // nothing useful to add about the shape of a file that did not parse.
+        $this->assertSame([], shape_warnings("[unclosed\n=== not ini ==="));
+    }
+
+    public function testEveryDefaultSectionStaysAnArray(): void
+    {
+        $config = $this->withConfig(
+            "menu_items = x\nfooter_items = x\nfeeds = x\npreconnect = x\nme = x\n"
+            . "redirections = x\nsyndicate_to = x\n"
+        );
+
+        foreach (['menu_items', 'footer_items', 'feeds', 'preconnect', 'me', 'redirections', 'syndicate_to'] as $key) {
+            $this->assertIsArray($config[$key], "$key must stay an array");
+        }
+    }
+}

--- a/tests/Unit/FrontMatterTypesTest.php
+++ b/tests/Unit/FrontMatterTypesTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Unit;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\parse_bean;
+use function Lamb\Post\matter_string;
+use function Lamb\Post\parse_matter;
+use function Lamb\Post\populate_bean;
+
+/**
+ * Front matter is YAML, so every value carries a type the author chose — a
+ * list, a map, a boolean, a date object — while the code reading it assumes a
+ * string. These tests pin the coercion that keeps a mistyped line from
+ * crashing the save (or the cron run that ingested it).
+ */
+class FrontMatterTypesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+    }
+
+    // matter_string()
+
+    public function testMatterStringPassesStringsThrough(): void
+    {
+        $this->assertSame('Hello', matter_string('Hello'));
+        $this->assertSame('', matter_string(''));
+    }
+
+    public function testMatterStringRendersNumbers(): void
+    {
+        $this->assertSame('42', matter_string(42));
+        $this->assertSame('1.5', matter_string(1.5));
+    }
+
+    public function testMatterStringCollapsesAListToItsFirstEntry(): void
+    {
+        $this->assertSame('a', matter_string(['a', 'b']));
+    }
+
+    public function testMatterStringRejectsAMap(): void
+    {
+        $this->assertNull(matter_string(['a' => 'b']));
+    }
+
+    public function testMatterStringRejectsANestedList(): void
+    {
+        // One level of unwrapping only — a list of lists has no textual form.
+        $this->assertNull(matter_string([['a'], 'b']));
+    }
+
+    public function testMatterStringRejectsBooleansAndNull(): void
+    {
+        // `title: true` is YAML's boolean; neither "1" nor "true" is reliably
+        // the text the author typed, so the value is reported as absent.
+        $this->assertNull(matter_string(true));
+        $this->assertNull(matter_string(false));
+        $this->assertNull(matter_string(null));
+    }
+
+    public function testMatterStringFormatsDatesAsTheAuthorTypedThem(): void
+    {
+        $this->assertSame('2024-01-02', matter_string(new DateTimeImmutable('2024-01-02 00:00:00')));
+        $this->assertSame(
+            '2024-01-02 10:30:00',
+            matter_string(new DateTimeImmutable('2024-01-02 10:30:00'))
+        );
+    }
+
+    // parse_matter() normalises the textual keys
+
+    public function testParseMatterCollapsesAListTitle(): void
+    {
+        $matter = parse_matter("---\ntitle: [a, b]\n---\nBody");
+
+        $this->assertSame('a', $matter['title']);
+        $this->assertSame('a', $matter['slug']);
+    }
+
+    public function testParseMatterKeepsADateTitleAsText(): void
+    {
+        // `title: 2024-01-02` is a YAML date, not a string. Before the coercion
+        // this reached slugify() as a DateTimeImmutable and threw a TypeError.
+        $matter = parse_matter("---\ntitle: 2024-01-02\n---\nBody");
+
+        $this->assertSame('2024-01-02', $matter['title']);
+        $this->assertSame('2024-01-02', $matter['slug']);
+    }
+
+    public function testParseMatterDropsAMapTitle(): void
+    {
+        $matter = parse_matter("---\ntitle:\n  a: b\n---\nBody");
+
+        $this->assertArrayNotHasKey('title', $matter);
+        $this->assertArrayNotHasKey('slug', $matter);
+    }
+
+    public function testParseMatterKeepsADateSlugAsText(): void
+    {
+        $matter = parse_matter("---\nslug: 2024-01-02\n---\nBody");
+
+        $this->assertSame('2024-01-02', $matter['slug']);
+    }
+
+    public function testParseMatterDropsAnUnusableSlugAndFallsBackToTheTitle(): void
+    {
+        // A boolean has no textual form, so the slug is derived from the title
+        // rather than stored as "" (which is what `(string) false` produced).
+        $matter = parse_matter("---\ntitle: My Post\nslug: false\n---\nBody");
+
+        $this->assertSame('my-post', $matter['slug']);
+    }
+
+    public function testParseMatterCollapsesAListSyndicatedTo(): void
+    {
+        $body = "---\nslug: ok\nsyndicated-to:\n  - https://a.example\n  - https://b.example\n---\nBody";
+
+        $this->assertSame('https://a.example', parse_matter($body)['syndicated-to']);
+    }
+
+    public function testParseMatterKeepsAListInReplyToCollapsed(): void
+    {
+        $body = "---\nin-reply-to:\n  - https://a.example\n  - https://b.example\n---\nBody";
+
+        $this->assertSame('https://a.example', parse_matter($body)['in-reply-to']);
+    }
+
+    // The save path must survive every shape
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function hostileFrontMatterProvider(): array
+    {
+        return [
+            'list title'            => ["---\ntitle: [a, b]\n---\nBody"],
+            'map title'             => ["---\ntitle:\n  a: b\n---\nBody"],
+            'date title'            => ["---\ntitle: 2024-01-02\n---\nBody"],
+            'boolean title'         => ["---\ntitle: true\n---\nBody"],
+            'list title with slug'  => ["---\nslug: ok\ntitle: [a, b]\n---\nBody"],
+            'date slug'             => ["---\nslug: 2024-01-02\n---\nBody"],
+            'list slug'             => ["---\nslug: [a, b]\n---\nBody"],
+            'list syndicated-to'    => ["---\nslug: ok\nsyndicated-to: [https://a, https://b]\n---\nBody"],
+            'date syndicated-to'    => ["---\nslug: ok\nsyndicated-to: 2024-01-02\n---\nBody"],
+            'list created'          => ["---\nslug: ok\ncreated: [a, b]\n---\nBody"],
+            'empty created'         => ["---\nslug: ok\ncreated:\n---\nBody"],
+            'map description'       => ["---\nslug: ok\ndescription:\n  a: b\n---\nBody"],
+            'list in-reply-to'      => ["---\nslug: ok\nin-reply-to: [https://a]\n---\nBody"],
+        ];
+    }
+
+    /**
+     * @dataProvider hostileFrontMatterProvider
+     */
+    public function testPopulateBeanStoresEveryFrontMatterShape(string $body): void
+    {
+        $bean = populate_bean($body);
+        R::store($bean);
+
+        // RedBean rejects an array or object property outright, so a value that
+        // survived un-coerced would abort the save with a RedException.
+        $this->assertIsString($bean->title);
+        $this->assertIsString($bean->slug);
+        $this->assertIsString($bean->syndicated_to);
+        $this->assertIsString($bean->in_reply_to);
+        $this->assertNotEmpty($bean->created);
+    }
+
+    public function testParseBeanKeepsTheCreatedDateWhenTheFrontMatterValueIsEmpty(): void
+    {
+        // `created:` with no value parses to null. isset() is false for null but
+        // the copy loop still saw the key, which blanked the column and left the
+        // post with no date at all.
+        $bean = R::dispense('post');
+        $bean->body = "---\nslug: ok\ncreated:\n---\nBody";
+        $bean->created = '2024-01-02 03:04:05';
+
+        parse_bean($bean);
+
+        $this->assertSame('2024-01-02 03:04:05', $bean->created);
+    }
+
+    public function testParseBeanTitleFromAListIsItsFirstEntry(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = "---\nslug: ok\ntitle: [First, Second]\n---\nBody";
+        $bean->slug = '';
+
+        parse_bean($bean);
+
+        $this->assertSame('First', $bean->title);
+    }
+}

--- a/tests/Unit/NetworkTest.php
+++ b/tests/Unit/NetworkTest.php
@@ -15,6 +15,7 @@ use function Lamb\Network\feed_fetch_due;
 use function Lamb\Network\get_structured_content;
 use function Lamb\Network\purge_deleted_posts;
 use function Lamb\Network\webmention_line;
+use function Lamb\Post\parse_matter;
 
 class NetworkTest extends TestCase
 {
@@ -83,7 +84,9 @@ class NetworkTest extends TestCase
         $item = $this->makeItem('My Post Title', 'Some content', 'https://example.com');
         $result = get_structured_content($item, 'Blog');
         $this->assertStringContainsString('---', $result);
-        $this->assertStringContainsString('title: My Post Title', $result);
+        // Assert the parsed title rather than the literal line: the block is
+        // rendered with Yaml::dump(), so the scalar may legitimately be quoted.
+        $this->assertSame('My Post Title', parse_matter($result)['title']);
     }
 
     public function testGetStructuredContentWithoutTitleHasNoFrontMatter(): void
@@ -101,11 +104,44 @@ class NetworkTest extends TestCase
         $this->assertStringContainsString('Originally written on', $result);
     }
 
-    public function testGetStructuredContentEscapesTitleSlashes(): void
+    public function testGetStructuredContentRoundTripsAnApostropheInTheTitle(): void
     {
+        // An apostrophe is the character YAML quoting exists for. The title has
+        // to come back out exactly as the feed sent it — the previous
+        // addslashes() left the backslash in the stored title.
         $item = $this->makeItem("It's a test", 'Content', 'https://example.com');
         $result = get_structured_content($item, 'Blog');
-        $this->assertStringContainsString("title: It\\'s a test", $result);
+        $this->assertSame("It's a test", parse_matter($result)['title']);
+    }
+
+    /**
+     * A remote feed must not be able to pick the YAML *type* of its own title.
+     *
+     * @dataProvider typedFeedTitleProvider
+     */
+    public function testGetStructuredContentKeepsATypedTitleAsText(string $title): void
+    {
+        $item = $this->makeItem($title, 'Content', 'https://example.com');
+
+        // Before the block was dumped rather than interpolated, `[a, b]` parsed
+        // as a list and `2024-01-02` as a date object — neither a string — and
+        // the ingest run died on the first such item.
+        $this->assertSame($title, parse_matter(get_structured_content($item, 'Blog'))['title']);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function typedFeedTitleProvider(): array
+    {
+        return [
+            'list'    => ['[a, b]'],
+            'map'     => ['{a: b}'],
+            'date'    => ['2024-01-02'],
+            'boolean' => ['true'],
+            'number'  => ['42'],
+            'null'    => ['~'],
+        ];
     }
 
     public function testGetStructuredContentReturnsString(): void
@@ -123,8 +159,11 @@ class NetworkTest extends TestCase
         $result = get_structured_content($item, 'Blog');
         // The injected "slug:" must not appear on its own front-matter line.
         $this->assertStringNotContainsString("\nslug:", $result);
-        // And the title must collapse to a single line.
-        $this->assertStringContainsString('title: Innocent slug: /evil', $result);
+        // And the whole thing must come back as one title, with the slug still
+        // derived from it rather than dictated by the feed.
+        $matter = parse_matter($result);
+        $this->assertSame('Innocent slug: /evil', $matter['title']);
+        $this->assertNotSame('/evil', $matter['slug']);
     }
 
     public function testGetStructuredContentTitleCannotCloseFrontMatterEarly(): void

--- a/tests/Unit/SyndicationLinksTest.php
+++ b/tests/Unit/SyndicationLinksTest.php
@@ -86,4 +86,38 @@ class SyndicationLinksTest extends TestCase
         $html = syndication_links($bean);
         $this->assertStringContainsString('Also on', $html);
     }
+
+    /**
+     * @dataProvider nonHttpTargetProvider
+     */
+    public function testSyndicationLinksDropsNonHttpTargets(string $uid): void
+    {
+        // escape() encodes HTML metacharacters, not URL schemes, so a
+        // `javascript:` target reached the href intact. The value is reachable
+        // from a Micropub client holding only `create` scope, via
+        // mp-syndicate-to, so it is not author-trusted.
+        $html = syndication_links($this->makeBean($uid));
+
+        $this->assertStringNotContainsString($uid, $html);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function nonHttpTargetProvider(): array
+    {
+        return [
+            'javascript' => ['javascript:alert(1)'],
+            'data'       => ['data:text/html,<script>alert(1)</script>'],
+            'relative'   => ['/not-a-silo'],
+        ];
+    }
+
+    public function testSyndicationLinksKeepsHttpTargetsAlongsideADroppedOne(): void
+    {
+        $html = syndication_links($this->makeBean('javascript:alert(1) https://bsky.app/profile/me'));
+
+        $this->assertStringNotContainsString('javascript:', $html);
+        $this->assertStringContainsString('https://bsky.app/profile/me', $html);
+    }
 }


### PR DESCRIPTION
## Summary

Add type normalization for configuration settings and front matter values to prevent fatal errors when authors accidentally write settings in the wrong shape. The INI parser and YAML parser both preserve the author's intended type, but consumers assume specific shapes. This change coerces mistyped values to their expected form or drops them to fall back to defaults, keeping the site running while warning the author of the mistake.

## Key Changes

- **Config type normalization** (`src/config.php`):
  - Add `normalize_config()` to coerce parsed INI values to their expected shapes based on a schema derived from seeded defaults
  - Add `normalize_config_section()` to flatten section entries and drop nested arrays (from repeated keys like `Home[] = /`)
  - Add `shape_warnings()` to report which settings were ignored due to wrong shape, displayed alongside the success message in settings
  - Define `CONFIG_SECTIONS` constant and `is_config_section()` helper to distinguish scalar settings from sections
  - Update `compose_config()` to call `normalize_config()` before merging with defaults
  - Update `ensure_explicit_theme()` to handle non-scalar theme values safely

- **Front matter type normalization** (`src/post.php`):
  - Add `matter_string()` to coerce YAML values to their textual form: strings/numbers pass through, lists collapse to first entry, dates format back to wall-clock text, maps/booleans/null return null
  - Add `normalize_matter_values()` to apply `matter_string()` to all textual front matter keys before they're consumed
  - Update `parse_matter()` to call `normalize_matter_values()` so all consumers of `title`, `slug`, `summary`, `description`, `in-reply-to`, `syndicated-to` receive strings or nothing
  - Define `MATTER_TEXT_KEYS` constant listing keys that must be text

- **Consumer updates**:
  - Update `normalize_in_reply_to()` in `src/lamb.php` to use `matter_string()` instead of inline list handling
  - Update `apply_frontmatter()` in `src/lamb.php` to use `matter_string()` for syndicated-to
  - Update Micropub adapter in `src/micropub.php` to use `matter_string()` and `normalize_datetime()` for safer type handling
  - Update `sanitize_feed_title()` in `src/network/ingest.php` to use `build_matter()` instead of string interpolation, preventing remote feeds from choosing YAML types
  - Update `syndication_links()` in `src/theme.php` to validate URLs before rendering

- **Documentation** (`docs/site-configuration.md`):
  - Add "Values and sections" section explaining the two setting shapes and common mistakes
  - Clarify that wrong shapes are silently ignored with warnings shown at save time

- **Tests**:
  - Add `ConfigTypesTest` covering all normalization cases: scalar settings written as sections, sections written as scalars, nested arrays, commented-out defaults, and the specific consumers that used to fatal
  - Add `FrontMatterTypesTest` covering YAML type coercion: lists, maps, dates, booleans, and the save path with hostile front matter
  - Update `NetworkTest` to assert parsed values rather than literal INI lines, and add cases for typed feed titles
  - Update `SyndicationLinksTest` to verify non-HTTP targets are dropped

## Notable Implementation Details

- Normalization happens once at parse time rather than guarding 50+ call sites
- Seeded defaults serve as the shape schema, so commented-out settings are still recognized as scalars
- Unknown keys keep their scalar values but drop arrays (conservative: keep author's custom settings when safe)
- Warnings are only about shape, not value validity (timezone, URL, theme name validation remains downstream)
- YAML date objects are formatted back to the text the author typed (bare date without time)
- Remote feed titles are dumped as YAML rather than interpolated, preventing the feed from choosing the title's PHP type

https://claude.ai/code/session_012d9Qt8gPssWA8qC5LkyjP3