### PR TITLE
Drop root privileges in the release FrankenPHP image

### DIFF
--- a/.docker/Dockerfile.release
+++ b/.docker/Dockerfile.release
@@ -25,6 +25,9 @@ RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # exact PHP version in X-Powered-By on every response.
 RUN printf 'upload_max_filesize = 100M\npost_max_size = 100M\nexpose_php = Off\n' > "$PHP_INI_DIR/conf.d/uploads.ini"
 
+# Allow FrankenPHP to bind :80 after dropping to www-data.
+RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/frankenphp
+
 COPY .docker/Caddyfile.release /etc/frankenphp/Caddyfile
 
 WORKDIR /app
@@ -35,6 +38,11 @@ COPY --from=vendor /app/vendor/ vendor/
 # SQLite database and uploads live outside the image.
 RUN mkdir -p data src/assets
 VOLUME ["/app/data", "/app/src/assets"]
+
+COPY .docker/entrypoint.release.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile"]
 
 EXPOSE 80
 HEALTHCHECK --interval=30s --timeout=5s CMD curl -fsS -o /dev/null http://localhost/ || exit 1

--- a/.docker/entrypoint.release.sh
+++ b/.docker/entrypoint.release.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# FrankenPHP runs PHP in-process, so the server itself must drop root
+# before serving, otherwise a code-execution bug in the app runs as
+# container root. Chown first so upgrades from volumes created by
+# earlier (root-only) releases still get www-data write access.
+mkdir -p /app/data /app/src/assets
+chown -R www-data:www-data /app/data /app/src/assets /data /config
+
+# Any parameters to this script will now be executed as www-data,
+# keeping the container environment (-p) so LAMB_LOGIN_PASSWORD survives.
+exec su -p -s /bin/sh www-data -c "$*"

--- a/devbox.lock
+++ b/devbox.lock
@@ -209,14 +209,6 @@
         }
       }
     },
-    "path:/home/sander/dev/php/lamb/.devbox/virtenv/php/flake": {
-      "last_modified": "2026-06-21T12:25:34Z",
-      "resolved": "path:/home/sander/dev/php/lamb/.devbox/virtenv/php/flake?lastModified=1782044734&narHash=sha256-YK3rOLjOqftyZUcaIcer%2B%2BqWt1AgLW9PnR35inXweiU%3D"
-    },
-    "path:/home/sander/dev/php/lamb/.devbox/virtenv/php/flake#composer": {
-      "last_modified": "2026-06-21T12:25:34Z",
-      "resolved": "path:/home/sander/dev/php/lamb/.devbox/virtenv/php/flake?lastModified=1782044734&narHash=sha256-YK3rOLjOqftyZUcaIcer%2B%2BqWt1AgLW9PnR35inXweiU%3D#composer"
-    },
     "php82Extensions.xdebug@latest": {
       "last_modified": "2026-06-13T05:27:44Z",
       "resolved": "github:NixOS/nixpkgs/5a722a7155bfc9fbe657f28d26b71860d95324bc#php82Extensions.xdebug",


### PR DESCRIPTION
## Summary
- FrankenPHP runs PHP in-process, so with no `USER` and no entrypoint, the published `ghcr.io/svandragt/lamb` image ran all application code as container root — any RCE landed as root.
- Mirrors the dev image's approach instead of a bare `USER` line: `setcap CAP_NET_BIND_SERVICE` on `frankenphp` so it can still bind `:80`, then a new `.docker/entrypoint.release.sh` chowns `/app/data`, `/app/src/assets`, `/data`, and `/config` to `www-data` and drops privileges via `su -p` before exec'ing FrankenPHP.
- The chown runs on every start, so volumes created by earlier root-owned releases regain `www-data` write access on upgrade instead of breaking.
- Also includes an unrelated `devbox.lock` update: `devbox install` in this checkout dropped two stale `path:` flake entries left over from a different clone's `.devbox` virtenv path.

Fixes #530

## Test plan
- [x] `docker build -f .docker/Dockerfile.release .` succeeds
- [x] Confirmed the base image (`dunglas/frankenphp:php8.2`) has no `Config.User`, i.e. runs as root by default
- [x] Fresh container: FrankenPHP itself runs as `www-data` (uid 33), only the `su` wrapper (PID 1) stays root to perform the privilege drop
- [x] Upgrade scenario: created a volume with `lamb.db` owned by root using the *old* image, booted the *patched* image against the same volume, confirmed ownership was corrected to `www-data` and read/write access preserved
- [x] Fresh end-to-end boot: HTTP 200, app initializes `lamb.db` and session storage as `www-data`
- [x] `vendor/bin/codecept run Unit` — 1405 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbXiW9T1C2A9UX6aTT4tGf