### PR TITLE
Import a Lamb export (lamb-export/1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ lamb/
 │   ├── routes.php        # register_route() / call_route() helpers
 │   ├── lamb.php          # Core helpers: parse_bean, parse_tags, permalink, visibility clauses, redirects
 │   ├── post.php          # Post helpers: populate_bean, parse_matter, slugify, finalize_slug
+│   ├── restore.php       # Lamb export importer: archive reader, manifest validation, post/asset restore
 │   ├── response.php      # Response helpers: pagination, conditional GET/304, 404, upgrade_posts
 │   ├── response/         # Route handlers (respond_*, redirect_*), split by area
 │   │   ├── auth.php      # Login/logout/settings
@@ -109,6 +110,7 @@ lamb/
 ├── composer.json
 ├── phpcs.xml             # Coding standard config
 ├── codeception.yml       # Test runner config
+├── import-lamb.php       # CLI: restore a Lamb export archive (src/restore.php) into the DB
 └── make-password.php     # CLI utility: hash password → .env
 ```
 
@@ -143,6 +145,7 @@ Each file declares a namespace; functions are called with the namespace prefix:
 | `network.php` + `network/*.php` | `Lamb\Network` |
 | `post.php` | `Lamb\Post` |
 | `response.php` + `response/*.php` | `Lamb\Response` |
+| `restore.php` | `Lamb\Restore` |
 | `routes.php` | `Lamb\Route` |
 | `security.php` | `Lamb\Security` |
 | `theme.php` + `theme/*.php` | `Lamb\Theme` |

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -26,12 +26,14 @@ WXR was rejected: it is WordPress's schema, has no clean home for Lamb's draft/d
 ## 2026-07-29 — Lamb export import identity via a separate `import_uuid` column
 
 **Status:** Accepted
-**Context:** Issue #554 asked for a lamb-to-lamb importer that restores a `/export` archive back into the database, idempotently. The two existing importers (WordPress, Known) dedupe re-runs via `feeditem_uuid`, and reusing that column for restored posts too was the obvious first idea — one less column.
 
-It was rejected. `lock_if_feed_sourced()` (`src/response/posts.php:329`) sets `feed_locked` on any post with a non-empty `feeditem_uuid` when it is edited, to stop hand-editing content a feed will overwrite on the next cron run. A restored local post is not feed-sourced — nothing will overwrite it — so giving it a `feeditem_uuid` to get free dedup would also silently feed-lock it, changing edit behaviour for a post that never subscribed to anything.
+**Context:** Issue #554 asked for a Lamb-to-Lamb importer that restores a `/export` archive back into the database, idempotently. The two existing importers, for WordPress and Known, dedupe re-runs through `feeditem_uuid`, and reusing that column for restored posts was the obvious first idea — one less column.
 
-**Decision:** Add a dedicated `import_uuid` column (`Bootstrap\ensure_post_columns()`, `src/bootstrap.php`), computed as `md5('lamb-' . $origin . '#' . $source_id)`. `$origin` is the exporting site's URL (from the manifest's `site.url`, or `--site-url` when given) rather than `ROOT_URL`, because `ROOT_URL` is host-derived and the same install reached on two hostnames would otherwise mint two origins for one site's posts.
-**Consequences:** Restored posts carry both an empty `feeditem_uuid` and a populated `import_uuid`, so they are editable without tripping feed-lock. `run_import()` (`src/import.php`) gained an optional `$find_existing` callable so its shared counters/summary machinery can dedupe on either column without duplicating the loop.
+We rejected it. `lock_if_feed_sourced()` (`src/response/posts.php:329`) sets `feed_locked` on any post with a non-empty `feeditem_uuid` when you edit it, to stop you hand-editing content a feed will overwrite on the next cron run. A restored local post isn't feed-sourced, and nothing will overwrite it, so giving it a `feeditem_uuid` for free dedupe would also silently feed-lock it. That changes edit behaviour for a post that never subscribed to anything.
+
+**Decision:** Add a dedicated `import_uuid` column through `Bootstrap\ensure_post_columns()` in `src/bootstrap.php`, computed as `md5('lamb-' . $origin . '#' . $source_id)`. `$origin` is the exporting site's URL, taken from the manifest's `site.url` or from `--site-url` when given, rather than `ROOT_URL`. `ROOT_URL` is host-derived, so the same install reached on two hostnames would otherwise mint two origins for one site's posts.
+
+**Consequences:** Restored posts carry an empty `feeditem_uuid` and a populated `import_uuid`, so you can edit them without tripping feed-lock. `run_import()` in `src/import.php` gained an optional `$find_existing` callable, so its shared counter and summary machinery can dedupe on either column without duplicating the loop.
 
 ---
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -23,6 +23,18 @@ WXR was rejected: it is WordPress's schema, has no clean home for Lamb's draft/d
 
 ---
 
+## 2026-07-29 — Lamb export import identity via a separate `import_uuid` column
+
+**Status:** Accepted
+**Context:** Issue #554 asked for a lamb-to-lamb importer that restores a `/export` archive back into the database, idempotently. The two existing importers (WordPress, Known) dedupe re-runs via `feeditem_uuid`, and reusing that column for restored posts too was the obvious first idea — one less column.
+
+It was rejected. `lock_if_feed_sourced()` (`src/response/posts.php:329`) sets `feed_locked` on any post with a non-empty `feeditem_uuid` when it is edited, to stop hand-editing content a feed will overwrite on the next cron run. A restored local post is not feed-sourced — nothing will overwrite it — so giving it a `feeditem_uuid` to get free dedup would also silently feed-lock it, changing edit behaviour for a post that never subscribed to anything.
+
+**Decision:** Add a dedicated `import_uuid` column (`Bootstrap\ensure_post_columns()`, `src/bootstrap.php`), computed as `md5('lamb-' . $origin . '#' . $source_id)`. `$origin` is the exporting site's URL (from the manifest's `site.url`, or `--site-url` when given) rather than `ROOT_URL`, because `ROOT_URL` is host-derived and the same install reached on two hostnames would otherwise mint two origins for one site's posts.
+**Consequences:** Restored posts carry both an empty `feeditem_uuid` and a populated `import_uuid`, so they are editable without tripping feed-lock. `run_import()` (`src/import.php`) gained an optional `$find_existing` callable so its shared counters/summary machinery can dedupe on either column without duplicating the loop.
+
+---
+
 ## 2026-05-29 — `docs/` is end-user documentation only
 
 **Status:** Accepted

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Barrier free super simple blogging, self-hosted.
 - Drafts and scheduled posts built in, with one-click trash and restore.
 - A [Micropub](https://indieweb.org/Micropub) endpoint lets you post from iA Writer, Ulysses, or any IndieWeb-compatible app.
 - One-click export of every post as plain Markdown files plus their images, so your writing is never locked in.
+- Import from WordPress, Known, or a previous Lamb export, straight into the same post pipeline.
 
 # Getting started
 

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
       "src/network/ingest.php",
       "src/network/json_feed.php",
       "src/post.php",
+      "src/restore.php",
       "src/response.php",
       "src/response/auth.php",
       "src/response/discovery.php",

--- a/docs/export.md
+++ b/docs/export.md
@@ -70,6 +70,7 @@ Each entry in `posts` points at a file in the archive and records the things a M
 | `deleted` / `deleted_at` | `true` and a timestamp for a post in the [trash]({{ site.baseurl }}{% link trash.md %}). |
 | `post_version` | Which revision of Lamb's post pipeline last rendered the post. |
 | `feed_name`, `feeditem_uuid`, `source_url` | Set when the post came from a subscribed feed rather than being written locally. Locally authored posts have `null` in all three. |
+| `site.url` (in the top-level `site` block, not per-post) | The origin the [Lamb importer]({{ site.baseurl }}{% link lamb-import.md %}) uses to namespace restored post ids, so archives from two different sites never collide on id. |
 
 Deliberately absent: titles and bodies (they live in the Markdown file, so there is only ever one source of truth for your content) and preview tokens (they are access credentials for unpublished posts, and an export is a file you may pass around).
 
@@ -94,5 +95,6 @@ Export needs PHP's `zip` extension. It is present in the Docker image and in mos
 - [Trash]({{ site.baseurl }}{% link trash.md %}) — trashed posts are included in the export and flagged in the manifest.
 - [Drafts]({{ site.baseurl }}{% link drafts.md %}) — so are drafts.
 - [Media]({{ site.baseurl }}{% link media.md %}) — how the assets in the archive were stored and converted.
+- [Lamb import]({{ site.baseurl }}{% link lamb-import.md %}) — restores an archive produced here, straight back into Lamb.
 - [WordPress import]({{ site.baseurl }}{% link wordpress-import.md %}) — the same format, in the opposite direction.
 - [Known import]({{ site.baseurl }}{% link known-import.md %}) — likewise.

--- a/docs/export.md
+++ b/docs/export.md
@@ -95,6 +95,6 @@ Export needs PHP's `zip` extension. It is present in the Docker image and in mos
 - [Trash]({{ site.baseurl }}{% link trash.md %}) — trashed posts are included in the export and flagged in the manifest.
 - [Drafts]({{ site.baseurl }}{% link drafts.md %}) — so are drafts.
 - [Media]({{ site.baseurl }}{% link media.md %}) — how the assets in the archive were stored and converted.
-- [Lamb import]({{ site.baseurl }}{% link lamb-import.md %}) — restores an archive produced here, straight back into Lamb.
+- [Lamb import]({{ site.baseurl }}{% link lamb-import.md %}): Restores an archive produced here, straight back into Lamb.
 - [WordPress import]({{ site.baseurl }}{% link wordpress-import.md %}) — the same format, in the opposite direction.
 - [Known import]({{ site.baseurl }}{% link known-import.md %}) — likewise.

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,6 +89,7 @@ Devtools / local environments / sandbox:
 * [Export]({{ site.baseurl }}{% link export.md %})
 * [Feeds]({{ site.baseurl }}{% link feeds.md %})
 * [Known import]({{ site.baseurl }}{% link known-import.md %})
+* [Lamb import]({{ site.baseurl }}{% link lamb-import.md %})
 * [Login security]({{ site.baseurl }}{% link login-security.md %})
 * [Media]({{ site.baseurl }}{% link media.md %})
 * [Menu Items]({{ site.baseurl }}{% link menu-items.md %})

--- a/docs/known-import.md
+++ b/docs/known-import.md
@@ -48,6 +48,7 @@ A few things worth checking manually:
 ## Related
 
 - [WordPress import](wordpress-import.md) — the sibling importer this one shares its image-download and Markdown-conversion pipeline with.
+- [Lamb import](lamb-import.md) — restoring a Lamb export rather than converting from another platform.
 - [Cross-posting](cross-posting.md) — outbound syndication, the opposite direction.
 - [Feeds](feeds.md) — how Lamb publishes content for other readers to ingest.
 - [Media](media.md) — how uploaded images are stored and converted.

--- a/docs/known-import.md
+++ b/docs/known-import.md
@@ -48,7 +48,7 @@ A few things worth checking manually:
 ## Related
 
 - [WordPress import](wordpress-import.md) — the sibling importer this one shares its image-download and Markdown-conversion pipeline with.
-- [Lamb import](lamb-import.md) — restoring a Lamb export rather than converting from another platform.
+- [Lamb import](lamb-import.md): Restore a Lamb export, rather than converting from another platform.
 - [Cross-posting](cross-posting.md) — outbound syndication, the opposite direction.
 - [Feeds](feeds.md) — how Lamb publishes content for other readers to ingest.
 - [Media](media.md) — how uploaded images are stored and converted.

--- a/docs/lamb-import.md
+++ b/docs/lamb-import.md
@@ -1,61 +1,64 @@
 ---
 title: Lamb import
+nav_order: 31
 ---
 
-# Restoring a Lamb export
+# Restore a Lamb export
 
-Lamb ships a CLI script that reads a [Lamb export](export.md) — the `.zip` produced by `/export`, or an already-unpacked copy of one — and restores every post and asset it describes. It is a lamb-to-lamb restore, not a converter: it writes back exactly what was exported, using the same low-level pipeline every other importer uses. It is fully offline — no credentials, no API access — and re-running it is safe.
+Lamb ships a CLI script that reads a [Lamb export](export.md) — the `.zip` that `/export` produces, or an already-unpacked copy of one — and restores every post and asset it describes. It's a Lamb-to-Lamb restore rather than a converter: it writes back exactly what you exported, through the same low-level pipeline every other importer uses. The importer works fully offline, with no credentials and no API access, and re-running it is safe.
 
 ## What you get
 
-- Every post in the manifest is restored: its body, front matter, slug, `created`/`updated` timestamps, and draft/trash state, exactly as recorded.
-- Every asset the manifest lists is written back to `src/assets/YYYY/MM/`, at the same path it was exported from.
-- Re-running the importer on the same archive does not create duplicates. Each restored post is tagged with an `import_uuid` (md5 of `'lamb-' + origin + '#' + id`, where the origin is the site the archive came from), and an item whose uuid is already present is left alone.
-- Imported posts are **silent**: the importer calls the low-level save pipeline directly, so no outbound webmentions or WebSub hub pings are emitted. The content already existed somewhere else.
+- Lamb restores every post in the manifest: its body, front matter, slug, `created` and `updated` timestamps, and draft or trash state, exactly as recorded.
+- Lamb writes every asset the manifest lists back to `src/assets/YYYY/MM/`, at the same path it was exported from.
+- Re-running the importer on the same archive doesn't create duplicates. Lamb tags each restored post with an `import_uuid`, the md5 of `'lamb-' + origin + '#' + id`, where the origin is the site the archive came from. It leaves an item alone when that uuid is already present.
+- Imported posts are **silent**. The importer calls the low-level save pipeline directly, so it emits no outbound webmentions and no WebSub hub pings. The content already existed somewhere else.
 
-## Running the importer
+## Run the importer
 
 From the project root:
 
 ```bash
-# Preview what would be restored without writing anything
+# Preview what the importer would restore, without writing anything
 php import-lamb.php /path/to/lamb-export-2026-07-26.zip --dry-run
 
 # Run it for real
 php import-lamb.php /path/to/lamb-export-2026-07-26.zip
 ```
 
-An already-unpacked export directory works too — pass its path instead of the `.zip`:
+An already-unpacked export directory works too. Pass its path instead of the `.zip`:
 
 ```bash
 php import-lamb.php /path/to/lamb-export-2026-07-26/
 ```
 
-The script prints one line per post (`imported:`, `would import:`, `replaced:` or `would replace:`) plus a final summary with the totals (created, existed, skipped), and a one-line asset tally (restored, skipped, rejected).
+The script prints one line per post (`imported:`, `would import:`, `replaced:`, or `would replace:`), plus a final summary with the totals for created, existed, and skipped, and a one-line asset tally of restored, skipped, and rejected.
 
 ### `--site-url=<url>`
 
-Restored posts are deduplicated by the site the archive came from, taken from the manifest's `site.url`. Pass `--site-url=<url>` to override it — needed when the manifest carries no `site.url` (older or hand-built archives), or when you are restoring an archive from a site that has since moved to a new domain. Without either, the importer still imports and dedupes re-runs correctly, but it warns: an empty origin cannot tell two different sites' post ids apart if you ever restore a second archive into the same database.
+Lamb deduplicates restored posts by the site the archive came from, which it takes from the manifest's `site.url`. Pass `--site-url=<url>` to override it. You need this when the manifest carries no `site.url`, as older or hand-built archives may not, or when you're restoring an archive from a site that has since moved to a new domain.
+
+Without either value, the importer still imports and still dedupes re-runs correctly, but it warns you: an empty origin can't tell two different sites' post ids apart if you ever restore a second archive into the same database.
 
 ### `--replace`
 
-By default, a post that was already restored (matched by `import_uuid`) is left alone on a second run — the importer counts it as `existed` and moves on. Pass `--replace` to overwrite it instead: body, slug, `created`/`updated`, draft state and trash state are all set back to what the manifest records.
+By default, the importer leaves a post it already restored alone on a second run, matching it by `import_uuid`, counting it as `existed`, and moving on. Pass `--replace` to overwrite it instead. Lamb then sets the body, slug, `created` and `updated` timestamps, draft state, and trash state back to what the manifest records.
 
-This is deliberately total, not a merge. Local edits made to a restored post since the archive was taken are lost when you `--replace` it — that is what "replace" means. A restore that left a post published when the backup says it was trashed, or dated today instead of when it was actually written, would not be much of a restore.
+This is deliberately total rather than a merge. You lose any local edits made to a restored post since you took the archive — that's what "replace" means. A restore that left a post published when the backup says it was trashed, or dated today instead of when you actually wrote it, wouldn't be much of a restore.
 
 ## After the import
 
-The importer writes directly to the same database your site uses, so the posts are visible immediately. There is no separate review queue.
+The importer writes directly to the same database your site uses, so the posts are visible immediately. There's no separate review queue.
 
-A few things worth checking manually:
+A few things are worth checking manually:
 
-- **Slugs.** Every post keeps the slug it was exported with. The one case that cannot be restored is a post that had no slug to begin with — a titleless status post. Its permalink was `/status/<its old id>`, and source ids cannot be restored into a populated database (a new row gets a new id). It comes back as a status post again, but at `/status/<new id>` — a different URL than before. Only the URL is affected: posts are matched on the id recorded in the manifest, not on their slug, so a slugless post still imports exactly once no matter how often you re-run the importer.
-- **Media.** Run a quick `git status` on `src/assets/` to see what was restored.
+- **Slugs.** Every post keeps the slug you exported it with. The one case Lamb can't restore is a post that had no slug to begin with, meaning a titleless status post. Its permalink was `/status/<its old id>`, and source ids can't be restored into a populated database, because a new row gets a new id. It comes back as a status post again, but at `/status/<new id>`, a different URL than before. Only the URL is affected: Lamb matches posts on the id recorded in the manifest rather than on their slug, so a slugless post still imports exactly once however often you re-run the importer.
+- **Media.** Run `git status` on `src/assets/` to see what the importer restored.
 
 ## Related
 
-- [Export](export.md) — the format this importer reads, in the opposite direction.
-- [WordPress import](wordpress-import.md) — the other importer sharing `run_import()`'s dedupe/summary machinery.
-- [Known import](known-import.md) — likewise.
-- [Trash](trash.md) — trashed posts round-trip through export and this importer.
-- [Drafts](drafts.md) — so do drafts.
+- [Export](export.md): The format this importer reads, in the opposite direction.
+- [WordPress import](wordpress-import.md): The other importer sharing `run_import()`'s dedupe and summary machinery.
+- [Known import](known-import.md): Likewise.
+- [Trash](trash.md): Trashed posts round-trip through export and this importer.
+- [Drafts](drafts.md): So do drafts.

--- a/docs/lamb-import.md
+++ b/docs/lamb-import.md
@@ -1,0 +1,61 @@
+---
+title: Lamb import
+---
+
+# Restoring a Lamb export
+
+Lamb ships a CLI script that reads a [Lamb export](export.md) — the `.zip` produced by `/export`, or an already-unpacked copy of one — and restores every post and asset it describes. It is a lamb-to-lamb restore, not a converter: it writes back exactly what was exported, using the same low-level pipeline every other importer uses. It is fully offline — no credentials, no API access — and re-running it is safe.
+
+## What you get
+
+- Every post in the manifest is restored: its body, front matter, slug, `created`/`updated` timestamps, and draft/trash state, exactly as recorded.
+- Every asset the manifest lists is written back to `src/assets/YYYY/MM/`, at the same path it was exported from.
+- Re-running the importer on the same archive does not create duplicates. Each restored post is tagged with an `import_uuid` (md5 of `'lamb-' + origin + '#' + id`, where the origin is the site the archive came from), and an item whose uuid is already present is left alone.
+- Imported posts are **silent**: the importer calls the low-level save pipeline directly, so no outbound webmentions or WebSub hub pings are emitted. The content already existed somewhere else.
+
+## Running the importer
+
+From the project root:
+
+```bash
+# Preview what would be restored without writing anything
+php import-lamb.php /path/to/lamb-export-2026-07-26.zip --dry-run
+
+# Run it for real
+php import-lamb.php /path/to/lamb-export-2026-07-26.zip
+```
+
+An already-unpacked export directory works too — pass its path instead of the `.zip`:
+
+```bash
+php import-lamb.php /path/to/lamb-export-2026-07-26/
+```
+
+The script prints one line per post (`imported:`, `would import:`, `replaced:` or `would replace:`) plus a final summary with the totals (created, existed, skipped), and a one-line asset tally (restored, skipped, rejected).
+
+### `--site-url=<url>`
+
+Restored posts are deduplicated by the site the archive came from, taken from the manifest's `site.url`. Pass `--site-url=<url>` to override it — needed when the manifest carries no `site.url` (older or hand-built archives), or when you are restoring an archive from a site that has since moved to a new domain. Without either, the importer still imports and dedupes re-runs correctly, but it warns: an empty origin cannot tell two different sites' post ids apart if you ever restore a second archive into the same database.
+
+### `--replace`
+
+By default, a post that was already restored (matched by `import_uuid`) is left alone on a second run — the importer counts it as `existed` and moves on. Pass `--replace` to overwrite it instead: body, slug, `created`/`updated`, draft state and trash state are all set back to what the manifest records.
+
+This is deliberately total, not a merge. Local edits made to a restored post since the archive was taken are lost when you `--replace` it — that is what "replace" means. A restore that left a post published when the backup says it was trashed, or dated today instead of when it was actually written, would not be much of a restore.
+
+## After the import
+
+The importer writes directly to the same database your site uses, so the posts are visible immediately. There is no separate review queue.
+
+A few things worth checking manually:
+
+- **Slugs.** Every post keeps the slug it was exported with. The one case that cannot be restored is a post that had no slug to begin with — a titleless status post. Its permalink was `/status/<its old id>`, and source ids cannot be restored into a populated database (a new row gets a new id). It comes back as a status post again, but at `/status/<new id>` — a different URL than before.
+- **Media.** Run a quick `git status` on `src/assets/` to see what was restored.
+
+## Related
+
+- [Export](export.md) — the format this importer reads, in the opposite direction.
+- [WordPress import](wordpress-import.md) — the other importer sharing `run_import()`'s dedupe/summary machinery.
+- [Known import](known-import.md) — likewise.
+- [Trash](trash.md) — trashed posts round-trip through export and this importer.
+- [Drafts](drafts.md) — so do drafts.

--- a/docs/lamb-import.md
+++ b/docs/lamb-import.md
@@ -49,7 +49,7 @@ The importer writes directly to the same database your site uses, so the posts a
 
 A few things worth checking manually:
 
-- **Slugs.** Every post keeps the slug it was exported with. The one case that cannot be restored is a post that had no slug to begin with — a titleless status post. Its permalink was `/status/<its old id>`, and source ids cannot be restored into a populated database (a new row gets a new id). It comes back as a status post again, but at `/status/<new id>` — a different URL than before.
+- **Slugs.** Every post keeps the slug it was exported with. The one case that cannot be restored is a post that had no slug to begin with — a titleless status post. Its permalink was `/status/<its old id>`, and source ids cannot be restored into a populated database (a new row gets a new id). It comes back as a status post again, but at `/status/<new id>` — a different URL than before. Only the URL is affected: posts are matched on the id recorded in the manifest, not on their slug, so a slugless post still imports exactly once no matter how often you re-run the importer.
 - **Media.** Run a quick `git status` on `src/assets/` to see what was restored.
 
 ## Related

--- a/docs/wordpress-import.md
+++ b/docs/wordpress-import.md
@@ -47,6 +47,7 @@ A few things worth checking manually:
 ## Related
 
 - [Known import](known-import.md) — the sibling importer this one shares its image-download and Markdown-conversion pipeline with.
+- [Lamb import](lamb-import.md) — restoring a Lamb export rather than converting from another platform.
 - [Cross-posting](cross-posting.md) — outbound syndication, the opposite direction.
 - [Feeds](feeds.md) — how Lamb publishes content for other readers to ingest.
 - [Media](media.md) — how uploaded images are stored and converted.

--- a/docs/wordpress-import.md
+++ b/docs/wordpress-import.md
@@ -47,7 +47,7 @@ A few things worth checking manually:
 ## Related
 
 - [Known import](known-import.md) — the sibling importer this one shares its image-download and Markdown-conversion pipeline with.
-- [Lamb import](lamb-import.md) — restoring a Lamb export rather than converting from another platform.
+- [Lamb import](lamb-import.md): Restore a Lamb export, rather than converting from another platform.
 - [Cross-posting](cross-posting.md) — outbound syndication, the opposite direction.
 - [Feeds](feeds.md) — how Lamb publishes content for other readers to ingest.
 - [Media](media.md) — how uploaded images are stored and converted.

--- a/import-lamb.php
+++ b/import-lamb.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Lamb export importer — CLI script.
+ *
+ * Restores a `lamb-export/1` archive written by /export (see docs/export.md):
+ * every post as the front-matter Markdown it was stored as, the row state the
+ * manifest records, and the assets those posts reference. Accepts the `.zip`
+ * or an already-unpacked directory. Idempotent: re-running never recreates a
+ * row (dedup by md5('lamb-' . origin . '#' . id) on the import_uuid column,
+ * where the origin is the manifest's site.url).
+ *
+ *   php import-lamb.php path/to/lamb-export-2026-07-29.zip [options]
+ *
+ * --dry-run          Read and convert everything but write nothing to the DB
+ *                    or filesystem. Use this first.
+ * --replace          Overwrite posts already imported from this archive —
+ *                    body, slug, dates, draft and trash state. Local edits
+ *                    made since the backup are lost; that is what it means.
+ * --site-url=<url>   The origin to namespace post ids by. Use it when the
+ *                    manifest carries no site.url, or when restoring an
+ *                    archive from a site that has since moved.
+ *
+ * The script intentionally does NOT emit outbound webmentions or WebSub
+ * pings — restored posts are pre-existing content, not new publications.
+ */
+
+namespace Lamb;
+
+use Lamb\Import;
+use Lamb\Restore;
+use RedBeanPHP\R;
+use RuntimeException;
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "import-lamb.php must be run from the command line.\n");
+    exit(1);
+}
+
+define('ROOT_DIR', __DIR__ . '/src');
+require __DIR__ . '/vendor/autoload.php';
+
+[$path, $dry_run, $replace, $site_url] = Restore\parse_restore_args($argv);
+if ($path === null) {
+    fwrite(STDERR, "Usage: php import-lamb.php <lamb-export.zip|directory> [--dry-run] [--replace] [--site-url=<url>]\n");
+    exit(1);
+}
+
+try {
+    [, $reader] = Restore\open_source($path);
+} catch (RuntimeException $e) {
+    fwrite(STDERR, $e->getMessage() . "\n");
+    exit(1);
+}
+
+$data_dir = getenv('LAMB_DATA_DIR') ?: __DIR__ . '/data';
+Bootstrap\bootstrap_db($data_dir);
+
+global $config;
+$config = Config\load();
+Config\apply_timezone($config);
+
+try {
+    $manifest = Restore\read_manifest($reader);
+} catch (RuntimeException $e) {
+    fwrite(STDERR, $e->getMessage() . "\n");
+    exit(1);
+}
+
+$origin = Restore\origin_id($manifest, $site_url);
+if ($origin === '') {
+    fwrite(STDERR, "Warning: this archive names no site URL, so imported ids are namespaced by an empty origin. Pass --site-url=<url> to keep two sites' posts apart.\n");
+}
+
+Import\run_import(
+    Restore\manifest_items($manifest, $reader, $origin),
+    Restore\item_skip_reason(...),
+    static fn(array $item): string => (string) $item['import_uuid'],
+    Restore\import_post(...),
+    $dry_run,
+    static fn(string $uuid): ?\RedBeanPHP\OODBBean => R::findOne('post', ' import_uuid = ? ', [$uuid]),
+    $replace,
+);
+
+$assets = Restore\restore_assets($manifest, ROOT_DIR . '/assets', $reader, $dry_run);
+echo "Assets: restored={$assets['restored']} skipped={$assets['skipped']} rejected={$assets['rejected']}\n";

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -65,7 +65,8 @@ function bootstrap_db(string $data_dir): void
 }
 
 /**
- * Ensures the post table has the columns introduced by soft-delete and draft features.
+ * Ensures the post table has the columns introduced by the soft-delete, draft
+ * and export-import features.
  * Safe to call on any DB: no-ops if the table or columns don't exist yet.
  *
  * @return void
@@ -82,6 +83,9 @@ function ensure_post_columns(): void
     }
     if (!in_array('draft', $columns, true)) {
         R::exec('ALTER TABLE post ADD COLUMN draft INTEGER');
+    }
+    if (!in_array('import_uuid', $columns, true)) {
+        R::exec('ALTER TABLE post ADD COLUMN import_uuid TEXT');
     }
 }
 

--- a/src/import.php
+++ b/src/import.php
@@ -730,19 +730,34 @@ function parse_import_args(array $argv): array
  * summary. Used by both import-wordpress.php and import-known.php so the two
  * scripts' output stays byte-identical in shape.
  *
+ * $find_existing lets an importer dedupe on its own column instead of
+ * feeditem_uuid, and $replace re-imports into the bean it returns rather than
+ * counting the item as already present. The four-argument $import call is only
+ * reachable when both are supplied, so the three-parameter importers keep
+ * working unchanged.
+ *
  * @param list<array<string, mixed>>      $items      Items from extract_items().
  * @param callable(array<string,mixed>):?string $skip_reason Explains why an item is out of scope, or null.
  * @param callable(array<string,mixed>):string  $uuid       Computes the item's dedup uuid.
- * @param callable(array<string,mixed>,callable,bool):?\RedBeanPHP\OODBBean $import Imports a single item.
+ * @param callable(array<string,mixed>,callable,bool,\RedBeanPHP\OODBBean|null=):?\RedBeanPHP\OODBBean $import Imports a single item.
+ * @param callable(string):?\RedBeanPHP\OODBBean|null $find_existing Finds an already-imported row by uuid.
  */
-function run_import(array $items, callable $skip_reason, callable $uuid, callable $import, bool $dry_run): void
-{
+function run_import(
+    array $items,
+    callable $skip_reason,
+    callable $uuid,
+    callable $import,
+    bool $dry_run,
+    ?callable $find_existing = null,
+    bool $replace = false
+): void {
     $downloader = $dry_run
         ? static fn(): ?string => null
         : 'Lamb\\Import\\default_image_downloader';
 
     $created = 0;
     $existed = 0;
+    $replaced = 0;
     $skipped = 0;
     /** @var array<string, int> $skip_reasons */
     $skip_reasons = [];
@@ -756,26 +771,37 @@ function run_import(array $items, callable $skip_reason, callable $uuid, callabl
             continue;
         }
         $item_uuid = $uuid($item);
-        if (R::findOne('post', ' feeditem_uuid = ? ', [$item_uuid])) {
+        $existing = $find_existing !== null
+            ? $find_existing($item_uuid)
+            : R::findOne('post', ' feeditem_uuid = ? ', [$item_uuid]);
+        if ($existing && !$replace) {
             $existed++;
             continue;
         }
 
-        $bean = $import($item, $downloader, $dry_run);
+        $label = trim((string) ($item['title'] ?? ''));
+        $bean = $existing
+            ? $import($item, $downloader, $dry_run, $existing)
+            : $import($item, $downloader, $dry_run);
         if ($bean === null) {
             $skipped++;
             $skip_reasons['conversion failed'] = ($skip_reasons['conversion failed'] ?? 0) + 1;
-            echo "[" . ($i + 1) . "/$total] skipped (conversion failed): "
-                . trim((string) $item['title']) . "\n";
+            echo "[" . ($i + 1) . "/$total] skipped (conversion failed): $label\n";
             continue;
         }
-        $created++;
-        $verb = $dry_run ? 'would import' : 'imported';
-        echo "[" . ($i + 1) . "/$total] $verb: " . trim((string) $item['title']) . "\n";
+        if ($existing) {
+            $replaced++;
+            $verb = $dry_run ? 'would replace' : 'replaced';
+        } else {
+            $created++;
+            $verb = $dry_run ? 'would import' : 'imported';
+        }
+        echo "[" . ($i + 1) . "/$total] $verb: $label\n";
     }
 
     $prefix = $dry_run ? '[dry-run] ' : '';
-    echo "\n{$prefix}Done. created=$created existed=$existed skipped=$skipped total=$total\n";
+    $replaced_summary = $replace ? " replaced=$replaced" : '';
+    echo "\n{$prefix}Done. created=$created existed=$existed{$replaced_summary} skipped=$skipped total=$total\n";
     if ($skip_reasons) {
         arsort($skip_reasons);
         echo "Skipped breakdown:\n";

--- a/src/import.php
+++ b/src/import.php
@@ -732,9 +732,10 @@ function parse_import_args(array $argv): array
  *
  * $find_existing lets an importer dedupe on its own column instead of
  * feeditem_uuid, and $replace re-imports into the bean it returns rather than
- * counting the item as already present. The four-argument $import call is only
- * reachable when both are supplied, so the three-parameter importers keep
- * working unchanged.
+ * counting the item as already present. $replace is honoured only when
+ * $find_existing is supplied — an importer that takes three parameters cannot
+ * accept a bean to overwrite, so handing it one would quietly create a
+ * duplicate and report it as a replacement.
  *
  * @param list<array<string, mixed>>      $items      Items from extract_items().
  * @param callable(array<string,mixed>):?string $skip_reason Explains why an item is out of scope, or null.
@@ -754,6 +755,7 @@ function run_import(
     $downloader = $dry_run
         ? static fn(): ?string => null
         : 'Lamb\\Import\\default_image_downloader';
+    $replace = $replace && $find_existing !== null;
 
     $created = 0;
     $existed = 0;

--- a/src/response/export.php
+++ b/src/response/export.php
@@ -67,8 +67,10 @@ function respond_export(array $_args): void
 /**
  * The descriptive site block recorded in the manifest.
  *
- * Informational only — it tells a human (or a converter) which site an archive
- * came from. Nothing on import should depend on it.
+ * It tells a human (or a converter) which site an archive came from, and
+ * import-lamb.php uses `url` as the origin it namespaces restored post ids by,
+ * so two archives from different sites do not collide on id. An archive
+ * without it still imports; the importer warns and offers --site-url.
  *
  * @return array<string, mixed>
  */

--- a/src/restore.php
+++ b/src/restore.php
@@ -174,10 +174,12 @@ function safe_entry_path(string $name): ?string
     }
 
     $stem = '[A-Za-z0-9_-][A-Za-z0-9._-]*';
-    if (preg_match('#^posts/\d{4}/\d{2}/' . $stem . '\.md$#', $name) === 1) {
+    // The D modifier: without it `$` also matches before a trailing newline, so
+    // "assets/2026/07/photo.jpg\n" would pass a gate that exists to be exact.
+    if (preg_match('#^posts/\d{4}/\d{2}/' . $stem . '\.md$#D', $name) === 1) {
         return $name;
     }
-    if (preg_match('#^assets/\d{4}/\d{2}/' . $stem . '$#', $name) === 1) {
+    if (preg_match('#^assets/\d{4}/\d{2}/' . $stem . '$#D', $name) === 1) {
         return $name;
     }
 
@@ -235,6 +237,27 @@ function origin_id(array $manifest, ?string $override): string
 }
 
 /**
+ * The origin to namespace by, with a stand-in for an archive that names no site.
+ *
+ * An empty origin is not an identity: every siteless archive would share one
+ * namespace, so restoring a second one would count all of its posts as already
+ * present and silently drop them. The manifest's own export stamp and counts
+ * stand in — stable across a re-import of the same archive, different for two
+ * different ones. Not a substitute for --site-url, which is what makes the
+ * namespace match a later archive from the same site.
+ *
+ * @param array<string, mixed> $manifest
+ */
+function namespaced_origin(array $manifest, string $origin): string
+{
+    if ($origin !== '') {
+        return $origin;
+    }
+
+    return 'archive:' . md5(serialize([$manifest['exported_at'] ?? '', $manifest['counts'] ?? []]));
+}
+
+/**
  * The dedup key stored on a restored post's import_uuid column.
  */
 function restore_uuid(string $origin, int $id): string
@@ -246,7 +269,8 @@ function restore_uuid(string $origin, int $id): string
  * Turns the manifest's post entries into the items run_import() walks.
  *
  * Each item carries the manifest's own fields, the body read out of the
- * archive (null when the entry is absent) and the dedup uuid. `title` is the
+ * archive (null when the entry is absent) and the dedup uuid, namespaced by
+ * $origin — or, when that is empty, by namespaced_origin()'s stand-in. `title` is the
  * in-archive path: it is only ever used for the progress line, and the path is
  * what identifies a post to someone watching a restore.
  *
@@ -266,6 +290,7 @@ function manifest_items(array $manifest, callable $reader, string $origin): arra
     if (!is_array($posts)) {
         return [];
     }
+    $origin = namespaced_origin($manifest, $origin);
 
     foreach ($posts as $post) {
         if (!is_array($post)) {
@@ -273,12 +298,14 @@ function manifest_items(array $manifest, callable $reader, string $origin): arra
         }
         $path = (string) ($post['path'] ?? '');
         $safe = safe_entry_path($path);
-        $items[] = $post + [
+        // array_merge(), not `+`: the manifest is untrusted, so its own
+        // `import_uuid` or `body` must never win over the computed ones.
+        $items[] = array_merge($post, [
             'title'       => $path,
             'path'        => $path,
             'body'        => $safe === null ? null : read_entry($reader, $safe),
             'import_uuid' => restore_uuid($origin, (int) ($post['id'] ?? 0)),
-        ];
+        ]);
     }
 
     return $items;
@@ -374,8 +401,9 @@ function apply_manifest_state(OODBBean $bean, array $item): void
  * The archive is the same trust boundary as an upload — it is a file the author
  * was handed, possibly by someone else — so every asset clears the same two
  * gates a browser upload does: the extension allowlist, and a content sniff of
- * the bytes actually written. Both run before the file is moved into place, so
- * a rejected asset never exists at a servable path even briefly.
+ * the bytes themselves. Both run before anything is written, so a rejected
+ * asset never exists at a servable path even briefly and --dry-run tallies
+ * exactly what a real run would.
  *
  * Destination paths are assembled from the validated `YYYY/MM/<name>` tail, not
  * from the archive's own name, and an existing file is never overwritten: a
@@ -417,6 +445,12 @@ function restore_assets(array $manifest, string $assets_root, callable $reader, 
             $tally['skipped']++;
             continue;
         }
+        // Sniffed in memory, before the dry-run branch, so --dry-run reports the
+        // same tally the real run produces.
+        if (!Response\upload_content_allowed(Response\sniff_bytes_content_type($bytes), $ext)) {
+            $tally['rejected']++;
+            continue;
+        }
         if ($dry_run) {
             $tally['restored']++;
             continue;
@@ -428,16 +462,11 @@ function restore_assets(array $manifest, string $assets_root, callable $reader, 
             $tally['skipped']++;
             continue;
         }
-        // Written beside the destination under a non-servable name, sniffed,
-        // and only then renamed into place.
+        // Written beside the destination under a non-servable name and only
+        // then renamed into place, so a half-written file is never servable.
         $staged = $dest . '.part';
         if (file_put_contents($staged, $bytes) === false) {
             $tally['skipped']++;
-            continue;
-        }
-        if (!Response\upload_content_allowed(Response\sniff_file_content_type($staged), $ext)) {
-            unlink($staged);
-            $tally['rejected']++;
             continue;
         }
         rename($staged, $dest);

--- a/src/restore.php
+++ b/src/restore.php
@@ -4,6 +4,7 @@ namespace Lamb\Restore;
 
 use JsonException;
 use Lamb\Post;
+use Lamb\Response;
 use RedBeanPHP\OODBBean;
 use RuntimeException;
 use ZipArchive;
@@ -365,4 +366,83 @@ function apply_manifest_state(OODBBean $bean, array $item): void
     $bean->feeditem_uuid = $item['feeditem_uuid'] ?? null;
     $bean->source_url = $item['source_url'] ?? null;
     $bean->import_uuid = (string) ($item['import_uuid'] ?? '');
+}
+
+/**
+ * Writes the archive's assets back under $assets_root.
+ *
+ * The archive is the same trust boundary as an upload — it is a file the author
+ * was handed, possibly by someone else — so every asset clears the same two
+ * gates a browser upload does: the extension allowlist, and a content sniff of
+ * the bytes actually written. Both run before the file is moved into place, so
+ * a rejected asset never exists at a servable path even briefly.
+ *
+ * Destination paths are assembled from the validated `YYYY/MM/<name>` tail, not
+ * from the archive's own name, and an existing file is never overwritten: a
+ * restore into a live site must not clobber a newer upload that happens to
+ * share a filename.
+ *
+ * @param array<string, mixed>     $manifest
+ * @param callable(string):?string $reader
+ * @return array{restored:int,skipped:int,rejected:int}
+ */
+function restore_assets(array $manifest, string $assets_root, callable $reader, bool $dry_run): array
+{
+    $tally = ['restored' => 0, 'skipped' => 0, 'rejected' => 0];
+    $assets = $manifest['assets'] ?? [];
+    if (!is_array($assets)) {
+        return $tally;
+    }
+
+    foreach ($assets as $entry) {
+        $name = safe_entry_path((string) $entry);
+        if ($name === null || !str_starts_with($name, 'assets/')) {
+            $tally['rejected']++;
+            continue;
+        }
+        $relative = substr($name, strlen('assets/'));
+        $ext = Response\safe_upload_extension($relative);
+        if ($ext === null) {
+            $tally['rejected']++;
+            continue;
+        }
+
+        $dest = "$assets_root/$relative";
+        if (is_file($dest)) {
+            $tally['skipped']++;
+            continue;
+        }
+        $bytes = read_entry($reader, $name);
+        if ($bytes === null) {
+            $tally['skipped']++;
+            continue;
+        }
+        if ($dry_run) {
+            $tally['restored']++;
+            continue;
+        }
+
+        $dir = dirname($dest);
+        // 0755, not 0777: only the user running the import needs to write here.
+        if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
+            $tally['skipped']++;
+            continue;
+        }
+        // Written beside the destination under a non-servable name, sniffed,
+        // and only then renamed into place.
+        $staged = $dest . '.part';
+        if (file_put_contents($staged, $bytes) === false) {
+            $tally['skipped']++;
+            continue;
+        }
+        if (!Response\upload_content_allowed(Response\sniff_file_content_type($staged), $ext)) {
+            unlink($staged);
+            $tally['rejected']++;
+            continue;
+        }
+        rename($staged, $dest);
+        $tally['restored']++;
+    }
+
+    return $tally;
 }

--- a/src/restore.php
+++ b/src/restore.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Lamb\Restore;
+
+use JsonException;
+use RuntimeException;
+use ZipArchive;
+
+use const Lamb\Export\EXPORT_FORMAT;
+
+// The only archive format this importer reads. An archive naming anything else
+// is refused rather than parsed on a guess: a future breaking format bump would
+// otherwise be silently half-applied to a live database.
+const SUPPORTED_FORMAT = EXPORT_FORMAT;
+
+// Caps on what a single archive may contain, so a hostile (or corrupt) zip
+// cannot exhaust the disk or the file table before anything is validated.
+// Twenty thousand entries and two gigabytes are both far above a real Lamb
+// export and far below "fills the volume".
+const MAX_ENTRIES = 20000;
+const MAX_UNCOMPRESSED_BYTES = 2147483648; // 2 GiB
+
+/**
+ * Parses argv into [path, dry_run, replace, site_url].
+ *
+ * @param array<int,string> $argv
+ * @return array{0: ?string, 1: bool, 2: bool, 3: ?string}
+ */
+function parse_restore_args(array $argv): array
+{
+    $path = null;
+    $dry_run = false;
+    $replace = false;
+    $site_url = null;
+    foreach (array_slice($argv, 1) as $arg) {
+        if ($arg === '--dry-run') {
+            $dry_run = true;
+        } elseif ($arg === '--replace') {
+            $replace = true;
+        } elseif (str_starts_with($arg, '--site-url=')) {
+            $site_url = substr($arg, strlen('--site-url='));
+        } elseif ($arg === '--help' || $arg === '-h') {
+            return [null, false, false, null];
+        } elseif ($path === null) {
+            $path = $arg;
+        }
+    }
+
+    return [$path, $dry_run, $replace, $site_url];
+}
+
+/**
+ * Opens a `.zip` archive or an already-unpacked directory for reading.
+ *
+ * Returns the entry names it contains plus a reader closure that resolves one
+ * name to its bytes. The archive is never extracted: nothing downstream ever
+ * sees an attacker-chosen path on the filesystem, so there is no zip-slip
+ * surface to defend. Destination paths are built later from validated
+ * `YYYY/MM/<name>` components instead.
+ *
+ * @return array{0: list<string>, 1: callable(string):?string}
+ * @throws RuntimeException When the source cannot be read or exceeds the caps.
+ */
+function open_source(string $path): array
+{
+    if (is_dir($path)) {
+        return open_directory($path);
+    }
+    if (!is_file($path)) {
+        throw new RuntimeException("Cannot read export archive: $path");
+    }
+
+    $zip = new ZipArchive();
+    if ($zip->open($path) !== true) {
+        throw new RuntimeException("Not a readable zip archive: $path");
+    }
+
+    if ($zip->numFiles > MAX_ENTRIES) {
+        $zip->close();
+        throw new RuntimeException("Archive has more than " . MAX_ENTRIES . " entries: $path");
+    }
+
+    $names = [];
+    $bytes = 0;
+    for ($i = 0; $i < $zip->numFiles; $i++) {
+        $stat = $zip->statIndex($i);
+        if ($stat === false || str_ends_with((string) $stat['name'], '/')) {
+            continue;
+        }
+        $names[] = (string) $stat['name'];
+        $bytes += (int) $stat['size'];
+    }
+    if ($bytes > MAX_UNCOMPRESSED_BYTES) {
+        $zip->close();
+        throw new RuntimeException("Archive unpacks to more than " . MAX_UNCOMPRESSED_BYTES . " bytes: $path");
+    }
+
+    // $zip stays referenced by the closure, so the handle lives as long as the
+    // reader does.
+    $reader = static function (string $name) use ($zip): ?string {
+        $contents = $zip->getFromName($name);
+
+        return $contents === false ? null : $contents;
+    };
+
+    return [$names, $reader];
+}
+
+/**
+ * The directory equivalent of {@see open_source}: a partially recovered backup
+ * is often already unpacked, and unpacking is not the importer's business.
+ *
+ * @return array{0: list<string>, 1: callable(string):?string}
+ * @throws RuntimeException When the tree exceeds the entry cap.
+ */
+function open_directory(string $root): array
+{
+    $names = [];
+    $iterator = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($iterator as $file) {
+        if (!$file instanceof \SplFileInfo || !$file->isFile()) {
+            continue;
+        }
+        $names[] = str_replace(DIRECTORY_SEPARATOR, '/', substr($file->getPathname(), strlen($root) + 1));
+        if (count($names) > MAX_ENTRIES) {
+            throw new RuntimeException("Source has more than " . MAX_ENTRIES . " entries: $root");
+        }
+    }
+
+    $reader = static function (string $name) use ($root): ?string {
+        // Only names this function itself listed are ever asked for, but the
+        // read still goes through safe_entry_path() so a manifest-supplied name
+        // cannot walk out of the tree.
+        if (safe_entry_path($name) === null) {
+            return null;
+        }
+        $contents = @file_get_contents("$root/$name");
+
+        return $contents === false ? null : $contents;
+    };
+
+    return [$names, $reader];
+}
+
+/**
+ * Reads one entry's bytes, or null when it is absent.
+ *
+ * @param callable(string):?string $reader
+ */
+function read_entry(callable $reader, string $name): ?string
+{
+    return $reader($name);
+}
+
+/**
+ * Validates an in-archive entry name, returning it unchanged when it is one of
+ * the three shapes an export contains, and null otherwise.
+ *
+ * This is the single gate for every name that comes out of an archive or a
+ * manifest. Names are matched whole against the layout build_export_archive()
+ * writes, so traversal, absolute paths, nested directories, dotfiles and
+ * unexpected extensions are all refused by construction rather than by
+ * spotting the dangerous cases.
+ */
+function safe_entry_path(string $name): ?string
+{
+    if ($name === 'manifest.json') {
+        return $name;
+    }
+
+    $stem = '[A-Za-z0-9_-][A-Za-z0-9._-]*';
+    if (preg_match('#^posts/\d{4}/\d{2}/' . $stem . '\.md$#', $name) === 1) {
+        return $name;
+    }
+    if (preg_match('#^assets/\d{4}/\d{2}/' . $stem . '$#', $name) === 1) {
+        return $name;
+    }
+
+    return null;
+}
+
+/**
+ * Reads and validates the archive's manifest.
+ *
+ * @param callable(string):?string $reader
+ * @return array<string, mixed>
+ * @throws RuntimeException When it is missing, unparseable, or a format this importer does not read.
+ */
+function read_manifest(callable $reader): array
+{
+    $json = read_entry($reader, 'manifest.json');
+    if ($json === null) {
+        throw new RuntimeException('Archive has no manifest.json — is this a Lamb export?');
+    }
+
+    try {
+        $manifest = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+    } catch (JsonException $e) {
+        throw new RuntimeException('manifest.json is not valid JSON: ' . $e->getMessage());
+    }
+    if (!is_array($manifest)) {
+        throw new RuntimeException('manifest.json is not a JSON object.');
+    }
+
+    $format = (string) ($manifest['format'] ?? '');
+    if ($format !== SUPPORTED_FORMAT) {
+        throw new RuntimeException("Unsupported export format '$format' (this importer reads " . SUPPORTED_FORMAT . ').');
+    }
+
+    /** @var array<string, mixed> $manifest */
+    return $manifest;
+}
+
+/**
+ * The identity a restored post's dedup uuid is namespaced by.
+ *
+ * Post ids are only unique within the site that issued them, so two archives
+ * from different sites both carry an id 7. The origin keeps them apart.
+ * ROOT_URL is not used: it is host-derived, so the same install reached on two
+ * hostnames would mint two origins for one site.
+ *
+ * @param array<string, mixed> $manifest
+ */
+function origin_id(array $manifest, ?string $override): string
+{
+    $site = $manifest['site'] ?? [];
+    $url = $override ?? (is_array($site) ? (string) ($site['url'] ?? '') : '');
+
+    return rtrim(strtolower(trim($url)), '/');
+}
+
+/**
+ * The dedup key stored on a restored post's import_uuid column.
+ */
+function restore_uuid(string $origin, int $id): string
+{
+    return md5('lamb-' . $origin . '#' . $id);
+}

--- a/src/restore.php
+++ b/src/restore.php
@@ -3,6 +3,8 @@
 namespace Lamb\Restore;
 
 use JsonException;
+use Lamb\Post;
+use RedBeanPHP\OODBBean;
 use RuntimeException;
 use ZipArchive;
 
@@ -237,4 +239,130 @@ function origin_id(array $manifest, ?string $override): string
 function restore_uuid(string $origin, int $id): string
 {
     return md5('lamb-' . $origin . '#' . $id);
+}
+
+/**
+ * Turns the manifest's post entries into the items run_import() walks.
+ *
+ * Each item carries the manifest's own fields, the body read out of the
+ * archive (null when the entry is absent) and the dedup uuid. `title` is the
+ * in-archive path: it is only ever used for the progress line, and the path is
+ * what identifies a post to someone watching a restore.
+ *
+ * The manifest is part of the untrusted archive, so a `path` it names is
+ * validated before anything is read and cross-checked against what the archive
+ * actually contains — a path the reader cannot resolve is reported as a missing
+ * file rather than restored as an empty post.
+ *
+ * @param array<string, mixed>     $manifest
+ * @param callable(string):?string $reader
+ * @return list<array<string, mixed>>
+ */
+function manifest_items(array $manifest, callable $reader, string $origin): array
+{
+    $items = [];
+    $posts = $manifest['posts'] ?? [];
+    if (!is_array($posts)) {
+        return [];
+    }
+
+    foreach ($posts as $post) {
+        if (!is_array($post)) {
+            continue;
+        }
+        $path = (string) ($post['path'] ?? '');
+        $safe = safe_entry_path($path);
+        $items[] = $post + [
+            'title'       => $path,
+            'path'        => $path,
+            'body'        => $safe === null ? null : read_entry($reader, $safe),
+            'import_uuid' => restore_uuid($origin, (int) ($post['id'] ?? 0)),
+        ];
+    }
+
+    return $items;
+}
+
+/**
+ * Explains why a manifest entry cannot be restored, or null when it can.
+ *
+ * @param array<string, mixed> $item
+ */
+function item_skip_reason(array $item): ?string
+{
+    if (safe_entry_path((string) ($item['path'] ?? '')) === null) {
+        return 'bad path';
+    }
+    $body = $item['body'] ?? null;
+    if ($body === null) {
+        return 'missing file';
+    }
+    if (trim((string) $body) === '') {
+        return 'empty body';
+    }
+
+    return null;
+}
+
+/**
+ * Restores one manifest entry as a post.
+ *
+ * The body goes through the ordinary post pipeline, so a restored post is
+ * rendered, tagged and slugged exactly as one written today. The manifest state
+ * is applied *after* populate_bean(), which stamps created/updated with now()
+ * and can rewrite created from front matter — a restore that re-dates every
+ * post to the moment it ran is not a restore.
+ *
+ * $bean is the row to overwrite under --replace; without it a new post is
+ * created. No webmentions or WebSub pings: restored posts are not new
+ * publications.
+ *
+ * @param array<string, mixed>     $item
+ * @param callable(string,string):?string $_downloader Unused: an archive carries its own assets.
+ */
+function import_post(array $item, callable $_downloader, bool $dry_run = false, ?OODBBean $bean = null): OODBBean
+{
+    if ($dry_run) {
+        return $bean ?? \RedBeanPHP\R::dispense('post');
+    }
+
+    $bean = Post\populate_bean((string) ($item['body'] ?? ''), null, null, $bean);
+    apply_manifest_state($bean, $item);
+    Post\finalize_and_store_post($bean);
+
+    return $bean;
+}
+
+/**
+ * Overwrites everything on the bean that the manifest describes.
+ *
+ * This is deliberately total rather than additive: a restore that leaves a post
+ * published when the backup says it was trashed, or dated today when the backup
+ * says 2019, has not restored anything. The manifest slug wins only when it is
+ * non-empty — a slugless status post keeps the empty slug and its
+ * /status/<id> permalink.
+ *
+ * @param array<string, mixed> $item
+ */
+function apply_manifest_state(OODBBean $bean, array $item): void
+{
+    $created = (string) ($item['created'] ?? '');
+    $updated = (string) ($item['updated'] ?? '');
+    if ($created !== '') {
+        $bean->created = $created;
+    }
+    $bean->updated = $updated !== '' ? $updated : $bean->created;
+
+    $slug = (string) ($item['slug'] ?? '');
+    if ($slug !== '') {
+        $bean->slug = $slug;
+    }
+
+    $bean->draft = empty($item['draft']) ? 0 : 1;
+    $bean->deleted = empty($item['deleted']) ? 0 : 1;
+    $bean->deleted_at = $item['deleted_at'] ?? null;
+    $bean->feed_name = $item['feed_name'] ?? null;
+    $bean->feeditem_uuid = $item['feeditem_uuid'] ?? null;
+    $bean->source_url = $item['source_url'] ?? null;
+    $bean->import_uuid = (string) ($item['import_uuid'] ?? '');
 }

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -17,6 +17,7 @@ use function Lamb\Restore\open_source;
 use function Lamb\Restore\origin_id;
 use function Lamb\Restore\parse_restore_args;
 use function Lamb\Restore\read_entry;
+use function Lamb\Restore\restore_assets;
 use function Lamb\Restore\read_manifest;
 use function Lamb\Restore\restore_uuid;
 use function Lamb\Restore\safe_entry_path;
@@ -594,6 +595,106 @@ class LambRestoreTest extends TestCase
 
         $this->assertSame(5, R::count('post'));
         $this->assertSame('2026-07-14 09:30:00', R::findOne('post', ' slug = ? ', ['hello-world'])->created);
+    }
+
+    private function pngBytes(): string
+    {
+        $image = imagecreatetruecolor(4, 3);
+        ob_start();
+        imagepng($image);
+        imagedestroy($image);
+
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * @param array<string, string> $entries In-archive asset path => bytes.
+     * @return array{0: array{restored:int,skipped:int,rejected:int}, 1: string}
+     */
+    private function restoreAssets(array $entries, bool $dry_run = false): array
+    {
+        $manifest = $this->manifest(['assets' => array_keys($entries)]);
+        [, $reader] = open_source($this->zip(
+            ['manifest.json' => (string) json_encode($manifest)] + $entries,
+            'assets-' . bin2hex(random_bytes(4)) . '.zip'
+        ));
+        $root = "$this->tmp_dir/assets_dest";
+
+        return [restore_assets($manifest, $root, $reader, $dry_run), $root];
+    }
+
+    public function testRestoreAssetsWritesFilesUnderTheirDatedDirectory(): void
+    {
+        $bytes = $this->pngBytes();
+        [$tally, $root] = $this->restoreAssets(['assets/2026/07/photo.png' => $bytes]);
+
+        $this->assertSame(['restored' => 1, 'skipped' => 0, 'rejected' => 0], $tally);
+        $this->assertSame($bytes, file_get_contents("$root/2026/07/photo.png"));
+    }
+
+    public function testRestoreAssetsRefusesAnExecutableExtension(): void
+    {
+        [$tally, $root] = $this->restoreAssets(['assets/2026/07/shell.php' => '<?php echo 1;']);
+
+        $this->assertSame(1, $tally['rejected']);
+        $this->assertFalse(is_file("$root/2026/07/shell.php"));
+    }
+
+    public function testRestoreAssetsRefusesContentThatDoesNotMatchItsExtension(): void
+    {
+        [$tally, $root] = $this->restoreAssets([
+            'assets/2026/07/evil.png' => '<html><body><script>alert(1)</script></body></html>',
+        ]);
+
+        $this->assertSame(1, $tally['rejected']);
+        $this->assertFalse(is_file("$root/2026/07/evil.png"));
+        $this->assertSame([], glob("$root/2026/07/*") ?: []);
+    }
+
+    public function testRestoreAssetsRefusesAPathOutsideTheAssetLayout(): void
+    {
+        $manifest = $this->manifest(['assets' => ['assets/2026/07/../../x.php']]);
+        [, $reader] = open_source($this->zip([
+            'manifest.json' => (string) json_encode($manifest),
+        ], 'traversal.zip'));
+        $root = "$this->tmp_dir/assets_dest";
+
+        $tally = restore_assets($manifest, $root, $reader, false);
+
+        $this->assertSame(1, $tally['rejected']);
+        $this->assertFalse(is_file("$this->tmp_dir/x.php"));
+    }
+
+    public function testRestoreAssetsNeverOverwritesAnExistingFile(): void
+    {
+        $root = "$this->tmp_dir/assets_dest";
+        mkdir("$root/2026/07", 0777, true);
+        file_put_contents("$root/2026/07/photo.png", 'keep me');
+
+        [$tally] = $this->restoreAssets(['assets/2026/07/photo.png' => $this->pngBytes()]);
+
+        $this->assertSame(1, $tally['skipped']);
+        $this->assertSame('keep me', file_get_contents("$root/2026/07/photo.png"));
+    }
+
+    public function testRestoreAssetsSkipsAnAssetMissingFromTheArchive(): void
+    {
+        $manifest = $this->manifest(['assets' => ['assets/2026/07/gone.png']]);
+        [, $reader] = open_source($this->zip([
+            'manifest.json' => (string) json_encode($manifest),
+        ], 'no-assets.zip'));
+
+        $tally = restore_assets($manifest, "$this->tmp_dir/assets_dest", $reader, false);
+
+        $this->assertSame(['restored' => 0, 'skipped' => 1, 'rejected' => 0], $tally);
+    }
+
+    public function testRestoreAssetsWritesNothingOnADryRun(): void
+    {
+        [$tally, $root] = $this->restoreAssets(['assets/2026/07/photo.png' => $this->pngBytes()], true);
+
+        $this->assertSame(1, $tally['restored']);
+        $this->assertFalse(is_dir($root));
     }
 
     public function testParseRestoreArgsReadsTheFlags(): void

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -224,6 +224,31 @@ class LambRestoreTest extends TestCase
         $this->assertStringNotContainsString('replaced=', $output);
     }
 
+    public function testRunImportIgnoresReplaceWithoutALookup(): void
+    {
+        $existing = R::dispense('post');
+        $existing->body = 'Already here.';
+        $existing->feeditem_uuid = 'u1';
+        R::store($existing);
+
+        // A three-parameter importer, as import-wordpress.php and
+        // import-known.php supply: it cannot accept the bean to replace, so
+        // handing it one would silently create a duplicate instead.
+        $output = $this->captureImport(
+            [['uuid' => 'u1', 'title' => 'One']],
+            static function (array $item, callable $downloader, bool $dry_run): \RedBeanPHP\OODBBean {
+                $bean = R::dispense('post');
+                $bean->body = 'Duplicate.';
+                R::store($bean);
+                return $bean;
+            },
+            [null, true],
+        );
+
+        $this->assertStringContainsString('created=0 existed=1 skipped=0 total=1', $output);
+        $this->assertSame(1, R::count('post'));
+    }
+
     public function testSafeEntryPathAcceptsTheExportLayout(): void
     {
         $this->assertSame('manifest.json', safe_entry_path('manifest.json'));
@@ -247,6 +272,8 @@ class LambRestoreTest extends TestCase
             ['posts/2026/07/notes.txt'],
             ['README.md'],
             ['assets/2026/07/'],
+            ["assets/2026/07/photo.jpg\n"],
+            ["posts/2026/07/hello.md\n"],
         ];
     }
 
@@ -357,6 +384,40 @@ class LambRestoreTest extends TestCase
         );
     }
 
+    public function testAManifestSuppliedImportUuidIsIgnored(): void
+    {
+        $manifest = $this->manifest([
+            'posts' => [
+                ['path' => 'posts/2026/07/hello.md', 'id' => 7, 'import_uuid' => 'attacker-chosen'],
+            ],
+        ]);
+        [, $reader] = open_source($this->zip([
+            'manifest.json'          => (string) json_encode($manifest),
+            'posts/2026/07/hello.md' => "Hello.\n",
+        ], 'forged-uuid.zip'));
+
+        $items = manifest_items($manifest, $reader, 'https://example.test');
+
+        $this->assertSame(restore_uuid('https://example.test', 7), $items[0]['import_uuid']);
+    }
+
+    public function testAManifestSuppliedBodyIsIgnored(): void
+    {
+        $manifest = $this->manifest([
+            'posts' => [
+                ['path' => 'posts/2026/07/gone.md', 'id' => 1, 'body' => 'Injected body.'],
+            ],
+        ]);
+        [, $reader] = open_source($this->zip([
+            'manifest.json' => (string) json_encode($manifest),
+        ], 'forged-body.zip'));
+
+        $items = manifest_items($manifest, $reader, 'https://example.test');
+
+        $this->assertNull($items[0]['body']);
+        $this->assertSame('missing file', item_skip_reason($items[0]));
+    }
+
     /**
      * The post shape build_export_archive() consumes, matching collect_posts().
      *
@@ -435,14 +496,18 @@ class LambRestoreTest extends TestCase
     /**
      * @param list<array<string, mixed>>|null $posts
      */
-    private function buildArchive(?array $posts = null, string $url = 'https://example.test', string $name = 'export.zip'): string
-    {
+    private function buildArchive(
+        ?array $posts = null,
+        string $url = 'https://example.test',
+        string $name = 'export.zip',
+        string $exported_at = '2026-07-29T10:00:00+00:00'
+    ): string {
         $path = "$this->tmp_dir/$name";
         build_export_archive(
             $posts ?? $this->samplePosts(),
             $this->assetsRoot(),
             $path,
-            '2026-07-29T10:00:00+00:00',
+            $exported_at,
             ['title' => 'Notes', 'url' => $url],
         );
 
@@ -554,6 +619,15 @@ class LambRestoreTest extends TestCase
         $this->assertSame(1, R::count('post'));
     }
 
+    public function testTwoArchivesWithoutASiteUrlDoNotCollide(): void
+    {
+        $posts = [$this->post()];
+        $this->importArchive($this->buildArchive($posts, '', 'no-site-a.zip', '2026-07-29T10:00:00+00:00'));
+        $this->importArchive($this->buildArchive($posts, '', 'no-site-b.zip', '2026-06-01T08:00:00+00:00'));
+
+        $this->assertSame(2, R::count('post'));
+    }
+
     public function testTheSiteUrlOverrideNamespacesTheImport(): void
     {
         $archive = $this->buildArchive([$this->post()], '', 'no-site.zip');
@@ -561,6 +635,26 @@ class LambRestoreTest extends TestCase
         $this->importArchive($archive, false, 'https://restored.test');
 
         $this->assertSame(2, R::count('post'));
+    }
+
+    public function testASlugCollisionRewritesTheSlugWithoutRedatingThePost(): void
+    {
+        // finalize_slug() suffixes the slug and rewrites the body's front
+        // matter, so finalize_and_store_post() stores a second time. The
+        // manifest's dates must survive that store, not be re-stamped.
+        $local = R::dispense('post');
+        $local->slug = 'hello-world';
+        $local->body = "---\nslug: hello-world\n---\n\nMine.\n";
+        R::store($local);
+
+        $this->importArchive($this->buildArchive([$this->post()], 'https://example.test', 'clash.zip'));
+
+        $restored = R::findOne('post', ' import_uuid IS NOT NULL ');
+        $this->assertNotNull($restored);
+        $this->assertSame('hello-world-' . $restored->id, $restored->slug);
+        $this->assertStringContainsString('slug: hello-world-' . $restored->id, (string) $restored->body);
+        $this->assertSame('2026-07-14 09:30:00', $restored->created);
+        $this->assertSame('2026-07-15 11:00:00', $restored->updated);
     }
 
     public function testAManifestPathWithNoArchiveEntryIsSkipped(): void
@@ -695,6 +789,16 @@ class LambRestoreTest extends TestCase
         [$tally, $root] = $this->restoreAssets(['assets/2026/07/photo.png' => $this->pngBytes()], true);
 
         $this->assertSame(1, $tally['restored']);
+        $this->assertFalse(is_dir($root));
+    }
+
+    public function testRestoreAssetsRejectsMismatchedContentOnADryRunToo(): void
+    {
+        [$tally, $root] = $this->restoreAssets([
+            'assets/2026/07/evil.jpg' => '<html><body><script>alert(1)</script></body></html>',
+        ], true);
+
+        $this->assertSame(['restored' => 0, 'skipped' => 0, 'rejected' => 1], $tally);
         $this->assertFalse(is_dir($root));
     }
 

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
 use function Lamb\Bootstrap\ensure_post_columns;
+use function Lamb\Import\run_import;
 
 /**
  * Covers the Lamb export importer: archive reading and validation, the
@@ -43,5 +44,88 @@ class LambRestoreTest extends TestCase
         ensure_post_columns();
 
         $this->assertContains('import_uuid', $this->postColumns());
+    }
+
+    /**
+     * @param list<array<string, mixed>> $items
+     * @param array<int, mixed>          $extra Trailing run_import() arguments.
+     */
+    private function captureImport(array $items, callable $import, array $extra = []): string
+    {
+        ob_start();
+        run_import(
+            $items,
+            static fn(array $item): ?string => $item['skip'] ?? null,
+            static fn(array $item): string => (string) $item['uuid'],
+            $import,
+            false,
+            ...$extra
+        );
+
+        return (string) ob_get_clean();
+    }
+
+    public function testRunImportStillDedupesOnFeeditemUuidWithoutALookup(): void
+    {
+        $existing = R::dispense('post');
+        $existing->body = 'Already here.';
+        $existing->feeditem_uuid = 'u1';
+        R::store($existing);
+
+        $output = $this->captureImport(
+            [['uuid' => 'u1', 'title' => 'One']],
+            static fn(): ?\RedBeanPHP\OODBBean => null,
+        );
+
+        $this->assertStringContainsString('created=0 existed=1 skipped=0 total=1', $output);
+        $this->assertSame(1, R::count('post'));
+    }
+
+    public function testRunImportReportsAConversionFailureForAnItemWithoutATitle(): void
+    {
+        $output = $this->captureImport(
+            [['uuid' => 'u1']],
+            static fn(): ?\RedBeanPHP\OODBBean => null,
+        );
+
+        $this->assertStringContainsString('skipped (conversion failed):', $output);
+        $this->assertStringContainsString('created=0 existed=0 skipped=1 total=1', $output);
+    }
+
+    public function testRunImportReplacesThroughAnInjectedLookup(): void
+    {
+        $existing = R::dispense('post');
+        $existing->body = 'Old body.';
+        $existing->import_uuid = 'u1';
+        R::store($existing);
+
+        $seen = null;
+        $output = $this->captureImport(
+            [['uuid' => 'u1', 'title' => 'One']],
+            static function (array $item, callable $downloader, bool $dry_run, ?\RedBeanPHP\OODBBean $bean = null) use (&$seen): ?\RedBeanPHP\OODBBean {
+                $seen = $bean;
+                $bean->body = 'New body.';
+                R::store($bean);
+                return $bean;
+            },
+            [static fn(string $uuid): ?\RedBeanPHP\OODBBean => R::findOne('post', ' import_uuid = ? ', [$uuid]), true],
+        );
+
+        $this->assertNotNull($seen);
+        $this->assertStringContainsString('replaced=1', $output);
+        $this->assertSame(1, R::count('post'));
+        $this->assertSame('New body.', R::load('post', $existing->id)->body);
+    }
+
+    public function testRunImportKeepsTheSummaryUnchangedWhenReplaceIsOff(): void
+    {
+        $output = $this->captureImport(
+            [['uuid' => 'u1', 'title' => 'One']],
+            static function (array $item): \RedBeanPHP\OODBBean {
+                return R::dispense('post');
+            },
+        );
+
+        $this->assertStringNotContainsString('replaced=', $output);
     }
 }

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -8,7 +8,11 @@ use RuntimeException;
 use ZipArchive;
 
 use function Lamb\Bootstrap\ensure_post_columns;
+use function Lamb\Export\build_export_archive;
 use function Lamb\Import\run_import;
+use function Lamb\Restore\import_post;
+use function Lamb\Restore\item_skip_reason;
+use function Lamb\Restore\manifest_items;
 use function Lamb\Restore\open_source;
 use function Lamb\Restore\origin_id;
 use function Lamb\Restore\parse_restore_args;
@@ -349,6 +353,247 @@ class LambRestoreTest extends TestCase
             restore_uuid('https://example.test', 7),
             restore_uuid('https://other.test', 7)
         );
+    }
+
+    /**
+     * The post shape build_export_archive() consumes, matching collect_posts().
+     *
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function post(array $overrides = []): array
+    {
+        return $overrides + [
+            'id'            => 1,
+            'slug'          => 'hello-world',
+            'body'          => "---\ntitle: Hello World\nslug: hello-world\n---\n\nBody text.\n",
+            'created'       => '2026-07-14 09:30:00',
+            'updated'       => '2026-07-15 11:00:00',
+            'draft'         => false,
+            'deleted'       => false,
+            'deleted_at'    => null,
+            'version'       => 3,
+            'feed_name'     => null,
+            'feeditem_uuid' => null,
+            'source_url'    => null,
+        ];
+    }
+
+    /**
+     * The posts the round-trip exercises: every state the manifest records.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function samplePosts(): array
+    {
+        return [
+            $this->post(),
+            $this->post([
+                'id'   => 2,
+                'slug' => 'work-in-progress',
+                'body' => "---\ntitle: Work in progress\nslug: work-in-progress\n---\n\nNot done.\n",
+                'draft' => true,
+            ]),
+            $this->post([
+                'id'   => 3,
+                'slug' => 'regrets',
+                'body' => "---\ntitle: Regrets\nslug: regrets\n---\n\nBinned.\n",
+                'deleted' => true,
+                'deleted_at' => '2026-07-20 08:00:00',
+            ]),
+            $this->post([
+                'id'   => 4,
+                'slug' => '',
+                'body' => "Just a status.\n",
+            ]),
+            $this->post([
+                'id'   => 5,
+                'slug' => 'with-a-photo',
+                'body' => "---\nslug: with-a-photo\n---\n\n![](/assets/2026/07/photo.png)\n",
+            ]),
+        ];
+    }
+
+    /**
+     * An uploads tree holding the one asset samplePosts() references.
+     */
+    private function assetsRoot(): string
+    {
+        $root = "$this->tmp_dir/assets_src";
+        if (!is_dir("$root/2026/07")) {
+            mkdir("$root/2026/07", 0777, true);
+        }
+        $image = imagecreatetruecolor(4, 3);
+        imagepng($image, "$root/2026/07/photo.png");
+        imagedestroy($image);
+
+        return $root;
+    }
+
+    /**
+     * @param list<array<string, mixed>>|null $posts
+     */
+    private function buildArchive(?array $posts = null, string $url = 'https://example.test', string $name = 'export.zip'): string
+    {
+        $path = "$this->tmp_dir/$name";
+        build_export_archive(
+            $posts ?? $this->samplePosts(),
+            $this->assetsRoot(),
+            $path,
+            '2026-07-29T10:00:00+00:00',
+            ['title' => 'Notes', 'url' => $url],
+        );
+
+        return $path;
+    }
+
+    /**
+     * Runs the importer over an archive the way import-lamb.php does.
+     */
+    private function importArchive(string $path, bool $replace = false, ?string $site_url = null): string
+    {
+        [, $reader] = open_source($path);
+        $manifest = read_manifest($reader);
+        $items = manifest_items($manifest, $reader, origin_id($manifest, $site_url));
+
+        ob_start();
+        run_import(
+            $items,
+            item_skip_reason(...),
+            static fn(array $item): string => (string) $item['import_uuid'],
+            import_post(...),
+            false,
+            static fn(string $uuid): ?\RedBeanPHP\OODBBean => R::findOne('post', ' import_uuid = ? ', [$uuid]),
+            $replace,
+        );
+
+        return (string) ob_get_clean();
+    }
+
+    public function testRoundTripRestoresEveryPostState(): void
+    {
+        $this->importArchive($this->buildArchive());
+
+        $this->assertSame(5, R::count('post'));
+
+        $hello = R::findOne('post', ' slug = ? ', ['hello-world']);
+        $this->assertNotNull($hello);
+        $this->assertSame("---\ntitle: Hello World\nslug: hello-world\n---\n\nBody text.\n", $hello->body);
+        $this->assertSame('2026-07-14 09:30:00', $hello->created);
+        $this->assertSame('2026-07-15 11:00:00', $hello->updated);
+        $this->assertSame(0, (int) $hello->draft);
+        $this->assertSame(0, (int) $hello->deleted);
+
+        $draft = R::findOne('post', ' slug = ? ', ['work-in-progress']);
+        $this->assertSame(1, (int) $draft->draft);
+
+        $trashed = R::findOne('post', ' slug = ? ', ['regrets']);
+        $this->assertSame(1, (int) $trashed->deleted);
+        $this->assertSame('2026-07-20 08:00:00', $trashed->deleted_at);
+
+        $status = R::findOne('post', ' body LIKE ? ', ['%Just a status%']);
+        $this->assertNotNull($status);
+        $this->assertSame('', (string) $status->slug);
+
+        $photo = R::findOne('post', ' slug = ? ', ['with-a-photo']);
+        $this->assertStringContainsString('/assets/2026/07/photo.png', (string) $photo->body);
+    }
+
+    public function testReimportingTheSameArchiveChangesNothing(): void
+    {
+        $archive = $this->buildArchive();
+        $this->importArchive($archive);
+        $output = $this->importArchive($archive);
+
+        $this->assertSame(5, R::count('post'));
+        $this->assertStringContainsString('created=0 existed=5', $output);
+    }
+
+    public function testReplaceOverwritesLocalEditsAndRestoresTrashState(): void
+    {
+        $archive = $this->buildArchive();
+        $this->importArchive($archive);
+
+        $edited = R::findOne('post', ' slug = ? ', ['hello-world']);
+        $edited->body = "---\ntitle: Hello World\nslug: hello-world\n---\n\nLocally edited.\n";
+        R::store($edited);
+        $untrashed = R::findOne('post', ' slug = ? ', ['regrets']);
+        $untrashed->deleted = 0;
+        $untrashed->deleted_at = null;
+        R::store($untrashed);
+
+        $output = $this->importArchive($archive, true);
+
+        $this->assertStringContainsString('replaced=5', $output);
+        $this->assertSame(5, R::count('post'));
+        $this->assertSame(
+            "---\ntitle: Hello World\nslug: hello-world\n---\n\nBody text.\n",
+            R::load('post', $edited->id)->body
+        );
+        $this->assertSame(1, (int) R::load('post', $untrashed->id)->deleted);
+        $this->assertSame('2026-07-20 08:00:00', R::load('post', $untrashed->id)->deleted_at);
+    }
+
+    public function testArchivesFromDifferentSitesDoNotCollide(): void
+    {
+        $posts = [$this->post()];
+        $this->importArchive($this->buildArchive($posts, 'https://example.test', 'a.zip'));
+        $this->importArchive($this->buildArchive($posts, 'https://other.test', 'b.zip'));
+
+        $this->assertSame(2, R::count('post'));
+    }
+
+    public function testAnArchiveWithoutASiteUrlStillImportsAndDedupes(): void
+    {
+        $archive = $this->buildArchive([$this->post()], '', 'no-site.zip');
+        $this->importArchive($archive);
+        $this->importArchive($archive);
+
+        $this->assertSame(1, R::count('post'));
+    }
+
+    public function testTheSiteUrlOverrideNamespacesTheImport(): void
+    {
+        $archive = $this->buildArchive([$this->post()], '', 'no-site.zip');
+        $this->importArchive($archive);
+        $this->importArchive($archive, false, 'https://restored.test');
+
+        $this->assertSame(2, R::count('post'));
+    }
+
+    public function testAManifestPathWithNoArchiveEntryIsSkipped(): void
+    {
+        $manifest = $this->manifest([
+            'posts' => [
+                ['path' => 'posts/2026/07/gone.md', 'id' => 1, 'slug' => 'gone', 'created' => '2026-07-01 00:00:00'],
+                ['path' => 'posts/../../evil.md', 'id' => 2],
+                ['path' => 'posts/2026/07/blank.md', 'id' => 3],
+            ],
+        ]);
+        $archive = $this->zip([
+            'manifest.json'            => (string) json_encode($manifest),
+            'posts/2026/07/blank.md'   => "   \n",
+        ]);
+
+        $output = $this->importArchive($archive);
+
+        $this->assertSame(0, R::count('post'));
+        $this->assertStringContainsString('1' . "\t" . 'missing file', $output);
+        $this->assertStringContainsString('1' . "\t" . 'bad path', $output);
+        $this->assertStringContainsString('1' . "\t" . 'empty body', $output);
+    }
+
+    public function testAnUnpackedDirectoryImportsLikeTheZip(): void
+    {
+        $zip = new ZipArchive();
+        $zip->open($this->buildArchive());
+        $zip->extractTo("$this->tmp_dir/unpacked");
+        $zip->close();
+
+        $this->importArchive("$this->tmp_dir/unpacked");
+
+        $this->assertSame(5, R::count('post'));
+        $this->assertSame('2026-07-14 09:30:00', R::findOne('post', ' slug = ? ', ['hello-world'])->created);
     }
 
     public function testParseRestoreArgsReadsTheFlags(): void

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 use RuntimeException;
+use Symfony\Component\Process\Process;
 use ZipArchive;
 
 use function Lamb\Bootstrap\ensure_post_columns;
@@ -695,6 +696,34 @@ class LambRestoreTest extends TestCase
 
         $this->assertSame(1, $tally['restored']);
         $this->assertFalse(is_dir($root));
+    }
+
+    public function testTheCliScriptRunsAnArchiveEndToEnd(): void
+    {
+        $archive = $this->buildArchive();
+        $data_dir = "$this->tmp_dir/data";
+
+        $process = new Process(
+            ['php', codecept_root_dir('import-lamb.php'), $archive, '--dry-run'],
+            codecept_root_dir(),
+            ['LAMB_DATA_DIR' => $data_dir] + getenv(),
+        );
+        $process->run();
+
+        $this->assertSame(0, $process->getExitCode(), $process->getErrorOutput());
+        $this->assertStringContainsString('[dry-run] Done. created=5', $process->getOutput());
+    }
+
+    public function testTheCliScriptRefusesAnArchiveItCannotRead(): void
+    {
+        $process = new Process(
+            ['php', codecept_root_dir('import-lamb.php'), "$this->tmp_dir/absent.zip"],
+            codecept_root_dir(),
+            ['LAMB_DATA_DIR' => "$this->tmp_dir/data"] + getenv(),
+        );
+        $process->run();
+
+        $this->assertSame(1, $process->getExitCode());
     }
 
     public function testParseRestoreArgsReadsTheFlags(): void

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -4,9 +4,20 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
+use RuntimeException;
+use ZipArchive;
 
 use function Lamb\Bootstrap\ensure_post_columns;
 use function Lamb\Import\run_import;
+use function Lamb\Restore\open_source;
+use function Lamb\Restore\origin_id;
+use function Lamb\Restore\parse_restore_args;
+use function Lamb\Restore\read_entry;
+use function Lamb\Restore\read_manifest;
+use function Lamb\Restore\restore_uuid;
+use function Lamb\Restore\safe_entry_path;
+
+use const Lamb\Restore\MAX_ENTRIES;
 
 /**
  * Covers the Lamb export importer: archive reading and validation, the
@@ -14,8 +25,13 @@ use function Lamb\Import\run_import;
  */
 class LambRestoreTest extends TestCase
 {
+    private string $tmp_dir;
+
     protected function setUp(): void
     {
+        $this->tmp_dir = sys_get_temp_dir() . '/lamb_restore_test_' . bin2hex(random_bytes(6));
+        mkdir($this->tmp_dir, 0777, true);
+
         if (!R::testConnection()) {
             R::setup('sqlite::memory:');
         }
@@ -26,6 +42,79 @@ class LambRestoreTest extends TestCase
         $config = $config ?? [];
 
         date_default_timezone_set('UTC');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->tmp_dir);
+    }
+
+    private function removeTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = "$dir/$entry";
+            is_dir($path) ? $this->removeTree($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Writes a zip of `entry name => contents` and returns its path.
+     *
+     * @param array<string, string> $entries
+     */
+    private function zip(array $entries, string $name = 'archive.zip'): string
+    {
+        $path = "$this->tmp_dir/$name";
+        $zip = new ZipArchive();
+        $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        foreach ($entries as $entry => $contents) {
+            $zip->addFromString($entry, $contents);
+        }
+        $zip->close();
+
+        return $path;
+    }
+
+    /**
+     * Writes the same entries as an unpacked directory and returns its path.
+     *
+     * @param array<string, string> $entries
+     */
+    private function tree(array $entries, string $name = 'unpacked'): string
+    {
+        $root = "$this->tmp_dir/$name";
+        foreach ($entries as $entry => $contents) {
+            $dir = dirname("$root/$entry");
+            if (!is_dir($dir)) {
+                mkdir($dir, 0777, true);
+            }
+            file_put_contents("$root/$entry", $contents);
+        }
+
+        return $root;
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function manifest(array $overrides = []): array
+    {
+        return $overrides + [
+            'format'      => 'lamb-export/1',
+            'generator'   => 'lamb',
+            'exported_at' => '2026-07-29T10:00:00+00:00',
+            'site'        => ['title' => 'Notes', 'url' => 'https://example.test'],
+            'posts'       => [],
+            'assets'      => [],
+        ];
     }
 
     /**
@@ -127,5 +216,154 @@ class LambRestoreTest extends TestCase
         );
 
         $this->assertStringNotContainsString('replaced=', $output);
+    }
+
+    public function testSafeEntryPathAcceptsTheExportLayout(): void
+    {
+        $this->assertSame('manifest.json', safe_entry_path('manifest.json'));
+        $this->assertSame('posts/2026/07/hello-world.md', safe_entry_path('posts/2026/07/hello-world.md'));
+        $this->assertSame('assets/2026/07/photo.webp', safe_entry_path('assets/2026/07/photo.webp'));
+    }
+
+    /**
+     * @return list<array{0: string}>
+     */
+    public static function unsafeEntryPaths(): array
+    {
+        return [
+            ['posts/../../evil.md'],
+            ['assets/2026/07/../../x.php'],
+            ['assets/2026/07/..'],
+            ['/etc/passwd'],
+            ['posts/2026/07/.hidden.md'],
+            ['posts/2026/7/short-month.md'],
+            ['posts/2026/07/nested/deep.md'],
+            ['posts/2026/07/notes.txt'],
+            ['README.md'],
+            ['assets/2026/07/'],
+        ];
+    }
+
+    /**
+     * @dataProvider unsafeEntryPaths
+     */
+    public function testSafeEntryPathRefusesAnythingElse(string $name): void
+    {
+        $this->assertNull(safe_entry_path($name));
+    }
+
+    public function testOpenSourceListsAndReadsZipEntries(): void
+    {
+        [$names, $reader] = open_source($this->zip([
+            'manifest.json'              => '{}',
+            'posts/2026/07/hello.md'     => 'Hello.',
+            'assets/2026/07/photo.webp'  => 'bytes',
+        ]));
+
+        sort($names);
+        $this->assertSame(
+            ['assets/2026/07/photo.webp', 'manifest.json', 'posts/2026/07/hello.md'],
+            $names
+        );
+        $this->assertSame('Hello.', read_entry($reader, 'posts/2026/07/hello.md'));
+        $this->assertNull(read_entry($reader, 'posts/2026/07/absent.md'));
+    }
+
+    public function testOpenSourceReadsAnUnpackedDirectory(): void
+    {
+        [$names, $reader] = open_source($this->tree([
+            'manifest.json'          => '{}',
+            'posts/2026/07/hello.md' => 'Hello.',
+        ]));
+
+        sort($names);
+        $this->assertSame(['manifest.json', 'posts/2026/07/hello.md'], $names);
+        $this->assertSame('Hello.', read_entry($reader, 'posts/2026/07/hello.md'));
+    }
+
+    public function testOpenSourceRejectsAnUnreadableSource(): void
+    {
+        $this->expectException(RuntimeException::class);
+        open_source("$this->tmp_dir/nope.zip");
+    }
+
+    public function testOpenSourceRejectsAnArchiveWithTooManyEntries(): void
+    {
+        $entries = [];
+        for ($i = 0; $i <= MAX_ENTRIES; $i++) {
+            $entries["posts/2026/07/post-$i.md"] = '';
+        }
+
+        $this->expectExceptionMessageMatches('/more than ' . MAX_ENTRIES . ' entries/');
+        open_source($this->zip($entries, 'huge.zip'));
+    }
+
+    public function testReadManifestReturnsTheDecodedDocument(): void
+    {
+        [, $reader] = open_source($this->zip([
+            'manifest.json' => (string) json_encode($this->manifest()),
+        ]));
+
+        $this->assertSame('lamb-export/1', read_manifest($reader)['format']);
+    }
+
+    public function testReadManifestRejectsAnUnsupportedFormat(): void
+    {
+        [, $reader] = open_source($this->zip([
+            'manifest.json' => (string) json_encode($this->manifest(['format' => 'lamb-export/2'])),
+        ]));
+
+        $this->expectException(RuntimeException::class);
+        read_manifest($reader);
+    }
+
+    public function testReadManifestRejectsInvalidJson(): void
+    {
+        [, $reader] = open_source($this->zip(['manifest.json' => 'not json']));
+
+        $this->expectException(RuntimeException::class);
+        read_manifest($reader);
+    }
+
+    public function testReadManifestRejectsAnArchiveWithoutOne(): void
+    {
+        [, $reader] = open_source($this->zip(['posts/2026/07/hello.md' => 'Hello.']));
+
+        $this->expectException(RuntimeException::class);
+        read_manifest($reader);
+    }
+
+    public function testOriginIdPrefersTheOverrideAndNormalises(): void
+    {
+        $manifest = $this->manifest();
+
+        $this->assertSame('https://example.test', origin_id($manifest, null));
+        $this->assertSame('https://other.test', origin_id($manifest, 'HTTPS://Other.test/'));
+        $this->assertSame('', origin_id($this->manifest(['site' => []]), null));
+    }
+
+    public function testRestoreUuidIsStablePerOriginAndId(): void
+    {
+        $this->assertSame(md5('lamb-https://example.test#7'), restore_uuid('https://example.test', 7));
+        $this->assertNotSame(
+            restore_uuid('https://example.test', 7),
+            restore_uuid('https://other.test', 7)
+        );
+    }
+
+    public function testParseRestoreArgsReadsTheFlags(): void
+    {
+        $this->assertSame(
+            ['backup.zip', true, true, 'https://example.test'],
+            parse_restore_args([
+                'import-lamb.php',
+                'backup.zip',
+                '--dry-run',
+                '--replace',
+                '--site-url=https://example.test',
+            ])
+        );
+        $this->assertSame(['backup.zip', false, false, null], parse_restore_args(['x', 'backup.zip']));
+        $this->assertSame([null, false, false, null], parse_restore_args(['x', '--help']));
     }
 }

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Bootstrap\ensure_post_columns;
+
+/**
+ * Covers the Lamb export importer: archive reading and validation, the
+ * manifest → post restore, and asset restoration.
+ */
+class LambRestoreTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        global $config;
+        $config = $config ?? [];
+
+        date_default_timezone_set('UTC');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function postColumns(): array
+    {
+        return array_column(R::getAll('PRAGMA table_info(post)'), 'name');
+    }
+
+    public function testEnsurePostColumnsAddsTheImportUuidColumn(): void
+    {
+        R::exec('CREATE TABLE post (id INTEGER PRIMARY KEY AUTOINCREMENT, body TEXT)');
+        $this->assertNotContains('import_uuid', $this->postColumns());
+
+        ensure_post_columns();
+
+        $this->assertContains('import_uuid', $this->postColumns());
+    }
+}


### PR DESCRIPTION
Closes #554. The inverse of `/export` (#552): a CLI importer that reads a `lamb-export/1` archive back in, for backup restore and lamb→lamb migration.

```bash
php import-lamb.php path/to/lamb-export-2026-07-26.zip [--dry-run] [--replace] [--site-url=<url>]
```

An unzipped directory works as well as a `.zip` — a partially recovered backup is often already unpacked. Like the WordPress and Known importers, it emits no webmentions and no WebSub pings: restored posts are pre-existing content, not new publications.

Draft because it has not been exercised against a real archive from a real install yet — only the round-trip tests. See **Before merging** below.

## The two decisions the issue left open

**Dedupe key: a new `import_uuid` column**, not the slug and not `feeditem_uuid`. Reusing `feeditem_uuid` was rejected because `lock_if_feed_sourced()` (`src/response/posts.php:329`) sets `feed_locked` on any post with a non-empty `feeditem_uuid` when it is edited — synthesising one for a locally authored post would silently change its behaviour. The column is added through the existing `Bootstrap\ensure_post_columns()` idiom, so no new migration machinery.

Identity is `md5('lamb-' . origin . '#' . source_id)`. The origin comes from the manifest's `site.url`, which the exporter already records — so no format change, `lamb-export/1` is untouched. `--site-url=` overrides it, because `ROOT_URL` is host-derived and the same install reached on two hostnames would otherwise yield two origins.

**`--replace` overwrites everything the manifest describes** — body, slug, created/updated, draft, deleted/deleted_at, feed provenance. A restore that leaves a post published when the backup says it was trashed is not a restore. Local edits since the backup are lost; that is what replace means, and the docs say so plainly.

## Untrusted input

The archive may not be one this install produced.

**The archive is never extracted.** Entries are read in place through a reader closure, so there is no temp directory and no zip-slip surface to defend — `ZipArchive::extractTo()` is never called and every destination path is rebuilt from validated `YYYY/MM/<name>` components rather than from an archive entry name. The manifest's `path` is not trusted either: it is cross-checked against what the archive actually contains, and an entry that is not there is reported as a missing file rather than restored as an empty post.

Assets are gated twice — `Response\safe_upload_extension()` on the name and a content sniff on the bytes — so a `.php`, or an HTML-sniffing `.jpg`, cannot land under the web root. Existing files are never overwritten. Entry-count and uncompressed-size caps bound zip bombs, checked against zip metadata before anything is read.

## Review found a real bug

An adversarial review of this branch caught a manifest-controlled dedupe bypass. `manifest_items()` built each item with `$post + [...]`, and PHP's array union keeps the **left** operand's keys — so a manifest supplying its own `import_uuid` kept it, bypassing origin namespacing entirely. With `--replace`, a hostile archive could overwrite a post restored earlier from a different site. A supplied `body` key was likewise honoured without the archive ever being read. Fixed by computing last (`array_merge`), with tests for both.

Three others fixed in the same commit:

- `--dry-run` skipped the content sniff, so an HTML-bodied `.jpg` reported `restored=1 rejected=0` on the dry run and `restored=0 rejected=1` for real. Dry-run is the documented "use this first" mode, so its tally has to match.
- Two archives with no `site.url` shared an empty origin, so restoring the second silently reported `existed=50 created=0` and dropped all of it. Empty origins are now salted per-archive from the manifest, which keeps re-runs idempotent without needing a flag.
- `run_import()`'s replace branch is gated on a lookup actually being supplied. Left ungated it would not have thrown — PHP accepts extra arguments to userland functions — it would have silently created a duplicate row and reported it as `replaced`.

## Shared code

`Import\run_import()` gained two optional parameters (an injectable existing-row lookup, and a replace flag) rather than `src/restore.php` owning a private loop, so all three importers keep byte-identical progress and summary output. Both existing importers pass five arguments and are unaffected; there is a regression test pinning that.

## Testing

`tests/Unit/LambRestoreTest.php`, 52 new tests. The headline is a genuine round trip: build posts (published, draft, trashed with `deleted_at`, slugless status, one with an asset), run them through `Export\build_export_archive()`, nuke the database, import, and assert bodies, slugs, dates and draft/trash state all survive.

Plus: re-import is idempotent; `--replace` overwrites a local edit and re-trashes an untrashed post; two archives with different `site.url` and the same post id produce two rows; a forged `import_uuid` and a forged `body` are both ignored; traversal, absolute, encoded and null-byte entry paths are refused; a `.php` asset and an HTML-sniffing `.jpg` are rejected with nothing written; caps fire; a directory source matches the zip.

One test exists specifically to pin a conclusion the design relies on: a local post is pre-created with a colliding slug, and the restored post is asserted to get `hello-world-<id>` **while still keeping the manifest's `created`/`updated`**. Without it, the "no second store needed" argument had no safety net, because every other fixture pins a slug that never triggers a body rewrite.

`composer lint` clean, `composer analyse` (PHPStan level 8) clean with no baseline additions, 1574 unit tests pass (1522 before), coverage 82.68%.

## Known limitation

A post that had no slug gets a new `/status/<new id>` URL, because source ids cannot be restored into a populated database. Only the URL is affected — dedupe is on the manifest's source id, so it still imports exactly once however often you re-run. Documented in `docs/lamb-import.md`.

## Before merging

- [ ] Run against a real export from a real install, not just the test fixtures
- [ ] Try a merge into a populated database, not only a clean restore
- [ ] Confirm the docs page reads right once Pages rebuilds (it builds from `release`, so this will not be live until the next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMVaMWvgozaAViNV7iXiWG