### PR TITLE
Keep preview links and private pages out of search indexes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,7 @@ All helpers must be imported with `use function Lamb\Theme\<name>` before use.
 | `the_styles()` | `void` | Emits `<link rel="stylesheet">` for `styles/styles.css` in the active theme |
 | `the_scripts()` | `void` | Emits `<script defer>` tags for application scripts in `src/scripts/`; logged-in users also get `src/scripts/logged_in/*.js` |
 | `the_opengraph()` | `void` | Emits `<meta>` OG/Twitter tags (status template only) |
+| `the_robots()` | `void` | Emits `<meta name="robots" content="noindex, nofollow">` when the response is marked noindex (private routes, `?preview=` links); nothing otherwise |
 | `the_preconnect()` | `void` | Emits `<link rel="preconnect">` for `$config['preconnect']` origins |
 | `part($name, $dir='parts')` | `void` | Includes a theme part (see resolution rules above) |
 | `csrf_token()` | `string` | Returns (and creates if needed) the current session CSRF token |

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -52,6 +52,22 @@ We rejected it. `lock_if_feed_sourced()` (`src/response/posts.php:329`) sets `fe
 
 ---
 
+## 2026-08-03 — Private pages and preview links carry their own noindex hint
+
+**Status:** Accepted
+
+**Context:** `robots.txt` was the only thing keeping unlisted pages out of search indexes, and it has two gaps. It disallows by *path*, so it cannot describe a preview link — an ordinary permalink plus `?preview=<token>` (`src/lamb.php: preview_token_valid()`). And it is only consulted by crawlers that fetch it first: a preview link is meant to be handed to someone who is not logged in, which is exactly how an unpublished post gets pasted into a page a crawler already follows.
+
+**Decision:** Keep `robots.txt` as the polite-crawler hint (it gains a `Disallow: /*?preview=` wildcard) and add a per-response one that travels with the page. `Response\should_noindex($action, $_GET)` is true for a route registered via `register_private_route()` or for any request carrying a `preview` parameter; `index.php` calls it before dispatching and `Response\mark_noindex()` sends `X-Robots-Tag: noindex, nofollow`. `Theme\the_robots()` emits the matching `<meta name="robots">` in each theme's `<head>`, because a page saved to disk or re-served by a proxy keeps its markup but loses its headers.
+
+The decision runs on the request's action rather than inside the preview-token check, so a handler that dies with its own body (feeds, the export download) is still covered — by the time `preview_token_valid()` runs, the header may already be too late.
+
+The `preview` parameter counts even when empty or wrong. A bad token never grants access, but the URL is still a duplicate of the canonical permalink and has no business being indexed on its own.
+
+**Consequences:** Private routes are noindexed by registration, not by a second hand-kept list — the same registry `robots.txt` is derived from. A new theme that omits `the_robots()` still gets the header, which is the layer that matters for a live crawl. Public pages emit no robots meta at all, so the default stays "index this".
+
+---
+
 ## 2026-05-29 — `docs/` is end-user documentation only
 
 **Status:** Accepted

--- a/docs/drafts.md
+++ b/docs/drafts.md
@@ -10,6 +10,10 @@ When logged in, all drafts are available from `/drafts`.
 
 Each draft (and scheduled post) shows a **Preview** link next to its Edit button. The link carries an expiring token valid for 24 hours, so you can share it with someone who isn't logged in. A fresh token is issued whenever you save the post after the old one expires.
 
+A preview page tells search engines not to index or follow it, so an
+unpublished post shared this way does not turn up in search results — see
+[Search Engines]({{ site.baseurl }}{% link search-engines.md %}).
+
 Feed ingested posts are saved as drafts by default to prioritize authorship over syndication. Should you prefer, add `feeds_draft = false` to the site settings and they will be published instead. Place it in the top-level section, above any `[section]` headers — inside `[feeds]` it would be read as a feed entry, not a setting.
 
 ## Related
@@ -20,3 +24,4 @@ Feed ingested posts are saved as drafts by default to prioritize authorship over
 - [Micropub]({{ site.baseurl }}{% link micropub.md %}): Drafts created via Micropub get the same 24-hour preview link.
 - [Cron Scheduled Tasks]({{ site.baseurl }}{% link cron-scheduled-tasks.md %}): The cron endpoint triggers feed ingestion.
 - [Export]({{ site.baseurl }}{% link export.md %}): Drafts are included in an export and flagged in the manifest.
+- [Search Engines]({{ site.baseurl }}{% link search-engines.md %}): Preview links are kept out of search indexes.

--- a/docs/search-engines.md
+++ b/docs/search-engines.md
@@ -45,6 +45,27 @@ endpoints. The list is derived automatically from the routes themselves, so it
 stays complete as the app grows. Those routes already require a login (or are
 internal), so this is a hint to crawlers rather than a security control.
 
+It also disallows `/*?preview=`, the
+[preview links]({{ site.baseurl }}{% link drafts.md %}) that open an
+unpublished post without a login.
+
+## Pages that ask not to be indexed
+
+`robots.txt` is only read by crawlers that look for it first, and it cannot
+cover a link someone else has published. So the pages that are not meant to be
+found say so on the page itself as well — every private page and every preview
+link is served with both a `X-Robots-Tag: noindex, nofollow` header and a
+matching `<meta name="robots">` tag:
+
+* the admin pages and actions listed above;
+* any URL carrying a `?preview=` token.
+
+Ordinary posts and pages carry neither, so nothing public changes.
+
+This matters most for preview links: they are meant to be shared with someone
+who is not logged in, which is exactly the way an unpublished post ends up in
+a search index. A preview link also expires after 24 hours.
+
 ### Overriding robots.txt
 
 If you want full control, drop your own `robots.txt` into the web root (the

--- a/docs/theme-functions.md
+++ b/docs/theme-functions.md
@@ -89,6 +89,7 @@ logged in.
 | `the_scripts()` | `void` | Emits the application `<script>` tags from `src/scripts/`; logged-in users also get the admin scripts. It does **not** load scripts from the theme directory. |
 | `the_opengraph()` | `void` | Emits OpenGraph/Twitter `<meta>` tags (status pages only). |
 | `the_preconnect()` | `void` | Emits `<link rel="preconnect">` tags for the origins in `$config['preconnect']`. |
+| `the_robots()` | `void` | Emits `<meta name="robots" content="noindex, nofollow">` on admin pages and `?preview=` links; nothing on public pages. Call it in your theme's `<head>` so previews stay out of search results. |
 | `the_reply_context($bean)` | `string` | See "Posts and content" above. |
 
 ## Parts and includes

--- a/src/index.php
+++ b/src/index.php
@@ -97,6 +97,13 @@ if (str_contains($redirect_path, '/')) {
 }
 
 Route\register_app_routes($action, $lookup, $sublookup);
+
+# Decided before the route runs, because a handler may send its own body and
+# die() (feeds, the export download) — by then it is too late for a header.
+if (Response\should_noindex($action, $_GET)) {
+    Response\mark_noindex();
+}
+
 $template = $action;
 if (post_has_slug($action) === $action) {
     Route\register_route($action, __NAMESPACE__ . '\\Response\respond_post', $action);

--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -113,6 +113,70 @@ function respond_sitemap(): never
 }
 
 /**
+ * The crawler hint emitted for pages that are not meant to be found: don't
+ * index this page, and don't follow the links on it (a preview page links back
+ * to its own ?preview= URL).
+ */
+const NOINDEX = 'noindex, nofollow';
+
+/**
+ * robots.txt pattern covering the shareable preview link. Preview URLs are
+ * ordinary permalinks plus a `?preview=<token>` query, so unlike the private
+ * routes they cannot be disallowed by path — hence the wildcard form, which
+ * the major crawlers understand.
+ */
+const PREVIEW_DISALLOW = '/*?preview=';
+
+/**
+ * Returns true when the current request must not be indexed: an admin/internal
+ * route, or a `?preview=` link.
+ *
+ * Preview links (src/lamb.php: preview_token_valid()) deliberately serve an
+ * unpublished post to anyone holding the token, with no login — which is
+ * exactly what makes them indexable if one is pasted into a page a crawler
+ * already follows. Any `preview` parameter counts, even an empty or wrong one:
+ * the token doesn't have to be valid for the URL to be a duplicate of the
+ * canonical permalink that should not be indexed on its own.
+ *
+ * @param bool|string          $action The current request action (first path segment).
+ * @param array<string, mixed> $query  The request query parameters (i.e. $_GET).
+ * @return bool
+ */
+function should_noindex(bool|string $action, array $query): bool
+{
+    return \Lamb\Route\is_private_route($action) || array_key_exists('preview', $query);
+}
+
+/**
+ * Marks the current response as noindex and sends the X-Robots-Tag header.
+ *
+ * The header covers responses no theme renders (redirects, the export
+ * download); Theme\the_robots() emits the matching <meta> so the hint survives
+ * a page saved or re-served without its headers.
+ *
+ * @return void
+ */
+function mark_noindex(): void
+{
+    global $noindex;
+    $noindex = true;
+    if (!headers_sent()) {
+        header('X-Robots-Tag: ' . NOINDEX);
+    }
+}
+
+/**
+ * Returns true when the current response has been marked noindex.
+ *
+ * @return bool
+ */
+function is_noindex(): bool
+{
+    global $noindex;
+    return !empty($noindex);
+}
+
+/**
  * Builds the default robots.txt body: allow crawling, point at the sitemap, and
  * disallow every private route.
  *
@@ -121,6 +185,9 @@ function respond_sitemap(): never
  * never drift out of sync with the admin/internal routes it is meant to cover.
  * It is already inaccessible to anonymous visitors, so this is a hint to
  * crawlers rather than a security control. Sorted for deterministic output.
+ *
+ * The preview-link pattern is appended after the sorted paths: it is not a
+ * route, so it has no entry in the private registry to sort with them.
  *
  * @return string The robots.txt content.
  */
@@ -131,6 +198,7 @@ function robots_txt_body(): string
         \Lamb\Route\private_routes()
     );
     sort($paths);
+    $paths[] = PREVIEW_DISALLOW;
 
     $lines = ['User-agent: *', 'Allow: /'];
     foreach ($paths as $path) {

--- a/src/routes.php
+++ b/src/routes.php
@@ -52,6 +52,22 @@ function private_routes(): array
 }
 
 /**
+ * Returns true when the action was registered via register_private_route().
+ *
+ * The same registry robots.txt is derived from also drives the per-response
+ * `noindex` hint (see Lamb\Response\should_noindex()), so a private route is
+ * covered by both without being listed twice.
+ *
+ * @param bool|string $action The route action to inspect.
+ * @return bool
+ */
+function is_private_route(bool|string $action): bool
+{
+    global $private_routes;
+    return isset($private_routes[$action]);
+}
+
+/**
  * Registers every application route into the global registry.
  *
  * Extracted from index.php so the route table (and which routes are private)

--- a/src/theme/meta.php
+++ b/src/theme/meta.php
@@ -171,6 +171,27 @@ function og_local_path(string $url): ?string
 }
 
 /**
+ * Emits <meta name="robots" content="noindex, nofollow"> when the current
+ * response has been marked private (see Lamb\Response\should_noindex()):
+ * admin pages, and the ?preview= link that opens an unpublished post without
+ * a login. Outputs nothing on ordinary public pages, so the default stays
+ * "index this".
+ *
+ * index.php already sends the same hint as an X-Robots-Tag header. This tag is
+ * the copy that travels with the HTML — a preview page saved to disk, re-served
+ * by a proxy, or scraped through an embed keeps it.
+ *
+ * @return void
+ */
+function the_robots(): void
+{
+    if (!\Lamb\Response\is_noindex()) {
+        return;
+    }
+    printf('<meta name="robots" content="%s">' . PHP_EOL, \Lamb\Response\NOINDEX);
+}
+
+/**
  * Emits a <meta name="description"> tag for the current page.
  *
  * For single-post (status) pages: uses the post's description field.

--- a/src/themes/2026/html.php
+++ b/src/themes/2026/html.php
@@ -8,6 +8,7 @@ use function Lamb\Theme\part;
 use function Lamb\Theme\the_meta_description;
 use function Lamb\Theme\the_opengraph;
 use function Lamb\Theme\the_preconnect;
+use function Lamb\Theme\the_robots;
 use function Lamb\Theme\the_scripts;
 use function Lamb\Theme\the_styles;
 
@@ -45,6 +46,7 @@ global $template;
     <link rel="preload" href="<?= ROOT_URL ?>/<?= THEME_URL ?>styles/fonts/geist-mono-500-latin.woff2" as="font" type="font/woff2" crossorigin>
 
     <?php
+    the_robots();
     the_meta_description();
     the_preconnect();
     the_styles();

--- a/src/themes/base/html.php
+++ b/src/themes/base/html.php
@@ -7,6 +7,7 @@ use function Lamb\Theme\part;
 use function Lamb\Theme\the_meta_description;
 use function Lamb\Theme\the_opengraph;
 use function Lamb\Theme\the_preconnect;
+use function Lamb\Theme\the_robots;
 use function Lamb\Theme\the_scripts;
 use function Lamb\Theme\the_styles;
 
@@ -40,6 +41,7 @@ global $template;
           title="<?= escape($data['title'] ?? $config['site_title']) ?>">
     <?php endif; ?>
     <?php
+    the_robots();
     the_meta_description();
     the_preconnect();
     the_styles();

--- a/tests/Acceptance/DraftPreviewLinkCest.php
+++ b/tests/Acceptance/DraftPreviewLinkCest.php
@@ -45,4 +45,25 @@ class DraftPreviewLinkCest
         $I->amOnUrl($href);
         $I->see($this->uniqueContent);
     }
+
+    public function testPreviewPageTellsCrawlersNotToIndexIt(AcceptanceTester $I): void
+    {
+        $this->login($I);
+        $this->createDraft($I);
+
+        $I->amOnPage('/drafts');
+        $href = $I->grabAttributeFrom('//article[contains(., "' . $this->uniqueContent . '")]//a[contains(@href, "?preview=")]', 'href');
+
+        $I->amOnPage('/logout');
+        $I->amOnUrl($href);
+        $I->seeElement('//meta[@name="robots"][@content="noindex, nofollow"]');
+        $I->seeResponseHeaderContains('X-Robots-Tag', 'noindex, nofollow');
+    }
+
+    public function testPublishedPostStaysIndexable(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/');
+        $I->dontSeeElement('//meta[@name="robots"]');
+        $I->dontSeeResponseHeader('X-Robots-Tag');
+    }
 }

--- a/tests/Unit/NoIndexTest.php
+++ b/tests/Unit/NoIndexTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Response\is_noindex;
+use function Lamb\Response\mark_noindex;
+use function Lamb\Response\should_noindex;
+use function Lamb\Route\is_private_route;
+use function Lamb\Route\register_app_routes;
+use function Lamb\Theme\the_robots;
+
+/**
+ * Pages that are not meant for the public — the admin routes and the
+ * ?preview=<token> link that opens an unpublished post without a login — must
+ * tell crawlers not to index them. robots.txt is only a hint a polite crawler
+ * reads first; the per-response meta/header is what covers a preview link that
+ * was pasted somewhere a crawler already follows.
+ */
+class NoIndexTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'https://example.com');
+        }
+        $GLOBALS['routes'] = [];
+        $GLOBALS['private_routes'] = [];
+        $GLOBALS['noindex'] = false;
+        register_app_routes('home', null, null);
+    }
+
+    public function testPrivateRoutesAreRecognised(): void
+    {
+        foreach (['edit', 'drafts', 'trash', 'scheduled', 'settings', 'login', '_cron'] as $action) {
+            $this->assertTrue(is_private_route($action), "'$action' should be private");
+        }
+    }
+
+    public function testPublicRoutesAreNotPrivate(): void
+    {
+        foreach (['home', 'status', 'tag', 'search', 'feed', 'sitemap.xml'] as $action) {
+            $this->assertFalse(is_private_route($action), "'$action' should be public");
+        }
+    }
+
+    public function testPrivateRoutesAreNoindexed(): void
+    {
+        $this->assertTrue(should_noindex('drafts', []));
+        $this->assertTrue(should_noindex('settings', []));
+    }
+
+    public function testPublicRoutesAreIndexable(): void
+    {
+        $this->assertFalse(should_noindex('home', []));
+        $this->assertFalse(should_noindex('status', []));
+    }
+
+    public function testPreviewLinkIsNoindexed(): void
+    {
+        $this->assertTrue(should_noindex('status', ['preview' => 'deadbeef']));
+        $this->assertTrue(should_noindex('some-page-slug', ['preview' => 'deadbeef']));
+    }
+
+    public function testEmptyPreviewParamStillCountsAsAPreviewUrl(): void
+    {
+        // ?preview= with no value never grants access, but it is still a
+        // duplicate of the canonical permalink and must not be indexed.
+        $this->assertTrue(should_noindex('status', ['preview' => '']));
+    }
+
+    public function testMarkNoindexFlagsTheResponse(): void
+    {
+        $this->assertFalse(is_noindex());
+        mark_noindex();
+        $this->assertTrue(is_noindex());
+    }
+
+    public function testMetaTagIsEmittedOnlyWhenFlagged(): void
+    {
+        ob_start();
+        the_robots();
+        $this->assertSame('', ob_get_clean());
+
+        mark_noindex();
+        ob_start();
+        the_robots();
+        $this->assertStringContainsString(
+            '<meta name="robots" content="noindex, nofollow">',
+            (string) ob_get_clean()
+        );
+    }
+}

--- a/tests/Unit/RobotsTest.php
+++ b/tests/Unit/RobotsTest.php
@@ -51,6 +51,13 @@ class RobotsTest extends TestCase
         }
     }
 
+    public function testDisallowsPreviewLinks(): void
+    {
+        // Preview links are permalinks with a ?preview=<token> query, so the
+        // path-based Disallow entries above cannot reach them.
+        $this->assertStringContainsString('Disallow: /*?preview=', robots_txt_body());
+    }
+
     public function testStaticFileOverridesGeneratedBody(): void
     {
         $dir = sys_get_temp_dir() . '/lamb-robots-' . uniqid();

--- a/tests/Unit/RouteVisibilityTest.php
+++ b/tests/Unit/RouteVisibilityTest.php
@@ -9,6 +9,8 @@ use function Lamb\Response\robots_txt_body;
 use function Lamb\Route\private_routes;
 use function Lamb\Route\register_app_routes;
 
+use const Lamb\Response\PREVIEW_DISALLOW;
+
 /**
  * Route visibility is the single source of truth behind robots.txt: a route is
  * registered either publicly (register_route) or privately (register_private_route),
@@ -88,6 +90,10 @@ class RouteVisibilityTest extends TestCase
             static fn ($action): string => '/' . ltrim((string) $action, '/'),
             private_routes()
         );
+        sort($expected);
+        // The one Disallow entry that is not a route: preview links are
+        // permalinks carrying a ?preview=<token> query.
+        $expected[] = PREVIEW_DISALLOW;
         sort($expected);
 
         $disallowed = [];


### PR DESCRIPTION
## Why

`robots.txt` was the only thing discouraging indexing of pages that aren't meant to be found, and it has two gaps:

- It disallows by **path**, so it cannot describe a preview link — those are ordinary permalinks plus `?preview=<token>`.
- It's only honoured by crawlers that fetch it first. A preview link is deliberately shareable *without a login*, which is exactly how an unpublished post ends up on a page a crawler already follows.

## What changed

- `Response\should_noindex($action, $_GET)` — true for a route registered via `register_private_route()`, or for any request carrying a `preview` parameter (even an empty/invalid one: the URL is still a duplicate of the canonical permalink). `index.php` calls it **before** dispatching, so handlers that die with their own body (feeds, the export download) are covered too.
- `Response\mark_noindex()` sends `X-Robots-Tag: noindex, nofollow`.
- `Theme\the_robots()` emits the matching `<meta name="robots">`, wired into the `base` and `2026` heads — headers are lost when a page is saved to disk or re-served by a proxy, the meta tag isn't.
- `robots.txt` gains `Disallow: /*?preview=`.

The private-route half is derived from the same registry `robots.txt` is built from, so the two can't drift apart. Public pages emit neither the header nor the meta, so nothing about ordinary posts changes.

## Tests

Red-green throughout.

- `tests/Unit/NoIndexTest.php` (new) — private vs public route classification, preview-param detection, the flag, and the meta output.
- `tests/Unit/RobotsTest.php` / `RouteVisibilityTest.php` — the new preview Disallow line, with the exact-match drift test updated to account for it.
- `tests/Acceptance/DraftPreviewLinkCest.php` — a real preview page serves both the meta tag and the header; the home page serves neither.

Full suite green (1694 tests), `phpcs` and `phpstan` clean.

## Docs

`docs/search-engines.md` (new "Pages that ask not to be indexed" section), `docs/drafts.md`, `docs/theme-functions.md` (`the_robots()`), `AGENTS.md`, and a `DECISIONS.md` entry for why the hint is per-response rather than only in `robots.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRnzZvLfhnGbAESCAedFJ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRnzZvLfhnGbAESCAedFJ7)_