### PR TITLE
Fix 404 page: raw HTTP status line as the title, and a search link to "404"

### DIFF
--- a/src/http.php
+++ b/src/http.php
@@ -24,17 +24,15 @@ function get_request_uri(): string|false
 }
 
 /**
- * The current request's path, without its leading or trailing slashes.
+ * The current request's path, without its leading or trailing slashes — the
+ * request as the visitor typed it, for showing back to them.
  *
- * The plain "what did the visitor ask for?" reading of the request, for callers
- * that want to show it back to them (the 404 page's search suggestion). Distinct
- * from {@see get_request_uri}, which is the router's view: that one keeps the
- * leading slash and rewrites `/` to `/home`, neither of which is something to
- * put in front of a visitor.
+ * Not {@see get_request_uri}, which is the router's view: it keeps the leading
+ * slash and rewrites `/` to `/home`, so a 404 at the site root would suggest
+ * searching for "home".
  *
- * Returns '' when there is no usable path (the site root, or a malformed
- * REQUEST_URI), so callers can drop the UI that depends on it rather than
- * render an empty one.
+ * Returns '' when there is no usable path, so callers can drop the UI that
+ * depends on it rather than render an empty one.
  *
  * @return string The path, e.g. `tag/php` for `/tag/php?utm=1`.
  */

--- a/src/http.php
+++ b/src/http.php
@@ -24,6 +24,28 @@ function get_request_uri(): string|false
 }
 
 /**
+ * The current request's path, without its leading or trailing slashes.
+ *
+ * The plain "what did the visitor ask for?" reading of the request, for callers
+ * that want to show it back to them (the 404 page's search suggestion). Distinct
+ * from {@see get_request_uri}, which is the router's view: that one keeps the
+ * leading slash and rewrites `/` to `/home`, neither of which is something to
+ * put in front of a visitor.
+ *
+ * Returns '' when there is no usable path (the site root, or a malformed
+ * REQUEST_URI), so callers can drop the UI that depends on it rather than
+ * render an empty one.
+ *
+ * @return string The path, e.g. `tag/php` for `/tag/php?utm=1`.
+ */
+function requested_path(): string
+{
+    $path = parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH);
+
+    return is_string($path) ? trim($path, '/') : '';
+}
+
+/**
  * Splits a trailing `/page/<N>` pagination segment off a request path.
  *
  * Clean pagination URLs append `/page/N` to whatever list path they paginate

--- a/src/response.php
+++ b/src/response.php
@@ -229,23 +229,8 @@ function respond_404(array $_args = [], bool $use_fallback = false): array
         // $data['action'] is always the literal '404' by the time the template
         // runs (the router overwrites it with this array's own action), so the
         // search suggestion offered to search for "404".
-        'requested' => requested_path(),
+        'requested' => \Lamb\Http\requested_path(),
     ];
-}
-
-/**
- * The path segment of the current request, without leading/trailing slashes.
- *
- * Returns '' when there is no usable path, so callers can drop the UI that
- * depends on it rather than render an empty one.
- *
- * @return string
- */
-function requested_path(): string
-{
-    $path = parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH);
-
-    return is_string($path) ? trim($path, '/') : '';
 }
 
 /**

--- a/src/response.php
+++ b/src/response.php
@@ -219,16 +219,11 @@ function respond_404(array $_args = [], bool $use_fallback = false): array
     header('HTTP/1.0 404 Not Found');
 
     return [
-        // A human title, not the raw status line: this is rendered as the page's
-        // <title> and <h1>, so visitors (and search results) were shown the
-        // literal string "HTTP/1.0 404 Not Found".
         'title' => 'Page not found',
         'intro' => 'Page not found.',
         'action' => '404',
-        // What the visitor asked for, so the template can offer to search for it.
-        // $data['action'] is always the literal '404' by the time the template
-        // runs (the router overwrites it with this array's own action), so the
-        // search suggestion offered to search for "404".
+        // Not derivable from `action`: the router overwrites that with this
+        // array's own '404' before the template renders.
         'requested' => \Lamb\Http\requested_path(),
     ];
 }

--- a/src/response.php
+++ b/src/response.php
@@ -203,7 +203,9 @@ function redirect_404(string $fallback): void
  *
  * @param array<int, string> $_args   Unused.
  * @param bool  $use_fallback Whether to redirect to the configured fallback URL.
- * @return array{title: string, intro: string, action: string} An array containing the title, intro, and action of the 404 error page.
+ * @return array{title: string, intro: string, action: string, requested: string} The
+ *         404 page's view data: the human title, intro, the action marker the
+ *         router switches on, and the path the visitor actually asked for.
  */
 function respond_404(array $_args = [], bool $use_fallback = false): array
 {
@@ -214,14 +216,36 @@ function respond_404(array $_args = [], bool $use_fallback = false): array
             redirect_404($fallback);
         }
     }
-    $header = "HTTP/1.0 404 Not Found";
-    header($header);
+    header('HTTP/1.0 404 Not Found');
 
     return [
-        'title' => $header,
+        // A human title, not the raw status line: this is rendered as the page's
+        // <title> and <h1>, so visitors (and search results) were shown the
+        // literal string "HTTP/1.0 404 Not Found".
+        'title' => 'Page not found',
         'intro' => 'Page not found.',
         'action' => '404',
+        // What the visitor asked for, so the template can offer to search for it.
+        // $data['action'] is always the literal '404' by the time the template
+        // runs (the router overwrites it with this array's own action), so the
+        // search suggestion offered to search for "404".
+        'requested' => requested_path(),
     ];
+}
+
+/**
+ * The path segment of the current request, without leading/trailing slashes.
+ *
+ * Returns '' when there is no usable path, so callers can drop the UI that
+ * depends on it rather than render an empty one.
+ *
+ * @return string
+ */
+function requested_path(): string
+{
+    $path = parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH);
+
+    return is_string($path) ? trim($path, '/') : '';
 }
 
 /**

--- a/src/themes/base/parts/404.php
+++ b/src/themes/base/parts/404.php
@@ -1,9 +1,16 @@
 <?php
 
+use function Lamb\Theme\escape;
 use function Lamb\Theme\page_intro;
 use function Lamb\Theme\page_title;
 
 global $data;
+
+// The path the visitor asked for. It used to read $data['action'], which the
+// router has always overwritten with the literal '404' by the time this runs —
+// so the page offered to search for "404". It is request-controlled, so it is
+// escaped for the href and the link text rather than echoed raw.
+$requested = (string) ($data['requested'] ?? '');
 ?>
 <?= page_title() ?>
 
@@ -11,4 +18,6 @@ global $data;
     <?= page_intro() ?>
 </section>
 
-<p>Why not try <a href="/search/<?= $data['action'] ?>">searching for <?= $data['action'] ?> </a></p>
+<?php if ($requested !== '') : ?>
+<p>Why not try <a href="/search/<?= escape(rawurlencode($requested)) ?>">searching for <?= escape($requested) ?></a></p>
+<?php endif; ?>

--- a/src/themes/base/parts/404.php
+++ b/src/themes/base/parts/404.php
@@ -6,10 +6,7 @@ use function Lamb\Theme\page_title;
 
 global $data;
 
-// The path the visitor asked for. It used to read $data['action'], which the
-// router has always overwritten with the literal '404' by the time this runs —
-// so the page offered to search for "404". It is request-controlled, so it is
-// escaped for the href and the link text rather than echoed raw.
+// Request-controlled, so escaped at both output sites below.
 $requested = (string) ($data['requested'] ?? '');
 ?>
 <?= page_title() ?>

--- a/tests/Unit/HttpTest.php
+++ b/tests/Unit/HttpTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use function Lamb\Http\extract_page_segment;
 use function Lamb\Http\get_request_uri;
 use function Lamb\Http\page_path;
+use function Lamb\Http\requested_path;
 
 class HttpTest extends TestCase
 {
@@ -50,6 +51,42 @@ class HttpTest extends TestCase
     {
         $_SERVER['REQUEST_URI'] = '/tag/php';
         $this->assertSame('/tag/php', get_request_uri());
+    }
+
+    // requested_path — the visitor-facing reading of the request path, as
+    // opposed to get_request_uri()'s router-facing one (which keeps the leading
+    // slash and rewrites `/` to `/home`).
+
+    public function testRequestedPathStripsSurroundingSlashes(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/no-such-page/';
+        $this->assertSame('no-such-page', requested_path());
+    }
+
+    public function testRequestedPathStripsQueryString(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/tag/php?utm=1';
+        $this->assertSame('tag/php', requested_path());
+    }
+
+    public function testRequestedPathIsEmptyForTheRoot(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/';
+        $this->assertSame('', requested_path());
+    }
+
+    public function testRequestedPathIsEmptyWhenRequestUriIsAbsent(): void
+    {
+        unset($_SERVER['REQUEST_URI']);
+        $this->assertSame('', requested_path());
+    }
+
+    public function testRequestedPathDoesNotRewriteTheRootToHome(): void
+    {
+        // get_request_uri() maps `/` to `/home` for routing; showing "home" back
+        // to a visitor as the thing they asked for would be wrong.
+        $_SERVER['REQUEST_URI'] = '/';
+        $this->assertNotSame('home', requested_path());
     }
 
     public function testExtractPageSegmentFromRootPageMapsToHome(): void

--- a/tests/Unit/ResponseHandlersTest.php
+++ b/tests/Unit/ResponseHandlersTest.php
@@ -105,6 +105,31 @@ class ResponseHandlersTest extends TestCase
         $this->assertStringContainsString('not found', strtolower($result['intro']));
     }
 
+    public function testRespond404TitleIsHumanReadableNotTheStatusLine(): void
+    {
+        // The title is rendered as the page's <title> and <h1>, so the raw
+        // status line ("HTTP/1.0 404 Not Found") must never reach it.
+        $result = respond_404();
+        $this->assertStringNotContainsString('HTTP/', $result['title']);
+        $this->assertStringContainsString('not found', strtolower($result['title']));
+    }
+
+    public function testRespond404ReportsTheRequestedPath(): void
+    {
+        // The template offers to search for what the visitor asked for; it used
+        // to read $data['action'], which is always the literal '404' by then.
+        $_SERVER['REQUEST_URI'] = '/no-such-page?utm=1';
+        $result = respond_404();
+        $this->assertSame('no-such-page', $result['requested']);
+    }
+
+    public function testRespond404RequestedPathIsEmptyForTheRoot(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/';
+        $result = respond_404();
+        $this->assertSame('', $result['requested']);
+    }
+
     // respond_home
 
     public function testRespondHomeReturnsArray(): void

--- a/tests/Unit/Theme404PartTest.php
+++ b/tests/Unit/Theme404PartTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the base theme's 404 part.
+ *
+ * The "why not search for …" suggestion used to read $data['action'], which the
+ * router has always overwritten with the literal '404' by render time — so every
+ * 404 page offered to search for "404". It is now driven by $data['requested']
+ * (the path the visitor actually asked for), which is request-controlled and so
+ * must also be escaped rather than echoed raw.
+ */
+class Theme404PartTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        global $data, $template;
+        $data = [];
+        $template = null;
+    }
+
+    private function render(string $requested): string
+    {
+        global $data, $config, $template;
+        $config   = ['site_title' => 'Test Blog'];
+        $template = '404';
+        $data     = [
+            'title'     => 'Page not found',
+            'intro'     => 'Page not found.',
+            'action'    => '404',
+            'requested' => $requested,
+        ];
+
+        ob_start();
+        include dirname(__DIR__, 2) . '/src/themes/base/parts/404.php';
+        return (string) ob_get_clean();
+    }
+
+    public function testSuggestsSearchingForTheRequestedPath(): void
+    {
+        $html = $this->render('missing-post');
+
+        $this->assertStringContainsString('/search/missing-post', $html);
+        $this->assertStringContainsString('searching for missing-post', $html);
+    }
+
+    public function testDoesNotSuggestSearchingForTheLiteral404(): void
+    {
+        $html = $this->render('missing-post');
+
+        $this->assertStringNotContainsString('/search/404', $html);
+    }
+
+    public function testOmitsTheSuggestionWhenThereIsNoRequestedPath(): void
+    {
+        $this->assertStringNotContainsString('/search/', $this->render(''));
+    }
+
+    public function testEscapesTheRequestedPath(): void
+    {
+        $html = $this->render('"><script>alert(1)</script>');
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testRendersTheHumanTitleRatherThanAStatusLine(): void
+    {
+        $html = $this->render('missing-post');
+
+        $this->assertStringContainsString('<h1>Page not found</h1>', $html);
+        $this->assertStringNotContainsString('HTTP/', $html);
+    }
+}


### PR DESCRIPTION
Two bugs on the 404 page. Before, on `/no-such-page`:

```html
<title>HTTP/1.0 404 Not Found</title>
...
<h1>HTTP/1.0 404 Not Found</h1>
<p>Why not try <a href="/search/404">searching for 404 </a></p>
```

After:

```html
<title>Page not found</title>
...
<h1>Page not found</h1>
<p>Why not try <a href="/search/no-such-page">searching for no-such-page</a></p>
```

### The title was the status line

`respond_404()` built `$header = "HTTP/1.0 404 Not Found"`, passed it to `header()`, and then returned the same string as `title` — which is rendered as the page's `<title>` and `<h1>`. The status line is now sent as a header only, and the returned title is human-readable.

### The search suggestion offered to search for "404"

The template read `$data['action']`, but the router overwrites `action` with the literal `'404'` (from this very array) before the template runs, so the suggestion never referred to what the visitor asked for. `respond_404()` now returns a `requested` key holding the request path, and the template uses that.

While there: the value is request-controlled and was echoed raw into both the href and the link text, so it is now escaped (and `rawurlencode`d for the href), and the whole suggestion is omitted when there is no path to suggest.

### Where the new helper lives

`requested_path()` sits in `Lamb\Http`, alongside `get_request_uri()`, `extract_page_segment()`, `page_path()` and `request_root_url()` — it is request parsing, so it belongs with the request parsing rather than in the response layer.

It is deliberately not `get_request_uri()`: that one is the *router's* view of the request (leading slash kept, `/` rewritten to `/home`), and neither of those is something to show a visitor — a 404 at the site root would otherwise suggest searching for "home". The docblock records the distinction, and a test pins it.

## Testing steps

### Automated

```bash
composer install
LAMB_WRITE_TEST_PASSWORD=1 php make-password.php <a-password>
vendor/bin/codecept run Unit --filter "HttpTest|Theme404PartTest|ResponseHandlersTest"
```

Expect 92 passing tests. To see them catch the bugs:

```bash
git checkout main -- src/response.php src/themes/base/parts/404.php
vendor/bin/codecept run Unit --filter "Theme404PartTest|ResponseHandlersTest"   # Tests: 70, Errors: 2, Failures: 5
git checkout HEAD -- src/response.php src/themes/base/parts/404.php
```

(The 2 errors are the assertions that read the new `requested` key, which does not exist on `main`.)

Full suite (`vendor/bin/codecept run` — 1615 tests) and `composer lint` are green.

### Manual

Run `composer serve` and, as an anonymous visitor:

1. **Title** — `curl -s http://localhost:8747/no-such-page | grep -o '<title>[^<]*</title>'`
   → `<title>Page not found</title>` (on `main`: `<title>HTTP/1.0 404 Not Found</title>`). Loading the page in a browser shows the same string as the `<h1>`.

2. **Search suggestion** — `curl -s http://localhost:8747/no-such-page | grep 'Why not try'`
   → links to `/search/no-such-page` (on `main`: `/search/404`, for every 404 URL alike). Following the link runs a real search for that term.

3. **Status code is unchanged** — `curl -sI http://localhost:8747/no-such-page | head -1`
   → `HTTP/1.0 404 Not Found`. The status line moved to the header only; it must still be a 404, not a 200.

4. **Escaping** — `curl -s 'http://localhost:8747/%22%3E%3Cscript%3Ealert(1)%3C/script%3E' | grep 'Why not try'`
   → the path appears as inert text and the response contains no executable `<script>` tag.

5. **Root** — `curl -sI http://localhost:8747/ | head -1` → still `200`; the home page is unaffected.

I ran steps 1–4 against a dev server on this branch; the outputs above are what it returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTVRRWkZ1eLFis47AS814B