### PR TITLE
Gate the WordPress, Known, and Lamb importers behind experimental_features

### DIFF
--- a/docs/known-import.md
+++ b/docs/known-import.md
@@ -6,6 +6,8 @@ title: Known import
 
 Lamb ships a CLI script that reads a [Known CMS](https://withknown.com) RSS export and feeds each published item through Lamb's existing post-creation pipeline. The importer is fully offline — no credentials, no API access — and re-running it is safe.
 
+**Experimental.** This importer is still gathering real-world testing. Enable it by setting `experimental_features = true` in [Settings](site-configuration.md) before running the script — it refuses to run otherwise.
+
 ## What you get
 
 - Every published item in the export is imported. Known's RSS export is a partial WXR veneer: post content lives in `<description>` (not `<content:encoded>`), there's no `<wp:post_name>`, and the only date field is `<pubDate>` — so a post's `created` and `updated` timestamps are always identical.

--- a/docs/lamb-import.md
+++ b/docs/lamb-import.md
@@ -7,6 +7,8 @@ nav_order: 31
 
 Lamb ships a CLI script that reads a [Lamb export](export.md) — the `.zip` that `/export` produces, or an already-unpacked copy of one — and restores every post and asset it describes. It's a Lamb-to-Lamb restore rather than a converter: it writes back exactly what you exported, through the same low-level pipeline every other importer uses. The importer works fully offline, with no credentials and no API access, and re-running it is safe.
 
+**Experimental.** This importer is still gathering real-world testing. Enable it by setting `experimental_features = true` in [Settings](site-configuration.md) before running the script — it refuses to run otherwise.
+
 ## What you get
 
 - Lamb restores every post in the manifest: its body, front matter, slug, `created` and `updated` timestamps, and draft or trash state, exactly as recorded.

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -51,6 +51,13 @@ token_endpoint = https://tokens.indieauth.com/token
 ;; Separate multiple hubs with commas.
 ;websub_hubs = https://hub.example.com/
 
+;; Gates features still gathering real-world testing before general release
+;; (currently: the WordPress, Known, and Lamb-export import CLI scripts — see
+;; wordpress-import.md, known-import.md, lamb-import.md). Off by default, and
+;; reset to false automatically whenever an upgrade changes what this gates,
+;; so check the docs for what's currently covered before turning it back on.
+experimental_features = false
+
 [menu_items]
 ;; Add <label>=<url> entries. URL can be:
 ;;   - A post slug, which hides the post from the feed and timeline

--- a/docs/wordpress-import.md
+++ b/docs/wordpress-import.md
@@ -6,6 +6,8 @@ title: WordPress import
 
 Lamb ships a CLI script that reads a [WordPress WXR export](https://wordpress.com/support/export/) and feeds each published post and page through Lamb's existing post-creation pipeline. The importer is fully offline — no credentials, no API access — and re-running it is safe.
 
+**Experimental.** This importer is still gathering real-world testing. Enable it by setting `experimental_features = true` in [Settings](site-configuration.md) before running the script — it refuses to run otherwise.
+
 ## What you get
 
 The first-pass scope is intentionally small:

--- a/import-known.php
+++ b/import-known.php
@@ -56,6 +56,11 @@ global $config;
 $config = Config\load();
 Config\apply_timezone($config);
 
+if (!Config\experimental_features_enabled($config)) {
+    fwrite(STDERR, "The Known importer is experimental. Enable it first: set experimental_features = true in Settings.\n");
+    exit(1);
+}
+
 $rss = Import\parse_rss_file($path);
 $items = Known\extract_items($rss);
 

--- a/import-lamb.php
+++ b/import-lamb.php
@@ -60,6 +60,11 @@ global $config;
 $config = Config\load();
 Config\apply_timezone($config);
 
+if (!Config\experimental_features_enabled($config)) {
+    fwrite(STDERR, "The Lamb export importer is experimental. Enable it first: set experimental_features = true in Settings.\n");
+    exit(1);
+}
+
 try {
     $manifest = Restore\read_manifest($reader);
 } catch (RuntimeException $e) {

--- a/import-wordpress.php
+++ b/import-wordpress.php
@@ -54,6 +54,11 @@ global $config;
 $config = Config\load();
 Config\apply_timezone($config);
 
+if (!Config\experimental_features_enabled($config)) {
+    fwrite(STDERR, "The WordPress importer is experimental. Enable it first: set experimental_features = true in Settings.\n");
+    exit(1);
+}
+
 $rss = WordPress\parse_wxr_file($path);
 $items = WordPress\extract_items($rss);
 

--- a/src/config.php
+++ b/src/config.php
@@ -69,6 +69,13 @@ token_endpoint = https://tokens.indieauth.com/token
 ;; Separate multiple hubs with commas.
 ;websub_hubs = https://hub.example.com/
 
+;; Gates features still gathering real-world testing before general release
+;; (currently: the WordPress, Known, and Lamb-export import CLI scripts).
+;; Off by default, and reset to false automatically whenever an upgrade
+;; changes what this gates — see docs for what is currently covered before
+;; turning it back on.
+experimental_features = false
+
 [menu_items]
 ;; Add <label>=<url> entries here where URL is either:
 ;;   - Slugs of an existing post, which is then hidden in the feed and the timeline (
@@ -403,6 +410,62 @@ function apply_timezone(array $config): string
 }
 
 /**
+ * Whether experimental features are enabled for this install — currently the
+ * WordPress, Known, and Lamb-export import CLI scripts.
+ *
+ * @param array<string, mixed> $config The loaded configuration.
+ * @return bool
+ */
+function experimental_features_enabled(array $config): bool
+{
+    return filter_var($config['experimental_features'] ?? false, FILTER_VALIDATE_BOOLEAN);
+}
+
+/**
+ * Bumped only when the set of features gated behind `experimental_features`
+ * changes (one graduates out, or a new one joins) — not on every release.
+ * reset_stale_experimental_flag() uses this to force a re-opt-in when that
+ * happens, so enabling the flag once cannot silently keep covering whatever
+ * gets added to the gate later.
+ */
+const EXPERIMENTAL_GATE_VERSION = 1;
+
+/**
+ * Forces `experimental_features` back to `false` when the gated feature set
+ * has changed since this install last read config, so opting in once cannot
+ * silently keep covering something added to the gate later.
+ *
+ * Tracked via a hidden `experimental_gate_version` option row — not part of
+ * the user-edited INI — compared against EXPERIMENTAL_GATE_VERSION. The
+ * stamp advances every time this runs behind, even when the flag is already
+ * `false`, so a stale stamp cannot cause a rewrite (and a save_ini_text()
+ * call) on every single read.
+ *
+ * @param string $ini_text The raw INI configuration text.
+ * @return string The INI text, with `experimental_features` reset if stale.
+ */
+function reset_stale_experimental_flag(string $ini_text): string
+{
+    $stamp = get_option('experimental_gate_version', 0);
+    if ((int) $stamp->value >= EXPERIMENTAL_GATE_VERSION) {
+        return $ini_text;
+    }
+
+    set_option($stamp, EXPERIMENTAL_GATE_VERSION);
+
+    if (!experimental_features_enabled(parse_ini_safe($ini_text))) {
+        return $ini_text;
+    }
+
+    return (string) preg_replace(
+        '/^(\h*experimental_features\h*=).*$/mi',
+        '${1} false',
+        $ini_text,
+        1
+    );
+}
+
+/**
  * Retrieves the raw INI text from the database or bootstraps it if not present.
  *
  * @return string The raw INI configuration text.
@@ -415,6 +478,10 @@ function get_ini_text(): string
         // can eventually be removed. Only rewrites (and bumps the cache
         // validator) on the first request after upgrade.
         $ini_text = ensure_explicit_theme($option->value);
+        // Same idea for the experimental-features gate: force a re-opt-in
+        // whenever the set of features it covers has changed since this
+        // install last saw it.
+        $ini_text = reset_stale_experimental_flag($ini_text);
         if ($ini_text !== $option->value) {
             save_ini_text($ini_text);
         }
@@ -432,6 +499,7 @@ function get_ini_text(): string
     }
 
     $ini_text = ensure_explicit_theme($ini_text);
+    $ini_text = reset_stale_experimental_flag($ini_text);
     save_ini_text($ini_text);
 
     return $ini_text;

--- a/tests/Unit/ConfigLoadTest.php
+++ b/tests/Unit/ConfigLoadTest.php
@@ -9,6 +9,7 @@ use function Lamb\Config\config_modified_timestamp;
 use function Lamb\Config\get_ini_text;
 use function Lamb\Config\load;
 use function Lamb\Config\parse_ini_safe;
+use function Lamb\Config\reset_stale_experimental_flag;
 use function Lamb\Config\save_ini_text;
 
 class ConfigLoadTest extends TestCase
@@ -21,6 +22,7 @@ class ConfigLoadTest extends TestCase
         R::freeze(false);
         // Remove any cached config option so each test starts fresh
         R::exec("DELETE FROM option WHERE name = 'site_config_ini'");
+        R::exec("DELETE FROM option WHERE name = 'experimental_gate_version'");
     }
 
     // parse_ini_safe
@@ -80,6 +82,55 @@ class ConfigLoadTest extends TestCase
         $this->assertSame('base', $parsed['theme']);
         // ...and the migration is persisted, so a second read is stable.
         $this->assertSame($text, get_ini_text());
+    }
+
+    public function testGetIniTextResetsStaleExperimentalFlagOnRead(): void
+    {
+        save_ini_text("experimental_features = true\n");
+
+        $text = get_ini_text();
+        $parsed = parse_ini_string($text, true, INI_SCANNER_RAW);
+
+        $this->assertSame('false', $parsed['experimental_features']);
+        // Persisted, so a second read is stable.
+        $this->assertSame($text, get_ini_text());
+    }
+
+    // reset_stale_experimental_flag
+
+    public function testResetStaleExperimentalFlagRewritesTrueToFalseWhenStampBehind(): void
+    {
+        $migrated = reset_stale_experimental_flag("experimental_features = true\n");
+        $parsed = parse_ini_string($migrated, true, INI_SCANNER_RAW);
+
+        $this->assertSame('false', $parsed['experimental_features']);
+    }
+
+    public function testResetStaleExperimentalFlagLeavesFalseUntouched(): void
+    {
+        $ini = "experimental_features = false\nsite_title = Example\n";
+
+        $this->assertSame($ini, reset_stale_experimental_flag($ini));
+    }
+
+    public function testResetStaleExperimentalFlagIsNoOpOnceStampCaughtUp(): void
+    {
+        $once = reset_stale_experimental_flag("experimental_features = true\n");
+        $twice = reset_stale_experimental_flag($once);
+
+        $this->assertSame($once, $twice);
+    }
+
+    public function testResetStaleExperimentalFlagPreservesOtherContent(): void
+    {
+        $ini = "site_title = Example\nexperimental_features = true\n[menu_items]\nAbout = about\n";
+
+        $migrated = reset_stale_experimental_flag($ini);
+        $parsed = parse_ini_string($migrated, true, INI_SCANNER_RAW);
+
+        $this->assertSame('Example', $parsed['site_title']);
+        $this->assertSame('about', $parsed['menu_items']['About']);
+        $this->assertSame('false', $parsed['experimental_features']);
     }
 
     // save_ini_text

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 use function Lamb\Config\compose_config;
 use function Lamb\Config\ensure_explicit_theme;
+use function Lamb\Config\experimental_features_enabled;
 use function Lamb\Config\get_default_ini_text;
 use function Lamb\Config\get_menu_slugs;
 use function Lamb\Config\is_menu_item;
@@ -257,5 +258,30 @@ class ConfigTest extends TestCase
         $config = compose_config("feeds_draft = false\n", get_default_ini_text());
 
         $this->assertFalse(filter_var($config['feeds_draft'], FILTER_VALIDATE_BOOLEAN));
+    }
+
+    public function testDefaultIniDisablesExperimentalFeaturesForNewInstalls(): void
+    {
+        $parsed = parse_ini_string(get_default_ini_text(), true, INI_SCANNER_RAW);
+
+        $this->assertArrayHasKey('experimental_features', $parsed);
+        $this->assertFalse(filter_var($parsed['experimental_features'], FILTER_VALIDATE_BOOLEAN));
+    }
+
+    // experimental_features_enabled
+
+    public function testExperimentalFeaturesEnabledReturnsFalseWhenKeyMissing(): void
+    {
+        $this->assertFalse(experimental_features_enabled([]));
+    }
+
+    public function testExperimentalFeaturesEnabledReturnsTrueWhenSetTrue(): void
+    {
+        $this->assertTrue(experimental_features_enabled(['experimental_features' => 'true']));
+    }
+
+    public function testExperimentalFeaturesEnabledReturnsFalseWhenSetFalse(): void
+    {
+        $this->assertFalse(experimental_features_enabled(['experimental_features' => 'false']));
     }
 }

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -492,6 +492,40 @@ class LambRestoreTest extends TestCase
     }
 
     /**
+     * Seeds a fresh, file-backed data dir with `experimental_features = true`,
+     * so a CLI-script subprocess pointed at it doesn't hit the experimental
+     * gate. A separate PHP process, because the subprocess under test bootstraps
+     * its own SQLite file at $data_dir — a distinct connection from this test's
+     * in-memory DB.
+     */
+    private function enableExperimentalFeaturesInDataDir(string $data_dir): void
+    {
+        mkdir($data_dir, 0777, true);
+        // __DIR__ has no file to resolve against in `-r` code, so the repo
+        // root is embedded as a literal instead.
+        $root = rtrim(codecept_root_dir(), '/');
+        $setup = new Process(
+            [
+                'php',
+                '-r',
+                "define('ROOT_DIR', '$root/src'); require '$root/vendor/autoload.php'; "
+                . "\\Lamb\\Bootstrap\\bootstrap_db(getenv('LAMB_DATA_DIR')); "
+                // Mirrors a real install: some earlier request always calls
+                // Config\load() (bumping the gate-version stamp) before a
+                // human can ever reach Settings to flip the flag on. Skipping
+                // straight to save_ini_text() would leave the stamp at 0, so
+                // the importer's own Config\load() would see this as a
+                // genuinely stale install and reset the flag right back.
+                . "\\Lamb\\Config\\load(); "
+                . "\\Lamb\\Config\\save_ini_text(\"experimental_features = true\\n\");",
+            ],
+            codecept_root_dir(),
+            ['LAMB_DATA_DIR' => $data_dir] + getenv(),
+        );
+        $setup->mustRun();
+    }
+
+    /**
      * Runs the importer over an archive the way import-lamb.php does.
      */
     private function importArchive(string $path, bool $replace = false, ?string $site_url = null): string
@@ -783,6 +817,7 @@ class LambRestoreTest extends TestCase
     {
         $archive = $this->buildArchive();
         $data_dir = "$this->tmp_dir/data";
+        $this->enableExperimentalFeaturesInDataDir($data_dir);
 
         $process = new Process(
             ['php', codecept_root_dir('import-lamb.php'), $archive, '--dry-run'],
@@ -795,8 +830,25 @@ class LambRestoreTest extends TestCase
         $this->assertStringContainsString('[dry-run] Done. created=5', $process->getOutput());
     }
 
+    public function testTheCliScriptRefusesWhenExperimentalFeaturesDisabled(): void
+    {
+        $archive = $this->buildArchive();
+
+        $process = new Process(
+            ['php', codecept_root_dir('import-lamb.php'), $archive, '--dry-run'],
+            codecept_root_dir(),
+            ['LAMB_DATA_DIR' => "$this->tmp_dir/data"] + getenv(),
+        );
+        $process->run();
+
+        $this->assertSame(1, $process->getExitCode());
+        $this->assertStringContainsString('experimental', $process->getErrorOutput());
+    }
+
     public function testTheCliScriptRefusesAnArchiveItCannotRead(): void
     {
+        // Fails on the unreadable-path check, before Config\load() runs — so
+        // this exits(1) for that reason regardless of experimental_features.
         $process = new Process(
             ['php', codecept_root_dir('import-lamb.php'), "$this->tmp_dir/absent.zip"],
             codecept_root_dir(),


### PR DESCRIPTION
## Summary
- Adds a single `experimental_features` config toggle (off by default, edited via the existing `/settings` INI textarea) that currently gates the WordPress, Known, and Lamb-export import CLI scripts.
- Each importer graduates out of the gate independently — delete its one `if` check when it's proven itself; the flag, predicate, and the other importers are untouched.
- The toggle resets itself to `false` after an upgrade changes what it covers, so opting in once can't silently keep covering something added to the gate later. Tracked via a hidden option-table stamp (`experimental_gate_version`) compared against a hand-bumped `EXPERIMENTAL_GATE_VERSION` constant, modeled directly on the existing `ensure_explicit_theme()` migrate-on-read pattern in `Config\get_ini_text()`. No version string, no change to the release process.
- Docs updated: `site-configuration.md` documents the new key; each importer doc (`wordpress-import.md`, `known-import.md`, `lamb-import.md`) notes it's experimental and how to enable it.

## Test plan
- [x] New Unit tests: `experimental_features_enabled()` predicate, `reset_stale_experimental_flag()` migration behavior (stale+true → rewritten false + stamp bumped, current stamp → no-op, already-false → no-op), and `get_ini_text()` integration.
- [x] Extended `LambRestoreTest`'s existing CLI subprocess test (`testTheCliScriptRunsAnArchiveEndToEnd`) to seed the flag on first, plus a new `testTheCliScriptRefusesWhenExperimentalFeaturesDisabled` covering the refusal path.
- [x] Full suite green: `vendor/bin/codecept run Unit` — 1611 tests, 2 unrelated skips.
- [x] `composer lint` and `composer analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)