### PR TITLE
Reserve image boxes with intrinsic width/height (#551)

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -48,6 +48,14 @@ To keep stored files small, **JPEG and PNG uploads are automatically re-encoded 
 
 If conversion ever fails (for example on a server whose PHP GD extension lacks WebP support), Lamb falls back to storing the original file unchanged, so uploads never break.
 
+## Image dimensions and layout shift
+
+Images in a post are rendered with their real pixel `width` and `height` on the `<img>` tag. Because images also load lazily, without those attributes the browser has no idea how tall an image will be until it arrives — so the text below it jumps down as you scroll. With them, the space is reserved up front and the page stays still.
+
+The dimensions are read from the stored file when the post is rendered, so they cost nothing on each page view, and they apply to older posts too: an existing post picks them up the next time Lamb re-renders it. Images hosted elsewhere (a plain `https://…` link in your Markdown) are left alone — Lamb won't fetch a remote file to measure it.
+
+This only sets the image's *intrinsic* size; how large it actually appears is still up to your theme's CSS. If you write your own theme, see [Themes]({{ site.baseurl }}{% link themes.md %}).
+
 ## Micropub uploads
 
 Images and video sent via Micropub — both inline `photo` files on a post and files sent to the media endpoint — go through the same storage (and, for images, WebP conversion) as editor uploads.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -56,6 +56,8 @@ Default:
 * Logged-in users additionally get the admin scripts in `src/scripts/logged_in/`.
 * Post bodies are stored at the author's literal heading levels (`#` → `<h1>`, `##` → `<h2>`, …). A theme decides where those headings sit in its own outline at render time with `anchor_headings($bean->transformed, $top)`: it shifts the body so its highest heading lands at level `$top`, keeping the rest relative (clamped at `<h6>`) so the outline stays in order for screen readers. The shift is signed — a body written deeper than `$top` is pulled up just as a shallower one is pushed down — so the level the author typed is immaterial. The built-in themes render the post title at `<h2>` and pass `$top = 3`, so the body's first heading always becomes `<h3>`. A theme that titles posts differently passes a different level, and one that wants the literal levels can echo `$bean->transformed` without anchoring.
 
+* Images inside `$bean->transformed` carry intrinsic `width` and `height` attributes (see [Media]({{ site.baseurl }}{% link media.md %})), so a theme's stylesheet **must** leave the aspect ratio free. If you constrain image width — the usual `img { max-width: 100% }` — pair it with `height: auto`, or images wider than their container will be squashed to the attribute's height. All three built-in themes set both.
+
 Have a look at the pre-existing themes for examples of the above.
 
 Any suggestions to improve theming are welcomed.
@@ -63,4 +65,5 @@ Any suggestions to improve theming are welcomed.
 ## Related
 
 * [Theme Functions]({{ site.baseurl }}{% link theme-functions.md %}): reference for the helper functions theme parts call.
+* [Media]({{ site.baseurl }}{% link media.md %}): rendered images carry intrinsic dimensions a theme's CSS has to accommodate.
 * [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}): Set the `theme` key in the config to activate a theme.

--- a/src/LambDown.php
+++ b/src/LambDown.php
@@ -7,6 +7,13 @@ use Parsedown;
 class LambDown extends Parsedown
 {
     /**
+     * Resolves an image `src` to its pixel dimensions, or null when unknown.
+     *
+     * @var (callable(string): (array{0:int,1:int}|null))|null
+     */
+    private $imageSizeResolver = null;
+
+    /**
      * Registers the GitHub-style task-list checkbox block.
      *
      * Internalised from leblanc-simon/parsedown-checkbox (which targets
@@ -193,6 +200,25 @@ class LambDown extends Parsedown
     }
 
     /**
+     * Supplies the lookup used to stamp intrinsic `width`/`height` on images.
+     *
+     * Injected rather than looked up here so the parser stays a pure
+     * string→string transform: it needs an image's pixel size but has no
+     * business knowing that uploads live under ROOT_DIR/assets, and unit tests
+     * can pass a stub instead of writing real files. Callers wire in
+     * Response\asset_dimensions(); with no resolver set, no dimensions are
+     * emitted and the markup is unchanged.
+     *
+     * @param (callable(string): (array{0:int,1:int}|null))|null $resolver
+     *        Receives an image `src`, returns [width, height] or null.
+     * @return void
+     */
+    public function setImageSizeResolver(?callable $resolver): void
+    {
+        $this->imageSizeResolver = $resolver;
+    }
+
+    /**
      * Inject lazy-loading attributes on every inline image so post bodies
      * with embedded screenshots do not block first paint on the homepage.
      *
@@ -220,11 +246,41 @@ class LambDown extends Parsedown
             return $image;
         }
 
-        $image['element']['attributes'] += [
+        $image['element']['attributes'] += $this->intrinsicDimensions($src) + [
             'loading'  => 'lazy',
             'decoding' => 'async',
         ];
         return $image;
+    }
+
+    /**
+     * The `width`/`height` attributes for an image, or none when its size is
+     * unknown.
+     *
+     * These are what let the browser reserve the right box before the image
+     * arrives — without them, `loading="lazy"` above guarantees every image in
+     * a post shifts the text below it as it decodes. They describe the
+     * intrinsic pixel size, and the themes' `img { max-width: 100%; height:
+     * auto; }` keeps CSS in charge of the rendered size.
+     *
+     * @param string $src The image's `src` attribute.
+     * @return array<string, string> `width`/`height`, or an empty array.
+     */
+    private function intrinsicDimensions(string $src): array
+    {
+        if ($this->imageSizeResolver === null) {
+            return [];
+        }
+
+        $size = ($this->imageSizeResolver)($src);
+        if (!is_array($size) || !isset($size[0], $size[1])) {
+            return [];
+        }
+
+        return [
+            'width'  => (string) (int) $size[0],
+            'height' => (string) (int) $size[1],
+        ];
     }
 
     /**

--- a/src/LambDown.php
+++ b/src/LambDown.php
@@ -273,7 +273,7 @@ class LambDown extends Parsedown
         }
 
         $size = ($this->imageSizeResolver)($src);
-        if (!is_array($size) || !isset($size[0], $size[1])) {
+        if ($size === null) {
             return [];
         }
 

--- a/src/constants.php
+++ b/src/constants.php
@@ -31,7 +31,7 @@ define('MINUTE_IN_SECONDS', 60);
 define('FEED_FETCH_INTERVAL', 30 * MINUTE_IN_SECONDS);
 // Current post render-format version. Bump when `transformed` output changes
 // (e.g. new syntax highlighting); older posts are re-parsed on read by upgrade_posts().
-define('POST_VERSION', 3);
+define('POST_VERSION', 4);
 // How long a login is remembered. The session cookie and the server-side session
 // both persist this long, so logins survive a browser restart and idle time.
 define('REMEMBER_LIFETIME', 7 * 24 * 60 * MINUTE_IN_SECONDS); // one week

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -291,6 +291,11 @@ function render_body(string $body): string
     [, $content] = split_frontmatter($body);
     $parser = new LambDown();
     $parser->setSafeMode(true);
+    // Stamp intrinsic width/height on images stored under src/assets/, so the
+    // browser can reserve their box instead of reflowing the post around each
+    // lazily-loaded image. Resolved once here, at parse time, and cached in
+    // `transformed` — not per request.
+    $parser->setImageSizeResolver(Response\asset_dimensions(...));
 
     return $parser->text(trim($content));
 }

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -558,3 +558,59 @@ function asset_url(string $sub_path, string $filename): string
 {
     return "/assets/$sub_path/$filename";
 }
+
+/**
+ * The pixel dimensions of a locally stored asset, given the URL a post body
+ * points at, or null when they cannot be determined.
+ *
+ * The inverse of asset_url(): it maps a root-relative `/assets/…` URL back to
+ * the file under ROOT_DIR so the renderer can emit intrinsic `width`/`height`
+ * on `<img>` (see LambDown::setImageSizeResolver()). Kept here rather than in
+ * the parser because this file already owns the URL ↔ disk-path mapping.
+ *
+ * Everything that isn't provably a file inside src/assets/ returns null, so
+ * the caller renders exactly as it did before rather than with wrong numbers:
+ *
+ * - A URL with a scheme or host, including protocol-relative `//host/assets/…`:
+ *   a remote path that merely starts with /assets/ must not be resolved
+ *   against the local tree.
+ * - Anything that escapes src/assets/ once resolved. Post bodies are
+ *   hand-written Markdown, so `/assets/../../etc/passwd` (percent-encoded or
+ *   not) is reachable input; realpath() containment rejects it, and covers
+ *   symlinks out of the tree too.
+ * - Files getimagesize() can't measure — a video, a truncated upload, or an
+ *   asset that has since been deleted.
+ *
+ * @param string $url The `src` from a post body's Markdown image.
+ * @return array{0:int,1:int}|null The [width, height] in pixels, or null.
+ */
+function asset_dimensions(string $url): ?array
+{
+    if (!defined('ROOT_DIR')) {
+        return null;
+    }
+    $parts = parse_url($url);
+    if ($parts === false || isset($parts['scheme']) || isset($parts['host'])) {
+        return null;
+    }
+    $path = $parts['path'] ?? '';
+    if (!str_starts_with($path, '/assets/')) {
+        return null;
+    }
+
+    $assets_root = realpath(ROOT_DIR . '/assets');
+    $file = realpath(ROOT_DIR . rawurldecode($path));
+    if ($assets_root === false || $file === false) {
+        return null;
+    }
+    if (!str_starts_with($file, $assets_root . DIRECTORY_SEPARATOR)) {
+        return null;
+    }
+
+    $size = @getimagesize($file);
+    if (!is_array($size) || (int) $size[0] <= 0 || (int) $size[1] <= 0) {
+        return null;
+    }
+
+    return [(int) $size[0], (int) $size[1]];
+}

--- a/src/themes/2024/styles/styles.css
+++ b/src/themes/2024/styles/styles.css
@@ -43,6 +43,10 @@ pre code {
 
 img {
     max-width: 100%;
+    /* Images carry intrinsic width/height attributes so the browser can
+       reserve their box; height: auto keeps the aspect ratio when max-width
+       shrinks one that is wider than its container. */
+    height: auto;
 }
 
 input[type='submit'], button {

--- a/src/themes/base/styles/styles.css
+++ b/src/themes/base/styles/styles.css
@@ -41,6 +41,10 @@ pre code {
 
 img {
     max-width: 100%;
+    /* Images carry intrinsic width/height attributes so the browser can
+       reserve their box; height: auto keeps the aspect ratio when max-width
+       shrinks one that is wider than its container. */
+    height: auto;
 }
 
 input[type='submit'], button {

--- a/tests/Unit/LambDownTest.php
+++ b/tests/Unit/LambDownTest.php
@@ -170,4 +170,58 @@ class LambDownTest extends TestCase
         $this->assertStringContainsString('<video', $html);
         $this->assertStringContainsString('src="video.mp4"', $html);
     }
+
+    public function testImageGetsIntrinsicDimensionsFromResolver(): void
+    {
+        $this->parser->setImageSizeResolver(static fn(string $src): array => [1600, 1200]);
+
+        $html = $this->parser->text('![photo](/assets/2026/07/photo.webp)');
+        $this->assertStringContainsString('width="1600"', $html);
+        $this->assertStringContainsString('height="1200"', $html);
+    }
+
+    public function testImageWithoutResolverHasNoDimensions(): void
+    {
+        $html = $this->parser->text('![photo](/assets/2026/07/photo.webp)');
+        $this->assertStringNotContainsString('width=', $html);
+        $this->assertStringNotContainsString('height=', $html);
+    }
+
+    public function testResolverReturningNullOmitsDimensions(): void
+    {
+        // An image whose size cannot be determined (remote URL, deleted file)
+        // must render exactly as it did before, not with bogus dimensions.
+        $this->parser->setImageSizeResolver(static fn(string $src): ?array => null);
+
+        $html = $this->parser->text('![photo](https://example.com/photo.png)');
+        $this->assertStringContainsString('<img', $html);
+        $this->assertStringNotContainsString('width=', $html);
+    }
+
+    public function testResolverReceivesTheImageSource(): void
+    {
+        $seen = [];
+        $this->parser->setImageSizeResolver(static function (string $src) use (&$seen): ?array {
+            $seen[] = $src;
+            return null;
+        });
+
+        $this->parser->text('![photo](/assets/2026/07/photo.webp)');
+        $this->assertSame(['/assets/2026/07/photo.webp'], $seen);
+    }
+
+    public function testVideoIsNotMeasured(): void
+    {
+        // getimagesize() cannot measure a video container, and <video> takes a
+        // different sizing path — the resolver must not be consulted for it.
+        $called = false;
+        $this->parser->setImageSizeResolver(static function (string $src) use (&$called): ?array {
+            $called = true;
+            return [640, 480];
+        });
+
+        $html = $this->parser->text('![clip](/assets/2026/07/clip.mp4)');
+        $this->assertFalse($called);
+        $this->assertStringNotContainsString('width=', $html);
+    }
 }

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+use function Lamb\Response\asset_dimensions;
 use function Lamb\Response\asset_url;
 use function Lamb\Response\convert_to_webp;
 use function Lamb\Response\convert_to_webp_from_bytes;
@@ -558,6 +559,80 @@ class UploadTest extends TestCase
 
         $this->assertNull($result);
         $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.webp');
+    }
+
+    // asset_dimensions — pixel size of a locally stored asset, for intrinsic
+    // width/height attributes on rendered <img> tags.
+
+    public function testAssetDimensionsReturnsStoredImageSize(): void
+    {
+        $sub_path = upload_subpath();
+        $dir = get_upload_dir($sub_path);
+        $filename = 'dims_' . uniqid() . '.png';
+        $this->writePng("$dir/$filename", 640, 480);
+
+        $this->assertSame([640, 480], asset_dimensions(asset_url($sub_path, $filename)));
+
+        unlink("$dir/$filename");
+    }
+
+    public function testAssetDimensionsIgnoresAQueryString(): void
+    {
+        $sub_path = upload_subpath();
+        $dir = get_upload_dir($sub_path);
+        $filename = 'dimsq_' . uniqid() . '.png';
+        $this->writePng("$dir/$filename", 12, 34);
+
+        $url = asset_url($sub_path, $filename) . '?ver=abc123';
+        $this->assertSame([12, 34], asset_dimensions($url));
+
+        unlink("$dir/$filename");
+    }
+
+    public function testAssetDimensionsReturnsNullForAMissingFile(): void
+    {
+        $this->assertNull(asset_dimensions(asset_url(upload_subpath(), 'nope_' . uniqid() . '.webp')));
+    }
+
+    public function testAssetDimensionsReturnsNullForARemoteUrl(): void
+    {
+        // A remote URL whose path happens to start with /assets/ must not be
+        // resolved against the local asset tree.
+        $this->assertNull(asset_dimensions('https://example.com/assets/2026/07/photo.webp'));
+        $this->assertNull(asset_dimensions('//example.com/assets/2026/07/photo.webp'));
+    }
+
+    public function testAssetDimensionsReturnsNullForANonAssetPath(): void
+    {
+        $this->assertNull(asset_dimensions('/themes/base/styles/styles.css'));
+        $this->assertNull(asset_dimensions('photo.png'));
+    }
+
+    public function testAssetDimensionsReturnsNullForPathTraversal(): void
+    {
+        // The URL comes from post Markdown, which the author types by hand.
+        $this->assertNull(asset_dimensions('/assets/../../../etc/passwd'));
+        $this->assertNull(asset_dimensions('/assets/%2e%2e/%2e%2e/etc/passwd'));
+    }
+
+    public function testAssetDimensionsReturnsNullForANonImageFile(): void
+    {
+        $sub_path = upload_subpath();
+        $dir = get_upload_dir($sub_path);
+        $filename = 'clip_' . uniqid() . '.mp4';
+        file_put_contents("$dir/$filename", 'not really a video');
+
+        $this->assertNull(asset_dimensions(asset_url($sub_path, $filename)));
+
+        unlink("$dir/$filename");
+    }
+
+    private function writePng(string $path, int $w, int $h): void
+    {
+        $im = imagecreatetruecolor($w, $h);
+        imagefill($im, 0, 0, imagecolorallocate($im, 10, 120, 200));
+        imagepng($im, $path);
+        imagedestroy($im);
     }
 
     private function makePng(int $w, int $h): string


### PR DESCRIPTION
Post images render lazily but without dimensions, so the browser cannot
know how tall one will be until it decodes — and lazy loading guarantees
that happens late. Every image therefore pushes the text below it down as
you scroll past.

Stamp the intrinsic pixel width/height on images stored under
src/assets/, read from the file once at parse time and cached in
`transformed` rather than resolved per request. The lookup is injected
(LambDown::setImageSizeResolver()) so the parser stays a pure
string→string transform with no knowledge of ROOT_DIR: the /assets/ URL →
disk-path mapping lives beside asset_url(), which owns the forward
direction already.

asset_dimensions() emits nothing rather than guessing whenever the src
isn't provably a file inside src/assets/ — a remote URL whose path merely
starts with /assets/, a traversal out of the tree (post bodies are
hand-written Markdown), a deleted upload, or a file getimagesize() cannot
measure, such as an uploaded video. Remote images are left alone; nothing
is fetched at parse time.

POST_VERSION is bumped so existing posts gain the attributes when
upgrade_posts() re-parses them on read.

The base and 2024 themes constrained image width without freeing height,
which with dimensions present would squash any image wider than its
container; both now set height: auto, as 2026 already did. Documented for
custom themes, since a theme's stylesheet can reintroduce the same
distortion.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nv8Std3CpMMGhDP4f3brnt