### PR TITLE
Reject malformed Micropub update actions instead of 500ing

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -469,10 +469,16 @@ class LambMicropubAdapter extends MicropubAdapter
         }
 
         foreach ($actions['replace'] ?? [] as $property => $values) {
+            if (!is_array($values) || !array_is_list($values)) {
+                return 'invalid_request';
+            }
             $this->applyReplace($bean, $property, $values);
         }
 
         foreach ($actions['add'] ?? [] as $property => $values) {
+            if (!is_array($values) || !array_is_list($values)) {
+                return 'invalid_request';
+            }
             $this->applyAdd($bean, $property, $values);
         }
 
@@ -485,6 +491,9 @@ class LambMicropubAdapter extends MicropubAdapter
         } else {
             // Associative array: delete specific values from each property.
             foreach ($delete as $property => $values) {
+                if (!is_array($values) || !array_is_list($values)) {
+                    return 'invalid_request';
+                }
                 $this->applyDeleteValues($bean, $property, $values);
             }
         }

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -904,6 +904,43 @@ class MicropubAdapterTest extends TestCase
         $this->assertNotContains('A future dated micropub post', $bodies, 'Future-dated micropub posts must not appear on the homepage');
     }
 
+    public function testCreateCallbackWithNonStringNameDropsTitleInsteadOf500(): void
+    {
+        // Regression for #533: a nested array `name` (a legitimate mf2 shape) used
+        // to TypeError inside assembleFrontMatter(). matter_string() (#f40d5c5)
+        // now reports it as absent, so the post still saves, just without a title.
+        $adapter = new LambMicropubAdapter();
+        $data = [
+            'type' => ['h-entry'],
+            'properties' => [
+                'name' => [['a' => 'b']],
+                'content' => ['Post body here.'],
+            ],
+        ];
+        $result = $adapter->createCallback($data);
+        $this->assertIsString($result);
+        $post = R::findOne('post', ' body = ? ', ['Post body here.']);
+        $this->assertNotNull($post);
+        $this->assertEmpty($post->title);
+    }
+
+    public function testCreateCallbackWithNonStringPublishedIgnoresDateInsteadOf500(): void
+    {
+        // Regression for #533: a non-string `published` used to TypeError inside
+        // strtotime(). normalize_datetime() (#f40d5c5) now returns null for it, so
+        // the post still saves with its default created date instead of crashing.
+        $adapter = new LambMicropubAdapter();
+        $data = [
+            'type' => ['h-entry'],
+            'properties' => [
+                'published' => [['a' => 'b']],
+                'content' => ['Post body here.'],
+            ],
+        ];
+        $result = $adapter->createCallback($data);
+        $this->assertIsString($result);
+    }
+
     public function testCreateCallbackReturnsInvalidRequestForMissingContent(): void
     {
         $adapter = new LambMicropubAdapter();
@@ -978,6 +1015,66 @@ class MicropubAdapterTest extends TestCase
         $this->assertSame('invalid_request', $result);
         $updated = R::load('post', $bean->id);
         $this->assertSame('Trashed content must not change', $updated->body);
+    }
+
+    public function testUpdateCallbackReturnsInvalidRequestForNonArrayReplaceValues(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Original content';
+        $bean->slug = '';
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['replace' => ['content' => 'Updated content']]
+        );
+
+        $this->assertSame('invalid_request', $result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('Original content', $updated->body);
+    }
+
+    public function testUpdateCallbackReturnsInvalidRequestForNonArrayAddValues(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Original content';
+        $bean->slug = '';
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['add' => ['category' => 'not-an-array']]
+        );
+
+        $this->assertSame('invalid_request', $result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('Original content', $updated->body);
+    }
+
+    public function testUpdateCallbackReturnsInvalidRequestForNonArrayDeleteValues(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Original content #tag';
+        $bean->slug = '';
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['delete' => ['category' => 'not-an-array']]
+        );
+
+        $this->assertSame('invalid_request', $result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('Original content #tag', $updated->body);
     }
 
     public function testUpdateCallbackReplaceContentUpdatesBody(): void


### PR DESCRIPTION
## Summary
- `updateCallback`'s replace/add/delete-values loops passed each action's values straight into typed array parameters, so a well-formed-but-wrong-shaped request (e.g. `{"replace":{"content":"str"}}`, a string instead of a list) raised an uncaught `TypeError` and answered 500.
- Guard each of the three loops with `is_array()`/`array_is_list()` and return `invalid_request` instead.
- The other two cases described in #533 (`name`, `published`) were already fixed by a prior commit (f40d5c5) via `matter_string()`/`normalize_datetime()` coercion — added regression tests confirming those no longer 500, rather than re-fixing them.

## Test plan
- [x] TDD: wrote failing tests for the three malformed-shape scenarios, confirmed red (`TypeError`), then implemented the guards and confirmed green
- [x] `vendor/bin/codecept run Unit` — full suite passes (1441 tests)
- [x] `composer lint` and `composer analyse` pass

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JaspRQGEAMTUVKzGk1q33