### PR TITLE
Scan the release image on PRs that change how it is built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,16 @@ on:
 
 jobs:
 
-  # Detect whether files relevant to the browser (Playwright) suite changed.
-  # The workflow itself always runs (no `paths:` filter on the triggers above)
-  # so the required `ci` check is always reported; the expensive playwright
-  # job below is what we gate on these paths, keeping doc-only PRs fast.
+  # Detect whether files relevant to the browser (Playwright) suite or the
+  # release image changed. The workflow itself always runs (no `paths:` filter
+  # on the triggers above) so the required `ci` check is always reported; the
+  # expensive playwright and image-scan jobs below are what we gate on these
+  # paths, keeping doc-only PRs fast.
   changes:
     runs-on: ubuntu-latest
     outputs:
       e2e: ${{ steps.filter.outputs.e2e }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
@@ -34,6 +36,8 @@ jobs:
               - 'playwright.config.ts'
               - 'package.json'
               - 'pnpm-lock.yaml'
+            docker:
+              - '.docker/**'
 
   quality:
     runs-on: ubuntu-latest
@@ -116,6 +120,45 @@ jobs:
       - name: Run JS tests
         run: pnpm test
 
+  # Build and scan the release image on PRs that change how it is built, so the
+  # image's CVE status is visible here rather than surfacing at release time.
+  #
+  # The scan is deliberately ADVISORY (exit-code 0): almost everything it finds
+  # lives in the base image's OS and Go layers, which a PR author neither
+  # introduced nor can fix. Blocking on that would hold unrelated work hostage
+  # to upstream's release cadence — a one-line Docker docs change should not be
+  # gated on a FrankenPHP Go dependency. The hard gate belongs in
+  # release-artifacts.yml, where publishing is a deliberate act and refusing to
+  # ship a known-vulnerable image is the right call. Read the findings in this
+  # job's log.
+  #
+  # The job still FAILS if the image does not build, which is a regression a PR
+  # can genuinely cause. Builds into the local daemon and never pushes, so it
+  # needs no registry credentials.
+  # Skipped when .docker/ is untouched, which the gate below treats as a pass.
+  image-scan:
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Build release image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: .docker/Dockerfile.release
+          load: true
+          tags: lamb:ci
+      - name: Scan image for vulnerabilities (advisory)
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          image-ref: lamb:ci
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '0'
+
   # Browser end-to-end suite. Only runs when e2e-relevant files change
   # (see the `changes` job); otherwise it is skipped and the gate below
   # treats that as a pass.
@@ -180,7 +223,7 @@ jobs:
   # passing — which would let a red PR merge.
   ci:
     runs-on: ubuntu-latest
-    needs: [quality, test, js-test, playwright]
+    needs: [quality, test, js-test, playwright, image-scan]
     if: always()
     steps:
       - name: Verify required jobs succeeded
@@ -189,6 +232,7 @@ jobs:
           echo "test:       ${{ needs.test.result }}"
           echo "js-test:    ${{ needs.js-test.result }}"
           echo "playwright: ${{ needs.playwright.result }}"
+          echo "image-scan: ${{ needs.image-scan.result }}"
           if [ "${{ needs.quality.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.js-test.result }}" != "success" ]; then
             echo "::error::quality, test or js-test did not succeed"
             exit 1
@@ -197,6 +241,11 @@ jobs:
           # only a real failure (or cancellation) should block the merge.
           if [ "${{ needs.playwright.result }}" != "success" ] && [ "${{ needs.playwright.result }}" != "skipped" ]; then
             echo "::error::playwright did not succeed"
+            exit 1
+          fi
+          # image-scan is likewise skipped when .docker/ is untouched.
+          if [ "${{ needs.image-scan.result }}" != "success" ] && [ "${{ needs.image-scan.result }}" != "skipped" ]; then
+            echo "::error::image-scan did not succeed"
             exit 1
           fi
           echo "All checks passed"


### PR DESCRIPTION
## Summary

Follow-up to #575, which added a Trivy gate to `release-artifacts.yml`. That gate only runs when a release is published, so a base image carrying new CVEs is discovered at the worst possible moment — after the release is tagged.

This builds and scans the same release image on PRs that touch `.docker/`, reusing the existing `changes`/paths-filter so the ~97% of PRs that don't change the image skip the job (4 of 118 commits on `main` touch `.docker/`). It builds into the local daemon and never pushes, so unlike the release job it needs no registry credentials.

**The PR scan is advisory, not a gate** (`exit-code: '0'`). Nearly everything it reports lives in the base image's OS and Go layers, which a PR author neither introduced nor can fix, so blocking would hold unrelated work hostage to upstream's release cadence — the last change under `.docker/` was a docs tweak (#492), and it would have been blocked by a FrankenPHP Go advisory. Publishing stays gated in `release-artifacts.yml`, where refusing to ship a known-vulnerable image is the right call because releasing is a deliberate act.

The job does still **fail if the image stops building**, which is a regression a PR can genuinely cause.

Wired into the `ci` aggregate gate with `skipped` treated as a pass, the same way `playwright` is — a skipped required check counts as passing, so the gate has to distinguish "skipped" from "failed" explicitly.

## Test plan

- [x] Both workflows parse as YAML; job graph resolves with no `needs` entry pointing at a nonexistent job
- [x] `image-scan` contains no `login-action` and no `push` — confirmed no registry write
- [x] `exit-code` confirmed `'0'` in `ci.yml` and `'1'` in `release-artifacts.yml`; release step order is build → scan → push
- [ ] **Not executed.** `ci.yml`'s push trigger covers `main`/`release` only, and this PR touches just `.github/`, so the `docker` filter is false and `image-scan` skips here. Verified by inspection only.

## Context on the current findings

The release gate was exercised for real against `0.12.0-rc1` ([run 30807688206](https://github.com/svandragt/lamb/actions/runs/30807688206)). It failed and correctly skipped the push, reporting two fixable CVEs in `/usr/local/bin/frankenphp` from the `dunglas/frankenphp:php8.2` base:

| Severity | Package | Advisory | Installed | Fixed in |
|---|---|---|---|---|
| CRITICAL | `github.com/getkin/kin-openapi` | [GHSA-r277-6w6q-xmqw](https://github.com/advisories/GHSA-r277-6w6q-xmqw) | v0.140.0 | 0.144.0 |
| HIGH | `google.golang.org/grpc` | [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf) | v1.81.1 | 1.82.1 |

Both look unreachable in Lamb's configuration — `Caddyfile.release` configures only `frankenphp`, `php_server`, `encode`, `header`, `respond` and a `path_regexp` matcher, with no OpenAPI validation handler and no gRPC/xDS listener. That is an assessment, not a proof.

Two consequences worth flagging:

- **The next release is still gated on this.** Deciding what to do (a `.trivyignore` with per-CVE justification, or waiting for upstream FrankenPHP to rebuild against patched Go deps) is a separate call and isn't urgent — with the PR scan advisory, nothing is blocked until a release is cut.
- **#573 will now report on `frankenphp:php8.4` without being blocked by it.** Since the Go dependency set is a property of the FrankenPHP release rather than the PHP variant, the 8.4 base likely carries the same two advisories — its `image-scan` log will confirm either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjUom53MHMvDVn2CWz5vhe


---
_Generated by [Claude Code](https://claude.ai/code/session_01FjUom53MHMvDVn2CWz5vhe)_