### PR TITLE
Fix theme bugs: swapped OpenGraph timestamps, dead menu-page filter

### DIFF
--- a/src/theme/meta.php
+++ b/src/theme/meta.php
@@ -42,10 +42,6 @@ function the_opengraph(): void
     }
     $og_tags += [
         'og:locale' => 'en_GB',
-        // `created` is when the post was published and `updated` when it was
-        // last changed; the two were wired to the opposite OpenGraph properties,
-        // so every scraper read a post's edit time as its publication date (and
-        // an unedited post as "modified" before it existed).
         'og:modified_time' => $bean->updated,
         'og:published_time' => $bean->created,
         'og:publisher' => ROOT_URL,

--- a/src/theme/meta.php
+++ b/src/theme/meta.php
@@ -42,8 +42,12 @@ function the_opengraph(): void
     }
     $og_tags += [
         'og:locale' => 'en_GB',
-        'og:modified_time' => $bean->created,
-        'og:published_time' => $bean->updated,
+        // `created` is when the post was published and `updated` when it was
+        // last changed; the two were wired to the opposite OpenGraph properties,
+        // so every scraper read a post's edit time as its publication date (and
+        // an unedited post as "modified" before it existed).
+        'og:modified_time' => $bean->updated,
+        'og:published_time' => $bean->created,
         'og:publisher' => ROOT_URL,
         'og:site_name' => $config['site_title'],
         'og:type' => 'article',

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -23,13 +23,11 @@ if (empty($data['posts'])) :
 else :
     foreach ($data['posts'] as $bean) :
         /** @var \RedBeanPHP\OODBBean $bean */
-        // is_menu_item() matches a slug. This read a non-existent `is_menu_item`
-        // property, so it always fell through to the numeric id and never
-        // matched — menu pages stayed in tag and search listings, which (unlike
-        // the home listing and the feeds) have no SQL-level exclusion. The
-        // `status` guard is what the 2024/2026 themes already carry: on a
-        // permalink the menu page *is* the requested post, so skipping it there
-        // would render an empty page.
+        // Menu pages are reachable from the nav, so they stay out of listings —
+        // tag and search have no SQL-level exclusion (unlike the home listing
+        // and the feeds, filtered in public_posts_clause). Not on a permalink,
+        // though: there the menu page *is* the requested post. Matches the
+        // 2024/2026 themes.
         if ($template !== 'status' && is_menu_item((string) ($bean->slug ?? ''))) :
             continue;
         endif;

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -23,7 +23,14 @@ if (empty($data['posts'])) :
 else :
     foreach ($data['posts'] as $bean) :
         /** @var \RedBeanPHP\OODBBean $bean */
-        if (is_menu_item($bean->is_menu_item ?? $bean->id)) :
+        // is_menu_item() matches a slug. This read a non-existent `is_menu_item`
+        // property, so it always fell through to the numeric id and never
+        // matched — menu pages stayed in tag and search listings, which (unlike
+        // the home listing and the feeds) have no SQL-level exclusion. The
+        // `status` guard is what the 2024/2026 themes already carry: on a
+        // permalink the menu page *is* the requested post, so skipping it there
+        // would render an empty page.
+        if ($template !== 'status' && is_menu_item((string) ($bean->slug ?? ''))) :
             continue;
         endif;
         ?>

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -23,11 +23,10 @@ if (empty($data['posts'])) :
 else :
     foreach ($data['posts'] as $bean) :
         /** @var \RedBeanPHP\OODBBean $bean */
-        // Menu pages are reachable from the nav, so they stay out of listings —
-        // tag and search have no SQL-level exclusion (unlike the home listing
-        // and the feeds, filtered in public_posts_clause). Not on a permalink,
-        // though: there the menu page *is* the requested post. Matches the
-        // 2024/2026 themes.
+        // Menu pages stay out of listings; tag and search have no SQL-level
+        // exclusion (unlike home and the feeds, via public_posts_clause). The
+        // `status` guard is load-bearing: on a permalink the menu page *is* the
+        // requested post, so skipping it there renders an empty page.
         if ($template !== 'status' && is_menu_item((string) ($bean->slug ?? ''))) :
             continue;
         endif;

--- a/tests/Unit/ThemeMenuItemsTest.php
+++ b/tests/Unit/ThemeMenuItemsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+/**
+ * Covers the base theme's "hide menu pages from listings" rule.
+ *
+ * A post whose slug is pinned in [menu_items] is a page reachable from the nav,
+ * so it is kept out of the chronological stream. The home listing and the feeds
+ * exclude it in SQL (public_posts_clause), but tag and search listings do not —
+ * the partial is the only thing filtering those. It used to test a non-existent
+ * `is_menu_item` bean property and fall through to the numeric id, so it never
+ * matched a slug and never hid anything.
+ *
+ * The rule must not apply on a permalink: there the menu page *is* the post that
+ * was asked for.
+ */
+class ThemeMenuItemsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        global $data, $template, $config;
+        $_SESSION = [];
+        $data     = [];
+        $template = null;
+        $config   = [];
+    }
+
+    /**
+     * @param array<string, string> $menu_items
+     */
+    private function render(string $slug, string $template_name, array $menu_items): string
+    {
+        $bean              = R::dispense('post');
+        $bean->slug        = $slug;
+        $bean->title       = 'About this site';
+        $bean->transformed = '<p>menu page body</p>';
+        $bean->created     = '2024-01-01 12:00:00';
+        $bean->deleted     = false;
+        R::store($bean);
+
+        global $data, $template, $config;
+        $config   = ['menu_items' => $menu_items];
+        $data     = ['posts' => [$bean]];
+        $template = $template_name;
+
+        ob_start();
+        include dirname(__DIR__, 2) . '/src/themes/base/parts/_items.php';
+        return (string) ob_get_clean();
+    }
+
+    public function testMenuPageIsHiddenFromAListing(): void
+    {
+        $html = $this->render('about', 'tag', ['About' => 'about']);
+
+        $this->assertStringNotContainsString('menu page body', $html);
+    }
+
+    public function testMenuPageIsHiddenWhenTheMenuUrlIsRootRelative(): void
+    {
+        $html = $this->render('about', 'search', ['About' => '/about']);
+
+        $this->assertStringNotContainsString('menu page body', $html);
+    }
+
+    public function testOrdinaryPostIsNotHiddenFromAListing(): void
+    {
+        $html = $this->render('hello-world', 'tag', ['About' => 'about']);
+
+        $this->assertStringContainsString('menu page body', $html);
+    }
+
+    public function testMenuPageStillRendersOnItsOwnPermalink(): void
+    {
+        $html = $this->render('about', 'status', ['About' => 'about']);
+
+        $this->assertStringContainsString('menu page body', $html);
+    }
+}

--- a/tests/Unit/ThemeMetaTest.php
+++ b/tests/Unit/ThemeMetaTest.php
@@ -359,44 +359,19 @@ class ThemeMetaTest extends TestCase
     // the_opengraph — published/modified times map to the right columns
     // -------------------------------------------------------------------------
 
-    public function testOpenGraphPublishedTimeIsTheCreatedDate(): void
+    public function testOpenGraphMapsPublishedAndModifiedTimesToTheirColumns(): void
     {
-        global $template, $data;
-        $template = 'status';
-
-        $bean              = R::dispense('post');
-        $bean->description = 'Timestamps';
-        $bean->created     = '2024-01-02 03:04:05';
-        $bean->updated     = '2025-06-07 08:09:10';
-        R::store($bean);
-        $data = ['posts' => [$bean]];
-
-        ob_start();
-        the_opengraph();
-        $output = ob_get_clean();
+        // Asserted together, against distinct dates, so a swap of the two
+        // properties cannot satisfy either assertion.
+        $output = $this->renderStatus([
+            'created' => '2024-01-02 03:04:05',
+            'updated' => '2025-06-07 08:09:10',
+        ]);
 
         $this->assertStringContainsString(
             '<meta property="og:published_time" content="2024-01-02 03:04:05"/>',
             $output
         );
-    }
-
-    public function testOpenGraphModifiedTimeIsTheUpdatedDate(): void
-    {
-        global $template, $data;
-        $template = 'status';
-
-        $bean              = R::dispense('post');
-        $bean->description = 'Timestamps';
-        $bean->created     = '2024-01-02 03:04:05';
-        $bean->updated     = '2025-06-07 08:09:10';
-        R::store($bean);
-        $data = ['posts' => [$bean]];
-
-        ob_start();
-        the_opengraph();
-        $output = ob_get_clean();
-
         $this->assertStringContainsString(
             '<meta property="og:modified_time" content="2025-06-07 08:09:10"/>',
             $output
@@ -406,7 +381,7 @@ class ThemeMetaTest extends TestCase
     /**
      * Renders the_opengraph() for a status post and returns the emitted markup.
      *
-     * @param array $fields Post bean fields (transformed, title, description).
+     * @param array $fields Post bean fields (transformed, title, description, created, updated).
      */
     private function renderStatus(array $fields = []): string
     {
@@ -417,8 +392,8 @@ class ThemeMetaTest extends TestCase
         $bean->title       = $fields['title'] ?? 'Image Post';
         $bean->description = $fields['description'] ?? 'A description';
         $bean->transformed = $fields['transformed'] ?? '';
-        $bean->created     = date('Y-m-d H:i:s');
-        $bean->updated     = date('Y-m-d H:i:s');
+        $bean->created     = $fields['created'] ?? date('Y-m-d H:i:s');
+        $bean->updated     = $fields['updated'] ?? date('Y-m-d H:i:s');
         R::store($bean);
         $data = ['posts' => [$bean]];
 

--- a/tests/Unit/ThemeMetaTest.php
+++ b/tests/Unit/ThemeMetaTest.php
@@ -355,6 +355,54 @@ class ThemeMetaTest extends TestCase
         return $dir;
     }
 
+    // -------------------------------------------------------------------------
+    // the_opengraph — published/modified times map to the right columns
+    // -------------------------------------------------------------------------
+
+    public function testOpenGraphPublishedTimeIsTheCreatedDate(): void
+    {
+        global $template, $data;
+        $template = 'status';
+
+        $bean              = R::dispense('post');
+        $bean->description = 'Timestamps';
+        $bean->created     = '2024-01-02 03:04:05';
+        $bean->updated     = '2025-06-07 08:09:10';
+        R::store($bean);
+        $data = ['posts' => [$bean]];
+
+        ob_start();
+        the_opengraph();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString(
+            '<meta property="og:published_time" content="2024-01-02 03:04:05"/>',
+            $output
+        );
+    }
+
+    public function testOpenGraphModifiedTimeIsTheUpdatedDate(): void
+    {
+        global $template, $data;
+        $template = 'status';
+
+        $bean              = R::dispense('post');
+        $bean->description = 'Timestamps';
+        $bean->created     = '2024-01-02 03:04:05';
+        $bean->updated     = '2025-06-07 08:09:10';
+        R::store($bean);
+        $data = ['posts' => [$bean]];
+
+        ob_start();
+        the_opengraph();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString(
+            '<meta property="og:modified_time" content="2025-06-07 08:09:10"/>',
+            $output
+        );
+    }
+
     /**
      * Renders the_opengraph() for a status post and returns the emitted markup.
      *


### PR DESCRIPTION
Two rendering bugs.

### OpenGraph published/modified times are swapped

`the_opengraph()` emitted:

```php
'og:modified_time'  => $bean->created,
'og:published_time' => $bean->updated,
```

Each column is wired to the opposite property, so every scraper reads a post's last edit as its publication date — and an unedited post reports as "modified" before it existed. Swapped to match the columns' meaning.

### The base theme's menu-page filter never fired

`src/themes/base/parts/_items.php` did:

```php
if (is_menu_item($bean->is_menu_item ?? $bean->id)) :
```

`is_menu_item()` matches a *slug*, and no post bean carries an `is_menu_item` property — so it always fell through to the numeric id, which never matches a configured slug. Menu pages therefore stayed in tag and search listings, which (unlike the home listing and the feeds, filtered in `public_posts_clause()`) have no SQL-level exclusion.

Matching on the slug also needs the `status` guard the 2024 and 2026 themes already carry: on a permalink the menu page *is* the requested post, so skipping it there would render an empty page. The base theme now matches those two.

## Testing steps

### Automated

```bash
composer install
LAMB_WRITE_TEST_PASSWORD=1 php make-password.php <a-password>
vendor/bin/codecept run Unit --filter "ThemeMetaTest|ThemeMenuItemsTest"
```

Expect 23 passing tests. To see them catch the bugs:

```bash
git checkout main -- src/theme/meta.php src/themes/base/parts/_items.php
vendor/bin/codecept run Unit --filter "ThemeMetaTest|ThemeMenuItemsTest"   # Tests: 23, Failures: 4
git checkout HEAD -- src/theme/meta.php src/themes/base/parts/_items.php
```

Full suite (`vendor/bin/codecept run`, `composer lint`) is also green.

### Manual — OpenGraph timestamps

1. `composer serve`, log in, create a post.
2. Give it distinct dates so a swap is visible:
   ```bash
   sqlite3 data/lamb.db "UPDATE post SET created='2024-01-02 03:04:05', updated='2025-06-07 08:09:10' WHERE id=1"
   ```
3. Fetch the permalink and read the two tags. Anonymous responses are cacheable, so add a cache-buster:
   ```bash
   curl -s "http://localhost:8747/status/1?x=$RANDOM" | grep -oE 'og:(published|modified)_time" content="[^"]*"'
   ```

   Expected:
   ```
   og:modified_time" content="2025-06-07 08:09:10"    # the edit date
   og:published_time" content="2024-01-02 03:04:05"   # the publication date
   ```
   On `main` the two values are the other way round.

### Manual — menu pages in listings

This one is base-theme-specific, so set the theme first (Settings → `theme = base`).

1. Create a page-like post with a slug and a tag:
   ```
   ---
   title: About
   slug: about
   ---
   About page body #hello
   ```
2. Create an ordinary post: `Normal post #hello`
3. In Settings, add under `[menu_items]`: `About = about`
4. Log out (or use a private window) and visit `/tag/hello`:
   - "About page body" must **not** appear — on `main` it does.
   - "Normal post" must still appear.
   - The same holds for a search that matches both.
5. Visit `/about` directly — the page must still render in full. This is the `status` guard; without it the fix would blank the page.

I ran steps 1–5 against a dev server on both revisions: the menu page appears in `/tag/hello` on `main` and is absent here, while `/about` renders on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTVRRWkZ1eLFis47AS814B