### PR TITLE
Pin outbound fetches to the resolved IP, closing a DNS-rebinding SSRF gap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
   ],
   "require": {
     "php": ">=8.2",
+    "ext-curl": "*",
     "ext-gettext": "*",
     "ext-pdo_mysql": "*",
     "ext-simplexml": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d02f9e722bea0e5535ffd564a361fc5d",
+    "content-hash": "619045334977ba23ce1685d67321e86e",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -5566,16 +5566,17 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2",
+        "ext-curl": "*",
         "ext-gettext": "*",
         "ext-pdo_mysql": "*",
         "ext-simplexml": "*",
         "ext-sqlite3": "*"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/src/http.php
+++ b/src/http.php
@@ -251,32 +251,26 @@ function resolve_host_ips(string $host): array
 }
 
 /**
- * Whether a URL is safe to fetch: an absolute http(s) URL whose host resolves
- * only to public, routable addresses.
+ * Resolve a host to the single public IP a connection should be pinned to,
+ * or false when it has no safe address.
  *
- * This closes an SSRF hole in {@see is_valid_http_url}, which only checks
- * that a URL is well-formed http(s) — it accepts `http://127.0.0.1/`,
- * `http://169.254.169.254/`, `http://10.0.0.1/`, etc. Anywhere a URL is
- * attacker-influenced and this server will make a request to it on the
- * attacker's behalf (webmention source verification, discovered webmention
- * endpoints, feed fetches), the resolved destination — not just the URL's
- * syntax — must be checked, since it's the destination that reaches internal
- * services. Must be re-checked after every redirect hop for the same reason.
+ * A host is only accepted when *every* address it resolves to is public —
+ * a DNS-rebinding host that answers with a mix of public and private
+ * addresses is rejected outright, since accepting it would mean the caller
+ * picked one of possibly-several answers without knowing which one a second,
+ * independent resolution (the TOCTOU this guards against) might return
+ * instead. When accepted, the first resolved address is returned so the
+ * caller can pin its connection to the exact address that was validated,
+ * rather than trusting whatever a later, separate DNS lookup returns.
  *
- * @param string        $url
+ * @param string        $host
  * @param callable|null $resolver fn(string $host): string[] — defaults to {@see resolve_host_ips}.
- * @return bool
+ * @return string|false
  */
-function is_public_http_url(string $url, ?callable $resolver = null): bool
+function resolve_validated_ip(string $host, ?callable $resolver = null): string|false
 {
-    if (!is_valid_http_url($url)) {
-        return false;
-    }
-
-    $host = (string) parse_url($url, PHP_URL_HOST);
-
     if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
-        return !is_private_ip($host);
+        return is_private_ip($host) ? false : $host;
     }
 
     $resolver ??= __NAMESPACE__ . '\\resolve_host_ips';
@@ -291,7 +285,41 @@ function is_public_http_url(string $url, ?callable $resolver = null): bool
         }
     }
 
-    return true;
+    return $ips[0];
+}
+
+/**
+ * Whether a URL is safe to fetch: an absolute http(s) URL whose host resolves
+ * only to public, routable addresses.
+ *
+ * This closes an SSRF hole in {@see is_valid_http_url}, which only checks
+ * that a URL is well-formed http(s) — it accepts `http://127.0.0.1/`,
+ * `http://169.254.169.254/`, `http://10.0.0.1/`, etc. Anywhere a URL is
+ * attacker-influenced and this server will make a request to it on the
+ * attacker's behalf (webmention source verification, discovered webmention
+ * endpoints, feed fetches), the resolved destination — not just the URL's
+ * syntax — must be checked, since it's the destination that reaches internal
+ * services. Must be re-checked after every redirect hop for the same reason.
+ *
+ * This only answers "is it safe" — it does not pin a connection to the
+ * address it checked, so a second, independent resolution (as `file_get_contents()`
+ * or curl would perform) can still return a different, private address. See
+ * {@see resolve_validated_ip}, which returns the address to connect to, and
+ * {@see fetch_guarded}, which pins the connection to it.
+ *
+ * @param string        $url
+ * @param callable|null $resolver fn(string $host): string[] — defaults to {@see resolve_host_ips}.
+ * @return bool
+ */
+function is_public_http_url(string $url, ?callable $resolver = null): bool
+{
+    if (!is_valid_http_url($url)) {
+        return false;
+    }
+
+    $host = (string) parse_url($url, PHP_URL_HOST);
+
+    return resolve_validated_ip($host, $resolver) !== false;
 }
 
 /**
@@ -341,12 +369,108 @@ function post_form(string $url, array $fields, int $timeout, string $user_agent)
 }
 
 /**
+ * Perform a single HTTP request pinned to a specific IP via curl, so the
+ * connection reaches the exact address {@see resolve_validated_ip} validated
+ * instead of letting the transport re-resolve the host itself (the
+ * DNS-rebinding TOCTOU {@see fetch_guarded} closes).
+ *
+ * `CURLOPT_RESOLVE` is used rather than rewriting the URL to the IP: it
+ * makes curl connect to the given address for the given host:port while
+ * still sending the original hostname in the `Host:` header, SNI, and
+ * certificate verification — a plain URL rewrite would break all three.
+ *
+ * Response headers/status are collected via `CURLOPT_HEADERFUNCTION` (curl
+ * does not populate `$http_response_header` the way streams do), and
+ * `max_bytes` is enforced via `CURLOPT_WRITEFUNCTION` aborting the transfer
+ * once the cap is exceeded, so an oversized body is never fully downloaded.
+ *
+ * @param string               $url
+ * @param array<string, mixed> $opts Same keys as {@see fetch}.
+ * @param array{host: string, ip: string} $pin
+ * @return array{status:int, headers:string[], body:string}|null
+ *               Null on transport failure or when the body exceeds `max_bytes`.
+ */
+function fetch_pinned(string $url, array $opts, array $pin): ?array
+{
+    $ch = curl_init();
+    if ($ch === false) {
+        return null;
+    }
+
+    $port = parse_url($url, PHP_URL_PORT);
+    if ($port === null) {
+        $port = strtolower((string) parse_url($url, PHP_URL_SCHEME)) === 'https' ? 443 : 80;
+    }
+
+    $headers = $opts['headers'] ?? [];
+    $hasUserAgent = false;
+    foreach ($headers as $line) {
+        if (stripos((string) $line, 'user-agent:') === 0) {
+            $hasUserAgent = true;
+            break;
+        }
+    }
+    if (!$hasUserAgent) {
+        $headers[] = 'User-Agent: ' . DEFAULT_USER_AGENT;
+    }
+
+    $max_bytes = isset($opts['max_bytes']) ? max(0, (int) $opts['max_bytes']) : null;
+    $body = '';
+    $truncated = false;
+    $responseHeaders = [];
+
+    $options = [
+        CURLOPT_URL => $url,
+        CURLOPT_RESOLVE => ["{$pin['host']}:$port:{$pin['ip']}"],
+        CURLOPT_CUSTOMREQUEST => $opts['method'] ?? 'GET',
+        CURLOPT_HTTPHEADER => $headers,
+        CURLOPT_FOLLOWLOCATION => false,
+        CURLOPT_HEADERFUNCTION => function ($ch, string $line) use (&$responseHeaders): int {
+            $trimmed = rtrim($line, "\r\n");
+            if ($trimmed !== '') {
+                $responseHeaders[] = $trimmed;
+            }
+            return strlen($line);
+        },
+        CURLOPT_WRITEFUNCTION => function ($ch, string $chunk) use (&$body, &$truncated, $max_bytes): int {
+            $body .= $chunk;
+            if ($max_bytes !== null && strlen($body) > $max_bytes) {
+                $truncated = true;
+                return 0;
+            }
+            return strlen($chunk);
+        },
+    ];
+    if (array_key_exists('timeout', $opts)) {
+        $options[CURLOPT_TIMEOUT] = (int) $opts['timeout'];
+    }
+    if (array_key_exists('content', $opts)) {
+        $options[CURLOPT_POSTFIELDS] = $opts['content'];
+    }
+
+    curl_setopt_array($ch, $options);
+    $ok = curl_exec($ch);
+    $status = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    curl_close($ch);
+
+    if ($ok === false || $truncated) {
+        return null;
+    }
+
+    return ['status' => $status, 'headers' => $responseHeaders, 'body' => $body];
+}
+
+/**
  * Perform a single HTTP request via the streams wrapper.
  *
  * This is the shared low-level fetch used by webmention discovery/verification
  * and Micropub token introspection. It owns stream-context construction so the
  * timeout / redirect / ignore_errors / User-Agent conventions live in one
  * place. See {@see build_http_context_options} for the recognised `$opts`.
+ *
+ * Pass `pin => ['host' => string, 'ip' => string]` to route the request
+ * through {@see fetch_pinned} instead — see its docblock for why. Every
+ * other caller (`post_form()`, Micropub's `introspectToken`) is unaffected.
  *
  * @param string               $url
  * @param array<string, mixed> $opts
@@ -355,6 +479,10 @@ function post_form(string $url, array $fields, int $timeout, string $user_agent)
  */
 function fetch(string $url, array $opts = []): ?array
 {
+    if (isset($opts['pin'])) {
+        return fetch_pinned($url, $opts, $opts['pin']);
+    }
+
     $context = stream_context_create(['http' => build_http_context_options($opts)]);
 
     $max_bytes = isset($opts['max_bytes']) ? max(0, (int) $opts['max_bytes']) : null;
@@ -427,8 +555,9 @@ function resolve_redirect_location(string $base, string $location): string
 
 /**
  * Fetch a URL like {@see fetch}, but only from public, non-internal addresses
- * (see {@see is_public_http_url}), re-validating the destination on every
- * redirect hop instead of trusting PHP's automatic `follow_location`.
+ * (see {@see resolve_validated_ip}), re-resolving and pinning the connection
+ * to the validated address on every redirect hop instead of trusting PHP's
+ * automatic `follow_location`.
  *
  * A remote server that responds fine on the first request but redirects to
  * a loopback/private address is exactly the SSRF bypass this closes: without
@@ -438,23 +567,44 @@ function resolve_redirect_location(string $base, string $location): string
  * attacker's behalf (webmention source verification, discovered webmention
  * endpoints, feed sources).
  *
+ * Resolving and then fetching are two separate operations, so a naive
+ * "check the URL, then fetch the URL" would let the transport's own,
+ * independent DNS lookup return a different (private) address than the one
+ * just validated — a DNS-rebinding TOCTOU. Each hop resolves the host once
+ * via {@see resolve_validated_ip} and passes that exact address to
+ * {@see fetch} as `pin`, so the connection cannot land anywhere except the
+ * address that was checked.
+ *
  * @param string               $url
  * @param array<string, mixed> $opts         Same as {@see fetch}; `follow_location`/`max_redirects` are ignored.
  * @param int                  $max_redirects
- * @param callable|null        $resolver     Passed through to {@see is_public_http_url}.
+ * @param callable|null        $resolver     Passed through to {@see resolve_validated_ip}.
+ * @param callable|null        $fetcher      fn(string $url, array $opts): array|null — defaults to {@see fetch}. Overridable for testing.
  * @return array{status:int, headers:string[], body:string}|null Null when the URL (or any redirect hop) is unsafe or unreachable.
  */
-function fetch_guarded(string $url, array $opts = [], int $max_redirects = 5, ?callable $resolver = null): ?array
-{
+function fetch_guarded(
+    string $url,
+    array $opts = [],
+    int $max_redirects = 5,
+    ?callable $resolver = null,
+    ?callable $fetcher = null
+): ?array {
     $opts['follow_location'] = 0;
     $opts['max_redirects'] = null;
+    $fetcher ??= __NAMESPACE__ . '\\fetch';
 
     for ($hop = 0; $hop <= $max_redirects; $hop++) {
-        if (!is_public_http_url($url, $resolver)) {
+        if (!is_valid_http_url($url)) {
             return null;
         }
 
-        $result = fetch($url, $opts);
+        $host = (string) parse_url($url, PHP_URL_HOST);
+        $ip = resolve_validated_ip($host, $resolver);
+        if ($ip === false) {
+            return null;
+        }
+
+        $result = $fetcher($url, $opts + ['pin' => ['host' => $host, 'ip' => $ip]]);
         if ($result === null) {
             return null;
         }

--- a/src/network/sources.php
+++ b/src/network/sources.php
@@ -5,8 +5,8 @@ namespace Lamb\Network;
 use SimplePie\File as SimplePieFile;
 use SimplePie\SimplePie;
 
-use function Lamb\Http\is_public_http_url;
 use function Lamb\Http\is_valid_http_url;
+use function Lamb\Http\resolve_validated_ip;
 
 // FEED_FETCH_TIMEOUT is defined in constants.php
 
@@ -24,7 +24,8 @@ function get_feeds(): array
 
 /**
  * SimplePie's remote-fetch class, hardened against SSRF: refuses to make a
- * request when the destination doesn't resolve to a public address.
+ * request when the destination doesn't resolve to a public address, and pins
+ * the curl connection to the exact address that was validated.
  *
  * A feed URL is admin-configured (trusted at add-time), but nothing pins its
  * *eventual* destination — if the feed host is later compromised, or simply
@@ -34,6 +35,15 @@ function get_feeds(): array
  * constructor), which — since PHP dispatches `$this->__construct()`
  * virtually — re-enters *this* subclass's override on every hop, so each
  * redirect target is checked, not just the initial URL.
+ *
+ * Checking the URL and then letting curl make its own, independent DNS
+ * lookup is itself a DNS-rebinding TOCTOU — the address curl connects to
+ * could differ from the one just validated. `CURLOPT_RESOLVE` closes that:
+ * it pins curl to a chosen address for a given host:port while still using
+ * the original hostname for the `Host:` header, SNI, and certificate
+ * verification. That only works through curl, so a request forced through
+ * `fsockopen` (which has no equivalent) is refused rather than left
+ * unpinned.
  */
 class SafeFile extends SimplePieFile
 {
@@ -49,13 +59,53 @@ class SafeFile extends SimplePieFile
         bool $force_fsockopen = false,
         array $curl_options = []
     ) {
-        if (!is_public_http_url($url)) {
+        $pinned = self::buildPinnedCurlOptions($url, $curl_options, $force_fsockopen);
+        if ($pinned === false) {
             $this->success = false;
             $this->error = 'Blocked: URL does not resolve to a public, routable address';
             return;
         }
 
-        parent::__construct($url, $timeout, $redirects, $headers, $useragent, $force_fsockopen, $curl_options);
+        parent::__construct($url, $timeout, $redirects, $headers, $useragent, false, $pinned);
+    }
+
+    /**
+     * Validates the URL's destination and, if safe, merges a `CURLOPT_RESOLVE`
+     * entry into `$curl_options` pinning the connection to it. Pure logic
+     * split out of the constructor so it can be unit-tested without making a
+     * real request (the constructor fetches immediately via SimplePie).
+     *
+     * @param array<int, mixed> $curl_options
+     * @return array<int, mixed>|false Merged curl options, or false when the
+     *                                  URL is unsafe or pinning isn't possible.
+     */
+    public static function buildPinnedCurlOptions(
+        string $url,
+        array $curl_options,
+        bool $force_fsockopen,
+        ?callable $resolver = null
+    ): array|false {
+        // fsockopen has no CURLOPT_RESOLVE equivalent, so a forced fsockopen
+        // request would re-resolve the host itself and reopen the TOCTOU.
+        if ($force_fsockopen || !is_valid_http_url($url)) {
+            return false;
+        }
+
+        $host = (string) parse_url($url, PHP_URL_HOST);
+        $ip = resolve_validated_ip($host, $resolver);
+        if ($ip === false) {
+            return false;
+        }
+
+        $port = parse_url($url, PHP_URL_PORT)
+            ?? (strtolower((string) parse_url($url, PHP_URL_SCHEME)) === 'https' ? 443 : 80);
+
+        $curl_options[CURLOPT_RESOLVE] = array_merge(
+            $curl_options[CURLOPT_RESOLVE] ?? [],
+            ["$host:$port:$ip"]
+        );
+
+        return $curl_options;
     }
 }
 

--- a/tests/Unit/HttpFetchTest.php
+++ b/tests/Unit/HttpFetchTest.php
@@ -13,6 +13,7 @@ use function Lamb\Http\is_valid_http_url;
 use function Lamb\Http\parse_status_line;
 use function Lamb\Http\post_form;
 use function Lamb\Http\resolve_redirect_location;
+use function Lamb\Http\resolve_validated_ip;
 
 class HttpFetchTest extends TestCase
 {
@@ -105,6 +106,86 @@ class HttpFetchTest extends TestCase
         $this->assertIsInt($result['status']);
     }
 
+    // fetch() with 'pin' (curl / CURLOPT_RESOLVE) ------------------------------
+
+    /**
+     * Starts a one-shot local HTTP responder in a subprocess bound to
+     * 127.0.0.1, serving exactly one connection with the given raw response
+     * bytes. Returns [process resource, port] — caller must proc_close().
+     *
+     * @return array{0: resource, 1: int}
+     */
+    private function startLocalResponder(string $rawResponse): array
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($socket, "failed to bind local test listener: $errstr");
+        $name = stream_socket_get_name($socket, false);
+        $port = (int) substr($name, strrpos($name, ':') + 1);
+        fclose($socket);
+
+        // The subprocess prints "READY\n" the instant it's bound and listening,
+        // so the parent can wait on that instead of probing with a real
+        // connection — a probe would consume the one accept() meant for the
+        // test's actual request.
+        $script = sprintf(
+            '$s = stream_socket_server("tcp://127.0.0.1:%d", $e, $s2); '
+            . 'echo "READY\n"; '
+            . '$c = stream_socket_accept($s, 5); '
+            . 'if ($c) { fread($c, 8192); fwrite($c, %s); fclose($c); }',
+            $port,
+            var_export($rawResponse, true)
+        );
+
+        $process = proc_open(
+            ['php', '-r', $script],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        $this->assertSame("READY\n", fgets($pipes[1]));
+
+        return [$process, $port];
+    }
+
+    public function testFetchPinnedConnectsToPinnedIpRegardlessOfHostname(): void
+    {
+        [$process, $port] = $this->startLocalResponder(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nhello-from-pinned-ip"
+        );
+
+        try {
+            // The hostname does not resolve in real DNS at all — only
+            // CURLOPT_RESOLVE (driven by the 'pin' opt) can make this connect.
+            $result = fetch("http://nonexistent.invalid:$port/", [
+                'pin' => ['host' => 'nonexistent.invalid', 'ip' => '127.0.0.1'],
+            ]);
+        } finally {
+            proc_close($process);
+        }
+
+        $this->assertNotNull($result);
+        $this->assertSame(200, $result['status']);
+        $this->assertSame('hello-from-pinned-ip', $result['body']);
+    }
+
+    public function testFetchPinnedEnforcesMaxBytes(): void
+    {
+        [$process, $port] = $this->startLocalResponder(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n" . str_repeat('x', 100)
+        );
+
+        try {
+            $result = fetch("http://nonexistent.invalid:$port/", [
+                'pin' => ['host' => 'nonexistent.invalid', 'ip' => '127.0.0.1'],
+                'max_bytes' => 10,
+            ]);
+        } finally {
+            proc_close($process);
+        }
+
+        $this->assertNull($result);
+    }
+
     // is_valid_http_url -------------------------------------------------------
 
     public function testIsValidHttpUrlAcceptsHttpAndHttps(): void
@@ -191,6 +272,44 @@ class HttpFetchTest extends TestCase
         $this->assertFalse(is_public_http_url('http://mixed.example/', $resolver));
     }
 
+    // resolve_validated_ip ------------------------------------------------------
+
+    public function testResolveValidatedIpAcceptsLiteralPublicIp(): void
+    {
+        $this->assertSame('93.184.216.34', resolve_validated_ip('93.184.216.34'));
+    }
+
+    public function testResolveValidatedIpRejectsLiteralPrivateIp(): void
+    {
+        $this->assertFalse(resolve_validated_ip('127.0.0.1'));
+    }
+
+    public function testResolveValidatedIpUsesInjectedResolverForHostnames(): void
+    {
+        $resolver = fn (string $host) => $host === 'evil.example' ? ['127.0.0.1'] : ['93.184.216.34'];
+
+        $this->assertFalse(resolve_validated_ip('evil.example', $resolver));
+        $this->assertSame('93.184.216.34', resolve_validated_ip('good.example', $resolver));
+    }
+
+    public function testResolveValidatedIpRejectsWhenResolutionFails(): void
+    {
+        $resolver = fn (string $host) => [];
+        $this->assertFalse(resolve_validated_ip('unresolvable.example', $resolver));
+    }
+
+    public function testResolveValidatedIpRejectsWhenAnyResolvedIpIsPrivate(): void
+    {
+        $resolver = fn (string $host) => ['93.184.216.34', '127.0.0.1'];
+        $this->assertFalse(resolve_validated_ip('mixed.example', $resolver));
+    }
+
+    public function testResolveValidatedIpReturnsFirstResolvedPublicIp(): void
+    {
+        $resolver = fn (string $host) => ['93.184.216.34', '203.0.113.5'];
+        $this->assertSame('93.184.216.34', resolve_validated_ip('good.example', $resolver));
+    }
+
     // resolve_redirect_location -------------------------------------------------
 
     public function testResolveRedirectLocationPassesThroughAbsoluteUrl(): void
@@ -241,5 +360,75 @@ class HttpFetchTest extends TestCase
     public function testFetchGuardedRejectsMalformedUrl(): void
     {
         $this->assertNull(fetch_guarded('not a url'));
+    }
+
+    public function testFetchGuardedPinsTheResolvedIpOnTheFetcherCall(): void
+    {
+        $resolver = fn (string $host) => ['93.184.216.34'];
+        $calls = [];
+        $fetcher = function (string $url, array $opts) use (&$calls) {
+            $calls[] = [$url, $opts];
+            return ['status' => 200, 'headers' => ['HTTP/1.1 200 OK'], 'body' => 'ok'];
+        };
+
+        $result = fetch_guarded('http://good.example/path', [], 5, $resolver, $fetcher);
+
+        $this->assertSame('ok', $result['body']);
+        $this->assertCount(1, $calls);
+        $this->assertSame(
+            ['host' => 'good.example', 'ip' => '93.184.216.34'],
+            $calls[0][1]['pin']
+        );
+    }
+
+    public function testFetchGuardedResolvesAndPinsEachRedirectHopIndependently(): void
+    {
+        $resolver = fn (string $host) => match ($host) {
+            'first.example' => ['93.184.216.34'],
+            'second.example' => ['203.0.113.5'],
+            default => [],
+        };
+        $calls = [];
+        $fetcher = function (string $url, array $opts) use (&$calls) {
+            $calls[] = [$url, $opts];
+            if ($url === 'http://first.example/') {
+                return [
+                    'status' => 302,
+                    'headers' => ['HTTP/1.1 302 Found', 'Location: http://second.example/'],
+                    'body' => '',
+                ];
+            }
+            return ['status' => 200, 'headers' => ['HTTP/1.1 200 OK'], 'body' => 'final'];
+        };
+
+        $result = fetch_guarded('http://first.example/', [], 5, $resolver, $fetcher);
+
+        $this->assertSame('final', $result['body']);
+        $this->assertCount(2, $calls);
+        $this->assertSame(['host' => 'first.example', 'ip' => '93.184.216.34'], $calls[0][1]['pin']);
+        $this->assertSame(['host' => 'second.example', 'ip' => '203.0.113.5'], $calls[1][1]['pin']);
+    }
+
+    public function testFetchGuardedRejectsRedirectToPrivateHostOnLaterHop(): void
+    {
+        $resolver = fn (string $host) => match ($host) {
+            'first.example' => ['93.184.216.34'],
+            'evil.example' => ['127.0.0.1'],
+            default => [],
+        };
+        $fetcher = function (string $url, array $opts) {
+            if ($url === 'http://first.example/') {
+                return [
+                    'status' => 302,
+                    'headers' => ['HTTP/1.1 302 Found', 'Location: http://evil.example/'],
+                    'body' => '',
+                ];
+            }
+            return ['status' => 200, 'headers' => [], 'body' => 'should never be reached'];
+        };
+
+        $result = fetch_guarded('http://first.example/', [], 5, $resolver, $fetcher);
+
+        $this->assertNull($result);
     }
 }

--- a/tests/Unit/SafeFileTest.php
+++ b/tests/Unit/SafeFileTest.php
@@ -51,4 +51,67 @@ class SafeFileTest extends TestCase
 
         $this->assertFalse($file->success);
     }
+
+    public function testBlocksForceFsockopenSinceItBypassesPinning(): void
+    {
+        // force_fsockopen would route the request through fsockopen instead
+        // of curl, which has no CURLOPT_RESOLVE equivalent — the DNS-rebinding
+        // TOCTOU this class exists to close would reopen. Fails closed before
+        // any network access, so this is safe to exercise directly.
+        $file = new SafeFile('http://93.184.216.34/', force_fsockopen: true);
+
+        $this->assertFalse($file->success);
+    }
+
+    // buildPinnedCurlOptions() -----------------------------------------------
+    // Pure logic extracted so the CURLOPT_RESOLVE pin can be verified without
+    // making a real request (SafeFile's constructor fetches immediately).
+
+    public function testBuildPinnedCurlOptionsMergesResolveEntryForLiteralIp(): void
+    {
+        $options = SafeFile::buildPinnedCurlOptions('http://93.184.216.34/', [], false);
+
+        $this->assertSame(['93.184.216.34:80:93.184.216.34'], $options[CURLOPT_RESOLVE]);
+    }
+
+    public function testBuildPinnedCurlOptionsUsesHttpsDefaultPort(): void
+    {
+        $options = SafeFile::buildPinnedCurlOptions('https://93.184.216.34/', [], false);
+
+        $this->assertSame(['93.184.216.34:443:93.184.216.34'], $options[CURLOPT_RESOLVE]);
+    }
+
+    public function testBuildPinnedCurlOptionsUsesInjectedResolverForHostnames(): void
+    {
+        $resolver = fn (string $host) => ['93.184.216.34'];
+
+        $options = SafeFile::buildPinnedCurlOptions('http://good.example/', [], false, $resolver);
+
+        $this->assertSame(['good.example:80:93.184.216.34'], $options[CURLOPT_RESOLVE]);
+    }
+
+    public function testBuildPinnedCurlOptionsPreservesExistingCurlOptions(): void
+    {
+        $options = SafeFile::buildPinnedCurlOptions('http://93.184.216.34/', [CURLOPT_TIMEOUT => 10], false);
+
+        $this->assertSame(10, $options[CURLOPT_TIMEOUT]);
+        $this->assertArrayHasKey(CURLOPT_RESOLVE, $options);
+    }
+
+    public function testBuildPinnedCurlOptionsReturnsFalseForPrivateResolvedIp(): void
+    {
+        $resolver = fn (string $host) => ['127.0.0.1'];
+
+        $this->assertFalse(SafeFile::buildPinnedCurlOptions('http://evil.example/', [], false, $resolver));
+    }
+
+    public function testBuildPinnedCurlOptionsReturnsFalseForMalformedUrl(): void
+    {
+        $this->assertFalse(SafeFile::buildPinnedCurlOptions('not a url', [], false));
+    }
+
+    public function testBuildPinnedCurlOptionsReturnsFalseWhenForceFsockopenRequested(): void
+    {
+        $this->assertFalse(SafeFile::buildPinnedCurlOptions('http://93.184.216.34/', [], true));
+    }
 }


### PR DESCRIPTION
## Summary
- `is_public_http_url()` validated a destination but let `fetch()` (streams) and SimplePie's curl client re-resolve the host independently — a 0-TTL DNS-rebinding attacker could pass the guard with a public IP and connect on loopback.
- Adds `resolve_validated_ip()`, which returns the exact address that was validated (not just a bool), and pins the actual connection to it via `CURLOPT_RESOLVE` in both `fetch_guarded()` (webmention/feed/websub/image-import fetches) and `SafeFile` (SimplePie feed fetches) — keeping the original hostname for `Host:`/SNI/cert checks, so TLS still works.
- `introspectToken()`/`post_form()` are untouched (not attacker-controlled, still stream-based).
- `SafeFile` now fails closed on `force_fsockopen`, since fsockopen has no `CURLOPT_RESOLVE` equivalent.
- Adds `ext-curl` as an explicit composer requirement (previously implicit via SimplePie).

Fixes #535.

## Test plan
- [x] `vendor/bin/codecept run Unit` — 1424 tests pass, including new coverage for `resolve_validated_ip()`, per-hop pinning in `fetch_guarded()`, and `SafeFile::buildPinnedCurlOptions()`
- [x] One test spins up a local subprocess listener and proves `CURLOPT_RESOLVE` actually redirects the connection (not just that the code runs)
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/phpcs .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1r32mS8TGeacvA8feEvc6