### PR TITLE
Record the comment convention in AGENTS.md: constraint, not changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,6 +458,36 @@ Parts you rarely need to override: `edit.php`, `login.php`, `settings.php`, `404
 - Underscore method names allowed in tests
 - Run `composer lint` before committing
 
+### Comments
+
+**Comment the constraint, not the changelog.**
+
+An inline comment earns its place when reverting the line would look *reasonable*
+to a future editor: a coupling across files, a counter-intuitive choice, a guard
+whose removal breaks something distant. Write what breaks if the line changes.
+
+Do not narrate the bug a line used to have. That belongs in the commit message,
+where `git blame` will find it. Once the code reads correctly on its own, the
+comment is noise:
+
+```php
+// Noise — archaeology. The line already states this.
+// `created` is when the post was published and `updated` when it was last
+// changed; the two were wired to the opposite properties, so every scraper
+// read a post's edit time as its publication date.
+'og:published_time' => $bean->created,
+
+// Earns its place — a coupling the next editor cannot see from here.
+// The status is load-bearing: upload-image.js keys on response.ok to tell
+// markdown-to-insert from error-to-report.
+header('HTTP/1.1 400 Bad Request');
+```
+
+Docblocks are the exception and are deliberately expansive in this codebase —
+they carry a function's "why" as a whole, and account for most of the ~44% of
+`src/` lines that are comments. Inline `//` rationale is the part to keep scarce:
+it runs at roughly **8% of non-docblock lines**, which is the level to aim for.
+
 ## Testing
 
 Tests use **Codeception 5** with PHPUnit underneath.


### PR DESCRIPTION
Adds a **Comments** subsection under Coding Standards, so the rule applies to future work by Claude, Codex, and anyone else reading `AGENTS.md` rather than living in one conversation.

## The rule

> **Comment the constraint, not the changelog.**

An inline comment earns its place when reverting the line would look *reasonable* to a future editor — a coupling across files, a counter-intuitive choice, a guard whose removal breaks something distant. Write what breaks if the line changes.

Do not narrate the bug a line used to have. That belongs in the commit message, where `git blame` will find it.

The section includes a worked noise/keep pair, both taken from real code in the sibling PRs (#566 and #568).

## Why it is worth writing down

The four bug-fix PRs (#565–#568) went the wrong way first. Inline rationale was added at **~42% of non-docblock lines** against a codebase that runs at **~8%** — five times the house rate — on the mistaken read that this codebase's deliberately expansive *docblocks* (~44% of `src/` lines) set the rate for inline comments too. They don't: the two are separate budgets, and only the docblock one is generous here.

Applying the rule brought that diff from 38 inline comment lines to 15 (42% → 22%, still above baseline because the diff is genuinely constraint-dense). The section names both numbers so the distinction isn't inferred again.

## Testing steps

Documentation only — no code, no behaviour change, nothing for CI to exercise beyond the existing checks.

To review:

```bash
git diff main...claude/bug-fixes-pr-organization-uyucwq-comment-convention -- AGENTS.md
```

Check the two claimed figures if you want them verified independently:

```bash
# ~8% of non-docblock lines in src/ are inline // comments
php -r '$f=array_merge(glob("src/*.php"),glob("src/*/*.php"));$t=$c=0;
foreach($f as $x){foreach(file($x) as $l){$s=trim($l);
if($s===""||str_starts_with($s,"*")||str_starts_with($s,"/**"))continue;$t++;
if(str_starts_with($s,"//"))$c++;}}printf("%.0f%%\n",100*$c/$t);'
```

Related: #565, #566, #567, #568 — the PRs whose comments this rule was derived from and applied to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTVRRWkZ1eLFis47AS814B

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTVRRWkZ1eLFis47AS814B)_