### PR TITLE
Fix post-editor bugs: body mangling on edit, and a stale render version

### DIFF
--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -277,7 +277,12 @@ function redirect_edited(): void
 
     parse_bean($bean);
     \Lamb\ensure_preview_token($bean);
-    $bean->version = 1;
+    // POST_VERSION, not a hardcoded 1: `version` records which render format
+    // `transformed` was produced with, and parse_bean() above has just produced
+    // the current one. Stamping 1 marked every freshly edited post as stale, so
+    // upgrade_posts() re-parsed and re-stored it on the next read — a write on a
+    // GET, and one that applies upgrade (not edit) semantics to the bean.
+    $bean->version = POST_VERSION;
     $bean->updated = \Lamb\now();
 
     if (is_reserved_route($bean->slug)) {

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -277,11 +277,8 @@ function redirect_edited(): void
 
     parse_bean($bean);
     \Lamb\ensure_preview_token($bean);
-    // POST_VERSION, not a hardcoded 1: `version` records which render format
-    // `transformed` was produced with, and parse_bean() above has just produced
-    // the current one. Stamping 1 marked every freshly edited post as stale, so
-    // upgrade_posts() re-parsed and re-stored it on the next read — a write on a
-    // GET, and one that applies upgrade (not edit) semantics to the bean.
+    // Must match the format parse_bean() above just rendered, or upgrade_posts()
+    // re-parses and re-stores the post on the next read.
     $bean->version = POST_VERSION;
     $bean->updated = \Lamb\now();
 

--- a/src/themes/base/parts/edit.php
+++ b/src/themes/base/parts/edit.php
@@ -11,10 +11,8 @@ $post = $data['post'];
 if (isset($_SESSION[SESSION_LOGIN]) && $post->id > 0) :
     $submitLabel = SUBMIT_EDIT;
     $heading     = 'Edit Status';
-    // escape(), not strip_tags(): the body is Markdown source, not markup to be
-    // filtered. strip_tags() deleted every `<…>` run in it, and that mangled
-    // text was what the form posted back — so opening the editor and saving
-    // destroyed content.
+    // escape(), never strip_tags(): the body is Markdown source, and the form
+    // posts back whatever this renders — filtering it here destroys content.
     $body        = escape((string) $post->body);
     ?>
     <h2><?= $heading ?></h2>

--- a/src/themes/base/parts/edit.php
+++ b/src/themes/base/parts/edit.php
@@ -11,19 +11,18 @@ $post = $data['post'];
 if (isset($_SESSION[SESSION_LOGIN]) && $post->id > 0) :
     $submitLabel = SUBMIT_EDIT;
     $heading     = 'Edit Status';
+    // escape(), not strip_tags(): the body is Markdown source, not markup to be
+    // filtered. strip_tags() deleted every `<…>` run in it, and that mangled
+    // text was what the form posted back — so opening the editor and saving
+    // destroyed content.
+    $body        = escape((string) $post->body);
     ?>
     <h2><?= $heading ?></h2>
 
     <form method="post" action="/edit" id="editform">
         <label for="contents">Contents</label><textarea placeholder="What's happening?" name="contents" required
                                                         id="contents"
-        ><?php // escape(), not strip_tags(): the body is Markdown source, not
-                // markup to be filtered. strip_tags() *deleted* every `<…>` run
-                // in it — an autolink, an HTML snippet inside a code fence, a
-                // literal `<` — and the mangled text was what the form posted
-                // back, so opening the editor and saving silently destroyed
-                // content. Escaping is what a textarea needs anyway.
-        ?><?= escape((string) $post->body) ?></textarea>
+        ><?= $body ?></textarea>
         <input type="hidden" name="id" value="<?= (int) $post->id ?>"/>
         <input type="submit" form="editform" name="submit" value="<?= $submitLabel ?>">
         <input type="hidden" name="<?= HIDDEN_CSRF_NAME ?>" value="<?= csrf_token() ?>"/>

--- a/src/themes/base/parts/edit.php
+++ b/src/themes/base/parts/edit.php
@@ -4,6 +4,7 @@ global $data;
 
 use function Lamb\Theme\action_delete;
 use function Lamb\Theme\csrf_token;
+use function Lamb\Theme\escape;
 
 $post = $data['post'];
 
@@ -16,8 +17,14 @@ if (isset($_SESSION[SESSION_LOGIN]) && $post->id > 0) :
     <form method="post" action="/edit" id="editform">
         <label for="contents">Contents</label><textarea placeholder="What's happening?" name="contents" required
                                                         id="contents"
-        ><?= strip_tags($post->body) ?></textarea>
-        <input type="hidden" name="id" value="<?= strip_tags($post->id) ?>"/>
+        ><?php // escape(), not strip_tags(): the body is Markdown source, not
+                // markup to be filtered. strip_tags() *deleted* every `<…>` run
+                // in it — an autolink, an HTML snippet inside a code fence, a
+                // literal `<` — and the mangled text was what the form posted
+                // back, so opening the editor and saving silently destroyed
+                // content. Escaping is what a textarea needs anyway.
+        ?><?= escape((string) $post->body) ?></textarea>
+        <input type="hidden" name="id" value="<?= (int) $post->id ?>"/>
         <input type="submit" form="editform" name="submit" value="<?= $submitLabel ?>">
         <input type="hidden" name="<?= HIDDEN_CSRF_NAME ?>" value="<?= csrf_token() ?>"/>
     </form>

--- a/tests/Acceptance/EditPostCest.php
+++ b/tests/Acceptance/EditPostCest.php
@@ -73,6 +73,55 @@ class EditPostCest
         $I->seeResponseCodeIs(200);
     }
 
+    public function testEditFormKeepsAngleBracketsInTheBody(AcceptanceTester $I): void
+    {
+        // The edit form used to run the body through strip_tags(), which deleted
+        // every `<…>` run in the Markdown source — an autolink, an HTML snippet
+        // in a code fence — and the mangled text was what the form posted back,
+        // so opening the editor and saving destroyed content.
+        $this->login($I);
+
+        $marker = 'edit-test-angle-' . uniqid();
+        $body   = $marker . " see <https://example.com> and `<div class=\"x\">`";
+        $I->amOnPage('/');
+        $I->fillField('contents', $body);
+        $I->click('Create post');
+
+        $id = (string) $I->grabAttributeFrom(
+            '//article[contains(., "' . $marker . '")]//button[contains(@class, "button-edit")]',
+            'data-id'
+        );
+
+        $I->amOnPage('/edit/' . $id);
+        $I->seeInField('contents', $body);
+
+        // Saving the untouched form must round-trip the body unchanged.
+        $I->click('Update post');
+        $I->amOnPage('/edit/' . $id);
+        $I->seeInField('contents', $body);
+    }
+
+    public function testEditStampsTheCurrentRenderVersion(AcceptanceTester $I): void
+    {
+        // An edit re-renders `transformed`, so the row must record the current
+        // format version. Stamping a stale one marked every edited post as
+        // needing an upgrade, so the next read re-parsed and re-stored it.
+        $this->login($I);
+        $this->createPost($I);
+
+        $id = (int) $this->editId($I);
+        $I->amOnPage('/edit/' . $id);
+        $I->fillField('contents', 'edit-test-version-' . uniqid());
+
+        // Check the row as the save left it: any page load after the redirect
+        // runs upgrade_posts(), which would repair a stale version behind our
+        // back — the very extra write this guards against.
+        $I->stopFollowingRedirects();
+        $I->click('Update post');
+        $I->seePostColumnEquals($id, 'version', POST_VERSION);
+        $I->startFollowingRedirects();
+    }
+
     public function testEditPageRequiresLogin(AcceptanceTester $I): void
     {
         // Seed a post while logged in, then drop the session.

--- a/tests/Acceptance/EditPostCest.php
+++ b/tests/Acceptance/EditPostCest.php
@@ -12,6 +12,10 @@ use Tests\Support\AcceptanceTester;
  */
 class EditPostCest
 {
+    /** Unique text present in the created post, used to locate it on the page. */
+    private string $marker = '';
+
+    /** The full body the post was created with (marker plus any extra content). */
     private string $original = '';
 
     private function login(AcceptanceTester $I): void
@@ -21,9 +25,17 @@ class EditPostCest
         $I->click('Log in');
     }
 
-    private function createPost(AcceptanceTester $I): void
+    /**
+     * Creates a post whose body is a unique marker followed by $extra.
+     *
+     * The marker is tracked separately because it is what editId() matches on:
+     * $extra may render to something other than its source (Markdown becomes
+     * HTML), so the full body is not reliably findable in the page text.
+     */
+    private function createPost(AcceptanceTester $I, string $extra = ''): void
     {
-        $this->original = 'edit-test-original-' . uniqid();
+        $this->marker   = 'edit-test-' . uniqid();
+        $this->original = $this->marker . $extra;
         $I->amOnPage('/');
         $I->fillField('contents', $this->original);
         $I->click('Create post');
@@ -34,7 +46,7 @@ class EditPostCest
         // The edit control is a <button class="button-edit" data-id="N"> that JS
         // upgrades into an /edit/N link; read the post id straight off data-id.
         return (string) $I->grabAttributeFrom(
-            '//article[contains(., "' . $this->original . '")]//button[contains(@class, "button-edit")]',
+            '//article[contains(., "' . $this->marker . '")]//button[contains(@class, "button-edit")]',
             'data-id'
         );
     }
@@ -80,25 +92,16 @@ class EditPostCest
         // in a code fence — and the mangled text was what the form posted back,
         // so opening the editor and saving destroyed content.
         $this->login($I);
+        $this->createPost($I, ' see <https://example.com> and `<div class="x">`');
 
-        $marker = 'edit-test-angle-' . uniqid();
-        $body   = $marker . " see <https://example.com> and `<div class=\"x\">`";
-        $I->amOnPage('/');
-        $I->fillField('contents', $body);
-        $I->click('Create post');
-
-        $id = (string) $I->grabAttributeFrom(
-            '//article[contains(., "' . $marker . '")]//button[contains(@class, "button-edit")]',
-            'data-id'
-        );
-
+        $id = $this->editId($I);
         $I->amOnPage('/edit/' . $id);
-        $I->seeInField('contents', $body);
+        $I->seeInField('contents', $this->original);
 
         // Saving the untouched form must round-trip the body unchanged.
         $I->click('Update post');
         $I->amOnPage('/edit/' . $id);
-        $I->seeInField('contents', $body);
+        $I->seeInField('contents', $this->original);
     }
 
     public function testEditStampsTheCurrentRenderVersion(AcceptanceTester $I): void

--- a/tests/Support/Helper/Acceptance.php
+++ b/tests/Support/Helper/Acceptance.php
@@ -30,6 +30,37 @@ class Acceptance extends Module
     }
 
     /**
+     * Reads a single column off a stored post, straight from the SQLite file the
+     * test server writes to.
+     *
+     * Some post state is deliberately invisible in the rendered page — the
+     * `version` column records which render format `transformed` was produced
+     * with — so asserting on it needs a look at the row itself.
+     */
+    public function grabPostColumn(int $id, string $column): mixed
+    {
+        $db = dirname(__DIR__) . '/Data/lamb.db';
+        $this->assertFileExists($db, 'Expected the acceptance database to exist');
+
+        $pdo = new \PDO('sqlite:' . $db, null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+        // The column name is test-supplied, never request data; quote it so a
+        // reserved word still parses.
+        $stmt = $pdo->prepare('SELECT "' . str_replace('"', '', $column) . '" FROM post WHERE id = ?');
+        $stmt->execute([$id]);
+
+        return $stmt->fetchColumn();
+    }
+
+    /**
+     * Asserts a stored post's column holds the expected value (compared as text,
+     * since SQLite's fluid columns may hand back either an int or a string).
+     */
+    public function seePostColumnEquals(int $id, string $column, mixed $expected): void
+    {
+        $this->assertSame((string) $expected, (string) $this->grabPostColumn($id, $column));
+    }
+
+    /**
      * Returns all values of a response header, joined by newlines.
      *
      * The installed PhpBrowser/InnerBrowser has no seeHttpHeader/grabHttpHeader,


### PR DESCRIPTION
Two bugs in the web post editor.

### The edit form deleted `<…>` content from the body

`src/themes/base/parts/edit.php` rendered the body with `strip_tags()`. The body is Markdown *source*, not markup to filter, so every `<…>` run in it was deleted before the author ever saw the form:

```
stored:  Check <https://example.com> and `<div class="x">` plus AT&T.
in form: Check  and `` plus AT&T.
```

That mangled text is what the form posts back, so opening a post in the editor and pressing save silently destroyed content — an autolink, an HTML snippet inside a code fence, a literal `<`. A textarea needs escaping; it is now `escape()` (`htmlspecialchars`), which also fixes `&` round-tripping. The hidden id field's `strip_tags()` became an `(int)` cast.

Only the base theme ships an `edit.php`, so this affects every theme.

### Every edit marked the post as needing a re-render

`redirect_edited()` stamped `$bean->version = 1` while the current render format is `POST_VERSION` (4). The column records which format `transformed` was produced with, and `parse_bean()` had just produced the current one — so each edited post was marked stale, and the next read ran `upgrade_posts()`, which re-parsed and re-stored it. That is a database write on an anonymous GET, applying upgrade (not edit) semantics to the bean.

## Testing steps

### Automated

```bash
composer install
LAMB_WRITE_TEST_PASSWORD=1 php make-password.php <a-password>
vendor/bin/codecept run Acceptance:EditPostCest
```

Expect 5 passing tests, including `Test edit form keeps angle brackets in the body` and `Test edit stamps the current render version`. To see them catch the bugs, revert just the source changes and re-run — both fail:

```bash
git checkout main -- src/themes/base/parts/edit.php src/response/posts.php
vendor/bin/codecept run Acceptance:EditPostCest   # 2 failures
git checkout HEAD -- src/themes/base/parts/edit.php src/response/posts.php
```

Full suite (`vendor/bin/codecept run`, `composer lint`) is also green.

### Manual — body mangling

1. `composer serve`, then log in at http://localhost:8747/login.
2. Create a post with this body:
   ```
   Check <https://example.com> and `<div class="x">` plus AT&T.
   ```
3. Click **Edit** on that post. The textarea must show the body **exactly as typed**. On `main` it shows `Check  and `` plus AT&T.` — the angle-bracketed runs are gone.
4. Press **Update post** without editing anything, then reopen the editor. The body must still be unchanged; on `main` the truncated version is now what's stored, and the loss is permanent.

### Manual — render version

The redirect after saving loads a page, and that page load runs `upgrade_posts()`, which repairs a stale `version` before you can look at it. So check the row with the redirect not followed — which is exactly what the acceptance test does (`stopFollowingRedirects()`), and why that test is the reliable check here. If you want to see it by hand, save an edit and then, **before loading any other page**, run:

```bash
sqlite3 data/lamb.db 'SELECT id, version FROM post'
```

Expect `4` (the current `POST_VERSION`). On `main` it is `1` until the next request rewrites it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTVRRWkZ1eLFis47AS814B