### PR TITLE
Throttle failed admin logins per client address (#443)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ RedBeanPHP (fluid mode) on SQLite. Beans are dispensed/loaded with `R::dispense`
 
 **Tables used:**
 - `post` — blog posts; columns include `body`, `slug`, `title`, `description`, `transformed`, `created`, `updated`, `version`, `feed_name`, `feeditem_uuid`, `source_url`
-- `option` — key/value store (e.g. `site_config_ini`, `last_processed_date`)
+- `option` — key/value store (e.g. `site_config_ini`, `last_processed_date`, `login_fail_*` throttle counters)
 - `redirect` — automatic 301 redirects created when a post slug changes; columns: `from_slug`, `to_url`
 - `webmention` — received (inbound) webmentions; columns: `source`, `target`, `post_id`, `type`, `author`, `content`, `status`, `created`, `verified_at`
 - `webmentionoutbox` — outbound webmention queue processed by `/_cron`; columns: `post_id`, `source`, `target`, `endpoint`, `status`, `attempts`, `created`, `processed_at`
@@ -424,6 +424,7 @@ Parts you rarely need to override: `edit.php`, `login.php`, `settings.php`, `404
 
 - CSRF: token stored in session, verified in `Security\require_csrf()`, consumed after use
 - `respond_upload()` (`src/response/upload.php`) and `respond_checkbox()` (`src/response/posts.php`) call `Security\require_login()` but deliberately skip `require_csrf()` — both fire mid-composition/mid-edit, and consuming the single-use token there would break the subsequent form submit's own CSRF check. Their protection rests entirely on `LAMBSESSID`/`lamb_logged_in` being `SameSite=Strict` (a cross-site POST carries neither cookie, so no session, so `require_login()` redirects). That invariant is pinned by `testSessionCookieIsSameSiteStrict()` / `testGetCookieOptionsSameSiteIsStrict()` rather than assumed — see #536
+- Login brute-force throttle (#443): after `LOGIN_THROTTLE_MAX_FAILURES` failed `/login` attempts from one client address, further attempts are refused for `LOGIN_THROTTLE_WINDOW` with `429` + `Retry-After`, checked *before* `password_verify()` so a blocked client costs no bcrypt. The counter is a `login_fail_<hmac(ip)>` row in the `option` table (no session exists on `/login` — see #462), cleared on a successful login and lazily pruned on the failure write path. Refused attempts are not counted, so retrying can't extend a block. `client_ip()` reads `REMOTE_ADDR` only — `X-Forwarded-For` is attacker-controlled on a directly-exposed install and would hand out a fresh bucket per request
 - Session hardening: `httponly`, `secure` (HTTPS), `SameSite=Strict`, user-agent validation
 - Auth: password stored as bcrypt hash in env var `LAMB_LOGIN_PASSWORD` (base64-encoded)
 - Login sets `$_SESSION[SESSION_LOGIN]` and a `lamb_logged_in` cookie; logout destroys the session and expires both cookies

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,6 +88,7 @@ Devtools / local environments / sandbox:
 * [Drafts]({{ site.baseurl }}{% link drafts.md %})
 * [Feeds]({{ site.baseurl }}{% link feeds.md %})
 * [Known import]({{ site.baseurl }}{% link known-import.md %})
+* [Login security]({{ site.baseurl }}{% link login-security.md %})
 * [Media]({{ site.baseurl }}{% link media.md %})
 * [Menu Items]({{ site.baseurl }}{% link menu-items.md %})
 * [Micropub]({{ site.baseurl }}{% link micropub.md %})

--- a/docs/login-security.md
+++ b/docs/login-security.md
@@ -1,0 +1,66 @@
+---
+title: Login security
+---
+
+# Login security
+
+Lamb has a single admin account, and `/login` is the only page an anonymous
+visitor can reach that accepts a password. Two things guard it out of the box —
+neither needs configuring.
+
+## Failed-attempt throttle
+
+After **10 failed attempts**, further attempts from the same address are refused
+for **15 minutes**. The login page comes back with the wait spelled out, and the
+response carries `429 Too Many Requests` with a `Retry-After` header.
+
+Details worth knowing:
+
+* The counter is **per client address**, so someone hammering your login form
+  cannot lock you out from your own machine.
+* A refused attempt is **not** counted, so retrying while blocked does not
+  extend the block — the 15 minutes always run from your last real attempt.
+* A **successful login clears the counter** immediately. A run of typos costs
+  you nothing once you get the password right.
+* The counter is refused *before* the password is checked, so a blocked client
+  cannot make the server do password-hashing work.
+
+Locked yourself out? Wait it out — there is no reset command, by design. The
+window is short and the block lapses on its own.
+
+## Failed-attempt logging
+
+Every failed attempt writes a line to PHP's error log:
+
+```
+failed admin login from 203.0.113.7
+```
+
+Your webserver or PHP-FPM configuration decides where that lands (commonly
+`/var/log/php-fpm/error.log` or the container's stderr). Grep for
+`failed admin login` to see whether anyone has been trying. The line never
+contains the submitted password.
+
+## Behind a reverse proxy
+
+Both features identify the client by its network address (`REMOTE_ADDR`) and
+deliberately ignore the `X-Forwarded-For` header, which any client can forge
+when Lamb is reachable directly.
+
+If Lamb sits behind a reverse proxy, CDN, or tunnel, that means every visitor
+looks like the proxy. The throttle then behaves like a single shared counter,
+and log lines show the proxy's address. Configure your proxy to present the real
+client address to PHP (for example with nginx's `realip` module) if you want
+per-visitor accuracy.
+
+## Choosing a password
+
+`make-password.php` warns on standard error when the password you give it is
+weak. The throttle raises the cost of guessing, but a strong password is what
+actually makes guessing hopeless.
+
+## Related
+
+* [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}): Settings are edited at `/settings`, behind this login.
+* [Nginx]({{ site.baseurl }}{% link nginx.md %}): Where to configure the real client address behind a proxy.
+* [Docker]({{ site.baseurl }}{% link docker.md %}): Setting `LAMB_LOGIN_PASSWORD` for a container install.

--- a/src/constants.php
+++ b/src/constants.php
@@ -39,6 +39,17 @@ define('REMEMBER_LIFETIME', 7 * 24 * 60 * MINUTE_IN_SECONDS); // one week
 // page is never cached (no-store), so a visitor always gets a fresh token, and
 // an expired one just means reloading /login.
 define('LOGIN_CSRF_LIFETIME', 60 * MINUTE_IN_SECONDS); // one hour
+// Failed /login attempts tolerated from one client address before further
+// attempts are refused without running bcrypt (issue #443). Ten per window is
+// ~40 guesses an hour — hopeless against any real password — while leaving room
+// for a typo-prone author (and for the browser suites, which submit several
+// wrong passwords from one address in a single run).
+define('LOGIN_THROTTLE_MAX_FAILURES', 10);
+// How long failures accumulate, and how long a refusal lasts once the limit is
+// met. Also the lifetime of a throttle row before it is pruned.
+define('LOGIN_THROTTLE_WINDOW', 15 * MINUTE_IN_SECONDS);
+// Prefix for the per-client throttle rows in the `option` table.
+define('LOGIN_THROTTLE_PREFIX', 'login_fail_');
 define('SESSION_LOGIN', 'logged_in');
 define('SUBMIT_CREATE', 'Create post');
 define('SUBMIT_EDIT', 'Update post');

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -9,6 +9,7 @@ use Lamb\Config;
 use Lamb\Network;
 use Lamb\Security;
 use Random\RandomException;
+use RedBeanPHP\R;
 
 /**
  * Handles the /login route without starting a session for anonymous visitors.
@@ -54,9 +55,20 @@ function redirect_login(): array
     }
     require_login_csrf();
 
+    // Refuse a client that has already burned through its attempts, before
+    // bcrypt runs (issue #443). A refused attempt is not itself recorded, so
+    // retrying can't extend the block indefinitely.
+    $ip  = client_ip();
+    $now = time();
+    $retry_after = login_throttle_retry_after($ip, $now);
+    if ($retry_after > 0) {
+        return throttled_login_response($retry_after);
+    }
+
     $user_pass = $_POST['password'] ?? '';
     if (!password_verify($user_pass, base64_decode(LOGIN_PASSWORD))) {
         log_failed_login();
+        record_login_failure($ip, $now);
         // Re-render the login page in place with the error: /login is sessionless
         // now, so there is no flash to carry the message across a redirect (#462).
         return login_page_data('Password is incorrect, please try again.');
@@ -68,6 +80,7 @@ function redirect_login(): array
     session_regenerate_id(true);
     set_login_marker();
     clear_login_csrf();
+    clear_login_failures($ip);
     $where = local_redirect_target(filter_input(INPUT_POST, 'redirect_to', FILTER_SANITIZE_URL) ?: null);
     redirect_uri($where);
 }
@@ -204,26 +217,224 @@ function clear_login_csrf(): void
 }
 
 /**
+ * Returns the client address for logging and throttling, or "unknown".
+ *
+ * Trust the value only behind a known proxy: REMOTE_ADDR is the immediate peer,
+ * so behind a reverse proxy it is the proxy's address rather than the real
+ * client. X-Forwarded-For is deliberately not consulted — it is attacker-
+ * controlled on a directly-exposed install, and honouring it would let one
+ * client mint a fresh throttle bucket per request.
+ *
+ * @return string
+ */
+function client_ip(): string
+{
+    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+    if (!is_string($ip) || $ip === '') {
+        return 'unknown';
+    }
+    return $ip;
+}
+
+/**
  * Writes an audit line for a failed admin login attempt via error_log().
  *
  * The line carries a fixed "failed admin login" marker (easy to grep) and the
- * client IP from REMOTE_ADDR, falling back to "unknown" when it is absent. It
- * deliberately records no secret — never the submitted password. error_log()
- * respects the host's configured log destination (web server / PHP-FPM), so a
- * self-hoster needs no new dependency to capture brute-force attempts.
- *
- * Trust the IP only behind a known proxy: REMOTE_ADDR is the immediate peer, so
- * behind a reverse proxy it is the proxy's address rather than the real client.
+ * client IP. It deliberately records no secret — never the submitted password.
+ * error_log() respects the host's configured log destination (web server /
+ * PHP-FPM), so a self-hoster needs no new dependency to capture brute-force
+ * attempts.
  *
  * @return void
  */
 function log_failed_login(): void
 {
-    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
-    if (!is_string($ip) || $ip === '') {
-        $ip = 'unknown';
+    error_log(sprintf('failed admin login from %s', client_ip()));
+}
+
+/**
+ * Names the `option` row holding one client's failed-attempt counter.
+ *
+ * The address is hashed rather than stored: the counter is a throttle, not a
+ * visitor log, and a fixed-width key keeps the rows uniform. The per-install
+ * login hash is the HMAC key so the same address yields a different row on
+ * different installs.
+ *
+ * @param string $ip Client address from client_ip().
+ * @return string    Option name, prefixed so pruning can find these rows.
+ */
+function login_throttle_key(string $ip): string
+{
+    return LOGIN_THROTTLE_PREFIX . substr(hash_hmac('sha256', $ip, LOGIN_PASSWORD), 0, 32);
+}
+
+/**
+ * Serialises a throttle counter as "<count>:<expires>".
+ *
+ * @param int $count   Failures recorded in the current window.
+ * @param int $expires Unix timestamp at which the window (and any block) lapses.
+ * @return string
+ */
+function encode_throttle_state(int $count, int $expires): string
+{
+    return $count . ':' . $expires;
+}
+
+/**
+ * Parses a stored throttle counter, treating anything unrecognised as "no
+ * failures" — a corrupt row must fail open rather than lock the author out.
+ *
+ * @param mixed $raw Stored option value.
+ * @return array{count: int, expires: int}
+ */
+function decode_throttle_state(mixed $raw): array
+{
+    $empty = ['count' => 0, 'expires' => 0];
+    if (!is_string($raw) && !is_int($raw)) {
+        return $empty;
     }
-    error_log(sprintf('failed admin login from %s', $ip));
+    $parts = explode(':', (string) $raw);
+    if (count($parts) !== 2 || !ctype_digit($parts[0]) || !ctype_digit($parts[1])) {
+        return $empty;
+    }
+
+    return ['count' => (int) $parts[0], 'expires' => (int) $parts[1]];
+}
+
+/**
+ * Decides how long a client must wait, given its counter — the pure half of the
+ * throttle, so the policy is testable without a database.
+ *
+ * A window that has lapsed means the counter is stale: the client starts over
+ * with a clean slate rather than staying blocked.
+ *
+ * @param array{count: int, expires: int} $state Decoded counter.
+ * @param int                             $now   Current Unix timestamp.
+ * @return int Seconds to wait, or 0 when the attempt may proceed.
+ */
+function throttle_retry_after(array $state, int $now): int
+{
+    if ($state['expires'] <= $now || $state['count'] < LOGIN_THROTTLE_MAX_FAILURES) {
+        return 0;
+    }
+
+    return $state['expires'] - $now;
+}
+
+/**
+ * Reads a client's counter and returns how long it must wait (0 = go ahead).
+ *
+ * @param string $ip  Client address.
+ * @param int    $now Current Unix timestamp.
+ * @return int Seconds to wait.
+ */
+function login_throttle_retry_after(string $ip, int $now): int
+{
+    $bean = \Lamb\get_option(login_throttle_key($ip), '');
+
+    return throttle_retry_after(decode_throttle_state($bean->value), $now);
+}
+
+/**
+ * Records a failed attempt for a client, starting a fresh window when the
+ * previous one has lapsed, and prunes rows left behind by other clients.
+ *
+ * Pruning rides on the write path because that is the only thing that creates
+ * these rows: a burst of attempts from many addresses cleans up after itself
+ * once each window lapses, so the `option` table doesn't keep a permanent row
+ * per address that ever probed the login form.
+ *
+ * @param string $ip  Client address.
+ * @param int    $now Current Unix timestamp.
+ * @return void
+ */
+function record_login_failure(string $ip, int $now): void
+{
+    prune_login_throttle($now);
+
+    $bean  = \Lamb\get_option(login_throttle_key($ip), '');
+    $state = decode_throttle_state($bean->value);
+    $count = $state['expires'] > $now ? $state['count'] + 1 : 1;
+
+    \Lamb\set_option($bean, encode_throttle_state($count, $now + LOGIN_THROTTLE_WINDOW));
+}
+
+/**
+ * Drops the client's counter after a successful login, so a session of typos
+ * costs nothing once the right password lands.
+ *
+ * @param string $ip Client address.
+ * @return void
+ */
+function clear_login_failures(string $ip): void
+{
+    $bean = R::findOne('option', ' name = ? ', [login_throttle_key($ip)]);
+    if ($bean !== null) {
+        R::trash($bean);
+    }
+}
+
+/**
+ * Deletes throttle rows whose window has lapsed.
+ *
+ * Bounded per call: a run only has to keep pace with the writes that create the
+ * rows, and an unbounded delete on a large table would make the login request
+ * that triggers it pay for every address that ever probed the site.
+ *
+ * @param int $now Current Unix timestamp.
+ * @return int Number of rows removed.
+ */
+function prune_login_throttle(int $now): int
+{
+    $rows = R::find('option', ' name LIKE ? LIMIT 200 ', [LOGIN_THROTTLE_PREFIX . '%']);
+
+    $pruned = 0;
+    foreach ($rows as $row) {
+        if (decode_throttle_state($row->value)['expires'] <= $now) {
+            R::trash($row);
+            $pruned++;
+        }
+    }
+
+    return $pruned;
+}
+
+/**
+ * Phrases the refusal for the login page: the author locked out by their own
+ * typos needs to know when to come back, not just that they were refused.
+ *
+ * @param int $seconds Seconds left on the block.
+ * @return string
+ */
+function throttle_message(int $seconds): string
+{
+    $minutes = max(1, (int) ceil($seconds / MINUTE_IN_SECONDS));
+
+    return sprintf(
+        'Too many failed attempts. Try again in %d %s.',
+        $minutes,
+        $minutes === 1 ? 'minute' : 'minutes'
+    );
+}
+
+/**
+ * Refuses a throttled login attempt: 429 with Retry-After, and the login page
+ * re-rendered in place with the wait spelled out.
+ *
+ * Deliberately not a sleep() — delaying the response would park a PHP-FPM
+ * worker for the duration, making the throttle a cheaper denial of service than
+ * the brute force it prevents.
+ *
+ * @param int $retryAfter Seconds left on the block.
+ * @return array<string, mixed>
+ * @throws RandomException
+ */
+function throttled_login_response(int $retryAfter): array
+{
+    header(($_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1') . ' 429 Too Many Requests');
+    header('Retry-After: ' . $retryAfter);
+
+    return login_page_data(throttle_message($retryAfter));
 }
 
 /**

--- a/tests/Acceptance/LoginCest.php
+++ b/tests/Acceptance/LoginCest.php
@@ -10,6 +10,11 @@ use Tests\Support\AcceptanceTester;
  * The cache-headers suite proves a *correct* password logs in; the security-
  * critical rejection of a *wrong* password, and the gating of settings/scheduled
  * (LogoutCest covers drafts/trash) had no browser-level coverage.
+ *
+ * Keep the number of wrong-password submissions in this suite below
+ * LOGIN_THROTTLE_MAX_FAILURES (issue #443): they all come from one address, and
+ * tripping the throttle would refuse the *correct* password for the rest of the
+ * run, failing every later cest that logs in.
  */
 class LoginCest
 {

--- a/tests/Unit/LoginThrottleTest.php
+++ b/tests/Unit/LoginThrottleTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Response\clear_login_failures;
+use function Lamb\Response\client_ip;
+use function Lamb\Response\decode_throttle_state;
+use function Lamb\Response\encode_throttle_state;
+use function Lamb\Response\login_throttle_key;
+use function Lamb\Response\login_throttle_retry_after;
+use function Lamb\Response\prune_login_throttle;
+use function Lamb\Response\record_login_failure;
+use function Lamb\Response\throttle_message;
+use function Lamb\Response\throttle_retry_after;
+
+/**
+ * Per-IP brute-force throttle for the admin login (issue #443).
+ *
+ * /login is sessionless for anonymous visitors (#462), so the counter cannot
+ * live in the session: it is a row in the `option` table keyed by a hash of the
+ * client IP. Failures inside a window accumulate; past the limit further
+ * attempts are refused before bcrypt runs, and a successful login clears the
+ * counter.
+ */
+class LoginThrottleTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        unset($_SERVER['REMOTE_ADDR']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_ADDR']);
+    }
+
+    // client_ip — the single source of the client address for logging + throttling
+
+    public function testClientIpReadsRemoteAddr(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+        $this->assertSame('203.0.113.7', client_ip());
+    }
+
+    public function testClientIpFallsBackWhenMissing(): void
+    {
+        unset($_SERVER['REMOTE_ADDR']);
+        $this->assertSame('unknown', client_ip());
+    }
+
+    // login_throttle_key — fixed-width, per-install, and not a log of who probed
+
+    public function testThrottleKeyIsStableForTheSameIp(): void
+    {
+        $this->assertSame(login_throttle_key('203.0.113.7'), login_throttle_key('203.0.113.7'));
+    }
+
+    public function testThrottleKeyDiffersPerIp(): void
+    {
+        $this->assertNotSame(login_throttle_key('203.0.113.7'), login_throttle_key('198.51.100.9'));
+    }
+
+    public function testThrottleKeyDoesNotLeakTheRawIp(): void
+    {
+        $this->assertStringNotContainsString('203.0.113.7', login_throttle_key('203.0.113.7'));
+    }
+
+    // throttle_retry_after — the pure decision, independent of storage
+
+    public function testAllowsAttemptsBelowTheLimit(): void
+    {
+        $state = ['count' => LOGIN_THROTTLE_MAX_FAILURES - 1, 'expires' => 1_000 + LOGIN_THROTTLE_WINDOW];
+        $this->assertSame(0, throttle_retry_after($state, 1_000));
+    }
+
+    public function testRefusesAtTheLimitForTheRemainderOfTheWindow(): void
+    {
+        $state = ['count' => LOGIN_THROTTLE_MAX_FAILURES, 'expires' => 1_000 + 120];
+        $this->assertSame(120, throttle_retry_after($state, 1_000));
+    }
+
+    public function testAllowsAgainOnceTheWindowHasElapsed(): void
+    {
+        $state = ['count' => LOGIN_THROTTLE_MAX_FAILURES + 3, 'expires' => 1_000];
+        $this->assertSame(0, throttle_retry_after($state, 1_000));
+        $this->assertSame(0, throttle_retry_after($state, 1_001));
+    }
+
+    // encode/decode — the option row holds "<count>:<expires>"
+
+    public function testStateRoundTrips(): void
+    {
+        $this->assertSame(['count' => 3, 'expires' => 1_700], decode_throttle_state(encode_throttle_state(3, 1_700)));
+    }
+
+    public function testDecodeTreatsGarbageAsNoFailures(): void
+    {
+        foreach ([null, '', 'nonsense', '1', ':', 'a:b'] as $raw) {
+            $this->assertSame(['count' => 0, 'expires' => 0], decode_throttle_state($raw));
+        }
+    }
+
+    // Storage-backed behaviour
+
+    public function testFailuresBelowTheLimitDoNotBlock(): void
+    {
+        $now = 1_000;
+        for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES - 1; $i++) {
+            record_login_failure('203.0.113.7', $now);
+        }
+
+        $this->assertSame(0, login_throttle_retry_after('203.0.113.7', $now));
+    }
+
+    public function testFailuresAtTheLimitBlockFurtherAttempts(): void
+    {
+        $now = 1_000;
+        for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
+            record_login_failure('203.0.113.7', $now);
+        }
+
+        $this->assertSame(LOGIN_THROTTLE_WINDOW, login_throttle_retry_after('203.0.113.7', $now));
+    }
+
+    public function testBlockIsPerIpNotGlobal(): void
+    {
+        $now = 1_000;
+        for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
+            record_login_failure('203.0.113.7', $now);
+        }
+
+        // The owner, on a different address, must still be able to log in — a
+        // global counter would hand any anonymous attacker a lockout button.
+        $this->assertSame(0, login_throttle_retry_after('198.51.100.9', $now));
+    }
+
+    public function testBlockLapsesAfterTheWindow(): void
+    {
+        $now = 1_000;
+        for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
+            record_login_failure('203.0.113.7', $now);
+        }
+
+        $this->assertSame(0, login_throttle_retry_after('203.0.113.7', $now + LOGIN_THROTTLE_WINDOW));
+    }
+
+    public function testSuccessfulLoginClearsTheCounter(): void
+    {
+        $now = 1_000;
+        for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
+            record_login_failure('203.0.113.7', $now);
+        }
+        clear_login_failures('203.0.113.7');
+
+        $this->assertSame(0, login_throttle_retry_after('203.0.113.7', $now));
+        $this->assertNull(R::findOne('option', ' name = ? ', [login_throttle_key('203.0.113.7')]));
+    }
+
+    // Pruning — the table must not grow one permanent row per attacking address
+
+    public function testPruneDropsExpiredRowsAndKeepsLiveOnes(): void
+    {
+        record_login_failure('203.0.113.7', 1_000);
+        record_login_failure('198.51.100.9', 1_500);
+
+        $pruned = prune_login_throttle(1_000 + LOGIN_THROTTLE_WINDOW);
+
+        $this->assertSame(1, $pruned);
+        $this->assertNull(R::findOne('option', ' name = ? ', [login_throttle_key('203.0.113.7')]));
+        $this->assertNotNull(R::findOne('option', ' name = ? ', [login_throttle_key('198.51.100.9')]));
+    }
+
+    public function testPruneLeavesUnrelatedOptionsAlone(): void
+    {
+        \Lamb\set_option(\Lamb\get_option('site_config_ini', 'site_title = Lamb'), 'site_title = Lamb');
+        record_login_failure('203.0.113.7', 1_000);
+
+        prune_login_throttle(1_000 + LOGIN_THROTTLE_WINDOW);
+
+        $this->assertNotNull(R::findOne('option', ' name = ? ', ['site_config_ini']));
+    }
+
+    public function testRecordingAFailurePrunesExpiredRows(): void
+    {
+        record_login_failure('203.0.113.7', 1_000);
+        record_login_failure('198.51.100.9', 1_000 + LOGIN_THROTTLE_WINDOW);
+
+        $this->assertNull(R::findOne('option', ' name = ? ', [login_throttle_key('203.0.113.7')]));
+    }
+
+    // The refusal message tells the owner when to come back
+
+    public function testThrottleMessageStatesTheWait(): void
+    {
+        $this->assertStringContainsString('1 minute', throttle_message(60));
+        $this->assertStringContainsString('2 minutes', throttle_message(61));
+        $this->assertStringContainsString('15 minutes', throttle_message(15 * 60));
+    }
+}

--- a/tests/Unit/ResponseAuthTest.php
+++ b/tests/Unit/ResponseAuthTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
 
 use function Lamb\Response\local_redirect_target;
 use function Lamb\Response\log_failed_login;
@@ -15,6 +16,14 @@ class ResponseAuthTest extends TestCase
 
     protected function setUp(): void
     {
+        // A failed login now writes a throttle counter to the `option` table
+        // (issue #443), so redirect_login() needs a database.
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
         $_SESSION = [];
         $_POST    = [];
         $_COOKIE  = [];
@@ -144,6 +153,53 @@ class ResponseAuthTest extends TestCase
         $this->assertSame('Password is incorrect, please try again.', $result['login_error']);
         $this->assertArrayHasKey('login_csrf', $result);
         $this->assertArrayNotHasKey(SESSION_LOGIN, $_SESSION);
+    }
+
+    /**
+     * Past the failure limit the same client is refused before password_verify()
+     * runs (issue #443): the page comes back with the wait spelled out rather
+     * than the generic wrong-password error, and no session is started.
+     */
+    public function testRedirectLoginRefusesOnceTheThrottleTrips(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+        for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
+            \Lamb\Response\record_login_failure('203.0.113.7', time());
+        }
+
+        $token = \Lamb\Response\issue_login_csrf();
+        $_POST['submit']         = SUBMIT_LOGIN;
+        $_POST[HIDDEN_CSRF_NAME] = $token;
+        $_POST['password']       = 'definitely-the-wrong-password-xyz';
+
+        $result = redirect_login();
+
+        $this->assertArrayHasKey('login_error', $result);
+        $this->assertStringContainsString('Too many failed attempts', $result['login_error']);
+        $this->assertArrayNotHasKey(SESSION_LOGIN, $_SESSION);
+    }
+
+    /**
+     * A refused attempt must not extend its own block — otherwise a client that
+     * keeps retrying (a script, or a browser tab on refresh) could never get
+     * back in.
+     */
+    public function testRefusedAttemptDoesNotExtendTheBlock(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+        $now = time();
+        for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
+            \Lamb\Response\record_login_failure('203.0.113.7', $now);
+        }
+        $before = \Lamb\Response\login_throttle_retry_after('203.0.113.7', $now);
+
+        $token = \Lamb\Response\issue_login_csrf();
+        $_POST['submit']         = SUBMIT_LOGIN;
+        $_POST[HIDDEN_CSRF_NAME] = $token;
+        $_POST['password']       = 'definitely-the-wrong-password-xyz';
+        redirect_login();
+
+        $this->assertSame($before, \Lamb\Response\login_throttle_retry_after('203.0.113.7', $now));
     }
 
     // local_redirect_target — the post-login redirect must stay on this site


### PR DESCRIPTION
Closes #443.

## What

`/login` placed no limit on password attempts. bcrypt's per-verify cost was the only friction; CSRF is not a throttle (the token is re-mintable by re-fetching `/login`), and anonymous visitors get no session (#462), so the counter cannot live there either.

Failed attempts are now counted in a `login_fail_<hmac(ip)>` row in the `option` table. Past `LOGIN_THROTTLE_MAX_FAILURES` (10) within `LOGIN_THROTTLE_WINDOW` (15 min), the client is refused with `429` + `Retry-After` and the login page re-rendered with the wait spelled out. A successful login clears the row; expired rows are pruned lazily on the failure write path.

## Design decisions

Issue #443 deliberately left these open:

- **Per-IP, not global.** A global counter hands any anonymous attacker a lockout button against the author. Per-IP keeps the author's own address unaffected.
- **429, not `sleep()`.** Delaying the response parks a PHP-FPM worker for the duration, making the throttle a cheaper denial of service than the brute force it prevents.
- **Checked before `password_verify()`**, so a blocked client cannot make the server do bcrypt work.
- **Refused attempts are not counted**, so retrying (a script, a browser refresh) cannot extend a block indefinitely.
- **The address is hashed** with the per-install login hash — the counter is a throttle, not a visitor log, and fixed-width keys keep the rows uniform.
- **`X-Forwarded-For` is ignored.** It is attacker-controlled on a directly-exposed install and would hand out a fresh bucket per request. The reverse-proxy caveat is documented.
- **Limit of 10** rather than a tighter number: ~40 guesses an hour is hopeless against any real password, and it leaves headroom for the browser suites, which submit several wrong passwords from one address in a single run.

`client_ip()` is extracted as the single source of the client address and now also backs `log_failed_login()` (#444), which had the same lookup inline.

## Tests

Red-green TDD. New `tests/Unit/LoginThrottleTest.php` (19 tests) covers the pure decision function, the `<count>:<expires>` encoding (garbage fails open rather than locking the author out), storage-backed accumulate/block/lapse/clear, per-IP isolation, and pruning (including that unrelated `option` rows survive). `tests/Unit/ResponseAuthTest.php` gains coverage that `redirect_login()` refuses once the throttle trips and that a refused attempt does not extend the block.

Unit suite green (1493 tests), `composer lint` and `composer analyse` clean. Verified end to end against the dev server: attempts 1–10 return 200, 11–12 return `429` with `Retry-After: 900` and a stable deadline, and a correct password afterwards logs in and deletes the row. One acceptance failure (`PaginationCest::secondPageRendersViaCleanPath`) reproduces on a clean tree — pre-existing, from leftover local DB state.

## Docs

New `docs/login-security.md` (linked from the index) covering the throttle, the failed-login log line, the reverse-proxy caveat, and the fact that there is no reset command by design. `AGENTS.md` security section and the `option` table description updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014N88BfbCECLS5C4QTjjEsD

---
_Generated by [Claude Code](https://claude.ai/code/session_014N88BfbCECLS5C4QTjjEsD)_