### PR TITLE
Add preview and edit fields to Micropub 201 response body

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1025,11 +1025,17 @@ function respond_micropub(): void
 
     // The adapter returns a bare 201 + Location on success with no body (spec-compliant —
     // Micropub only requires the Location header). Some clients (e.g. mpcli) unconditionally
-    // JSON-parse the body and error out on the empty string, even though the post succeeded.
+    // JSON-parse the body and require url/preview/edit fields, even though the post succeeded.
+    // Lamb has no separate preview/edit URL, so all three point at the same permalink.
     if ($status === 201 && $response->getBody()->getSize() === 0) {
+        $location = $response->getHeaderLine('Location');
         $response = $response
             ->withHeader('Content-Type', 'application/json')
-            ->withBody(Stream::create(json_encode(['url' => $response->getHeaderLine('Location')]) ?: '{}'));
+            ->withBody(Stream::create(json_encode([
+                'url'     => $location,
+                'preview' => $location,
+                'edit'    => $location,
+            ]) ?: '{}'));
     }
 
     mp_log('response', [
@@ -1168,6 +1174,6 @@ function respond_micropub_media(): void
     http_response_code(201);
     header('Location: ' . $url);
     header('Content-Type: application/json');
-    echo json_encode(['url' => $url]);
+    echo json_encode(['url' => $url, 'preview' => $url, 'edit' => $url]);
     exit;
 }


### PR DESCRIPTION
## Summary
- Follow-up to #578. mpcli's `mplib` crate (its underlying Micropub client library) deserializes the 201 response body into a struct requiring `url`, `preview`, and `edit` as non-optional string fields — confirmed by pulling `mplib` 0.1.1 from crates.io and reading `src/publish.rs`'s `ApiPostResponse`.
- The url-only body from #578 satisfied the spec but still failed mpcli's stricter parsing (`missing field \`preview\``).
- Lamb has no distinct preview/edit URL for a post, so all three fields point at the same permalink.

## Test plan
- [x] `composer run lint` clean
- [x] `composer run analyse` clean
- [x] `vendor/bin/codecept run Unit` passes (1617 tests)
- [ ] Re-test `mp post` against vandragt.com for a clean success (pending merge + deploy)