### PR TITLE
Cut WebP conversion's double-buffering, add LAMB_MAX_UPLOAD_PIXELS

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -48,7 +48,7 @@ Your site is now ready at http://localhost
 
 Uploaded images and video are stored under `src/assets/` inside the app container.
 
-Both images accept uploads up to 100&nbsp;MB (`upload_max_filesize = 100M`, `post_max_size = 100M`) — see [Media]({{ site.baseurl }}{% link media.md %}).
+Both images accept uploads up to 100&nbsp;MB (`upload_max_filesize = 100M`, `post_max_size = 100M`) — see [Media]({{ site.baseurl }}{% link media.md %}). On a memory-constrained host, `LAMB_MAX_UPLOAD_PIXELS` lets you lower how large an image WebP conversion will attempt to decode — see [Pixel cap and memory]({{ site.baseurl }}{% link media.md %}#pixel-cap-and-memory).
 
 Errors can be inspected with `docker compose logs -f app`.
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -65,6 +65,20 @@ Images are converted to WebP and resized server-side, so the original file size 
 
 If an upload over the limit fails, it fails silently from the editor's point of view — check the server limits first when a large image or video won't upload.
 
+### Pixel cap and memory
+
+Before decoding a JPEG/PNG for WebP conversion, Lamb rejects anything whose declared width × height exceeds `MAX_UPLOAD_PIXELS` (40 megapixels by default) — a guard against a small file declaring an enormous size ("decompression bomb"). 40 megapixels comfortably covers real photos, including high-resolution phone camera modes.
+
+The pixel cap does **not** protect against memory exhaustion the way PHP's `memory_limit` might suggest: GD allocates its decoded pixel buffer outside PHP's memory manager, so it neither counts against `memory_limit` nor is limited by it. The real ceiling is the host's actual free RAM — roughly 4 bytes per pixel for the decode, plus a second buffer of similar size while resizing. A 40&nbsp;MP image can transiently use several hundred megabytes of real memory during conversion.
+
+If you're running Lamb on a memory-constrained host and see conversions crash or the process get killed on large uploads, lower the cap with the `LAMB_MAX_UPLOAD_PIXELS` environment variable:
+
+```shell
+-e LAMB_MAX_UPLOAD_PIXELS=12000000   # ~12 megapixels
+```
+
+Any positive integer is accepted; an unset, non-numeric, zero, or negative value falls back to the 40-megapixel default. Uploads whose declared pixel count exceeds the cap are stored in their original format, unconverted, the same as when WebP support itself is missing.
+
 WebP conversion relies on PHP's [GD extension](https://www.php.net/manual/en/book.image.php) being built **with WebP support**. This is the common default, but it isn't guaranteed on every host. WebP support is the only thing the conversion needs — if it's missing, nothing breaks: Lamb stores each upload in its original format instead, so JPEG and PNG files are saved as-is rather than being converted. You simply don't get the smaller WebP files.
 
 ### Checking for WebP support

--- a/src/constants.php
+++ b/src/constants.php
@@ -18,13 +18,6 @@ define('IMAGE_FILES', 'imageFiles');
 define('IMAGE_UPLOAD_EXTENSIONS', ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif']);
 // Video extensions accepted for upload; browsers decode these containers natively.
 define('VIDEO_UPLOAD_EXTENSIONS', ['mp4', 'webm', 'mov']);
-// Upper bound on a source image's declared width*height before WebP conversion
-// decodes it. GD allocates the full pixel buffer as soon as it decodes an
-// image's header, before any of this app's own downscaling runs — a small
-// file can declare an enormous width/height ("decompression bomb") and force
-// a multi-gigabyte allocation. 40 megapixels comfortably covers any real
-// photo or screenshot while capping the worst case.
-define('MAX_UPLOAD_PIXELS', 40_000_000);
 // Seconds before a single feed fetch is abandoned during /_cron ingestion.
 define('FEED_FETCH_TIMEOUT', 15);
 // Largest feed body kept during /_cron ingestion. /_cron is unauthenticated, so an

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -314,12 +314,65 @@ function store_webp_copy(string $src_path, string $ext, string $dest_dir, string
 }
 
 /**
+ * Upper bound on a source image's declared width*height before WebP conversion
+ * decodes it. GD allocates the full pixel buffer as soon as it decodes an
+ * image's header, before any of this app's own downscaling runs — a small
+ * file can declare an enormous width/height ("decompression bomb") and force
+ * a multi-gigabyte allocation. 40 megapixels comfortably covers any real
+ * photo (including high-resolution phone modes) while capping the worst case.
+ *
+ * GD's pixel buffers are allocated outside PHP's memory manager, so they
+ * neither count against memory_limit nor are limited by it — the real
+ * ceiling is the host's actual free RAM. LAMB_MAX_UPLOAD_PIXELS lets a
+ * self-hoster on a memory-constrained box lower the cap if conversions are
+ * getting OOM-killed, without a code change.
+ *
+ * @return int The pixel cap: LAMB_MAX_UPLOAD_PIXELS if set to a positive
+ *             integer, otherwise the 40-megapixel default.
+ */
+function max_upload_pixels(): int
+{
+    $env = getenv('LAMB_MAX_UPLOAD_PIXELS');
+    if ($env !== false && ctype_digit($env) && (int) $env > 0) {
+        return (int) $env;
+    }
+
+    return 40_000_000;
+}
+
+/**
+ * Maps an IMAGETYPE_* constant to the GD function that decodes that format
+ * directly from a file path, so the encoded bytes never have to be read into
+ * a PHP string first — GD's per-format decoders stream the file themselves.
+ *
+ * @param int $image_type One of the IMAGETYPE_* constants from getimagesize().
+ * @return (callable(string): (\GdImage|false))|null
+ */
+function image_decoder_for_type(int $image_type): ?callable
+{
+    return match ($image_type) {
+        IMAGETYPE_JPEG => imagecreatefromjpeg(...),
+        IMAGETYPE_PNG => imagecreatefrompng(...),
+        IMAGETYPE_GIF => imagecreatefromgif(...),
+        IMAGETYPE_WEBP => imagecreatefromwebp(...),
+        IMAGETYPE_BMP => imagecreatefrombmp(...),
+        default => null,
+    };
+}
+
+/**
  * Re-encodes an image file as WebP, writing the result to $dest_path.
  *
  * Reads $src_path with GD, preserves alpha transparency, downscales anything wider
  * or taller than $max_dimension (so phone-sized screenshots are not served at their
  * full resolution), and writes a WebP. Returns false (writing nothing) when the
  * source cannot be decoded, so callers can fall back to storing the original bytes.
+ *
+ * Decodes straight from $src_path with a format-specific GD function
+ * (image_decoder_for_type()) rather than file_get_contents() +
+ * imagecreatefromstring(), so the encoded file is never also held as a full
+ * PHP string alongside the decoded pixel buffer. Formats GD can't be told
+ * apart in advance fall back to the string-based decode.
  *
  * @param string $src_path      Path to the source image (e.g. an uploaded temp file).
  * @param string $dest_path     Path the WebP should be written to.
@@ -329,11 +382,30 @@ function store_webp_copy(string $src_path, string $ext, string $dest_dir, string
  */
 function convert_to_webp(string $src_path, string $dest_path, int $quality = 82, int $max_dimension = 1600): bool
 {
-    $data = @file_get_contents($src_path);
-    if ($data === false) {
+    $size = @getimagesize($src_path);
+    if (is_array($size) && $size[0] > 0 && $size[1] > 0 && $size[0] * $size[1] > max_upload_pixels()) {
         return false;
     }
-    return convert_to_webp_from_bytes($data, $dest_path, $quality, $max_dimension);
+
+    $decoder = is_array($size) ? image_decoder_for_type($size[2]) : null;
+    $image = $decoder !== null ? @$decoder($src_path) : false;
+
+    if ($image === false) {
+        // Unknown/undetected format: fall back to the old string-based decode,
+        // which auto-detects from the bytes themselves.
+        $data = @file_get_contents($src_path);
+        if ($data === false) {
+            return false;
+        }
+        $image = @imagecreatefromstring($data);
+        unset($data);
+    }
+
+    if ($image === false) {
+        return false;
+    }
+
+    return finish_webp_from_image($image, $dest_path, $quality, $max_dimension);
 }
 
 /**
@@ -362,15 +434,35 @@ function convert_to_webp_from_bytes(string $bytes, string $dest_path, int $quali
     // getimagesizefromstring() can't parse is left to imagecreatefromstring()
     // itself, unchanged from prior behaviour.
     $size = @getimagesizefromstring($bytes);
-    if (is_array($size) && $size[0] > 0 && $size[1] > 0 && $size[0] * $size[1] > MAX_UPLOAD_PIXELS) {
+    if (is_array($size) && $size[0] > 0 && $size[1] > 0 && $size[0] * $size[1] > max_upload_pixels()) {
         return false;
     }
 
     $image = @imagecreatefromstring($bytes);
+    // The decoded pixel buffer (below) and the resize's own buffer are both
+    // still to come; drop the encoded-bytes buffer now instead of waiting for
+    // $bytes to go out of scope, so it isn't resident during those.
+    unset($bytes);
     if ($image === false) {
         return false;
     }
 
+    return finish_webp_from_image($image, $dest_path, $quality, $max_dimension);
+}
+
+/**
+ * Preserves alpha, downscales to $max_dimension, and writes the WebP —
+ * the tail shared by convert_to_webp() and convert_to_webp_from_bytes()
+ * once each has its own decoded $image.
+ *
+ * @param \GdImage $image         Decoded source image; consumed and destroyed.
+ * @param string   $dest_path     Path the WebP should be written to.
+ * @param int      $quality       WebP quality (0-100).
+ * @param int      $max_dimension Longest edge to keep; larger images are scaled down.
+ * @return bool True when a WebP was written, false on failure.
+ */
+function finish_webp_from_image(\GdImage $image, string $dest_path, int $quality, int $max_dimension): bool
+{
     // Preserve transparency from PNG sources.
     imagepalettetotruecolor($image);
     imagealphablending($image, false);

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -8,6 +8,8 @@ use function Lamb\Response\asset_url;
 use function Lamb\Response\convert_to_webp;
 use function Lamb\Response\convert_to_webp_from_bytes;
 use function Lamb\Response\get_upload_dir;
+use function Lamb\Response\image_decoder_for_type;
+use function Lamb\Response\max_upload_pixels;
 use function Lamb\Response\normalize_uploaded_files;
 use function Lamb\Response\safe_upload_extension;
 use function Lamb\Response\upload_subpath;
@@ -35,6 +37,7 @@ class UploadTest extends TestCase
     {
         // Clean up any directories created under tempRootDir
         $this->removeDirectory($this->tempRootDir);
+        putenv('LAMB_MAX_UPLOAD_PIXELS');
     }
 
     private function removeDirectory(string $path): void
@@ -342,6 +345,47 @@ class UploadTest extends TestCase
         $this->assertFileDoesNotExist($dest);
     }
 
+    // image_decoder_for_type — this dispatch table is what lets convert_to_webp()
+    // decode straight from $src_path (GD's own file-reading decoders) instead of
+    // file_get_contents() + imagecreatefromstring(), so the encoded file is never
+    // also held as a second full PHP string alongside GD's decoded pixel buffer.
+    // A wrong or missing mapping here would silently reintroduce that double-buffering
+    // for the affected format.
+
+    public function testImageDecoderForTypeMapsPng(): void
+    {
+        $decoder = image_decoder_for_type(IMAGETYPE_PNG);
+        $src = $this->makePng(10, 10);
+
+        $this->assertNotNull($decoder);
+        $this->assertInstanceOf(\GdImage::class, $decoder($src));
+    }
+
+    public function testImageDecoderForTypeMapsJpeg(): void
+    {
+        $this->assertNotNull(image_decoder_for_type(IMAGETYPE_JPEG));
+    }
+
+    public function testImageDecoderForTypeMapsGif(): void
+    {
+        $this->assertNotNull(image_decoder_for_type(IMAGETYPE_GIF));
+    }
+
+    public function testImageDecoderForTypeMapsWebp(): void
+    {
+        $this->assertNotNull(image_decoder_for_type(IMAGETYPE_WEBP));
+    }
+
+    public function testImageDecoderForTypeMapsBmp(): void
+    {
+        $this->assertNotNull(image_decoder_for_type(IMAGETYPE_BMP));
+    }
+
+    public function testImageDecoderForTypeReturnsNullForUnmappedType(): void
+    {
+        $this->assertNull(image_decoder_for_type(IMAGETYPE_TIFF_II));
+    }
+
     public function testConvertRejectsDeclaredDimensionsOverPixelCap(): void
     {
         // Decompression-bomb guard: a PNG whose IHDR declares an enormous
@@ -366,6 +410,51 @@ class UploadTest extends TestCase
 
         $this->assertTrue(convert_to_webp_from_bytes((string) file_get_contents($src), $dest));
         $this->assertFileExists($dest);
+    }
+
+    // max_upload_pixels — LAMB_MAX_UPLOAD_PIXELS lets a self-hoster lower the
+    // pixel cap if conversions are getting OOM-killed on a memory-constrained host.
+
+    public function testMaxUploadPixelsDefaultsWhenEnvUnset(): void
+    {
+        putenv('LAMB_MAX_UPLOAD_PIXELS');
+
+        $this->assertSame(40_000_000, max_upload_pixels());
+    }
+
+    public function testMaxUploadPixelsUsesValidEnvOverride(): void
+    {
+        putenv('LAMB_MAX_UPLOAD_PIXELS=8000000');
+
+        $this->assertSame(8_000_000, max_upload_pixels());
+    }
+
+    public function testMaxUploadPixelsFallsBackOnNonNumericEnv(): void
+    {
+        putenv('LAMB_MAX_UPLOAD_PIXELS=lots');
+
+        $this->assertSame(40_000_000, max_upload_pixels());
+    }
+
+    public function testMaxUploadPixelsFallsBackOnZeroOrNegativeEnv(): void
+    {
+        putenv('LAMB_MAX_UPLOAD_PIXELS=0');
+        $this->assertSame(40_000_000, max_upload_pixels());
+
+        putenv('LAMB_MAX_UPLOAD_PIXELS=-5');
+        $this->assertSame(40_000_000, max_upload_pixels());
+    }
+
+    public function testConvertRejectsUnderLoweredEnvPixelCap(): void
+    {
+        // A 40x30 image (1,200px) is well within the 40MP default but exceeds
+        // a self-hoster's lowered cap.
+        putenv('LAMB_MAX_UPLOAD_PIXELS=1000');
+        $src = $this->makePng(40, 30);
+        $dest = $this->tempRootDir . '/out.webp';
+
+        $this->assertFalse(convert_to_webp($src, $dest));
+        $this->assertFileDoesNotExist($dest);
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #532.

- `convert_to_webp()` now decodes straight from the source file with a format-specific GD decoder (`imagecreatefromjpeg`/`png`/`gif`/`webp`/`bmp`) instead of `file_get_contents()` + `imagecreatefromstring()`, so the encoded file is never also held as a full PHP string alongside GD's decoded pixel buffer. `convert_to_webp_from_bytes()` frees its bytes buffer immediately after decode instead of holding it through the resize step.
- Measured that GD's pixel buffers are allocated outside PHP's memory manager — `MAX_UPLOAD_PIXELS` was never actually protected by PHP's `memory_limit` as #532 assumed; the real ceiling is the host's free RAM.
- Since self-hosters run on wildly different hardware, the pixel cap is now overridable at runtime via `LAMB_MAX_UPLOAD_PIXELS` instead of a fixed constant, so a memory-constrained host can lower it without a code change — while the 40MP default (covering phone photos) is unchanged for everyone else.
- Documented the env var and the GD/`memory_limit` caveat in `docs/media.md`, cross-linked from `docs/docker.md`.

## Test plan

- [x] `composer lint` (phpcs)
- [x] `composer analyse` (phpstan)
- [x] `vendor/bin/codecept run Unit` — 1416 tests, all green
- [x] New tests written test-first (confirmed red before implementation)
- [x] Regression test for `image_decoder_for_type()` verified to actually catch a broken mapping (manually sabotaged, watched it fail, reverted)

https://claude.ai/code/session_01DUNoVtwNos1V2p9JFktDc7