### PR TITLE
Fold site_or_page_title() into page_title()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,6 @@ All helpers must be imported with `use function Lamb\Theme\<name>` before use.
 | `escape($str)` | `string` | `htmlspecialchars` for HTML5 output — use on every user-supplied value |
 | `site_title($type='html')` | `string` | `<h1>` wrapping `$config['site_title']`, or plain text if `$type !== 'html'` |
 | `page_title($type='html')` | `string` | `<h1>` wrapping `$data['title']` (falls back to `site_title`) |
-| `site_or_page_title($type)` | `string` | Page title if set, otherwise site title |
 | `page_intro()` | `string` | `<p>` wrapping `$data['intro']`, or `''` |
 | `li_menu_items()` | `string` | `<li><a>` tags from `$config['menu_items']` |
 | `date_created($bean)` | `string` | `<a><time>` linking to the post permalink with human-readable timestamp |

--- a/docs/theme-functions.md
+++ b/docs/theme-functions.md
@@ -45,7 +45,6 @@ re-render `body`), `$bean->description`, `$bean->created`, `$bean->updated`,
 |----------|---------|-------------|
 | `site_title($type = 'html')` | `string` | The site title. Wrapped in `<h1>` for HTML output, or plain text when `$type` is not `'html'`. |
 | `page_title($type = 'html')` | `string` | The current page title (`$data['title']`), falling back to the site title. |
-| `site_or_page_title($type = 'html')` | `string` | The page title when one is set, otherwise the site title. |
 | `page_intro()` | `string` | A `<p>` wrapping `$data['intro']` (used on tag and search pages), or `''`. |
 
 ## Posts and content

--- a/src/theme.php
+++ b/src/theme.php
@@ -209,21 +209,6 @@ function site_title($type = 'html'): string
 }
 
 /**
- * Returns the page title if set, otherwise falls back to the site title.
- *
- * @param string $type Output format: 'html' (default) wraps in <h1>, anything else returns plain text.
- * @return string HTML or plain-text page or site title.
- */
-function site_or_page_title($type = 'html'): string
-{
-    $page_title = page_title($type);
-    if (empty($page_title)) {
-        return site_title($type);
-    }
-    return $page_title;
-}
-
-/**
  * Returns the current page title (from $data['title']) as an <h1>, or plain text when $type !== 'html'.
  * Falls back to the site title when no page title is set.
  *

--- a/src/themes/2026/html.php
+++ b/src/themes/2026/html.php
@@ -3,8 +3,8 @@
 use function Lamb\Theme\escape;
 use function Lamb\Theme\li_footer_items;
 use function Lamb\Theme\li_menu_items;
+use function Lamb\Theme\page_title;
 use function Lamb\Theme\part;
-use function Lamb\Theme\site_or_page_title;
 use function Lamb\Theme\the_meta_description;
 use function Lamb\Theme\the_opengraph;
 use function Lamb\Theme\the_preconnect;
@@ -22,7 +22,7 @@ global $template;
     <meta name="author" content="<?= escape($config['author_name'] ?? '') ?>">
     <meta name="generator" content="Lamb">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><?= escape(site_or_page_title('text')) ?></title>
+    <title><?= escape(page_title('text')) ?></title>
     <link rel="alternate" type="application/atom+xml" href="<?= ROOT_URL . '/feed' ?>"
           title="<?= escape($config['site_title']) ?>">
     <link rel="alternate" type="application/feed+json" href="<?= ROOT_URL . '/feed.json' ?>"

--- a/src/themes/base/html.php
+++ b/src/themes/base/html.php
@@ -2,8 +2,8 @@
 
 use function Lamb\Theme\escape;
 use function Lamb\Theme\li_menu_items;
+use function Lamb\Theme\page_title;
 use function Lamb\Theme\part;
-use function Lamb\Theme\site_or_page_title;
 use function Lamb\Theme\the_meta_description;
 use function Lamb\Theme\the_opengraph;
 use function Lamb\Theme\the_preconnect;
@@ -21,7 +21,7 @@ global $template;
     <meta name="author" content="<?= escape($config['author_name'] ?? '') ?>">
     <meta name="generator" content="Lamb">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><?= escape(site_or_page_title('text')) ?></title>
+    <title><?= escape(page_title('text')) ?></title>
     <link rel="alternate" type="application/atom+xml" href="<?= ROOT_URL . '/feed' ?>"
           title="<?= escape($config['site_title']) ?>">
     <link rel="alternate" type="application/feed+json" href="<?= ROOT_URL . '/feed.json' ?>"

--- a/tests/Unit/ThemePageTest.php
+++ b/tests/Unit/ThemePageTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 
 use function Lamb\Theme\page_intro;
 use function Lamb\Theme\page_title;
-use function Lamb\Theme\site_or_page_title;
 use function Lamb\Theme\site_title;
 use function Lamb\Theme\wrap_title;
 
@@ -75,28 +74,6 @@ class ThemePageTest extends TestCase
     {
         $result = page_title('text');
         $this->assertSame('Test Blog', $result);
-    }
-
-    // site_or_page_title
-
-    public function testSiteOrPageTitleReturnsPageTitleWhenDataTitleSet(): void
-    {
-        global $data;
-        $data['title'] = 'Page Title';
-        $this->assertSame('<h1>Page Title</h1>', site_or_page_title());
-    }
-
-    public function testSiteOrPageTitleReturnsSiteTitleWhenNoDataTitle(): void
-    {
-        $result = site_or_page_title();
-        $this->assertStringContainsString('Test Blog', $result);
-    }
-
-    public function testSiteOrPageTitlePlainTextMode(): void
-    {
-        global $data;
-        $data['title'] = 'My Page';
-        $this->assertSame('My Page', site_or_page_title('text'));
     }
 
     // HTML escaping of titles (untrusted feed titles can reach $data['title'])


### PR DESCRIPTION
site_or_page_title() called page_title() and fell back to site_title()
when the result was empty, but page_title() already applies that
fallback itself. The guard could only fire when both $data['title'] and
$config['site_title'] were empty, in which case site_title() returns the
same empty string — and in HTML mode wrap_title() returns <h1></h1>, so
it never fired at all.

Drop the wrapper and point the two <title> callers at page_title().
Behaviour is unchanged; the deleted unit tests duplicated page_title()
cases that are still covered.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018zGpPehnQqyWWdjYDtxviM