### PR TITLE
Raise minimum PHP version to 8.4

### DIFF
--- a/.claude/model-policy.json
+++ b/.claude/model-policy.json
@@ -13,7 +13,7 @@
     },
     "code": {
       "model": "sonnet",
-      "rationale": "Strong safety net makes mid-tier safe: 1489 unit tests across 118 files, PHPStan level 8 with a baseline, phpcs, a 70% coverage gate, and a 4-version CI matrix (PHP 8.2-8.5) plus Playwright e2e. Not lowered further — 13.7k LOC of hand-rolled routing and auth is not boilerplate CRUD."
+      "rationale": "Strong safety net makes mid-tier safe: 1489 unit tests across 118 files, PHPStan level 8 with a baseline, phpcs, a 70% coverage gate, and a 2-version CI matrix (PHP 8.4-8.5) plus Playwright e2e. Not lowered further — 13.7k LOC of hand-rolled routing and auth is not boilerplate CRUD."
     },
     "review": {
       "model": "sonnet",

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: lamb
 type: php
 docroot: src
-php_version: "8.2"
+php_version: "8.4"
 webserver_type: nginx-fpm
 xdebug_enabled: true
 additional_hostnames: [ ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,12 +3,12 @@
 	"name": "PHP",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	// bookworm, not bullseye: Debian 11 LTS security support ends 2026-08-31.
-	"image": "mcr.microsoft.com/devcontainers/php:1-8.2-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/php:1-8.4-bookworm",
 
 	"features": {
 		"ghcr.io/devcontainers/features/php:1": {
 			"installComposer": true,
-			"version": "8.2"
+			"version": "8.4"
 		}
 	},
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:php8.2
+FROM dunglas/frankenphp:php8.4
 LABEL maintainer="Sander van Dragt <sander@vandragt.com>"
 
 # Install application dependencies (gd powers WebP upload conversion)

--- a/.docker/Dockerfile.release
+++ b/.docker/Dockerfile.release
@@ -9,7 +9,7 @@ RUN composer install --no-dev --no-interaction --prefer-dist --no-scripts --no-a
 COPY src/ src/
 RUN composer dump-autoload --no-dev --optimize --ignore-platform-reqs
 
-FROM dunglas/frankenphp:php8.2
+FROM dunglas/frankenphp:php8.4
 LABEL maintainer="Sander van Dragt <sander@vandragt.com>"
 LABEL org.opencontainers.image.source="https://github.com/svandragt/lamb"
 

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -17,7 +17,7 @@ don't touch e2e-relevant paths like `src/**`; see the `changes` job.)
 Why this matters: without a required status check, a PR can be merged the
 instant it opens — before CI has finished, or even when it has failed.
 That is exactly how red PRs reached `main` (e.g. #309 merged with a failing
-`test (8.2)`). The `ci` job is also written with `if: always()` so a failed
+`test (8.4)`). The `ci` job is also written with `if: always()` so a failed
 dependency makes it report **failure**, not *skipped* — GitHub counts a
 skipped required check as passing, so a plain aggregate job would not block
 anything.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ '8.2', '8.3', '8.4', '8.5' ]
+        php-version: [ '8.4', '8.5' ]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -78,7 +78,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: ${{ matrix.php-version == '8.2' && 'pcov' || 'none' }}
+          coverage: ${{ matrix.php-version == '8.4' && 'pcov' || 'none' }}
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
@@ -89,7 +89,7 @@ jobs:
           vendor/bin/codecept run --steps
 
       - name: Check code coverage
-        if: matrix.php-version == '8.2'
+        if: matrix.php-version == '8.4'
         run: composer coverage
 
   # Client-side JavaScript unit tests (node:test + jsdom). Fast and
@@ -172,7 +172,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: sqlite3, gettext, simplexml
       - name: Cache Composer dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: sqlite3, gettext, simplexml
 
       - name: Install production dependencies

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -2,7 +2,7 @@
 # server-distinct documented ways of running Lamb that ci.yml does not cover.
 #
 # ci.yml already exercises the built-in PHP server (composer serve) on every PR
-# across PHP 8.2-8.5, so that path is intentionally not duplicated here. This
+# across PHP 8.4-8.5, so that path is intentionally not duplicated here. This
 # workflow adds:
 #   - the Docker/FrankenPHP release image (.docker/Dockerfile.release, what
 #     release-artifacts.yml publishes to GHCR)
@@ -32,7 +32,7 @@ jobs:
       - name: Setup PHP (test runner)
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: sqlite3, gettext, simplexml, mbstring, curl
 
       - name: Install dependencies
@@ -83,7 +83,7 @@ jobs:
       - name: Setup PHP (test runner)
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: sqlite3, gettext, simplexml, mbstring, curl
 
       - name: Install dependencies
@@ -97,12 +97,12 @@ jobs:
           sed -i "s|^SITE_URL=.*|SITE_URL='http://127.0.0.1:8080'|" .env
 
       - name: Install nginx and php-fpm
-        # Add the ondrej/php PPA explicitly so php8.2-* is installable on runner
-        # images whose default PHP is newer (e.g. Ubuntu 24.04 ships 8.3).
+        # Add the ondrej/php PPA explicitly so php8.4-* is installable on runner
+        # images whose default PHP is older (e.g. Ubuntu 24.04 ships 8.3).
         run: |
           sudo add-apt-repository -y ppa:ondrej/php
           sudo apt-get update
-          sudo apt-get install -y nginx php8.2-fpm php8.2-sqlite3 php8.2-mbstring php8.2-xml
+          sudo apt-get install -y nginx php8.4-fpm php8.4-sqlite3 php8.4-mbstring php8.4-xml
 
       - name: Configure php-fpm pool
         run: |
@@ -110,13 +110,13 @@ jobs:
           chmod 0777 tests/Support/Data
           chmod o+x "$HOME" "$GITHUB_WORKSPACE"
           HASH=$(grep LAMB_LOGIN_PASSWORD .env | cut -d"'" -f2)
-          POOL=/etc/php/8.2/fpm/pool.d/www.conf
+          POOL=/etc/php/8.4/fpm/pool.d/www.conf
           sudo tee -a "$POOL" > /dev/null <<EOF
           clear_env = no
           env[LAMB_LOGIN_PASSWORD] = $HASH
           env[LAMB_DATA_DIR] = $GITHUB_WORKSPACE/tests/Support/Data
           EOF
-          sudo systemctl restart php8.2-fpm
+          sudo systemctl restart php8.4-fpm
 
       - name: Configure nginx from the shipped .nginx/ files
         run: |

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -260,7 +260,7 @@
       </interpreter>
     </phpInfoCache>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="8.2">
+  <component name="PhpProjectSharedConfiguration" php_language_level="8.4">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
   </component>
   <component name="PhpRuntimeConfiguration">

--- a/.nginx/sites-available/lamb.test
+++ b/.nginx/sites-available/lamb.test
@@ -4,7 +4,7 @@ server {
 	access_log /var/log/nginx/lamb.test-access.log;
 	error_log /var/log/nginx/lamb.test-error.log;
 
-	include snippets/php-82.conf;
+	include snippets/php-84.conf;
 	include snippets/lamb.conf;
 
 	server_name lamb.test;

--- a/.nginx/snippets/php-84.conf
+++ b/.nginx/snippets/php-84.conf
@@ -11,7 +11,7 @@ location ~ ^/assets/.*\.(?i:php|phar|phtml)$ {
 
 location ~ \.php$  {
     include snippets/fastcgi-php.conf;
-    fastcgi_pass unix:/run/php/php8.2-fpm.sock;
+    fastcgi_pass unix:/run/php/php8.4-fpm.sock;
 }
 
 # deny access to .htaccess files, if Apache's document root

--- a/.workshop/README.md
+++ b/.workshop/README.md
@@ -48,7 +48,7 @@ workshop stop dev / workshop start dev
 
 | Hook | Runs as | Does |
 |------|---------|------|
-| `setup-base` | root, once on install | `apt-get install` PHP 8.3 + extensions, Composer, Ruby, openssl, pkg-config |
+| `setup-base` | root, once on install | `apt-get install` PHP 8.4 + extensions, Composer, Ruby, openssl, pkg-config |
 | `setup-project` | workshop user, every launch/refresh | `composer install` + `pnpm install` (mirrors `devbox.json` `init_hook`) |
 | `check-health` | workshop user, after setup | verifies php/composer/node/ruby + required extensions, reports health |
 
@@ -71,12 +71,11 @@ the host. The server binds `0.0.0.0:8747`, so:
 
 - **Shared project mount.** Workshop bind-mounts your host checkout at
   `/project`, so `composer install` / `pnpm install` write to the *same*
-  `vendor/` and `node_modules/` that Devbox uses. They are not isolated; the
-  trees are built for slightly different PHP/Node versions (8.2 vs 8.3) but are
-  compatible in practice.
+  `vendor/` and `node_modules/` that Devbox uses. They are not isolated, but
+  both environments install matching PHP/Node versions so this is fine.
 - **`ext-pdo_mysql` is required** even though lamb uses SQLite — RedBeanPHP
   references a MySQL PDO constant at load time and fatals without it. It's
-  declared in `composer.json`; `setup-base` installs `php8.3-mysql`.
+  declared in `composer.json`; `setup-base` installs `php8.4-mysql`.
 - **`workshopctl set-health`** statuses are lowercase (`okay` / `waiting` /
   `error` / `unknown`).
 

--- a/.workshop/lamb/hooks/setup-base
+++ b/.workshop/lamb/hooks/setup-base
@@ -1,21 +1,25 @@
 #!/bin/bash
 # Runs once as root against the base image (cwd /).
 # Installs lamb's OS-level toolchain, mirroring devbox.json packages.
-# Ubuntu 24.04 ships PHP 8.3 via apt (lamb requires >=8.2).
+# Ubuntu 24.04 ships PHP 8.3 via apt (lamb requires >=8.4), so add the
+# ondrej/php PPA to get php8.4-*.
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
+apt-get install -y --no-install-recommends software-properties-common
+add-apt-repository -y ppa:ondrej/php
+apt-get update
 apt-get install -y --no-install-recommends \
-  php8.3-cli \
-  php8.3-sqlite3 \
-  php8.3-mysql \
-  php8.3-xml \
-  php8.3-mbstring \
-  php8.3-curl \
-  php8.3-zip \
-  php8.3-gd \
-  php8.3-xdebug \
+  php8.4-cli \
+  php8.4-sqlite3 \
+  php8.4-mysql \
+  php8.4-xml \
+  php8.4-mbstring \
+  php8.4-curl \
+  php8.4-zip \
+  php8.4-gd \
+  php8.4-xdebug \
   composer \
   ruby-full \
   openssl \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Lamb Codebase Guide
 
-Lamb is a self-hosted, single-author microblog. It uses PHP 8.2+, SQLite (via RedBeanPHP ORM), and a procedural-with-namespaces architecture. There is no MVC framework — routing, responses, and views are handled by small namespaced PHP files.
+Lamb is a self-hosted, single-author microblog. It uses PHP 8.4+, SQLite (via RedBeanPHP ORM), and a procedural-with-namespaces architecture. There is no MVC framework — routing, responses, and views are handled by small namespaced PHP files.
 
 ## Documentation (End-User)
 
@@ -485,7 +485,7 @@ Parts you rarely need to override: `edit.php`, `login.php`, `settings.php`, `404
 
 ## Coding Standards
 
-- **PSR-12** with PHPCompatibility checks for PHP 8.2+
+- **PSR-12** with PHPCompatibility checks for PHP 8.4+
 - Line length limit disabled (`Generic.Files.LineLength.TooLong` excluded)
 - Side effects with symbols allowed (`PSR1.Files.SideEffects.FoundWithSymbols` excluded)
 - Underscore method names allowed in tests

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -140,11 +140,11 @@ The `preview` parameter counts even when empty or wrong. A bad token never grant
 
 ---
 
-## [deduced] PHP 8.2+ with PSR-12
+## [deduced] PHP 8.4+ with PSR-12
 
 **Status:** Accepted
 **Context:** Lamb targets modern PHP for type safety and performance. PSR-12 provides a widely understood coding standard.
-**Decision:** Require PHP 8.2+; enforce PSR-12 via PHP_CodeSniffer with PHPCompatibility checks.
+**Decision:** Require PHP 8.4+; enforce PSR-12 via PHP_CodeSniffer with PHPCompatibility checks.
 **Consequences:** Cannot run on older PHP versions; contributors must run `composer lint` before committing.
 
 ---

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=8.2",
+    "php": ">=8.4",
     "ext-curl": "*",
     "ext-gettext": "*",
     "ext-pdo_mysql": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "619045334977ba23ce1685d67321e86e",
+    "content-hash": "88a866bfaad053e8ef1365ccc6ab7092",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -5554,7 +5554,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "ext-curl": "*",
         "ext-gettext": "*",
         "ext-pdo_mysql": "*",

--- a/devbox.json
+++ b/devbox.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetpack-io/devbox/0.10.1/.schema/devbox.schema.json",
   "packages": [
-    "php@8.2",
-    "php82Extensions.xdebug@latest",
+    "php@8.4",
+    "php84Extensions.xdebug@latest",
     "nodejs@24",
     "ruby@3.3",
     "openssl@latest",

--- a/devbox.lock
+++ b/devbox.lock
@@ -210,9 +210,9 @@
         }
       }
     },
-    "php82Extensions.xdebug@latest": {
-      "last_modified": "2026-06-13T05:27:44Z",
-      "resolved": "github:NixOS/nixpkgs/5a722a7155bfc9fbe657f28d26b71860d95324bc#php82Extensions.xdebug",
+    "php84Extensions.xdebug@latest": {
+      "last_modified": "2026-07-23T05:10:05Z",
+      "resolved": "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17#php84Extensions.xdebug",
       "source": "devbox-search",
       "version": "3.5.3",
       "systems": {
@@ -220,90 +220,90 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ilfr18fqh30w0p7vl7nj765h9vvxwiaw-php-xdebug-3.5.3",
+              "path": "/nix/store/yhi6vc2z5qj4bj6lwrp2ljf7syv79p1y-php-xdebug-3.5.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ilfr18fqh30w0p7vl7nj765h9vvxwiaw-php-xdebug-3.5.3"
+          "store_path": "/nix/store/yhi6vc2z5qj4bj6lwrp2ljf7syv79p1y-php-xdebug-3.5.3"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/cvdfj3zjqghyrg18lpw5ic2zxsajhml5-php-xdebug-3.5.3",
+              "path": "/nix/store/22kin5rxd9z287l4dkw6ls029j5i50dl-php-xdebug-3.5.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/cvdfj3zjqghyrg18lpw5ic2zxsajhml5-php-xdebug-3.5.3"
+          "store_path": "/nix/store/22kin5rxd9z287l4dkw6ls029j5i50dl-php-xdebug-3.5.3"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/g5v9xg2lgzq8cyx63v8wkfgi9y4zfqgc-php-xdebug-3.5.3",
+              "path": "/nix/store/dg19ya910rk0a80zns94cqbd27wrs21j-php-xdebug-3.5.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/g5v9xg2lgzq8cyx63v8wkfgi9y4zfqgc-php-xdebug-3.5.3"
+          "store_path": "/nix/store/dg19ya910rk0a80zns94cqbd27wrs21j-php-xdebug-3.5.3"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/xvyjq3i5rk7apcpg2m6qdvgrvyfdkxhp-php-xdebug-3.5.3",
+              "path": "/nix/store/m921mz41jvszrrvx1idqi0r2mmphf4pi-php-xdebug-3.5.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/xvyjq3i5rk7apcpg2m6qdvgrvyfdkxhp-php-xdebug-3.5.3"
+          "store_path": "/nix/store/m921mz41jvszrrvx1idqi0r2mmphf4pi-php-xdebug-3.5.3"
         }
       }
     },
-    "php@8.2": {
-      "last_modified": "2024-03-22T11:26:23Z",
+    "php@8.4": {
+      "last_modified": "2026-07-23T05:10:05Z",
       "plugin_version": "0.0.3",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#php",
+      "resolved": "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17#php",
       "source": "devbox-search",
-      "version": "8.2.17",
+      "version": "8.4.23",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/hrsrp8pcpvg389an9qr9j33vlc4clmji-php-with-extensions-8.2.17",
+              "path": "/nix/store/hqalpfixh9abvcps4w4lln9bz51ah2iy-php-with-extensions-8.4.23",
               "default": true
             }
           ],
-          "store_path": "/nix/store/hrsrp8pcpvg389an9qr9j33vlc4clmji-php-with-extensions-8.2.17"
+          "store_path": "/nix/store/hqalpfixh9abvcps4w4lln9bz51ah2iy-php-with-extensions-8.4.23"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/d342l5vwrl8zlq18s04n9jqna173d9v1-php-with-extensions-8.2.17",
+              "path": "/nix/store/p4rgi3frdf2pc0c2r2n35hx4pxa70458-php-with-extensions-8.4.23",
               "default": true
             }
           ],
-          "store_path": "/nix/store/d342l5vwrl8zlq18s04n9jqna173d9v1-php-with-extensions-8.2.17"
+          "store_path": "/nix/store/p4rgi3frdf2pc0c2r2n35hx4pxa70458-php-with-extensions-8.4.23"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/gvdgll0bgdjm38i2cpvcyvwf7dfhk5sx-php-with-extensions-8.2.17",
+              "path": "/nix/store/jnl9g59h253x7iwyx5bny4spwc9s87lx-php-with-extensions-8.4.23",
               "default": true
             }
           ],
-          "store_path": "/nix/store/gvdgll0bgdjm38i2cpvcyvwf7dfhk5sx-php-with-extensions-8.2.17"
+          "store_path": "/nix/store/jnl9g59h253x7iwyx5bny4spwc9s87lx-php-with-extensions-8.4.23"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/8bhl0kwwqiwf7919s5nsgiwym8x9hsyz-php-with-extensions-8.2.17",
+              "path": "/nix/store/k8b1zsixrczzs2i5grvjpi6lpq9dl63c-php-with-extensions-8.4.23",
               "default": true
             }
           ],
-          "store_path": "/nix/store/8bhl0kwwqiwf7919s5nsgiwym8x9hsyz-php-with-extensions-8.2.17"
+          "store_path": "/nix/store/k8b1zsixrczzs2i5grvjpi6lpq9dl63c-php-with-extensions-8.4.23"
         }
       }
     },

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,7 +14,7 @@ Every release publishes a ready-to-run image to GitHub Container Registry. It bu
 
 ```shell
 # Generate a password hash on any machine with PHP, or inside a throwaway container:
-$ docker run --rm php:8.2-cli php -r "echo base64_encode(password_hash('hackme', PASSWORD_DEFAULT));"
+$ docker run --rm php:8.4-cli php -r "echo base64_encode(password_hash('hackme', PASSWORD_DEFAULT));"
 
 # Run Lamb
 $ docker run -d --name lamb -p 80:80 \

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Barrier free super simple blogging, self-hosted. [Read about the features](https
 
 ## Requirements
 
-- PHP 8.2 – 8.5
+- PHP 8.4 – 8.5
 - SQLite3, gettext, simplexml, mbstring, pdo_mysql extensions (pdo_mysql is required by the database library even though Lamb uses SQLite)
 - gd extension, recommended: converts image uploads to WebP (without it originals are stored as-is)
 

--- a/docs/local-php-setup.md
+++ b/docs/local-php-setup.md
@@ -4,7 +4,7 @@ title: Local PHP setup
 
 # Local PHP setup
 
-> **Well-travelled path.** The built-in PHP webserver is exercised by the full test suite on every change, across PHP 8.2–8.5 (the `ci` workflow).
+> **Well-travelled path.** The built-in PHP webserver is exercised by the full test suite on every change, across PHP 8.4–8.5 (the `ci` workflow).
 
 Make sure everything is installed:
 
@@ -12,7 +12,7 @@ Make sure everything is installed:
 # Install required system packages, for example on Debian Linux derivatives like Ubuntu
 sudo apt update
 sudo apt install php8.4 php8.4-gettext php8.4-mbstring php8.4-sqlite3 php8.4-xml php8.4-mysql php8.4-gd composer
-# PHP 8.2–8.5 are supported; replace 8.4 with your preferred version
+# PHP 8.4–8.5 are supported; replace 8.4 with your preferred version
 # php8.4-mysql (pdo_mysql) is required by the database library even though Lamb uses SQLite
 # php8.4-gd converts image uploads to WebP; without it originals are stored as-is
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -122,7 +122,7 @@ Add the cache directives to the `location ~ \.php$` block in
 ```nginx
 location ~ \.php$  {
     include snippets/fastcgi-php.conf;
-    fastcgi_pass unix:/run/php/php8.2-fpm.sock;
+    fastcgi_pass unix:/run/php/php8.4-fpm.sock;
 
     # --- fastcgi_cache (optional) ---
     fastcgi_cache       lamb;

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -117,7 +117,7 @@ map $request_method $lamb_skip_cache_method {
 ### 2. Enable the cache on the PHP location (server context)
 
 Add the cache directives to the `location ~ \.php$` block in
-`snippets/php-82.conf` (or your own copy):
+`snippets/php-84.conf` (or your own copy):
 
 ```nginx
 location ~ \.php$  {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,10 +3,10 @@
     <description>PHP Coding Standards for Lamb</description>
 
     <!-- Set the PHP version to use for PHP_CodeSniffer (and thus HM Linter) to PHP 8.0. -->
-    <config name="php_version" value="80200"/>
+    <config name="php_version" value="80400"/>
 
     <!-- Set the PHP version range for PHPCompatibility (matches composer.json require). -->
-    <config name="testVersion" value="8.2-8.5"/>
+    <config name="testVersion" value="8.4-8.5"/>
 
     <!-- Show sniff codes in all reports. -->
     <arg value="s"/>


### PR DESCRIPTION
## Summary
- Bump Lamb's minimum supported PHP version from 8.2 to 8.4 (closes #470): `composer.json`, `phpcs.xml`, CI (`ci.yml`, `release-verify.yml`, `release-artifacts.yml`), both `.docker/Dockerfile*` base images, dev environments (Devbox, DDev, devcontainer, Workshop), and docs (`README`/`docs/`, `DECISIONS.md`, `AGENTS.md`).
- Workshop's `setup-base` hook now adds the `ondrej/php` PPA, since Ubuntu 24.04's apt only ships PHP 8.3 by default.
- No application code changes - nothing in `src/`/`tests/` branches on PHP version.
- Regenerated `composer.lock`'s `platform.php` and `content-hash`, which were stale against the bumped `composer.json` requirement.

## Test plan
- [x] `composer validate` - valid
- [x] `composer lint` (PHPCS/PHPCompatibility, `testVersion 8.4-8.5`) - clean
- [x] `composer analyse` (PHPStan level 8) - no errors
- [x] `vendor/bin/codecept run Unit` on real PHP 8.4.23 (via Devbox) - passes; matches CI's `test (8.4)` job (1686 tests, 0 failures)
- [x] `vendor/bin/codecept run Acceptance` on real PHP 8.4.23 - 74/74 pass
- [x] CI green on this PR (`test` matrix now `[8.4, 8.5]`)

## Upgrade notes
Breaking change for installs still on PHP 8.2/8.3 - call this out in the next release's Upgrade notes and bump SemVer accordingly (per `RELEASING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)