### PR TITLE
Document /upload and /checkbox CSRF reliance on SameSite=Strict

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,6 +423,7 @@ Parts you rarely need to override: `edit.php`, `login.php`, `settings.php`, `404
 ### Security
 
 - CSRF: token stored in session, verified in `Security\require_csrf()`, consumed after use
+- `respond_upload()` (`src/response/upload.php`) and `respond_checkbox()` (`src/response/posts.php`) call `Security\require_login()` but deliberately skip `require_csrf()` — both fire mid-composition/mid-edit, and consuming the single-use token there would break the subsequent form submit's own CSRF check. Their protection rests entirely on `LAMBSESSID`/`lamb_logged_in` being `SameSite=Strict` (a cross-site POST carries neither cookie, so no session, so `require_login()` redirects). That invariant is pinned by `testSessionCookieIsSameSiteStrict()` / `testGetCookieOptionsSameSiteIsStrict()` rather than assumed — see #536
 - Session hardening: `httponly`, `secure` (HTTPS), `SameSite=Strict`, user-agent validation
 - Auth: password stored as bcrypt hash in env var `LAMB_LOGIN_PASSWORD` (base64-encoded)
 - Login sets `$_SESSION[SESSION_LOGIN]` and a `lamb_logged_in` cookie; logout destroys the session and expires both cookies

--- a/tests/Unit/SessionBootstrapTest.php
+++ b/tests/Unit/SessionBootstrapTest.php
@@ -129,6 +129,21 @@ class SessionBootstrapTest extends TestCase
     }
 
     /**
+     * /upload and /checkbox (src/response/upload.php, src/response/posts.php)
+     * skip require_csrf() and rely entirely on this cookie being SameSite=Strict
+     * to block cross-site POSTs (see issue #536). Pin it so a future change to
+     * configure_session() can't silently widen that gap.
+     */
+    public function testSessionCookieIsSameSiteStrict(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+        configure_session();
+        $this->assertSame('Strict', session_get_cookie_params()['samesite']);
+    }
+
+    /**
      * The server-side session must outlive the cookie too, or GC reaps the
      * session data before the persistent cookie expires.
      */


### PR DESCRIPTION
## Summary
- Adds a bullet to AGENTS.md's Security section explaining why `respond_upload()` and `respond_checkbox()` skip `require_csrf()` and rely on `SameSite=Strict` cookies instead (single-use CSRF token would break the follow-up submit)
- Adds `testSessionCookieIsSameSiteStrict()` to pin the `LAMBSESSID` cookie's `SameSite=Strict` attribute, complementing the existing `testGetCookieOptionsSameSiteIsStrict()` for `lamb_logged_in` — so the invariant these two routes depend on is enforced, not assumed

This implements the third option from #536: cheapest fix that closes the actual risk (silent regression of the SameSite property), without the added complexity of a non-consuming CSRF check or a second token.

## Test plan
- [x] `vendor/bin/codecept run Unit` passes (1472 tests)
- [x] New test fails if `SameSite=Strict` is removed from `configure_session()` (verified reasoning, not run against a broken build)

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAXB4gnx9KdJ7UQe3anaKR