### PR TITLE
Fix a rejected image upload pasting its error message into the post

### DIFF
--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -41,7 +41,11 @@ function respond_upload(array $_args): void
     $out = '';
     foreach ($files as $f) {
         if ($f['error'] !== UPLOAD_ERR_OK) {
-            // File upload failed
+            // File upload failed. The status code matters: the browser-side
+            // handler keys on response.ok to decide whether the body is markdown
+            // to insert or an error to report, and a 200 here made it paste the
+            // error message into the post.
+            header('HTTP/1.1 400 Bad Request');
             echo json_encode('File upload error: ' . $f['error'], JSON_THROW_ON_ERROR);
             die();
         }
@@ -73,6 +77,7 @@ function respond_upload(array $_args): void
             $new_fn = "$seed.$ext";
             $new_fp = sprintf("%s/%s", $dir, $new_fn);
             if (!move_uploaded_file($temp_fp, $new_fp)) {
+                header('HTTP/1.1 500 Internal Server Error');
                 echo json_encode('Move upload error: ' . $temp_fp, JSON_THROW_ON_ERROR);
                 die();
             }

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -41,10 +41,8 @@ function respond_upload(array $_args): void
     $out = '';
     foreach ($files as $f) {
         if ($f['error'] !== UPLOAD_ERR_OK) {
-            // File upload failed. The status code matters: the browser-side
-            // handler keys on response.ok to decide whether the body is markdown
-            // to insert or an error to report, and a 200 here made it paste the
-            // error message into the post.
+            // The status is load-bearing: upload-image.js keys on response.ok to
+            // tell markdown-to-insert from error-to-report.
             header('HTTP/1.1 400 Bad Request');
             echo json_encode('File upload error: ' . $f['error'], JSON_THROW_ON_ERROR);
             die();

--- a/src/scripts/logged_in/upload-image.js
+++ b/src/scripts/logged_in/upload-image.js
@@ -65,16 +65,70 @@ function handleFiles(files, textarea) {
     })
         // The endpoint answers a rejected upload with an error status and a JSON
         // *string* ("Unsupported file type.", "File contents do not match its
-        // type."). Without this check that message was treated as the markdown
-        // to insert, so a failed upload silently pasted the error text into the
-        // post being written. Reject instead and leave the textarea untouched.
-        .then(response => response.ok ? response.json() : Promise.reject(new Error(`Upload failed (${response.status})`)))
+        // type."). That message is for the author, not for the post: without
+        // this check it was inserted as if it were the markdown. Read the body
+        // either way, so a refusal can be reported rather than swallowed.
+        .then(response => response.json().catch(() => null).then(body => {
+            if (!response.ok) {
+                throw new Error(uploadErrorMessage(body, response.status))
+            }
+            return body
+        }))
         .then(data => {
             const markdown = data.replace(/!\[[^\]]*\]/g, '![]')
             textarea.value = text.slice(0, cursor) + markdown + text.slice(cursor)
             const altStart = cursor + markdown.indexOf('![') + 2
             textarea.setSelectionRange(altStart, altStart)
             textarea.dispatchEvent(new Event('input'))
+            clearUploadError()
         })
-        .catch(error => console.error(error))
+        .catch(error => {
+            console.error(error)
+            showUploadError(textarea, error.message)
+        })
+}
+
+/**
+ * The message to show for a refused upload: the endpoint's own explanation when
+ * it sent one, otherwise the bare status so the author still gets something
+ * actionable.
+ *
+ * @param {*} body - The parsed response body (a string for this endpoint's errors).
+ * @param {number} status - The HTTP status code.
+ * @returns {string}
+ */
+function uploadErrorMessage(body, status) {
+    return typeof body === 'string' && body.trim() !== ''
+        ? body.trim()
+        : `Upload failed (${status})`
+}
+
+/**
+ * Shows an upload failure above the entry form.
+ *
+ * Uploads happen without a page load, so the server-rendered $_SESSION['flash']
+ * messages can't carry this — but reusing their `.flash` class means the notice
+ * is styled by whichever theme is active, with no new CSS. Replacing the text of
+ * an existing notice keeps repeated failures from stacking up.
+ *
+ * @param {HTMLElement} textarea - The textarea the upload was started from.
+ * @param {string} message
+ */
+function showUploadError(textarea, message) {
+    const anchor = textarea.closest('form') || textarea
+    let flash = $('.flash.upload-error')
+    if (!flash) {
+        flash = document.createElement('div')
+        flash.className = 'flash upload-error'
+        flash.setAttribute('role', 'alert')
+        anchor.parentNode.insertBefore(flash, anchor)
+    }
+    flash.textContent = `⚠ ${message}`
+}
+
+/**
+ * Removes a previous upload failure notice once an upload succeeds.
+ */
+function clearUploadError() {
+    $('.flash.upload-error')?.remove()
 }

--- a/src/scripts/logged_in/upload-image.js
+++ b/src/scripts/logged_in/upload-image.js
@@ -63,7 +63,12 @@ function handleFiles(files, textarea) {
     fetch('/upload', {
         method: 'POST', body: formData
     })
-        .then(response => response.json())
+        // The endpoint answers a rejected upload with an error status and a JSON
+        // *string* ("Unsupported file type.", "File contents do not match its
+        // type."). Without this check that message was treated as the markdown
+        // to insert, so a failed upload silently pasted the error text into the
+        // post being written. Reject instead and leave the textarea untouched.
+        .then(response => response.ok ? response.json() : Promise.reject(new Error(`Upload failed (${response.status})`)))
         .then(data => {
             const markdown = data.replace(/!\[[^\]]*\]/g, '![]')
             textarea.value = text.slice(0, cursor) + markdown + text.slice(cursor)

--- a/src/scripts/logged_in/upload-image.js
+++ b/src/scripts/logged_in/upload-image.js
@@ -63,11 +63,8 @@ function handleFiles(files, textarea) {
     fetch('/upload', {
         method: 'POST', body: formData
     })
-        // The endpoint answers a rejected upload with an error status and a JSON
-        // *string* ("Unsupported file type.", "File contents do not match its
-        // type."). That message is for the author, not for the post: without
-        // this check it was inserted as if it were the markdown. Read the body
-        // either way, so a refusal can be reported rather than swallowed.
+        // A refusal carries a JSON *string* message, not markdown — hence the
+        // ok check. The body is read either way so the message can be shown.
         .then(response => response.json().catch(() => null).then(body => {
             if (!response.ok) {
                 throw new Error(uploadErrorMessage(body, response.status))

--- a/tests/js/upload-image.test.mjs
+++ b/tests/js/upload-image.test.mjs
@@ -136,3 +136,64 @@ test('handleFiles leaves the textarea alone when the upload is rejected', async 
   assert.equal(ta.value, 'draft text')
   assert.equal(errors.length, 1)
 })
+
+test('handleFiles shows the rejection reason to the author', async () => {
+  // Leaving the textarea alone is only half the job: uploads happen without a
+  // page load, so the author has to be told why nothing appeared.
+  const { window, document, api } = load('<!DOCTYPE html><body><form><textarea></textarea></form></body>')
+  const ta = document.querySelector('textarea')
+  window.console.error = () => {}
+  window.fetch = () => Promise.resolve({
+    ok: false,
+    status: 400,
+    json: () => Promise.resolve('Unsupported file type.'),
+  })
+
+  api.handleFiles([new window.File(['x'], 'evil.svg', { type: 'image/svg+xml' })], ta)
+  await flush()
+
+  const flash = document.querySelector('.flash.upload-error')
+  assert.ok(flash, 'an upload failure should be surfaced in the page')
+  assert.match(flash.textContent, /Unsupported file type\./)
+  assert.equal(flash.getAttribute('role'), 'alert')
+  // Above the form, so it is not pushed off-screen by a long draft.
+  assert.equal(flash.nextElementSibling.tagName, 'FORM')
+})
+
+test('handleFiles falls back to the status when the endpoint sends no message', async () => {
+  const { window, document, api } = load('<!DOCTYPE html><body><form><textarea></textarea></form></body>')
+  const ta = document.querySelector('textarea')
+  window.console.error = () => {}
+  window.fetch = () => Promise.resolve({
+    ok: false,
+    status: 500,
+    json: () => Promise.reject(new Error('not json')),
+  })
+
+  api.handleFiles([new window.File(['x'], 'a.png', { type: 'image/png' })], ta)
+  await flush()
+
+  assert.match(document.querySelector('.flash.upload-error').textContent, /Upload failed \(500\)/)
+})
+
+test('handleFiles does not stack repeated failures, and clears on success', async () => {
+  const { window, document, api } = load('<!DOCTYPE html><body><form><textarea></textarea></form></body>')
+  const ta = document.querySelector('textarea')
+  window.console.error = () => {}
+  window.fetch = () => Promise.resolve({
+    ok: false,
+    status: 400,
+    json: () => Promise.resolve('Unsupported file type.'),
+  })
+
+  api.handleFiles([new window.File(['x'], 'a.svg', { type: 'image/svg+xml' })], ta)
+  await flush()
+  api.handleFiles([new window.File(['x'], 'b.svg', { type: 'image/svg+xml' })], ta)
+  await flush()
+  assert.equal(document.querySelectorAll('.flash.upload-error').length, 1)
+
+  window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve('![](/img.webp)') })
+  api.handleFiles([new window.File(['x'], 'c.png', { type: 'image/png' })], ta)
+  await flush()
+  assert.equal(document.querySelectorAll('.flash.upload-error').length, 0)
+})

--- a/tests/js/upload-image.test.mjs
+++ b/tests/js/upload-image.test.mjs
@@ -51,7 +51,7 @@ test('handleFiles inserts the upload response at the cursor and fires input', as
   let posted
   window.fetch = (url, opts) => {
     posted = { url, opts }
-    return Promise.resolve({ json: () => Promise.resolve('![](/img.webp)') })
+    return Promise.resolve({ ok: true, json: () => Promise.resolve('![](/img.webp)') })
   }
 
   api.handleFiles([new window.File(['x'], 'a.png', { type: 'image/png' })], ta)
@@ -73,7 +73,7 @@ test('handleFiles posts a dropped video file the same way as an image', async ()
   let posted
   window.fetch = (url, opts) => {
     posted = { url, opts }
-    return Promise.resolve({ json: () => Promise.resolve('![](/clip.mp4)') })
+    return Promise.resolve({ ok: true, json: () => Promise.resolve('![](/clip.mp4)') })
   }
 
   api.handleFiles([new window.File(['x'], 'clip.mp4', { type: 'video/mp4' })], ta)
@@ -90,7 +90,7 @@ test('handleFiles strips server alt text so the user sees empty [] to fill in', 
   ta.value = ''
   ta.setSelectionRange(0, 0)
 
-  window.fetch = () => Promise.resolve({ json: () => Promise.resolve('![photo.jpg](/img.webp)') })
+  window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve('![photo.jpg](/img.webp)') })
 
   api.handleFiles([new window.File(['x'], 'photo.jpg', { type: 'image/png' })], ta)
   await flush()
@@ -104,7 +104,7 @@ test('handleFiles positions cursor inside [] after insertion', async () => {
   ta.value = 'abcd'
   ta.setSelectionRange(2, 2) // cursor between "ab" and "cd"
 
-  window.fetch = () => Promise.resolve({ json: () => Promise.resolve('![photo.jpg](/img.webp)') })
+  window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve('![photo.jpg](/img.webp)') })
 
   api.handleFiles([new window.File(['x'], 'photo.jpg', { type: 'image/png' })], ta)
   await flush()
@@ -112,4 +112,27 @@ test('handleFiles positions cursor inside [] after insertion', async () => {
   assert.equal(ta.value, 'ab![](/img.webp)cd')
   assert.equal(ta.selectionStart, 4) // inside the [], after ![
   assert.equal(ta.selectionEnd, 4)
+})
+
+test('handleFiles leaves the textarea alone when the upload is rejected', async () => {
+  // A rejected upload answers with an error status and a JSON *string* error
+  // message. That message must never be inserted into the post being written.
+  const { window, document, api } = load('<!DOCTYPE html><body><textarea></textarea></body>')
+  const ta = document.querySelector('textarea')
+  ta.value = 'draft text'
+  ta.setSelectionRange(5, 5)
+
+  const errors = []
+  window.console.error = (e) => errors.push(e)
+  window.fetch = () => Promise.resolve({
+    ok: false,
+    status: 400,
+    json: () => Promise.resolve('Unsupported file type.'),
+  })
+
+  api.handleFiles([new window.File(['x'], 'evil.svg', { type: 'image/svg+xml' })], ta)
+  await flush()
+
+  assert.equal(ta.value, 'draft text')
+  assert.equal(errors.length, 1)
 })


### PR DESCRIPTION
Dropping or pasting a file the upload endpoint rejects inserted the rejection message into the post being written — and, once that was stopped, told the author nothing at all. Both halves are fixed here.

## The message ended up in the post

`handleFiles()` passed every response straight to `.json()` and inserted the result at the cursor:

```js
.then(response => response.json())
.then(data => {
    const markdown = data.replace(/!\[[^\]]*\]/g, '[]')
    textarea.value = text.slice(0, cursor) + markdown + text.slice(cursor)
```

A rejected upload answers with a JSON *string* — `"Unsupported file type."`, `"File contents do not match its type."` — so that string became the "markdown" to insert.

Two of the endpoint's own failure paths also returned their error with no status code at all (an upload PHP itself rejected, and a failed `move_uploaded_file()`), so any status check would have read them as successes. They now send 400 and 500.

## …and then nothing took its place

Simply refusing to insert the body would have made a rejected upload a silent no-op, with the only trace a `console.error` the author will never see. That is arguably worse than the original bug: the message was at least visible before, if in the wrong place.

The refusal is now shown above the entry form, carrying the endpoint's own explanation and falling back to the status code when there is no message to read:

```
⚠ Unsupported file type.
```

Uploads happen without a page load, so the server-rendered `$_SESSION['flash']` messages cannot carry this. Reusing their `.flash` class means the notice inherits whichever theme is active (all three style it) and needs no new CSS. `role="alert"` announces it to screen readers, repeated failures replace rather than stack, and a later successful upload clears it.

## Testing steps

### Automated

```bash
pnpm install
pnpm test
```

Expect 37 passing tests. Four cover this change:

- `leaves the textarea alone when the upload is rejected` — the draft is untouched
- `shows the rejection reason to the author` — the `.flash` notice, its text, its `role`, and its position above the form
- `falls back to the status when the endpoint sends no message` — an unparseable body yields `Upload failed (500)`
- `does not stack repeated failures, and clears on success`

To see the first one catch the original bug:

```bash
git checkout main -- src/scripts/logged_in/upload-image.js
pnpm test   # the error string is inserted into the textarea
git checkout HEAD -- src/scripts/logged_in/upload-image.js
```

The pre-existing `handleFiles` tests stubbed `fetch` with a bare `{ json }` and no `ok`, so their stubs now set `ok: true` — worth a look during review, since that is a test change rather than a behaviour change.

PHP side: `vendor/bin/codecept run` (1610 tests) and `composer lint` are green.

### Manual

Run `composer serve` and log in at http://localhost:8747/login. On the home page's entry form:

1. Type some draft text, then **drag and drop a rejected file** onto the textarea — e.g. `notes.txt`, or an `.svg` (deliberately not in the allowlist, since SVG can carry scripts).
   - Expected: the draft is **unchanged**, and `⚠ Unsupported file type.` appears above the form.
   - On `main`: `Unsupported file type.` is inserted into the post at the cursor.
2. Drop a second rejected file — the notice updates in place rather than a second one appearing.
3. **Paste** a screenshot, or drop a real `.png`/`.jpg`.
   - Expected: `[](/assets/YYYY/MM/….webp)` is inserted at the cursor with the caret inside the `[]` for alt text, and the earlier notice disappears. This is the unchanged happy path — worth confirming it still works.
4. Optional, for the endpoint status codes: post a file larger than `upload_max_filesize` and confirm the response is a `400` rather than a `200` carrying an error string.

The DOM behaviour in steps 1–3 is covered by the jsdom tests above; step 4 is the only part not exercised automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTVRRWkZ1eLFis47AS814B