### PR TITLE
Require a token for q=config, per Micropub spec

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -112,26 +112,6 @@ class LambMicropubAdapter extends MicropubAdapter
     }
 
     /**
-     * Override handleRequest to allow unauthenticated ?q=config discovery queries,
-     * and to accept bearer tokens sent in both the Authorization header and POST body
-     * (common in real-world clients like Quill and micro.blog for backward compatibility).
-     *
-     * @param \Psr\Http\Message\ServerRequestInterface $request
-     * @return \Psr\Http\Message\ResponseInterface
-     */
-    public function handleRequest(\Psr\Http\Message\ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
-    {
-        // q=config is a discovery endpoint; return it without requiring a token.
-        if (strtolower($request->getMethod()) === 'get' && ($request->getQueryParams()['q'] ?? '') === 'config') {
-            $this->request = $request;
-            $configResult = $this->configurationQueryCallback($request->getQueryParams());
-            return new Response(200, ['content-type' => 'application/json'], json_encode($configResult) ?: '');
-        }
-
-        return parent::handleRequest($request);
-    }
-
-    /**
      * Verify the bearer token by introspecting it against the configured token endpoint.
      *
      * @param string $token

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -58,13 +58,37 @@ class MicropubAdapterTest extends TestCase
 
     // --- handleRequest ---
 
-    public function testConfigQueryResponds200WithoutAccessToken(): void
+    public function testConfigQueryRequiresAccessToken(): void
     {
+        // W3C Micropub §3.7 requires a token on the query endpoint; q=config must
+        // not be a special-cased exception, or it discloses the media-endpoint URL
+        // and every configured syndicate-to target to anyone (#534).
         $adapter = new StubMicropubAdapter();
 
         $request = new \Nyholm\Psr7\ServerRequest(
             'GET',
             ROOT_URL . '/micropub?q=config'
+        );
+        $request = $request->withQueryParams(['q' => 'config']);
+
+        $response = $adapter->handleRequest($request);
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function testConfigQueryRespondsWithAnyValidToken(): void
+    {
+        // Same rule as q=source/q=syndicate-to: any verified token may read
+        // q=config, regardless of its scope.
+        $adapter = new StubMicropubAdapter();
+        $adapter->stubResponse = [
+            'me'    => ROOT_URL . '/',
+            'scope' => 'create',
+        ];
+
+        $request = new \Nyholm\Psr7\ServerRequest(
+            'GET',
+            ROOT_URL . '/micropub?q=config',
+            ['Authorization' => 'Bearer valid-jwt']
         );
         $request = $request->withQueryParams(['q' => 'config']);
 


### PR DESCRIPTION
## Summary
- `q=config` no longer answers unauthenticated: it now falls through to the parent adapter's standard token check, same as `q=source`/`q=syndicate-to`
- Any verified token (regardless of scope) still gets the config response; a request with no/invalid token gets 401
- Removes the special-cased override added for a client that could not be identified — no known Micropub client requires the unauthenticated path

## Test plan
- [x] `vendor/bin/codecept run Unit` — full suite (1406 tests) passes
- [x] `vendor/bin/phpcs` passes on changed files
- [x] New unit tests cover both the 401-without-token and 200-with-valid-token cases for `q=config`

Fixes #534

https://claude.ai/code/session_01FNa6gVcmCD9cKUpcpAZCWV