### PR TITLE
Stop modelling imported posts as feed items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Each file declares a namespace; functions are called with the namespace prefix:
 RedBeanPHP (fluid mode) on SQLite. Beans are dispensed/loaded with `R::dispense`, `R::load`, `R::findOne`, `R::find`, `R::findAll`. Schema evolves automatically.
 
 **Tables used:**
-- `post` — blog posts; columns include `body`, `slug`, `title`, `description`, `transformed`, `created`, `updated`, `version`, `feed_name`, `feeditem_uuid`, `source_url`
+- `post` — blog posts; columns include `body`, `slug`, `title`, `description`, `transformed`, `created`, `updated`, `version`, `feed_name`, `feeditem_uuid`, `import_uuid`, `source_url`
 - `option` — key/value store (e.g. `site_config_ini`, `last_processed_date`, `login_fail_*` throttle counters)
 - `redirect` — automatic 301 redirects created when a post slug changes; columns: `from_slug`, `to_url`
 - `webmention` — received (inbound) webmentions; columns: `source`, `target`, `post_id`, `type`, `author`, `content`, `status`, `created`, `verified_at`
@@ -292,6 +292,7 @@ index.php
 | `$bean->updated` | Datetime string |
 | `$bean->feed_name` | Source feed name (only present for ingested feed items) |
 | `$bean->feeditem_uuid` | MD5 dedup key (only for feed items) |
+| `$bean->import_uuid` | MD5 dedup key for posts brought in by an importer (WordPress, Known, lamb export) |
 | `$bean->source_url` | Permalink of the original feed item (only for feed items; used by `link_source()`) |
 | `$bean->is_menu_item` | Truthy if the post is pinned as a menu item |
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -23,6 +23,21 @@ WXR was rejected: it is WordPress's schema, has no clean home for Lamb's draft/d
 
 ---
 
+## 2026-07-29 — Imported posts are your own content, not feed items
+
+**Status:** Accepted
+**Context:** The WordPress and Known importers stamped every migrated post with `feed_name = 'wordpress'`/`'known'` and a `feeditem_uuid`, borrowing the feed-ingest columns to get re-run dedup for free. Neither importer sets `source_url`, so `Theme\link_source()` took its plain-text branch and every migrated post publicly read "Via wordpress" / "Via known". Worse, `Webmention\enqueue_for_post()` and `WebSub\ping_for_post()` both bail on a non-empty `feed_name`, and the WebSub ping query excludes those rows — so a migrated post could never send a webmention or a WebSub ping, not even when edited years later. `lock_if_feed_sourced()` would also feed-lock them on first edit: exactly the trap the lamb-export importer had already refused to walk into.
+
+**Decision:** Both importers now write their dedup key to `import_uuid` — the column the lamb-export importer added — and set no feed identity at all. The `'wordpress-'`/`'known-'` prefixes stay, so the three importers keep separate dedup namespaces. Suppressing outbound notifications during an import run is still correct, and still happens the same way: `import_item()` stops at `finalize_and_store_post()`, which never calls `notify_post_subscribers()`. What is no longer true is that the suppression is permanent.
+
+With all three importers supplying their own lookup, `run_import()`'s `$find_existing` parameter became required and its `feeditem_uuid` fallback was deleted — one dedup concept instead of two.
+
+Installs that already ran an import are migrated on boot by `Bootstrap\backfill_imported_post_identity()`. It only touches rows with `source_url IS NULL`, because a user may legitimately subscribe to a feed literally named `wordpress` or `known`: feed ingestion always records the item permalink in `source_url` (`src/post.php`), the importers never did. `bootstrap_db()` runs before `Config\load()`, so the configured feed names cannot be consulted there — the `source_url` guard is the only discriminator available, and mangling someone's real feed posts would be far worse than leaving a cosmetic attribution line in place.
+
+**Consequences:** Migrated posts render without attribution and participate in webmentions and WebSub like any other post. The backfill is idempotent and skips a row whose uuid another post already claims, so it is safe to run on every boot, matching the existing `UPDATE post SET version = 1 WHERE version IS NULL` precedent.
+
+---
+
 ## 2026-07-29 — Lamb export import identity via a separate `import_uuid` column
 
 **Status:** Accepted
@@ -31,7 +46,7 @@ WXR was rejected: it is WordPress's schema, has no clean home for Lamb's draft/d
 It was rejected. `lock_if_feed_sourced()` (`src/response/posts.php:329`) sets `feed_locked` on any post with a non-empty `feeditem_uuid` when it is edited, to stop hand-editing content a feed will overwrite on the next cron run. A restored local post is not feed-sourced — nothing will overwrite it — so giving it a `feeditem_uuid` to get free dedup would also silently feed-lock it, changing edit behaviour for a post that never subscribed to anything.
 
 **Decision:** Add a dedicated `import_uuid` column (`Bootstrap\ensure_post_columns()`, `src/bootstrap.php`), computed as `md5('lamb-' . $origin . '#' . $source_id)`. `$origin` is the exporting site's URL (from the manifest's `site.url`, or `--site-url` when given) rather than `ROOT_URL`, because `ROOT_URL` is host-derived and the same install reached on two hostnames would otherwise mint two origins for one site's posts.
-**Consequences:** Restored posts carry both an empty `feeditem_uuid` and a populated `import_uuid`, so they are editable without tripping feed-lock. `run_import()` (`src/import.php`) gained an optional `$find_existing` callable so its shared counters/summary machinery can dedupe on either column without duplicating the loop.
+**Consequences:** Restored posts carry both an empty `feeditem_uuid` and a populated `import_uuid`, so they are editable without tripping feed-lock. `run_import()` (`src/import.php`) gained an optional `$find_existing` callable so its shared counters/summary machinery can dedupe on either column without duplicating the loop. (Superseded above: the parameter is now required and the `feeditem_uuid` fallback is gone.)
 
 ---
 

--- a/docs/known-import.md
+++ b/docs/known-import.md
@@ -33,7 +33,9 @@ php import-known.php /path/to/export.rss --dry-run
 php import-known.php /path/to/export.rss
 ```
 
-The script prints one line per item (`imported:` or `would import:`) plus a final summary with the totals (created, existed, skipped). An item that was already imported in a previous run is recognised by its `feeditem_uuid` (md5 of `'known-' + guid`) and left alone.
+The script prints one line per item (`imported:` or `would import:`) plus a final summary with the totals (created, existed, skipped). An item that was already imported in a previous run is recognised by its `import_uuid` (md5 of `'known-' + guid`) and left alone.
+
+Imported posts are treated as **your own content**, not as syndicated feed items: they carry no "Via …" attribution line, and they take part in webmentions and WebSub exactly like a post you wrote in Lamb. The import run itself stays silent — nothing is pinged for content that was published years ago — but editing an imported post later notifies the way any other edit does.
 
 ## After the import
 

--- a/docs/known-import.md
+++ b/docs/known-import.md
@@ -33,7 +33,15 @@ php import-known.php /path/to/export.rss --dry-run
 php import-known.php /path/to/export.rss
 ```
 
-The script prints one line per item (`imported:` or `would import:`) plus a final summary with the totals (created, existed, skipped). An item that was already imported in a previous run is recognised by its `import_uuid` (md5 of `'known-' + guid`) and left alone.
+The script prints one line per item (`imported:`, `would import:`, `replaced:` or `would replace:`) plus a final summary with the totals (created, existed, skipped). An item that was already imported in a previous run is recognised by its `import_uuid` (md5 of `'known-' + guid`) and left alone.
+
+### `--replace`
+
+By default, an item that was already imported is left alone on a second run — the importer counts it as `existed` and moves on. Pass `--replace` to re-apply it instead: body, title, slug, `created`/`updated` and draft state are all set back to what the export describes. The post keeps its id and its `import_uuid`, so its permalink and every redirect pointing at it still work.
+
+This is deliberately total, not a merge. Local edits made to an imported post since the import are lost when you `--replace` it — that is what "replace" means. The case it exists for is Known's HTML→Markdown conversion: when a fix lands for something that came across badly, re-run the same export with `--replace` and take the new conversion.
+
+Images already downloaded by an earlier run are not fetched again: the downloader names each file after `sha1(<source url>)` and returns the existing file when it is already on disk.
 
 Imported posts are treated as **your own content**, not as syndicated feed items: they carry no "Via …" attribution line, and they take part in webmentions and WebSub exactly like a post you wrote in Lamb. The import run itself stays silent — nothing is pinged for content that was published years ago — but editing an imported post later notifies the way any other edit does.
 

--- a/docs/wordpress-import.md
+++ b/docs/wordpress-import.md
@@ -32,7 +32,9 @@ php import-wordpress.php /path/to/wordpress.WordPress.xml --dry-run
 php import-wordpress.php /path/to/wordpress.WordPress.xml
 ```
 
-The script prints one line per item (`imported:` or `would import:`) plus a final summary with the totals (created, existed, skipped). An item that was already imported in a previous run is recognised by its `feeditem_uuid` (md5 of `'wordpress-' + guid`) and left alone.
+The script prints one line per item (`imported:` or `would import:`) plus a final summary with the totals (created, existed, skipped). An item that was already imported in a previous run is recognised by its `import_uuid` (md5 of `'wordpress-' + guid`) and left alone.
+
+Imported posts are treated as **your own content**, not as syndicated feed items: they carry no "Via …" attribution line, and they take part in webmentions and WebSub exactly like a post you wrote in Lamb. The import run itself stays silent — nothing is pinged for content that was published years ago — but editing an imported post later notifies the way any other edit does.
 
 ## After the import
 

--- a/docs/wordpress-import.md
+++ b/docs/wordpress-import.md
@@ -32,7 +32,15 @@ php import-wordpress.php /path/to/wordpress.WordPress.xml --dry-run
 php import-wordpress.php /path/to/wordpress.WordPress.xml
 ```
 
-The script prints one line per item (`imported:` or `would import:`) plus a final summary with the totals (created, existed, skipped). An item that was already imported in a previous run is recognised by its `import_uuid` (md5 of `'wordpress-' + guid`) and left alone.
+The script prints one line per item (`imported:`, `would import:`, `replaced:` or `would replace:`) plus a final summary with the totals (created, existed, skipped). An item that was already imported in a previous run is recognised by its `import_uuid` (md5 of `'wordpress-' + guid`) and left alone.
+
+### `--replace`
+
+By default, an item that was already imported is left alone on a second run — the importer counts it as `existed` and moves on. Pass `--replace` to re-apply it instead: body, title, slug, `created`/`updated` and draft state are all set back to what the WXR describes. The post keeps its id and its `import_uuid`, so its permalink and every redirect pointing at it still work.
+
+This is deliberately total, not a merge. Local edits made to an imported post since the import are lost when you `--replace` it — that is what "replace" means. The case it exists for is re-running an export after fixing something in the conversion, where the freshly converted version is the one you want.
+
+Images already downloaded by an earlier run are not fetched again: the downloader names each file after `sha1(<source url>)` and returns the existing file when it is already on disk.
 
 Imported posts are treated as **your own content**, not as syndicated feed items: they carry no "Via …" attribution line, and they take part in webmentions and WebSub exactly like a post you wrote in Lamb. The import run itself stays silent — nothing is pinged for content that was published years ago — but editing an imported post later notifies the way any other edit does.
 

--- a/import-known.php
+++ b/import-known.php
@@ -9,7 +9,7 @@
  * rather than <content:encoded>, there is no <wp:post_name> (the slug comes
  * from the <link> path leaf instead), and dates only carry <pubDate>.
  * Idempotent: re-running an import never recreates a row (dedup by
- * md5('known-' . guid) on the feeditem_uuid column).
+ * md5('known-' . guid) on the import_uuid column).
  *
  *   php import-known.php path/to/export.rss [--dry-run]
  *
@@ -24,6 +24,8 @@ namespace Lamb;
 
 use Lamb\Import;
 use Lamb\Known;
+use RedBeanPHP\OODBBean;
+use RedBeanPHP\R;
 
 if (PHP_SAPI !== 'cli') {
     fwrite(STDERR, "import-known.php must be run from the command line.\n");
@@ -60,4 +62,5 @@ Import\run_import(
     static fn(array $item): string => Known\known_uuid((string) $item['guid']),
     Known\import_item(...),
     $dry_run,
+    static fn(string $uuid): ?OODBBean => R::findOne('post', ' import_uuid = ? ', [$uuid]),
 );

--- a/import-known.php
+++ b/import-known.php
@@ -11,10 +11,13 @@
  * Idempotent: re-running an import never recreates a row (dedup by
  * md5('known-' . guid) on the import_uuid column).
  *
- *   php import-known.php path/to/export.rss [--dry-run]
+ *   php import-known.php path/to/export.rss [--dry-run] [--replace]
  *
  * --dry-run     Parse and convert every item but write nothing to the DB
  *               or filesystem. Use this first to surface parsing errors.
+ * --replace     Re-apply every already-imported item over its existing post
+ *               instead of skipping it. Local edits made since the import are
+ *               lost. For re-running an export after an HTML→Markdown fix.
  *
  * The script intentionally does NOT emit outbound webmentions or WebSub
  * pings — imported posts are pre-existing content, not new publications.
@@ -35,9 +38,9 @@ if (PHP_SAPI !== 'cli') {
 define('ROOT_DIR', __DIR__ . '/src');
 require __DIR__ . '/vendor/autoload.php';
 
-[$path, $dry_run] = Import\parse_import_args($argv);
+[$path, $dry_run, $replace] = Import\parse_import_args($argv);
 if ($path === null) {
-    fwrite(STDERR, "Usage: php import-known.php <export.rss> [--dry-run]\n");
+    fwrite(STDERR, "Usage: php import-known.php <export.rss> [--dry-run] [--replace]\n");
     exit(1);
 }
 
@@ -63,4 +66,5 @@ Import\run_import(
     Known\import_item(...),
     $dry_run,
     static fn(string $uuid): ?OODBBean => R::findOne('post', ' import_uuid = ? ', [$uuid]),
+    $replace,
 );

--- a/import-wordpress.php
+++ b/import-wordpress.php
@@ -9,10 +9,13 @@
  * round. Idempotent: re-running an import never recreates a row (dedup by
  * md5('wordpress-' . guid) on the import_uuid column).
  *
- *   php import-wordpress.php path/to/wxr.xml [--dry-run]
+ *   php import-wordpress.php path/to/wxr.xml [--dry-run] [--replace]
  *
  * --dry-run     Parse and convert every item but write nothing to the DB
  *               or filesystem. Use this first to surface parsing errors.
+ * --replace     Re-apply every already-imported item over its existing post
+ *               instead of skipping it. Local edits made since the import are
+ *               lost. For re-running an export after a conversion fix.
  *
  * The script intentionally does NOT emit outbound webmentions or WebSub
  * pings — imported posts are pre-existing content, not new publications.
@@ -33,9 +36,9 @@ if (PHP_SAPI !== 'cli') {
 define('ROOT_DIR', __DIR__ . '/src');
 require __DIR__ . '/vendor/autoload.php';
 
-[$path, $dry_run] = Import\parse_import_args($argv);
+[$path, $dry_run, $replace] = Import\parse_import_args($argv);
 if ($path === null) {
-    fwrite(STDERR, "Usage: php import-wordpress.php <wxr.xml> [--dry-run]\n");
+    fwrite(STDERR, "Usage: php import-wordpress.php <wxr.xml> [--dry-run] [--replace]\n");
     exit(1);
 }
 
@@ -61,4 +64,5 @@ Import\run_import(
     WordPress\import_item(...),
     $dry_run,
     static fn(string $uuid): ?OODBBean => R::findOne('post', ' import_uuid = ? ', [$uuid]),
+    $replace,
 );

--- a/import-wordpress.php
+++ b/import-wordpress.php
@@ -7,7 +7,7 @@
  * published Post and Page through Lamb's existing post-creation pipeline.
  * Drafts, private posts, comments and custom post types are skipped this
  * round. Idempotent: re-running an import never recreates a row (dedup by
- * md5('wordpress-' . guid) on the feeditem_uuid column).
+ * md5('wordpress-' . guid) on the import_uuid column).
  *
  *   php import-wordpress.php path/to/wxr.xml [--dry-run]
  *
@@ -22,6 +22,8 @@ namespace Lamb;
 
 use Lamb\Import;
 use Lamb\WordPress;
+use RedBeanPHP\OODBBean;
+use RedBeanPHP\R;
 
 if (PHP_SAPI !== 'cli') {
     fwrite(STDERR, "import-wordpress.php must be run from the command line.\n");
@@ -58,4 +60,5 @@ Import\run_import(
     static fn(array $item): string => WordPress\wordpress_uuid((string) $item['guid']),
     WordPress\import_item(...),
     $dry_run,
+    static fn(string $uuid): ?OODBBean => R::findOne('post', ' import_uuid = ? ', [$uuid]),
 );

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -87,6 +87,36 @@ function ensure_post_columns(): void
     if (!in_array('import_uuid', $columns, true)) {
         R::exec('ALTER TABLE post ADD COLUMN import_uuid TEXT');
     }
+    backfill_imported_post_identity($columns);
+}
+
+/**
+ * One-time migration: the WordPress and Known importers used to stamp migrated
+ * posts as feed items, which made every one of them render "Via wordpress" and
+ * barred them from webmentions and WebSub forever. Move them onto import_uuid.
+ *
+ * The `source_url IS NULL` guard is what keeps a genuinely subscribed feed
+ * literally named `wordpress` or `known` out of the migration: feed ingestion
+ * records the item permalink in source_url (src/post.php), the importers never
+ * did. bootstrap_db() runs before Config\load(), so the configured feed names
+ * are not available here — the guard is the only discriminator there is.
+ *
+ * Rows whose uuid is already claimed by another post's import_uuid are left
+ * alone rather than duplicated. Idempotent, so running it every boot is fine.
+ *
+ * @param list<string> $columns Column names as they were before this call.
+ */
+function backfill_imported_post_identity(array $columns): void
+{
+    if (!in_array('feed_name', $columns, true) || !in_array('feeditem_uuid', $columns, true)) {
+        return;
+    }
+    $source_url = in_array('source_url', $columns, true) ? ' AND source_url IS NULL' : '';
+    R::exec(
+        'UPDATE post SET import_uuid = feeditem_uuid, feeditem_uuid = NULL, feed_name = NULL'
+        . " WHERE feed_name IN ('wordpress', 'known') AND feeditem_uuid IS NOT NULL" . $source_url
+        . ' AND NOT EXISTS (SELECT 1 FROM post other WHERE other.import_uuid = post.feeditem_uuid)'
+    );
 }
 
 /**

--- a/src/import.php
+++ b/src/import.php
@@ -15,10 +15,10 @@ use function Lamb\Http\fetch_guarded;
 use function Lamb\Response\asset_url;
 
 /**
- * Stable dedup key for an imported feed item. Mirrors the feed-ingest
- * convention (`feeditem_uuid = md5($feed_name . $id)`), so re-running an
- * import never recreates a row. Called with a per-CMS prefix ('wordpress-',
- * 'known-', …) so dedup identity can never collide across importers.
+ * Stable dedup key for an imported item, stored on the post's `import_uuid`
+ * column, so re-running an import never recreates a row. Called with a
+ * per-CMS prefix ('wordpress-', 'known-', …) so dedup identity can never
+ * collide across importers.
  */
 function import_uuid(string $prefix, string $guid): string
 {
@@ -730,18 +730,14 @@ function parse_import_args(array $argv): array
  * summary. Used by both import-wordpress.php and import-known.php so the two
  * scripts' output stays byte-identical in shape.
  *
- * $find_existing lets an importer dedupe on its own column instead of
- * feeditem_uuid, and $replace re-imports into the bean it returns rather than
- * counting the item as already present. $replace is honoured only when
- * $find_existing is supplied — an importer that takes three parameters cannot
- * accept a bean to overwrite, so handing it one would quietly create a
- * duplicate and report it as a replacement.
+ * $find_existing looks an already-imported row up by uuid; $replace re-imports
+ * into the bean it returns rather than counting the item as already present.
  *
  * @param list<array<string, mixed>>      $items      Items from extract_items().
  * @param callable(array<string,mixed>):?string $skip_reason Explains why an item is out of scope, or null.
  * @param callable(array<string,mixed>):string  $uuid       Computes the item's dedup uuid.
  * @param callable(array<string,mixed>,callable,bool,\RedBeanPHP\OODBBean|null=):?\RedBeanPHP\OODBBean $import Imports a single item.
- * @param callable(string):?\RedBeanPHP\OODBBean|null $find_existing Finds an already-imported row by uuid.
+ * @param callable(string):?\RedBeanPHP\OODBBean $find_existing Finds an already-imported row by uuid.
  */
 function run_import(
     array $items,
@@ -749,13 +745,12 @@ function run_import(
     callable $uuid,
     callable $import,
     bool $dry_run,
-    ?callable $find_existing = null,
+    callable $find_existing,
     bool $replace = false
 ): void {
     $downloader = $dry_run
         ? static fn(): ?string => null
         : 'Lamb\\Import\\default_image_downloader';
-    $replace = $replace && $find_existing !== null;
 
     $created = 0;
     $existed = 0;
@@ -773,9 +768,7 @@ function run_import(
             continue;
         }
         $item_uuid = $uuid($item);
-        $existing = $find_existing !== null
-            ? $find_existing($item_uuid)
-            : R::findOne('post', ' feeditem_uuid = ? ', [$item_uuid]);
+        $existing = $find_existing($item_uuid);
         if ($existing && !$replace) {
             $existed++;
             continue;

--- a/src/import.php
+++ b/src/import.php
@@ -705,15 +705,19 @@ function store_redirect(string $from, string $to): void
  * the path is missing or help was asked for.
  *
  * Shared by every CLI importer, including Lamb\Restore\parse_restore_args(),
- * which adds only its own `--site-url=` on top — so `--dry-run` and
- * `--replace` are spelled in exactly one place. Flag-looking arguments are
- * never taken as the path: an unrecognised `--foo` is ignored rather than
- * silently becoming the file to import.
+ * which passes its own `--site-url=` as an extra prefix — so `--dry-run` and
+ * `--replace` are spelled in exactly one place.
+ *
+ * An unrecognised flag refuses the whole invocation rather than being ignored.
+ * `--dryrun` is one keystroke from `--dry-run`, and ignoring it would run the
+ * real, unrehearsed import the operator was explicitly trying to avoid; the
+ * caller prints usage and exits non-zero on a null path.
  *
  * @param array<int,string> $argv
+ * @param list<string>      $extra_prefixes Flag prefixes a caller accepts on top of the shared ones.
  * @return array{0: ?string, 1: bool, 2: bool}
  */
-function parse_import_args(array $argv): array
+function parse_import_args(array $argv, array $extra_prefixes = []): array
 {
     $path = null;
     $dry_run = false;
@@ -725,7 +729,14 @@ function parse_import_args(array $argv): array
             $replace = true;
         } elseif ($arg === '--help' || $arg === '-h') {
             return [null, false, false];
-        } elseif ($path === null && !str_starts_with($arg, '-')) {
+        } elseif (str_starts_with($arg, '-')) {
+            foreach ($extra_prefixes as $prefix) {
+                if (str_starts_with($arg, $prefix)) {
+                    continue 2;
+                }
+            }
+            return [null, false, false];
+        } elseif ($path === null) {
             $path = $arg;
         }
     }

--- a/src/import.php
+++ b/src/import.php
@@ -701,26 +701,35 @@ function store_redirect(string $from, string $to): void
 }
 
 /**
- * Parses argv into [path, dry_run]. Returns [null, false] when the path is
- * missing.
+ * Parses argv into [path, dry_run, replace]. Returns [null, false, false] when
+ * the path is missing or help was asked for.
+ *
+ * Shared by every CLI importer, including Lamb\Restore\parse_restore_args(),
+ * which adds only its own `--site-url=` on top — so `--dry-run` and
+ * `--replace` are spelled in exactly one place. Flag-looking arguments are
+ * never taken as the path: an unrecognised `--foo` is ignored rather than
+ * silently becoming the file to import.
  *
  * @param array<int,string> $argv
- * @return array{0: ?string, 1: bool}
+ * @return array{0: ?string, 1: bool, 2: bool}
  */
 function parse_import_args(array $argv): array
 {
     $path = null;
     $dry_run = false;
+    $replace = false;
     foreach (array_slice($argv, 1) as $arg) {
         if ($arg === '--dry-run') {
             $dry_run = true;
+        } elseif ($arg === '--replace') {
+            $replace = true;
         } elseif ($arg === '--help' || $arg === '-h') {
-            return [null, false];
-        } elseif ($path === null) {
+            return [null, false, false];
+        } elseif ($path === null && !str_starts_with($arg, '-')) {
             $path = $arg;
         }
     }
-    return [$path, $dry_run];
+    return [$path, $dry_run, $replace];
 }
 
 /**

--- a/src/known.php
+++ b/src/known.php
@@ -285,6 +285,12 @@ function normalize_known_html_in_dom(DOMDocument $dom): void
  * `known_uuid()` already exists the existing bean is returned untouched —
  * re-running an import is therefore safe and idempotent.
  *
+ * Passing $bean (run_import() does so under `--replace`) re-imports into that
+ * row instead: everything the export describes is written over it, in place, so
+ * the row keeps its id and its import_uuid and any local edit since the
+ * original import is lost. This is the escape hatch for re-running an import
+ * after a fix to the HTML→Markdown conversion.
+ *
  * Synthetic-title items (Known-generated status updates — title ends `...`
  * or the body carries microformats2 `p-name`) are imported titleless, so
  * they fall through to Lamb's native `/status/<id>` permalink instead of
@@ -299,17 +305,20 @@ function normalize_known_html_in_dom(DOMDocument $dom): void
  *
  * @param array<string, mixed>            $item       Item from extract_items().
  * @param callable(string,string):?string $downloader Image downloader.
+ * @param OODBBean|null                   $bean       Existing row to overwrite.
  */
-function import_item(array $item, callable $downloader, bool $dry_run = false): ?OODBBean
+function import_item(array $item, callable $downloader, bool $dry_run = false, ?OODBBean $bean = null): ?OODBBean
 {
     if (!should_import($item)) {
         return null;
     }
 
     $uuid = known_uuid((string) $item['guid']);
-    $existing = R::findOne('post', ' import_uuid = ? ', [$uuid]);
-    if ($existing) {
-        return $existing;
+    if ($bean === null) {
+        $existing = R::findOne('post', ' import_uuid = ? ', [$uuid]);
+        if ($existing) {
+            return $existing;
+        }
     }
 
     $body_html = (string) ($item['content'] ?? '');
@@ -340,7 +349,7 @@ function import_item(array $item, callable $downloader, bool $dry_run = false): 
 
     $body = build_post_body($title, $markdown, $tags, $slug);
 
-    $bean = populate_bean($body);
+    $bean = populate_bean($body, null, null, $bean);
     if (!empty($item['created'])) {
         $bean->created = (string) $item['created'];
     }

--- a/src/known.php
+++ b/src/known.php
@@ -61,9 +61,10 @@ function strip_structural_hashtags(string $markdown): string
 }
 
 /**
- * Stable dedup key for a Known post. Mirrors the feed-ingest convention
- * (`feeditem_uuid = md5($feed_name . $id)`), so re-running an import never
- * recreates a row.
+ * Stable dedup key for a Known post, stored on the post's `import_uuid`
+ * column, so re-running an import never recreates a row. Imported posts are
+ * the author's own content, so they deliberately do NOT get feed identity
+ * (`feed_name`/`feeditem_uuid`) — see DECISIONS.md.
  */
 function known_uuid(string $guid): string
 {
@@ -306,7 +307,7 @@ function import_item(array $item, callable $downloader, bool $dry_run = false): 
     }
 
     $uuid = known_uuid((string) $item['guid']);
-    $existing = R::findOne('post', ' feeditem_uuid = ? ', [$uuid]);
+    $existing = R::findOne('post', ' import_uuid = ? ', [$uuid]);
     if ($existing) {
         return $existing;
     }
@@ -346,8 +347,7 @@ function import_item(array $item, callable $downloader, bool $dry_run = false): 
     if (!empty($item['updated'])) {
         $bean->updated = (string) $item['updated'];
     }
-    $bean->feeditem_uuid = $uuid;
-    $bean->feed_name = 'known';
+    $bean->import_uuid = $uuid;
 
     if ($dry_run) {
         return $bean;

--- a/src/restore.php
+++ b/src/restore.php
@@ -26,26 +26,24 @@ const MAX_UNCOMPRESSED_BYTES = 2147483648; // 2 GiB
 /**
  * Parses argv into [path, dry_run, replace, site_url].
  *
+ * The path and the two flags every importer shares come from
+ * {@see \Lamb\Import\parse_import_args}; only `--site-url=`, which no other
+ * importer takes, is read here.
+ *
  * @param array<int,string> $argv
  * @return array{0: ?string, 1: bool, 2: bool, 3: ?string}
  */
 function parse_restore_args(array $argv): array
 {
-    $path = null;
-    $dry_run = false;
-    $replace = false;
+    [$path, $dry_run, $replace] = \Lamb\Import\parse_import_args($argv);
+    if ($path === null) {
+        return [null, false, false, null];
+    }
+
     $site_url = null;
     foreach (array_slice($argv, 1) as $arg) {
-        if ($arg === '--dry-run') {
-            $dry_run = true;
-        } elseif ($arg === '--replace') {
-            $replace = true;
-        } elseif (str_starts_with($arg, '--site-url=')) {
+        if (str_starts_with($arg, '--site-url=')) {
             $site_url = substr($arg, strlen('--site-url='));
-        } elseif ($arg === '--help' || $arg === '-h') {
-            return [null, false, false, null];
-        } elseif ($path === null) {
-            $path = $arg;
         }
     }
 

--- a/src/restore.php
+++ b/src/restore.php
@@ -35,7 +35,7 @@ const MAX_UNCOMPRESSED_BYTES = 2147483648; // 2 GiB
  */
 function parse_restore_args(array $argv): array
 {
-    [$path, $dry_run, $replace] = \Lamb\Import\parse_import_args($argv);
+    [$path, $dry_run, $replace] = \Lamb\Import\parse_import_args($argv, ['--site-url=']);
     if ($path === null) {
         return [null, false, false, null];
     }

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -194,22 +194,30 @@ function html_to_markdown(string $html): string
  * an item with the same `wordpress_uuid()` already exists the existing bean is
  * returned untouched — re-running an import is therefore safe and idempotent.
  *
+ * Passing $bean (run_import() does so under `--replace`) re-imports into that
+ * row instead: everything the WXR describes is written over it, in place, so
+ * the row keeps its id and its import_uuid and any local edit since the
+ * original import is lost.
+ *
  * No outbound webmentions or WebSub pings are emitted: the call path stops at
  * finalize_and_store_post(), which never invokes notify_post_subscribers().
  *
  * @param array<string, mixed>            $item       Item from extract_items().
  * @param callable(string,string):?string $downloader Image downloader.
+ * @param OODBBean|null                   $bean       Existing row to overwrite.
  */
-function import_item(array $item, callable $downloader, bool $dry_run = false): ?OODBBean
+function import_item(array $item, callable $downloader, bool $dry_run = false, ?OODBBean $bean = null): ?OODBBean
 {
     if (!should_import($item)) {
         return null;
     }
 
     $uuid = wordpress_uuid((string) $item['guid']);
-    $existing = R::findOne('post', ' import_uuid = ? ', [$uuid]);
-    if ($existing) {
-        return $existing;
+    if ($bean === null) {
+        $existing = R::findOne('post', ' import_uuid = ? ', [$uuid]);
+        if ($existing) {
+            return $existing;
+        }
     }
 
     // Sanitize and image-rewrite share one DOM so the body is parsed and
@@ -225,7 +233,7 @@ function import_item(array $item, callable $downloader, bool $dry_run = false): 
     $slug = wordpress_status_path($item) !== null ? '' : (string) ($item['slug'] ?? '');
     $body = build_post_body((string) $item['title'], $markdown, $tags, $slug);
 
-    $bean = populate_bean($body);
+    $bean = populate_bean($body, null, null, $bean);
     if (!empty($item['created'])) {
         $bean->created = (string) $item['created'];
     }

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -20,9 +20,10 @@ const WXR_NS = 'http://wordpress.org/export/1.2/';
 const CONTENT_NS = 'http://purl.org/rss/1.0/modules/content/';
 
 /**
- * Stable dedup key for a WordPress post. Mirrors the feed-ingest convention
- * (`feeditem_uuid = md5($feed_name . $id)`), so re-running an import never
- * recreates a row.
+ * Stable dedup key for a WordPress post, stored on the post's `import_uuid`
+ * column, so re-running an import never recreates a row. Imported posts are
+ * the author's own content, so they deliberately do NOT get feed identity
+ * (`feed_name`/`feeditem_uuid`) — see DECISIONS.md.
  */
 function wordpress_uuid(string $guid): string
 {
@@ -206,7 +207,7 @@ function import_item(array $item, callable $downloader, bool $dry_run = false): 
     }
 
     $uuid = wordpress_uuid((string) $item['guid']);
-    $existing = R::findOne('post', ' feeditem_uuid = ? ', [$uuid]);
+    $existing = R::findOne('post', ' import_uuid = ? ', [$uuid]);
     if ($existing) {
         return $existing;
     }
@@ -231,8 +232,7 @@ function import_item(array $item, callable $downloader, bool $dry_run = false): 
     if (!empty($item['updated'])) {
         $bean->updated = (string) $item['updated'];
     }
-    $bean->feeditem_uuid = $uuid;
-    $bean->feed_name = 'wordpress';
+    $bean->import_uuid = $uuid;
 
     if ($dry_run) {
         return $bean;

--- a/tests/Unit/ImportIdentityBackfillTest.php
+++ b/tests/Unit/ImportIdentityBackfillTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Bootstrap\ensure_post_columns;
+
+/**
+ * Covers the one-time migration in ensure_post_columns() that moves posts
+ * stamped by the old WordPress/Known importers off the feed columns and onto
+ * import_uuid.
+ *
+ * The migration keys on `source_url IS NULL` because a user may legitimately
+ * subscribe to a feed literally named `wordpress` or `known`; feed ingestion
+ * always records the item permalink in source_url, the importers never did.
+ */
+class ImportIdentityBackfillTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+        R::exec(
+            'CREATE TABLE post (id INTEGER PRIMARY KEY AUTOINCREMENT, body TEXT,'
+            . ' feed_name TEXT, feeditem_uuid TEXT, source_url TEXT)'
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function row(int $id): array
+    {
+        $row = R::getRow('SELECT * FROM post WHERE id = ?', [$id]);
+        return is_array($row) ? $row : [];
+    }
+
+    private function insert(string $feed_name, string $feeditem_uuid, ?string $source_url): int
+    {
+        R::exec(
+            'INSERT INTO post (body, feed_name, feeditem_uuid, source_url) VALUES (?, ?, ?, ?)',
+            ['body', $feed_name, $feeditem_uuid, $source_url]
+        );
+        return (int) R::getCell('SELECT last_insert_rowid()');
+    }
+
+    public function testBackfillMovesLegacyImportedPostsOntoImportUuid(): void
+    {
+        $wp = $this->insert('wordpress', md5('wordpress-https://old.example/?p=1'), null);
+        $known = $this->insert('known', md5('known-https://old.example/view/a'), null);
+
+        ensure_post_columns();
+
+        foreach ([$wp => 'wordpress-https://old.example/?p=1', $known => 'known-https://old.example/view/a'] as $id => $seed) {
+            $row = $this->row($id);
+            $this->assertSame(md5($seed), $row['import_uuid']);
+            $this->assertNull($row['feeditem_uuid']);
+            $this->assertNull($row['feed_name']);
+        }
+    }
+
+    public function testBackfillLeavesGenuineFeedPostsWithTheSameFeedNameAlone(): void
+    {
+        $id = $this->insert('wordpress', md5('wordpressitem-1'), 'https://feed.example/item-1');
+
+        ensure_post_columns();
+
+        $row = $this->row($id);
+        $this->assertSame('wordpress', $row['feed_name']);
+        $this->assertSame(md5('wordpressitem-1'), $row['feeditem_uuid']);
+        $this->assertNull($row['import_uuid']);
+    }
+
+    public function testBackfillIsIdempotent(): void
+    {
+        $id = $this->insert('wordpress', md5('wordpress-https://old.example/?p=1'), null);
+
+        ensure_post_columns();
+        $first = $this->row($id);
+        ensure_post_columns();
+
+        $this->assertSame($first, $this->row($id));
+    }
+
+    public function testBackfillSkipsRowsWhoseImportUuidIsAlreadyTaken(): void
+    {
+        $uuid = md5('wordpress-https://old.example/?p=1');
+        R::exec('ALTER TABLE post ADD COLUMN import_uuid TEXT');
+        R::exec(
+            'INSERT INTO post (body, import_uuid) VALUES (?, ?)',
+            ['restored', $uuid]
+        );
+        $legacy = $this->insert('wordpress', $uuid, null);
+
+        ensure_post_columns();
+
+        $row = $this->row($legacy);
+        $this->assertNull($row['import_uuid']);
+        $this->assertSame('wordpress', $row['feed_name']);
+        $this->assertSame(1, (int) R::getCell('SELECT COUNT(*) FROM post WHERE import_uuid = ?', [$uuid]));
+    }
+
+    public function testBackfillNoOpsWithoutAPostTable(): void
+    {
+        R::exec('DROP TABLE post');
+
+        ensure_post_columns();
+
+        $this->assertNull(R::getCell("SELECT name FROM sqlite_master WHERE type='table' AND name='post'"));
+    }
+}

--- a/tests/Unit/KnownImportTest.php
+++ b/tests/Unit/KnownImportTest.php
@@ -17,6 +17,7 @@ use function Lamb\Known\should_import;
 use function Lamb\Known\skip_reason;
 use function Lamb\Known\strip_structural_hashtags;
 use function Lamb\Post\split_frontmatter;
+use function Lamb\Theme\link_source;
 
 /**
  * Covers parsing, Known-specific DOM normalisation, body assembly and
@@ -410,7 +411,7 @@ XML;
         $this->assertSame(1, substr_count(strtolower((string) $bean->body), '#cuttlefish'));
     }
 
-    public function testImportItemCreatesPostWithKnownUuidFeedNameAndDates(): void
+    public function testImportItemCreatesPostWithKnownUuidAndDatesButNoFeedIdentity(): void
     {
         $items = $this->sampleItems();
         $downloader = fn(): ?string => null;
@@ -419,8 +420,13 @@ XML;
 
         $this->assertNotNull($bean);
         $this->assertNotEmpty($bean->id);
-        $this->assertSame(known_uuid('https://known.example/view/aaaa1111'), $bean->feeditem_uuid);
-        $this->assertSame('known', $bean->feed_name);
+        $this->assertSame(known_uuid('https://known.example/view/aaaa1111'), $bean->import_uuid);
+        // An imported post is the author's own content, not a feed item: it
+        // must not carry feed identity, or it would render "Via known" and be
+        // permanently barred from webmentions and WebSub.
+        $this->assertEmpty($bean->feed_name);
+        $this->assertEmpty($bean->feeditem_uuid);
+        $this->assertSame('', link_source($bean));
         $this->assertSame('2020-05-26 12:48:16', $bean->created);
     }
 

--- a/tests/Unit/KnownImportTest.php
+++ b/tests/Unit/KnownImportTest.php
@@ -503,6 +503,33 @@ XML;
         $this->assertCount(1, R::findAll('post'));
     }
 
+    public function testImportItemReplacesAnEditedPostInPlace(): void
+    {
+        $items = $this->sampleItems();
+        $downloader = fn(): ?string => null;
+
+        $first = import_item($items[0], $downloader, false);
+        $this->assertNotNull($first);
+        $id = (int) $first->id;
+        $uuid = (string) $first->import_uuid;
+
+        // Local edit since the import: body rewritten and the post drafted.
+        $first->body = "---\ntitle: Edited\n---\n\nLocal changes.\n";
+        $first->draft = 1;
+        R::store($first);
+
+        $replaced = import_item($items[0], $downloader, false, R::load('post', $id));
+
+        $this->assertNotNull($replaced);
+        $this->assertSame($id, (int) $replaced->id);
+        $this->assertSame($uuid, (string) $replaced->import_uuid);
+        $this->assertStringContainsString('People recognise faces.', (string) $replaced->body);
+        $this->assertStringNotContainsString('Local changes.', (string) $replaced->body);
+        $this->assertSame(0, (int) $replaced->draft);
+        $this->assertSame('2020-05-26 12:48:16', (string) $replaced->created);
+        $this->assertCount(1, R::findAll('post'));
+    }
+
     public function testImportItemDryRunStoresNothing(): void
     {
         $items = $this->sampleItems();

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -143,10 +143,12 @@ class LambRestoreTest extends TestCase
 
     /**
      * @param list<array<string, mixed>> $items
-     * @param array<int, mixed>          $extra Trailing run_import() arguments.
+     * @param array<int, mixed>          $extra Trailing run_import() arguments,
+     *                                           replacing the default import_uuid lookup.
      */
     private function captureImport(array $items, callable $import, array $extra = []): string
     {
+        $extra = $extra ?: [static fn(string $uuid): ?\RedBeanPHP\OODBBean => R::findOne('post', ' import_uuid = ? ', [$uuid])];
         ob_start();
         run_import(
             $items,
@@ -160,11 +162,11 @@ class LambRestoreTest extends TestCase
         return (string) ob_get_clean();
     }
 
-    public function testRunImportStillDedupesOnFeeditemUuidWithoutALookup(): void
+    public function testRunImportCountsAnAlreadyImportedItemAsExisting(): void
     {
         $existing = R::dispense('post');
         $existing->body = 'Already here.';
-        $existing->feeditem_uuid = 'u1';
+        $existing->import_uuid = 'u1';
         R::store($existing);
 
         $output = $this->captureImport(
@@ -222,31 +224,6 @@ class LambRestoreTest extends TestCase
         );
 
         $this->assertStringNotContainsString('replaced=', $output);
-    }
-
-    public function testRunImportIgnoresReplaceWithoutALookup(): void
-    {
-        $existing = R::dispense('post');
-        $existing->body = 'Already here.';
-        $existing->feeditem_uuid = 'u1';
-        R::store($existing);
-
-        // A three-parameter importer, as import-wordpress.php and
-        // import-known.php supply: it cannot accept the bean to replace, so
-        // handing it one would silently create a duplicate instead.
-        $output = $this->captureImport(
-            [['uuid' => 'u1', 'title' => 'One']],
-            static function (array $item, callable $downloader, bool $dry_run): \RedBeanPHP\OODBBean {
-                $bean = R::dispense('post');
-                $bean->body = 'Duplicate.';
-                R::store($bean);
-                return $bean;
-            },
-            [null, true],
-        );
-
-        $this->assertStringContainsString('created=0 existed=1 skipped=0 total=1', $output);
-        $this->assertSame(1, R::count('post'));
     }
 
     public function testSafeEntryPathAcceptsTheExportLayout(): void

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -13,6 +13,7 @@ use function Lamb\Import\response_is_image;
 use function Lamb\Import\rewrite_image_links;
 use function Lamb\Import\sanitize_html;
 use function Lamb\Response\persist_image_bytes;
+use function Lamb\Theme\link_source;
 use function Lamb\WordPress\extract_items;
 use function Lamb\WordPress\html_to_markdown;
 use function Lamb\WordPress\import_item;
@@ -766,7 +767,13 @@ XML;
         $this->assertNotNull($bean);
         $this->assertNotEmpty($bean->id);
         $expected = md5('wordpress-https://oldsite.example/?p=42');
-        $this->assertSame($expected, $bean->feeditem_uuid);
+        $this->assertSame($expected, $bean->import_uuid);
+        // An imported post is the author's own content, not a feed item: it
+        // must not carry feed identity, or it would render "Via wordpress"
+        // and be permanently barred from webmentions and WebSub.
+        $this->assertEmpty($bean->feed_name);
+        $this->assertEmpty($bean->feeditem_uuid);
+        $this->assertSame('', link_source($bean));
         $this->assertSame('2024-03-03 10:00:00', $bean->created);
         $this->assertStringContainsString('**world**', (string) $bean->body);
         $this->assertStringContainsString('#news', (string) $bean->body);

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -9,7 +9,9 @@ use SimpleXMLElement;
 use function Lamb\Import\asset_dir_for_date;
 use function Lamb\Import\build_post_body;
 use function Lamb\Import\default_image_downloader;
+use function Lamb\Import\parse_import_args;
 use function Lamb\Import\response_is_image;
+use function Lamb\Import\run_import;
 use function Lamb\Import\rewrite_image_links;
 use function Lamb\Import\sanitize_html;
 use function Lamb\Response\persist_image_bytes;
@@ -20,6 +22,7 @@ use function Lamb\WordPress\import_item;
 use function Lamb\WordPress\parse_wxr_file;
 use function Lamb\WordPress\parse_wxr_string;
 use function Lamb\WordPress\should_import;
+use function Lamb\WordPress\skip_reason;
 use function Lamb\WordPress\wordpress_uuid;
 
 /**
@@ -880,6 +883,108 @@ XML;
         $this->assertNotNull($second);
         $this->assertSame($first->id, $second->id);
         $this->assertCount(1, R::findAll('post'));
+    }
+
+    /**
+     * The item the replace tests import, edit locally and re-import.
+     *
+     * @return array<string, mixed>
+     */
+    private function replaceItem(): array
+    {
+        return [
+            'title' => 'Once',
+            'guid' => 'https://oldsite.example/?p=7',
+            'created' => '2024-01-01 00:00:00',
+            'updated' => '2024-01-01 00:00:00',
+            'content' => '<p>From the export.</p>',
+            'tags' => [],
+            'status' => 'publish',
+            'post_type' => 'post',
+            'slug' => 'once',
+        ];
+    }
+
+    /**
+     * Runs the item through the CLI loop exactly as import-wordpress.php does.
+     *
+     * @param array<string, mixed> $item
+     */
+    private function runWordPressImport(array $item, bool $replace): string
+    {
+        ob_start();
+        run_import(
+            [$item],
+            skip_reason(...),
+            static fn(array $i): string => wordpress_uuid((string) $i['guid']),
+            import_item(...),
+            false,
+            static fn(string $uuid): ?\RedBeanPHP\OODBBean => R::findOne('post', ' import_uuid = ? ', [$uuid]),
+            $replace,
+        );
+
+        return (string) ob_get_clean();
+    }
+
+    public function testRunImportWithReplaceRewritesTheImportedRowInPlace(): void
+    {
+        if (!class_exists(\League\HTMLToMarkdown\HtmlConverter::class)) {
+            $this->markTestSkipped('league/html-to-markdown is not installed');
+        }
+        $item = $this->replaceItem();
+        $first = import_item($item, fn() => null, false);
+        $this->assertNotNull($first);
+        $id = (int) $first->id;
+        $uuid = (string) $first->import_uuid;
+
+        // Local edit since the import: body rewritten and the post drafted.
+        $first->body = "---\ntitle: Edited\n---\n\nLocal changes.\n";
+        $first->draft = 1;
+        R::store($first);
+
+        $output = $this->runWordPressImport($item, true);
+
+        $this->assertStringContainsString('replaced=1', $output);
+        $this->assertCount(1, R::findAll('post'));
+        $replaced = R::load('post', $id);
+        $this->assertSame($id, (int) $replaced->id);
+        $this->assertSame($uuid, (string) $replaced->import_uuid);
+        $this->assertStringContainsString('From the export.', (string) $replaced->body);
+        $this->assertStringNotContainsString('Local changes.', (string) $replaced->body);
+        $this->assertSame(0, (int) $replaced->draft);
+        $this->assertSame('2024-01-01 00:00:00', (string) $replaced->created);
+    }
+
+    public function testRunImportWithoutReplaceLeavesAnEditedRowAlone(): void
+    {
+        if (!class_exists(\League\HTMLToMarkdown\HtmlConverter::class)) {
+            $this->markTestSkipped('league/html-to-markdown is not installed');
+        }
+        $item = $this->replaceItem();
+        $first = import_item($item, fn() => null, false);
+        $this->assertNotNull($first);
+        $first->body = "---\ntitle: Edited\n---\n\nLocal changes.\n";
+        $first->draft = 1;
+        R::store($first);
+
+        $output = $this->runWordPressImport($item, false);
+
+        $this->assertStringContainsString('created=0 existed=1', $output);
+        $this->assertStringNotContainsString('replaced=', $output);
+        $this->assertCount(1, R::findAll('post'));
+        $untouched = R::load('post', (int) $first->id);
+        $this->assertStringContainsString('Local changes.', (string) $untouched->body);
+        $this->assertSame(1, (int) $untouched->draft);
+    }
+
+    public function testParseImportArgsReadsTheFlags(): void
+    {
+        $this->assertSame(
+            ['wxr.xml', true, true],
+            parse_import_args(['import-wordpress.php', 'wxr.xml', '--dry-run', '--replace'])
+        );
+        $this->assertSame(['wxr.xml', false, false], parse_import_args(['x', 'wxr.xml']));
+        $this->assertSame([null, false, false], parse_import_args(['x', '--help']));
     }
 
     public function testImportItemDryRunDoesNotStore(): void

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -987,6 +987,17 @@ XML;
         $this->assertSame([null, false, false], parse_import_args(['x', '--help']));
     }
 
+    /**
+     * A mistyped flag must not degrade into a real import. `--dryrun` is one
+     * keystroke from `--dry-run`, and silently ignoring it would run the
+     * unrehearsed import the operator was explicitly trying to avoid.
+     */
+    public function testParseImportArgsRefusesAnUnknownFlag(): void
+    {
+        $this->assertSame([null, false, false], parse_import_args(['x', '--dryrun', 'wxr.xml']));
+        $this->assertSame([null, false, false], parse_import_args(['x', 'wxr.xml', '-n']));
+    }
+
     public function testImportItemDryRunDoesNotStore(): void
     {
         if (!class_exists(\League\HTMLToMarkdown\HtmlConverter::class)) {


### PR DESCRIPTION
Stacked on #558 — **base is `feature/554-import-lamb-export`, not `main`**. Merge #558 first; GitHub will retarget this at `main` automatically.

## The bug

Both CLI importers stamp migrated posts as if they were feed items: `feed_name = 'wordpress'` (`src/wordpress.php:235`) / `'known'` (`src/known.php:350`), plus a `feeditem_uuid`. Neither sets `source_url`. Three consequences, none of them intended and none documented:

1. **Every imported post publicly reads "Via wordpress" or "Via known".** `Theme\link_source()` (`src/theme.php:339`) renders an attribution line for any post with a `feed_name`; with `source_url` unset it falls to the plain-text branch at `:354`, so it is not even a link to the original — just the bare word.
2. **They can never send webmentions or WebSub pings.** `src/webmention.php:431` and `src/websub.php:85` bail on a non-empty `feed_name`, and `src/websub.php:157` excludes those rows from the ping query. This is permanent: edit a migrated post years later and it still notifies nobody.
3. **`lock_if_feed_sourced()` (`src/response/posts.php:329`) sets `feed_locked` on first edit.** Inert today, since no configured feed produces a matching uuid — but it is exactly the trap #554 declined to walk into.

Suppressing outbound notifications *during* an import is right. Making it a permanent property of the post is not: migrated posts are your own content, which is the entire point of importing them.

This surfaced from #554's analysis of why the Lamb importer must not reuse `feeditem_uuid` as its dedupe key. The same reasoning applies to the two importers that were already doing it.

## The fix

Both importers now use the `import_uuid` column #558 adds, and set neither `feed_name` nor `feeditem_uuid`. One dedupe concept instead of two.

With all three importers passing an `import_uuid` lookup, `run_import()`'s `feeditem_uuid` fallback had no callers left, so `$find_existing` is now required and the fallback is gone. The `$replace && $find_existing !== null` guard added in #558 became dead code and went with it.

## Migration

Installs that already imported carry the old shape, so `Bootstrap\backfill_imported_post_identity()` moves them over at boot — alongside the existing automatic `UPDATE post SET version = 1` precedent in `bootstrap_db()`. It is idempotent, so running every boot is fine.

**The guard clauses are load-bearing.** A user could have a genuinely configured feed named literally `wordpress` or `known`, and mangling their real feed posts would be far worse than the cosmetic bug this fixes. `bootstrap_db()` runs *before* `Config\load()` (`src/index.php:13,16`), so the backfill cannot consult configured feed names — SQL is the only defence available:

- `source_url IS NULL` — feed ingestion sets `source_url` from the item permalink (`src/post.php:52`); the importers never do.
- `NOT EXISTS (... other.import_uuid = post.feeditem_uuid)` — never clobber a uuid another row already owns.
- No-op when `feed_name` / `feeditem_uuid` do not exist yet (RedBean creates columns lazily, so a site that never ingested a feed has neither).

Not airtight: a feed named exactly `wordpress` or `known` whose items also stored no permalink would still be caught. No better signal exists before config load. Worth a line in the release notes.

## Behaviour change for existing sites

The "Via wordpress" / "Via known" lines disappear from already-imported posts on the next boot, and those posts start participating in webmentions and WebSub. That is the fix, but it is a visible change to live content — it belongs under **Upgrade notes**.

## Testing

Red-green throughout; `tests/Unit/KnownImportTest.php:423` asserted `feed_name === 'known'`, which pinned the bug and had to change.

New `tests/Unit/ImportIdentityBackfillTest.php`: migrates a legacy row, **leaves a genuine feed-sourced row with `feed_name = 'wordpress'` untouched because it has a `source_url`**, is idempotent across two runs, skips a uuid another row already holds, and no-ops without a `post` table. Both importers now assert empty `feed_name`/`feeditem_uuid`, a populated `import_uuid`, and — asserting the user-visible bug directly — that `Theme\link_source()` returns `''`.

1578 unit tests pass (1574 on #558). `composer lint` clean, `composer analyse` (PHPStan level 8) clean, coverage 82.72%.

## Not included

`--replace` for the WordPress and Known importers. `run_import()` now supports it for ~2 lines each and it would help re-running after fixing a conversion bug, but it is a separate concern from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMVaMWvgozaAViNV7iXiWG

## Added after review: `--replace` for WordPress and Known

`run_import()` already supported it, so this is wiring plus the update-in-place path. Semantics match the Lamb importer: **`--replace` re-applies everything the source describes** — body, title, slug, created/updated, draft state — onto the existing row, and local edits made since the original import are lost. Without it, an already-imported item is still counted `existed` and skipped. The use case is re-running after fixing a conversion bug, which is realistic for the Known importer's HTML→Markdown path.

Images are not re-fetched: `Import\default_image_downloader()` seeds filenames with `sha1($url)` and returns an existing file before fetching.

The two argument parsers are now one — `parse_restore_args()` delegates to `parse_import_args()` and adds only `--site-url=`, so `--dry-run` and `--replace` are spelled in a single place.

### One data-safety fix that came out of that

Unifying the parsers made flag-shaped arguments skip the path slot, which meant an unrecognised flag was **silently ignored**. That turns a typo into a real problem: `import-wordpress.php --dryrun export.xml` is one keystroke from `--dry-run`, and ignoring the bad flag ran the real, unrehearsed import the operator was explicitly trying to avoid. Before the parsers were unified this failed safe — the mistyped flag became the path and the file was not found.

An unknown flag now returns a null path, which every importer already handles by printing usage and exiting non-zero. Callers pass the flag prefixes they accept, so the shared parser can tell a caller's flag from a typo. Test asserts both `--dryrun` and a bare `-n` are refused.

1583 unit tests pass (1578 before this addition); lint, PHPStan level 8 and coverage all still clean.