### PR TITLE
Move pnpm overrides to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,6 @@
     "@types/node": "^26.1.1",
     "jsdom": "^29.1.1"
   },
-  "pnpm": {
-    "overrides": {
-      "undici": "^7.28.0"
-    }
-  },
   "scripts": {
     "screenshot": "pnpm exec node scripts/screenshot.mjs",
     "test": "node --test \"tests/js/**/*.test.mjs\""

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: ^7.28.0
+
 importers:
 
   .:
@@ -207,8 +210,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.27.1:
-    resolution: {integrity: sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   w3c-xmlserializer@5.0.0:
@@ -353,7 +356,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.27.1
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -408,7 +411,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.27.1: {}
+  undici@7.29.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  undici: ^7.28.0


### PR DESCRIPTION
## Summary
- pnpm 10+ stopped reading the `pnpm` field in `package.json`, causing a warning on every install
- Moved the `overrides.undici` setting into `pnpm-workspace.yaml`, the new location pnpm expects

## Test plan
- [x] `pnpm install` runs with no warning
- [x] `pnpm-lock.yaml` regenerated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YYffPmJKeaureQi43KmZm