### PR TITLE
Key feed ingestion on the newest item seen, not on the crawl clock

### DIFF
--- a/docs/cross-posting.md
+++ b/docs/cross-posting.md
@@ -37,9 +37,16 @@ It is your responsibility to [call the `_cron` endpoint]({{ site.baseurl }}{% li
 
 The first cron run after adding a feed imports every item currently present in the feed itself — typically the publisher's most recent 10–20 entries, depending on how many they include. It does not reach back through the publisher's full archive.
 
-After that first run, only items published or updated since the previous run are imported.
+After that first run, an item is imported when it is newer than the newest entry the feed has offered before, and an
+already-imported post is re-synced when the publisher has changed the item since Lamb last copied it.
 
 An item is matched to its existing post by a stable identifier, so a later crawl never creates a duplicate of something it has already imported — even if the publisher restamps the item's date.
+
+Both of those comparisons use dates the *feed* supplies, never the time of the crawl. Earlier versions compared an
+item's date against the clock time of the last successful crawl, which quietly dropped items: if a crawl succeeded
+against a cached or lagging copy of the feed that did not yet list the item, the item's own date was by then older than
+that crawl and it was never imported at all. Upgrading fixes this, and the first crawl after upgrading imports anything
+still in the feed window that was lost this way.
 
 ## Editing an imported post
 

--- a/src/constants.php
+++ b/src/constants.php
@@ -32,6 +32,10 @@ define('FEED_FETCH_TIMEOUT', 15);
 // an endless body into the worker's memory until it fatals.
 define('FEED_FETCH_MAX_BYTES', 5_000_000);
 define('MINUTE_IN_SECONDS', 60);
+// How often /_cron re-fetches an individual feed. Also caps how long SimplePie may
+// serve a feed from its own cache: a cache outliving this window would make every
+// other crawl read a stale copy of the feed while still counting as a success.
+define('FEED_FETCH_INTERVAL', 30 * MINUTE_IN_SECONDS);
 // Current post render-format version. Bump when `transformed` output changes
 // (e.g. new syntax highlighting); older posts are re-parsed on read by upgrade_posts().
 define('POST_VERSION', 3);

--- a/src/network.php
+++ b/src/network.php
@@ -46,7 +46,7 @@ function cron_run_due(int $last_run, int $now): bool
  */
 function feed_fetch_due(int $last_attempt, int $now): bool
 {
-    return ($now - $last_attempt) >= MINUTE_IN_SECONDS * 30;
+    return ($now - $last_attempt) >= FEED_FETCH_INTERVAL;
 }
 
 /**

--- a/src/network/ingest.php
+++ b/src/network/ingest.php
@@ -18,15 +18,28 @@ use function Lamb\Post\populate_bean;
  *
  * Deduplication lives here: an item that already has a post is never recreated
  * (the source of the recreated-draft bug when a feed re-stamps an item's
- * publication date past the watermark). A brand-new item is created only when
- * its publication date is newer than the watermark. An already-ingested post is
- * re-synced from the source only when the item was modified after the watermark
- * AND the author has not taken the post over via the edit form
- * (`feed_locked`) — so a published, re-slugged post is left intact.
+ * publication date past the watermark).
+ *
+ * Both remaining date comparisons are against something the *feed* said, never
+ * against the clock:
+ *
+ * - A brand-new item is created when its publication date is newer than the
+ *   newest entry this feed has ever offered us (`feedstatus.last_item_date`).
+ *   That mark exists only to stop an entry still sitting in the feed window
+ *   from resurrecting a post the author trashed and /_cron later purged. It
+ *   used to be the *crawl* timestamp, which quietly dropped items for good: any
+ *   crawl that succeeded without seeing the entry — a cached or CDN-stale copy
+ *   of the feed, a feed that publishes with a lag — still stamped
+ *   `last_success = now`, and the entry's own publication date was by then
+ *   older than that stamp, so it was never created and never would be.
+ * - An already-ingested post is re-synced only when the item was modified after
+ *   the copy we stored (its `updated` column, which update_item() stamps from
+ *   the item) AND the author has not taken the post over via the edit form
+ *   (`feed_locked`) — so a published, re-slugged post is left intact.
  *
  * @param SimplePieItem|JsonFeedItem $item      The feed item.
  * @param string        $name      Feed name from config.
- * @param int           $watermark The feed's last-success timestamp.
+ * @param int           $watermark Newest entry publication timestamp seen so far.
  * @return bool True when a post was created or updated (counts toward the run total).
  */
 function ingest_item(SimplePieItem|JsonFeedItem $item, string $name, int $watermark): bool
@@ -42,12 +55,50 @@ function ingest_item(SimplePieItem|JsonFeedItem $item, string $name, int $waterm
         return false;
     }
 
-    if (!$existing->feed_locked && (int) $item->get_updated_date('U') > $watermark) {
+    // The post's own `updated` is the copy we last took from the feed:
+    // update_item() and populate_bean() both stamp it from the item. Comparing
+    // against it makes the re-sync decision independent of when /_cron happens
+    // to run, and stops a re-synced item from being re-synced on every crawl.
+    $synced_at = (int) strtotime((string) $existing->updated);
+    if (!$existing->feed_locked && (int) $item->get_updated_date('U') > $synced_at) {
         update_item($item, $name);
         return true;
     }
 
     return false;
+}
+
+/**
+ * Runs a crawled feed's entries through ingest_item() against that feed's
+ * ingestion watermark, and reports what the run should record.
+ *
+ * Shared by the SimplePie and JSON Feed crawls so the two cannot drift on which
+ * watermark they read — the divergence this pattern is prone to, and the reason
+ * the pair already share begin_crawl()/record_crawl_*().
+ *
+ * @param array<array-key, SimplePieItem|JsonFeedItem> $items  The feed's entries.
+ * @param string   $name   Feed name from config.
+ * @param OODBBean $status The feed's status bean from begin_crawl().
+ * @return array{0: int, 1: int|null} Entries created or updated, and the newest
+ *                                    entry date seen (null when none is dated).
+ */
+function ingest_items(array $items, string $name, OODBBean $status): array
+{
+    $watermark = (int) $status->last_item_date;
+    $ingested  = 0;
+    $newest    = null;
+
+    foreach ($items as $item) {
+        if (ingest_item($item, $name, $watermark)) {
+            $ingested++;
+        }
+        $date = (int) $item->get_date('U');
+        if ($date > 0 && ($newest === null || $date > $newest)) {
+            $newest = $date;
+        }
+    }
+
+    return [$ingested, $newest];
 }
 
 function update_item(SimplePieItem|JsonFeedItem $item, string $name): void

--- a/src/network/json_feed.php
+++ b/src/network/json_feed.php
@@ -51,8 +51,9 @@ function parse_json_feed(string $json): ?array
  * feedstatus bean — the JSON Feed counterpart of record_feed_crawl().
  *
  * Mirrors the SimplePie path: a failed fetch or a body that is not a JSON Feed
- * stamps the error without advancing the success watermark; on success, items
- * newer than the watermark are created/updated and the watermark advances.
+ * stamps the error without advancing the success watermark; on success, entries
+ * newer than the newest one this feed has offered before are created/updated and
+ * that ingestion watermark is raised.
  *
  * @param string $name Feed name from config.
  * @param string $url  Feed URL from config.
@@ -77,15 +78,9 @@ function record_json_feed_crawl(string $name, string $url): array
             : 'Not a valid JSON Feed (missing jsonfeed.org version).');
     }
 
-    $watermark = (int) $status->last_success;
-    $items     = 0;
-    foreach ($feed['items'] as $item) {
-        if (ingest_item($item, $name, $watermark)) {
-            $items++;
-        }
-    }
+    [$items, $newest] = ingest_items($feed['items'], $name, $status);
 
-    return record_crawl_success($status, $now, $items);
+    return record_crawl_success($status, $now, $items, $newest);
 }
 
 /**

--- a/src/network/sources.php
+++ b/src/network/sources.php
@@ -3,7 +3,6 @@
 namespace Lamb\Network;
 
 use SimplePie\File as SimplePieFile;
-use SimplePie\Item as SimplePieItem;
 use SimplePie\SimplePie;
 
 use function Lamb\Http\is_public_http_url;
@@ -79,16 +78,18 @@ function ensure_feed_cache(string $dir): string|false
 }
 
 /**
- * Builds and initialises a SimplePie instance for a feed URL, wiring up the
- * shared cache directory (disabling caching when it is not writable) and the
- * per-fetch timeout that stops a slow or hostile feed stalling the cron run.
+ * Wires a SimplePie instance up for a feed URL: the SSRF-guarded fetch class, the
+ * shared cache directory (disabling caching when it is not writable), the cache
+ * lifetime, and the per-fetch timeout that stops a slow or hostile feed stalling
+ * the cron run. Split from init_simplepie_feed() so the wiring is testable without
+ * a network fetch.
  *
- * @param string $url The RSS/Atom feed URL.
- * @return SimplePie The initialised SimplePie instance.
+ * @param SimplePie $feed The instance to configure.
+ * @param string    $url  The RSS/Atom feed URL.
+ * @return void
  */
-function init_simplepie_feed(string $url): SimplePie
+function configure_simplepie_feed(SimplePie $feed, string $url): void
 {
-    $feed = new SimplePie();
     $feed->get_registry()->register(SimplePieFile::class, SafeFile::class, true);
     $cache_dir = ensure_feed_cache('../data/cache/simplepie');
     if ($cache_dir === false) {
@@ -97,9 +98,26 @@ function init_simplepie_feed(string $url): SimplePie
         /** @noinspection PhpDeprecationInspection */
         $feed->set_cache_location($cache_dir);
     }
+    // SimplePie keeps a feed for an hour by default, while /_cron re-fetches every
+    // half hour: every other crawl then read an up-to-an-hour-old copy of the feed
+    // and still recorded a success. Align the two so a crawl always revalidates
+    // (the cache stays useful — it is what carries the ETag/Last-Modified).
+    $feed->set_cache_duration(FEED_FETCH_INTERVAL);
     $feed->set_feed_url($url);
     // Cap each fetch so a slow or hostile feed URL cannot stall the cron run.
     $feed->set_timeout(FEED_FETCH_TIMEOUT);
+}
+
+/**
+ * Builds and initialises a SimplePie instance for a feed URL.
+ *
+ * @param string $url The RSS/Atom feed URL.
+ * @return SimplePie The initialised SimplePie instance.
+ */
+function init_simplepie_feed(string $url): SimplePie
+{
+    $feed = new SimplePie();
+    configure_simplepie_feed($feed, $url);
     $feed->init();
 
     return $feed;
@@ -110,9 +128,9 @@ function init_simplepie_feed(string $url): SimplePie
  *
  * A failed fetch (`!$feed->data` or a non-empty `$feed->error()`) does NOT advance the
  * success watermark — it only stamps `last_attempt` and records the error so the
- * Logs tab can surface it. On success, items newer than the watermark are created or
- * updated, the watermark advances, the item count is recorded and any prior error is
- * cleared.
+ * Logs tab can surface it. On success, entries newer than the newest one this feed
+ * has offered before are created or updated, that ingestion watermark is raised, the
+ * item count is recorded and any prior error is cleared.
  *
  * @param string    $name Feed name from config.
  * @param string    $url  Feed URL from config.
@@ -132,14 +150,7 @@ function record_feed_crawl(string $name, string $url, SimplePie $feed): array
         return record_crawl_failure($status, $now, (string)($error ?: 'Feed fetch failed: no data returned.'));
     }
 
-    $watermark = (int)$status->last_success;
-    $items     = 0;
-    /** @var SimplePieItem $item */
-    foreach ($feed->get_items() as $item) {
-        if (ingest_item($item, $name, $watermark)) {
-            $items++;
-        }
-    }
+    [$items, $newest] = ingest_items($feed->get_items(), $name, $status);
 
-    return record_crawl_success($status, $now, $items);
+    return record_crawl_success($status, $now, $items, $newest);
 }

--- a/src/network/status.php
+++ b/src/network/status.php
@@ -14,6 +14,11 @@ use RedBeanPHP\R;
  * `last_processed_date_<key>` option so existing installs do not re-ingest (and
  * duplicate) every item on the first run after upgrade.
  *
+ * `last_item_date` is the ingestion watermark (see ingest_item()); `last_success`
+ * is only crawl health. They are separate because the first answers "how new is
+ * the newest entry we have seen?" and the second "when did we last reach the
+ * host?" — conflating them is what silently dropped items.
+ *
  * @param string $name Feed name from config.
  * @param string $url  Feed URL from config.
  * @return OODBBean    Existing or freshly dispensed (unsaved) feedstatus bean.
@@ -28,6 +33,7 @@ function feed_status_bean(string $name, string $url): OODBBean
         $bean->url          = $url;
         $legacy             = R::findOne('option', ' name = ? ', ['last_processed_date_' . $key]);
         $bean->last_success = $legacy ? (int)$legacy->value : 0;
+        $bean->last_item_date = 0;
         $bean->last_attempt = 0;
         $bean->last_error   = 0;
         $bean->item_count   = 0;
@@ -79,18 +85,28 @@ function record_crawl_failure(OODBBean $status, int $now, string $message): arra
 }
 
 /**
- * Records a successful crawl: advances the watermark, counts items, clears any error.
+ * Records a successful crawl: stamps crawl health, counts items, clears any error,
+ * and raises the ingestion watermark to the newest entry the feed offered.
  *
- * @param OODBBean $status The status bean from begin_crawl().
- * @param int      $now    The attempt timestamp from begin_crawl().
- * @param int      $items  Number of items created or updated this run.
+ * The watermark only ever moves forward. A feed whose newest entry has scrolled
+ * out of its window (or that briefly serves a truncated copy) must not lower it,
+ * or every older entry still listed becomes eligible for ingestion again.
+ *
+ * @param OODBBean $status      The status bean from begin_crawl().
+ * @param int      $now         The attempt timestamp from begin_crawl().
+ * @param int      $items       Number of items created or updated this run.
+ * @param int|null $newest_item Newest entry publication timestamp seen, or null
+ *                              when the feed carried no dated entries.
  * @return array{ok: bool, items: int, error: ?string}
  */
-function record_crawl_success(OODBBean $status, int $now, int $items): array
+function record_crawl_success(OODBBean $status, int $now, int $items, ?int $newest_item = null): array
 {
     $status->last_success  = $now;
     $status->item_count    = $items;
     $status->error_message = '';
+    if ($newest_item !== null) {
+        $status->last_item_date = max((int)$status->last_item_date, $newest_item);
+    }
     R::store($status);
 
     return ['ok' => true, 'items' => $items, 'error' => null];

--- a/tests/Unit/FeedFetchWindowTest.php
+++ b/tests/Unit/FeedFetchWindowTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SimplePie\SimplePie;
+
+use function Lamb\Network\configure_simplepie_feed;
+use function Lamb\Network\feed_fetch_due;
+
+/**
+ * SimplePie's own cache must not outlive the /_cron re-fetch window.
+ *
+ * SimplePie defaults to caching a feed for an hour while /_cron re-fetches every
+ * half hour, so every other crawl read an up-to-an-hour-old copy of the feed and
+ * still recorded a success. Aligning the two means a crawl always revalidates.
+ */
+class FeedFetchWindowTest extends TestCase
+{
+    public function testCacheDurationDoesNotOutliveTheFetchWindow(): void
+    {
+        $feed = new SimplePie();
+        configure_simplepie_feed($feed, 'https://example.com/feed.atom');
+
+        $this->assertLessThanOrEqual(FEED_FETCH_INTERVAL, $feed->cache_duration);
+    }
+
+    public function testConfigureAppliesTheFetchTimeout(): void
+    {
+        $feed = new SimplePie();
+        configure_simplepie_feed($feed, 'https://example.com/feed.atom');
+
+        $this->assertSame(FEED_FETCH_TIMEOUT, $feed->timeout);
+    }
+
+    public function testFetchWindowMatchesTheConfiguredInterval(): void
+    {
+        $this->assertFalse(feed_fetch_due(1000, 1000 + FEED_FETCH_INTERVAL - 1));
+        $this->assertTrue(feed_fetch_due(1000, 1000 + FEED_FETCH_INTERVAL));
+    }
+}

--- a/tests/Unit/FeedStatusTest.php
+++ b/tests/Unit/FeedStatusTest.php
@@ -169,7 +169,7 @@ class FeedStatusTest extends TestCase
     {
         R::exec('DELETE FROM post');
         $status = feed_status_bean('TestBlog', 'https://testblog.example.com/feed');
-        $status->last_success = time() + 7200; // watermark in the future
+        $status->last_item_date = time() + 7200; // watermark in the future
         R::store($status);
 
         $items = [$this->makeItem('old', 'Old', time(), time())];

--- a/tests/Unit/FeedWatermarkTest.php
+++ b/tests/Unit/FeedWatermarkTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+use SimplePie\Item as SimplePieItem;
+use SimplePie\SimplePie;
+
+use function Lamb\Network\feed_status_bean;
+use function Lamb\Network\ingest_item;
+use function Lamb\Network\record_feed_crawl;
+
+/**
+ * The feed watermark: an item is new relative to the newest item already seen
+ * in that feed, not relative to the wall-clock time of the last crawl.
+ *
+ * Keying "is this item new?" on the crawl clock silently dropped items: any
+ * crawl that succeeded without seeing the item (a cached/CDN-stale copy of the
+ * feed, a feed that publishes with a lag) still stamped `last_success = now`,
+ * and the item's own publication date was by then older than that stamp, so it
+ * was never created and never would be.
+ */
+class FeedWatermarkTest extends TestCase
+{
+    private const NAME = 'lamb-releases';
+    private const URL  = 'https://github.com/svandragt/lamb/releases.atom';
+
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        global $config;
+        $config = [
+            'feeds'       => [self::NAME => self::URL],
+            'feeds_draft' => true,
+        ];
+    }
+
+    private function makeItem(string $id, int $date, ?int $updated = null): SimplePieItem
+    {
+        $updated ??= $date;
+        $item = $this->createMock(SimplePieItem::class);
+        $item->method('get_id')->willReturn($id);
+        $item->method('get_title')->willReturn('Lamb ' . $id);
+        $item->method('get_description')->willReturn('Release notes');
+        $item->method('get_permalink')->willReturn('https://example.com/' . $id);
+        $item->method('get_date')->willReturnCallback(
+            fn(string $format = 'U') => $format === 'U' ? (string) $date : date($format, $date)
+        );
+        $item->method('get_updated_date')->willReturnCallback(
+            fn(string $format = 'U') => $format === 'U' ? (string) $updated : date($format, $updated)
+        );
+        return $item;
+    }
+
+    /**
+     * @param list<SimplePieItem> $items
+     */
+    private function makeFeed(array $items): SimplePie
+    {
+        $feed = $this->createMock(SimplePie::class);
+        $feed->data = ['type' => 1];
+        $feed->method('error')->willReturn(null);
+        $feed->method('get_items')->willReturn($items);
+        $feed->method('get_title')->willReturn('Release notes from lamb');
+        return $feed;
+    }
+
+    public function testItemPublishedBeforeTheLastCrawlIsStillIngested(): void
+    {
+        // A crawl succeeded a minute ago against a stale copy of the feed, so
+        // the item was not in it. The item itself was published before that.
+        $status = feed_status_bean(self::NAME, self::URL);
+        $status->last_success = time();
+        R::store($status);
+
+        $feed = $this->makeFeed([$this->makeItem('0.12.0', time() - 3600)]);
+        $result = record_feed_crawl(self::NAME, self::URL, $feed);
+
+        $this->assertSame(1, $result['items']);
+        $this->assertSame(1, R::count('post'));
+    }
+
+    public function testSuccessfulCrawlRecordsTheNewestItemDate(): void
+    {
+        $newest = time() - 60;
+        $feed   = $this->makeFeed([
+            $this->makeItem('0.11.0', $newest - 86400),
+            $this->makeItem('0.12.0', $newest),
+        ]);
+
+        record_feed_crawl(self::NAME, self::URL, $feed);
+
+        $status = feed_status_bean(self::NAME, self::URL);
+        $this->assertSame($newest, (int) $status->last_item_date);
+    }
+
+    public function testItemOlderThanTheNewestSeenIsNotRecreatedAfterPurge(): void
+    {
+        // The high-water mark is what stops a hard-purged post from being
+        // resurrected by an item still sitting in the feed window.
+        $newest = time() - 60;
+        $status = feed_status_bean(self::NAME, self::URL);
+        $status->last_item_date = $newest;
+        R::store($status);
+
+        $feed = $this->makeFeed([$this->makeItem('0.11.0', $newest - 86400)]);
+        $result = record_feed_crawl(self::NAME, self::URL, $feed);
+
+        $this->assertSame(0, $result['items']);
+        $this->assertSame(0, R::count('post'));
+    }
+
+    public function testItemDateWatermarkDoesNotRegressOnALaterCrawl(): void
+    {
+        $newest = time() - 60;
+        record_feed_crawl(self::NAME, self::URL, $this->makeFeed([$this->makeItem('0.12.0', $newest)]));
+        // A later crawl of a feed whose newest entry has scrolled out of the
+        // window must not lower the mark and re-open the door to old items.
+        record_feed_crawl(self::NAME, self::URL, $this->makeFeed([$this->makeItem('0.11.0', $newest - 86400)]));
+
+        $status = feed_status_bean(self::NAME, self::URL);
+        $this->assertSame($newest, (int) $status->last_item_date);
+    }
+
+    public function testExistingPostIsResyncedWhenTheSourceChangedSinceLastSync(): void
+    {
+        // The re-sync decision belongs to the post, not to the crawl clock: the
+        // item was modified after the copy we stored, whatever the watermark says.
+        $bean = R::dispense('post');
+        $bean->feeditem_uuid = md5(self::NAME . '0.12.0');
+        $bean->body    = 'Original body';
+        $bean->version = 1;
+        $bean->created = '2026-07-25 11:34:15';
+        $bean->updated = '2026-07-25 11:34:15';
+        R::store($bean);
+
+        $status = feed_status_bean(self::NAME, self::URL);
+        $status->last_item_date = PHP_INT_MAX; // no item can beat this
+        R::store($status);
+
+        $item = $this->makeItem('0.12.0', strtotime('2026-07-25 11:34:15'), strtotime('2026-07-25 18:00:00'));
+        $this->assertTrue(ingest_item($item, self::NAME, PHP_INT_MAX));
+
+        $reloaded = R::load('post', $bean->id);
+        $this->assertSame('2026-07-25 18:00:00', $reloaded->updated);
+    }
+
+    public function testExistingPostIsNotResyncedWhenTheSourceIsUnchanged(): void
+    {
+        $bean = R::dispense('post');
+        $bean->feeditem_uuid = md5(self::NAME . '0.12.0');
+        $bean->body    = 'Original body';
+        $bean->version = 1;
+        $bean->created = '2026-07-25 11:34:15';
+        $bean->updated = '2026-07-25 11:34:15';
+        R::store($bean);
+
+        $item = $this->makeItem('0.12.0', strtotime('2026-07-25 11:34:15'));
+        $this->assertFalse(ingest_item($item, self::NAME, 0));
+
+        $reloaded = R::load('post', $bean->id);
+        $this->assertSame('Original body', $reloaded->body);
+    }
+}

--- a/tests/Unit/NetworkFeedTest.php
+++ b/tests/Unit/NetworkFeedTest.php
@@ -52,8 +52,21 @@ class NetworkFeedTest extends TestCase
         $item->method('get_description')->willReturn($description);
         $item->method('get_permalink')->willReturn($permalink);
         $item->method('get_id')->willReturn($id);
-        $item->method('get_date')->willReturn($date);
-        $item->method('get_updated_date')->willReturn($updated);
+        // Format-aware, as SimplePie is: `U` is a Unix timestamp, anything else
+        // goes through date(). The ingest decisions compare `U` values against
+        // stored timestamps, so a mock that returns a date string for every
+        // format would compare 2024 (the cast of '2024-01-01 …') against epoch
+        // seconds and exercise nothing real.
+        $item->method('get_date')->willReturnCallback(
+            fn(string $format = 'U') => $format === 'U'
+                ? (string) strtotime($date)
+                : date($format, (int) strtotime($date))
+        );
+        $item->method('get_updated_date')->willReturnCallback(
+            fn(string $format = 'U') => $format === 'U'
+                ? (string) strtotime($updated)
+                : date($format, (int) strtotime($updated))
+        );
         return $item;
     }
 


### PR DESCRIPTION
New items from a subscribed feed stopped appearing at all — not as drafts, not as posts. Reported against the lamb releases atom feed on vandragt.com.

## The bug

`ingest_item()` created a post only when the item's publication date was newer than `feedstatus.last_success` — the **wall-clock time of the last successful crawl**. Those two things are not comparable. Any crawl that succeeded *without seeing the item* still stamped `last_success = now`, and by the time the item did show up its own date was older than that stamp, so it was skipped — permanently, since every later crawl only moved the stamp further ahead.

Getting into that state needs nothing exotic. SimplePie caches a feed for an hour by default while `/_cron` re-fetches every half hour, so **every other crawl reads an up-to-an-hour-old copy of the feed and records a success from it**. In that steady state an item published in the 30 minutes before a cache-served crawl is lost for good — half the timeline. A CDN serving a stale feed, or a publisher whose feed lags the release, does the same thing.

## The fix

Both date comparisons now use dates the *feed* supplies:

- **Creation** compares against `feedstatus.last_item_date`, the newest entry the feed has ever offered. That mark exists only to stop an entry still sitting in the feed window from resurrecting a post the author trashed and `/_cron` later purged; it is immune to when the crawl happens. It only ever moves forward, so a feed briefly serving a truncated window cannot re-open the door to old entries.
- **Re-sync** compares the item's modification date against the post's own `updated`, which is the copy we last took from the feed — so the decision is "has the source changed since we copied it", with no watermark involved.

Alongside that:

- SimplePie's cache duration is pinned to the `/_cron` re-fetch window (`FEED_FETCH_INTERVAL`, now shared with `feed_fetch_due()`), so a crawl always revalidates instead of reading up to an hour of staleness. The cache stays useful — it is what carries the ETag/Last-Modified.
- `ingest_items()` collapses the crawl loop the SimplePie and JSON Feed paths had each written out, so they cannot drift on which watermark they read — the divergence that pair is prone to, and why they already share `begin_crawl()`/`record_crawl_*()`.
- `NetworkFeedTest`'s item mock is format-aware, as SimplePie is. It returned a date string for *every* format, so `U` comparisons were measuring the integer cast of `"2024-01-01 …"` against epoch seconds and could not have caught this.

## Upgrade behaviour

`last_item_date` starts unset on existing installs, so **the first crawl after upgrading imports anything still in the feed window that the old watermark lost** — including the missing release posts. Already-imported items are unaffected (dedup is by `feeditem_uuid`). Documented in `docs/cross-posting.md`.

## Tests

Red-green, both new suites failing before the change:

- `tests/Unit/FeedWatermarkTest.php` — item published before the last crawl is still ingested; the newest item date is recorded and never regresses; an item older than the mark is not recreated after a purge; re-sync keys on the post's own `updated`.
- `tests/Unit/FeedFetchWindowTest.php` — the SimplePie cache duration does not outlive the fetch window.

`vendor/bin/codecept run Unit` → 1405 tests green (1 pre-existing skip). `composer lint` and `composer analyse` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_012jP8MJfSqriVTdG5wLC21j)_