### PR TITLE
Carry in-reply-to through feeds and the Micropub property paths

### DIFF
--- a/docs/replies.md
+++ b/docs/replies.md
@@ -18,15 +18,28 @@ in-reply-to: https://example.com/their-post
 Great point — here's my reply.
 ```
 
-`in_reply_to` (underscore) is accepted as well. [Micropub]({{ site.baseurl }}{% link micropub.md %}) clients can send the standard `in-reply-to` property, which Lamb stores the same way.
+`in_reply_to` (underscore) is accepted as well. [Micropub]({{ site.baseurl }}{% link micropub.md %}) clients can send the standard `in-reply-to` property — either a plain URL or an embedded `h-cite` object — which Lamb stores the same way. Only one reply target is kept: a list collapses to its first entry.
 
 Remove the value from the front matter and re-save to turn the post back into a normal post.
 
 ## What it does
 
-- **On the post page** a small "In reply to …" line is shown above the content, linked to the parent and marked up with `u-in-reply-to` so Webmention receivers treat it as a reply.
+- **On the post page and in listings** a small "In reply to …" line is shown above the content, linked to the parent and marked up with `u-in-reply-to` so Webmention receivers treat it as a reply.
 - **Atom feed**: emits `<thr:in-reply-to ref="…" href="…" />` (the `http://purl.org/syndication/thread/1.0` thread extension).
 - **JSON feed**: emits `_microblog.in_reply_to_url` (the micro.blog reply convention).
+- **Both feeds** also carry the same "In reply to …" line inside the item's HTML content, because the two metadata fields above are extensions most readers ignore, and services that thread replies look for the `u-in-reply-to` markup itself.
+
+## Editing a reply over Micropub
+
+A Micropub client sees the reply target in a `q=source` response as the `in-reply-to`
+property, and can change it with an update:
+
+- `replace` sets a new target (an empty value list clears it);
+- `add` sets the target on a post that has none;
+- `delete` removes it, either as a whole property or by naming the current value.
+
+Because a post stores a single target, *adding* a second one is refused with
+`invalid_request` rather than silently overwriting or dropping it.
 
 Replying to a page is the most common kind of [webmention]({{ site.baseurl }}{% link webmentions.md %}), and Lamb sends them automatically — there is nothing to configure. The link in your reply is picked up and the parent is notified on the next `/_cron` run.
 

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -537,9 +537,16 @@ class LambMicropubAdapter extends MicropubAdapter
         }
 
         if ($property === 'in-reply-to') {
+            // Adding nothing is a no-op, not a failure.
+            if ($values === []) {
+                return true;
+            }
+            // But a value carrying no URL is an add that cannot be honoured, and
+            // reporting success for it reads to the client as "saved" — the same
+            // reason applyReplace() refuses it.
             $target = $this->replyTargetUrl($values[0] ?? null);
             if ($target === null) {
-                return true;
+                return false;
             }
             // A post stores a single reply target, so adding a second one would
             // have to either overwrite the first or be dropped; both lie about

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -27,6 +27,7 @@ use function Lamb\Post\finalize_and_store_post;
 use function Lamb\Post\matter_string;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\populate_bean;
+use function Lamb\Post\set_reply_to;
 use function Lamb\Post\split_frontmatter;
 
 class LambMicropubAdapter extends MicropubAdapter
@@ -103,6 +104,10 @@ class LambMicropubAdapter extends MicropubAdapter
         $tags = get_tags($body);
         if (!empty($tags)) {
             $props['category'] = $tags;
+        }
+
+        if (!empty($bean->in_reply_to)) {
+            $props['in-reply-to'] = [(string) $bean->in_reply_to];
         }
 
         if (!empty($bean->syndicated_to)) {
@@ -473,14 +478,21 @@ class LambMicropubAdapter extends MicropubAdapter
             if (!is_array($values) || !array_is_list($values)) {
                 return 'invalid_request';
             }
-            $this->applyReplace($bean, $property, $values);
+            if (!$this->applyReplace($bean, $property, $values)) {
+                return 'invalid_request';
+            }
         }
 
         foreach ($actions['add'] ?? [] as $property => $values) {
             if (!is_array($values) || !array_is_list($values)) {
                 return 'invalid_request';
             }
-            $this->applyAdd($bean, $property, $values);
+            // Nothing is stored until the end of this method, so refusing here
+            // leaves the post exactly as it was — which is the point: a 200 for
+            // an add the storage cannot hold reads to the client as "saved".
+            if (!$this->applyAdd($bean, $property, $values)) {
+                return 'invalid_request';
+            }
         }
 
         $delete = $actions['delete'] ?? [];
@@ -511,16 +523,34 @@ class LambMicropubAdapter extends MicropubAdapter
     /**
      * Apply an add operation for a single property to a post bean.
      *
-     * @param OODBBean     $bean
-     * @param string       $property
-     * @param list<string> $values
-     * @return void
+     * @param OODBBean    $bean
+     * @param string      $property
+     * @param list<mixed> $values
+     * @return bool False when the operation cannot be honoured (the caller turns
+     *              that into an invalid_request response).
      */
-    private function applyAdd(OODBBean $bean, string $property, array $values): void
+    private function applyAdd(OODBBean $bean, string $property, array $values): bool
     {
         if ($property === 'category') {
-            $bean->body = add_body_tags($bean->body ?? '', $values);
+            $bean->body = add_body_tags($bean->body ?? '', array_map('strval', $values));
+            return true;
         }
+
+        if ($property === 'in-reply-to') {
+            $target = $this->replyTargetUrl($values[0] ?? null);
+            if ($target === null) {
+                return true;
+            }
+            // A post stores a single reply target, so adding a second one would
+            // have to either overwrite the first or be dropped; both lie about
+            // what happened.
+            if ($this->currentReplyTo($bean) !== '') {
+                return false;
+            }
+            $bean->body = set_reply_to($bean->body ?? '', $target);
+        }
+
+        return true;
     }
 
     /**
@@ -535,20 +565,35 @@ class LambMicropubAdapter extends MicropubAdapter
         if ($property === 'category') {
             $bean->body = strip_trailing_body_tags($bean->body ?? '');
         }
+        if ($property === 'in-reply-to') {
+            $bean->body = set_reply_to($bean->body ?? '', '');
+        }
     }
 
     /**
      * Apply a delete-values operation for a single property to a post bean.
      *
-     * @param OODBBean     $bean
-     * @param string       $property
-     * @param list<string> $values
+     * @param OODBBean    $bean
+     * @param string      $property
+     * @param list<mixed> $values
      * @return void
      */
     private function applyDeleteValues(OODBBean $bean, string $property, array $values): void
     {
         if ($property === 'category') {
-            $bean->body = remove_body_tags($bean->body ?? '', $values);
+            $bean->body = remove_body_tags($bean->body ?? '', array_map('strval', $values));
+        }
+
+        if ($property === 'in-reply-to') {
+            // Value-scoped delete: only the target the client named goes, so a
+            // stale value in a client's copy cannot clear the current reply.
+            $current = $this->currentReplyTo($bean);
+            foreach ($values as $value) {
+                if ($current !== '' && $this->replyTargetUrl($value) === $current) {
+                    $bean->body = set_reply_to($bean->body ?? '', '');
+                    return;
+                }
+            }
         }
     }
 
@@ -558,14 +603,76 @@ class LambMicropubAdapter extends MicropubAdapter
      * @param OODBBean    $bean
      * @param string      $property
      * @param list<mixed> $values
-     * @return void
+     * @return bool False when the operation cannot be honoured (the caller turns
+     *              that into an invalid_request response).
      */
-    private function applyReplace(OODBBean $bean, string $property, array $values): void
+    private function applyReplace(OODBBean $bean, string $property, array $values): bool
     {
         if ($property === 'content') {
             $newContent = (string) ($values[0] ?? '');
             $bean->body = $this->rebuildBody($bean, $newContent);
+            return true;
         }
+
+        if ($property === 'in-reply-to') {
+            // An empty value list is Micropub's "replace with nothing", i.e. the
+            // post stops being a reply.
+            if ($values === []) {
+                $bean->body = set_reply_to($bean->body ?? '', '');
+                return true;
+            }
+
+            $target = $this->replyTargetUrl($values[0] ?? null);
+            if ($target === null) {
+                return false;
+            }
+            $bean->body = set_reply_to($bean->body ?? '', $target);
+        }
+
+        return true;
+    }
+
+    /**
+     * The reply target currently recorded in a bean's front matter.
+     *
+     * Read from the body rather than $bean->in_reply_to: an update applies a
+     * sequence of operations to the body, and the column is only refreshed by
+     * the parse_bean() call at the end of updateCallback().
+     *
+     * @param OODBBean $bean
+     * @return string The target URL, or '' when the post is not a reply.
+     */
+    private function currentReplyTo(OODBBean $bean): string
+    {
+        $matter = parse_matter((string) ($bean->body ?? ''));
+
+        return trim(matter_string($matter['in-reply-to'] ?? null) ?? '');
+    }
+
+    /**
+     * Extract a reply target URL from a Micropub `in-reply-to` value.
+     *
+     * The value is a URL string in the simple case, but Micropub also allows an
+     * embedded h-cite object (`{type: [h-cite], properties: {url: [...]}}`), which
+     * is what a client sends when it has the parent's author and name to hand.
+     * Both shapes have to yield the URL — matter_string() alone returns null for
+     * the object, which silently turned an h-cite reply into a normal post.
+     *
+     * @param mixed $value A single value from the `in-reply-to` property.
+     * @return string|null The target URL, or null when the value carries none.
+     */
+    private function replyTargetUrl(mixed $value): ?string
+    {
+        if (is_array($value)) {
+            $nested = $value['properties']['url'] ?? $value['url'] ?? null;
+            if ($nested !== null) {
+                return $this->replyTargetUrl(is_array($nested) ? ($nested[0] ?? null) : $nested);
+            }
+        }
+
+        $url = matter_string($value);
+
+        return $url !== null && trim($url) !== '' ? trim($url) : null;
     }
 
     /**
@@ -711,7 +818,7 @@ class LambMicropubAdapter extends MicropubAdapter
         // `name`. Both reached the ?string parameters of assembleFrontMatter()
         // as arrays and 500ed the create.
         $title = matter_string($props['name'][0] ?? null);
-        $replyTo = matter_string($props['in-reply-to'][0] ?? null);
+        $replyTo = $this->replyTargetUrl($props['in-reply-to'][0] ?? null);
 
         $photos = $this->buildPhotos($props['photo'] ?? []);
         if ($photos !== '') {
@@ -752,7 +859,13 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     private function buildExtraProperties(array $props): string
     {
-        $known = ['content', 'name', 'category', 'photo', 'published', 'post-status', 'mp-syndicate-to'];
+        // `in-reply-to` belongs here with the rest: buildBody() consumes it into
+        // front matter, so leaving it out dumped the reply target into the post
+        // body a second time as a JSON code block readers could see.
+        $known = [
+            'content', 'name', 'category', 'photo', 'published', 'post-status',
+            'mp-syndicate-to', 'in-reply-to',
+        ];
         $extra = array_diff_key($props, array_flip($known));
 
         if (empty($extra)) {

--- a/src/post.php
+++ b/src/post.php
@@ -446,6 +446,62 @@ function set_matter(string $body, string $key, string $value, bool $quote = fals
 }
 
 /**
+ * Sets (or clears) the reply target in a body's leading YAML front-matter block.
+ *
+ * Surgical on purpose: every other front-matter key — including ones this
+ * codebase does not recognise — is carried over verbatim, because the Micropub
+ * update path that calls this must not silently drop a hand-written `slug:` or
+ * `draft:` while changing a reply target. A body with no front matter gains a
+ * block; a block left with nothing but the reply target loses its fence again.
+ *
+ * Both `in-reply-to` and `in_reply_to` spellings are removed before the new
+ * value is appended (parse_matter() normalises them onto one key, so two lines
+ * would race for it), and the value is dumped through the YAML writer rather
+ * than interpolated, so a newline in it cannot inject further keys.
+ *
+ * @param string $body The raw post body.
+ * @param string $value The reply target URL, or '' to remove it.
+ * @return string The body with its front-matter reply target set.
+ */
+function set_reply_to(string $body, string $value): string
+{
+    $body  = normalize_frontmatter_fence($body);
+    $value = trim($value);
+    [$yaml, $content] = split_frontmatter($body);
+
+    if ($yaml === '') {
+        return $value === '' ? $body : build_matter(['in-reply-to' => $value], $body);
+    }
+
+    $kept = [];
+    $dropping = false;
+    foreach (preg_split('/\R/', $yaml) ?: [] as $line) {
+        if (preg_match('/^[ \t]*in[-_]reply[-_]to[ \t]*:/i', $line) === 1) {
+            $dropping = true;
+            continue;
+        }
+        // An indented line after the key is its YAML list/continuation: dropping
+        // the key but keeping `  - https://…` leaves the block unparseable.
+        if ($dropping && preg_match('/^[ \t]+\S/', $line) === 1) {
+            continue;
+        }
+        $dropping = false;
+        $kept[] = $line;
+    }
+
+    $new_yaml = rtrim(implode("\n", $kept), "\n");
+    if ($value !== '') {
+        $new_yaml = ($new_yaml === '' ? '' : $new_yaml . "\n") . trim(Yaml::dump(['in-reply-to' => $value]));
+    }
+
+    if (trim($new_yaml) === '') {
+        return $content;
+    }
+
+    return "---\n" . $new_yaml . "\n---\n" . $content;
+}
+
+/**
  * Rewrites the `slug` value inside a body's leading YAML front-matter block to
  * the given actual slug, leaving all other front matter intact.
  *

--- a/src/post.php
+++ b/src/post.php
@@ -476,7 +476,10 @@ function set_reply_to(string $body, string $value): string
     $kept = [];
     $dropping = false;
     foreach (preg_split('/\R/', $yaml) ?: [] as $line) {
-        if (preg_match('/^[ \t]*in[-_]reply[-_]to[ \t]*:/i', $line) === 1) {
+        // Anchored to column zero: an indented `in-reply-to` belongs to whatever
+        // block encloses it, and claiming it here took that block's remaining
+        // lines with it as "continuations" of a key that was never ours.
+        if (preg_match('/^in[-_]reply[-_]to[ \t]*:/i', $line) === 1) {
             $dropping = true;
             continue;
         }

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -59,7 +59,14 @@ foreach ($data['posts'] as $bean) {
     $Entry->addChild('title', escape($bean->title ?: ''));
     $Entry->addChild('published', date(DATE_ATOM, strtotime($bean->created)));
     $Entry->addChild('updated', date(DATE_ATOM, strtotime($bean->updated)));
-    $Content = $Entry->addChild('content', Lamb\absolute_urls($bean->transformed));
+    // The reply context travels inside <content>, not only in the theme: thr:
+    // below is invisible to readers that ignore the extension, and services that
+    // thread replies (micro.blog) look for the u-in-reply-to microformat in the
+    // item's HTML. Its markup is already escaped, so addChild() is safe here.
+    $Content = $Entry->addChild(
+        'content',
+        Lamb\Theme\the_reply_context($bean) . Lamb\absolute_urls($bean->transformed)
+    );
     $Content->addAttribute('type', 'html');
     if (!empty($bean->in_reply_to)) {
         // Raw URL: SimpleXML escapes attribute values itself, so pre-escaping

--- a/src/themes/base/feed_json.php
+++ b/src/themes/base/feed_json.php
@@ -34,7 +34,10 @@ foreach ($data['posts'] as $bean) {
     $item = [
         'id'             => $url,
         'url'            => $url,
-        'content_html'   => Lamb\absolute_urls($bean->transformed),
+        // Reply context inside content_html as well as _microblog below: the
+        // extension is a micro.blog convention, while the u-in-reply-to markup is
+        // what a plain reader shows and what mf2 consumers parse.
+        'content_html'   => Lamb\Theme\the_reply_context($bean) . Lamb\absolute_urls($bean->transformed),
         'date_published' => date(DATE_RFC3339, strtotime($bean->created)),
         'date_modified'  => date(DATE_RFC3339, strtotime($bean->updated)),
     ];

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -1943,6 +1943,44 @@ class MicropubAdapterTest extends TestCase
         $this->assertSame('https://other.example/post', $updated->in_reply_to);
     }
 
+    public function testUpdateAddInReplyToRejectsValueCarryingNoUrl(): void
+    {
+        // Mirrors the replace path: an h-cite with no url is not a reply target,
+        // and returning 200 for an add that stored nothing tells the client its
+        // edit was saved.
+        $bean = $this->storeReply('Not yet a reply');
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['add' => ['in-reply-to' => [[
+                'type'       => ['h-cite'],
+                'properties' => ['name' => ['No url here']],
+            ]]]]
+        );
+
+        $this->assertSame('invalid_request', $result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('', (string) $updated->in_reply_to);
+    }
+
+    public function testUpdateAddInReplyToWithEmptyValueListIsANoOp(): void
+    {
+        // An empty value list asks for nothing to be added, which is not the same
+        // as asking for something impossible: it must not be an error.
+        $bean = $this->storeReply('Not yet a reply');
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['add' => ['in-reply-to' => []]]
+        );
+
+        $this->assertTrue($result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('', (string) $updated->in_reply_to);
+    }
+
     // --- has_micropub_scope ---
 
     public function testHasMicropubScopeTrueWhenScopePresent(): void

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -1700,6 +1700,249 @@ class MicropubAdapterTest extends TestCase
         $this->assertSame('https://bsky.app/profile/me', $post->syndicated_to);
     }
 
+    // --- in-reply-to (create / source / update) ---
+
+    /**
+     * Store a reply post and return its bean.
+     */
+    private function storeReply(string $body): OODBBean
+    {
+        $bean = R::dispense('post');
+        $bean->body = $body;
+        $bean->slug = '';
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        \Lamb\parse_bean($bean);
+        R::store($bean);
+
+        return $bean;
+    }
+
+    public function testCreateCallbackAcceptsInReplyToHCiteObject(): void
+    {
+        // Micropub allows in-reply-to to be a nested h-cite rather than a bare
+        // URL; the target has to come out of its `url` property, not be dropped.
+        $adapter = new LambMicropubAdapter();
+        $adapter->createCallback([
+            'type'       => ['h-entry'],
+            'properties' => [
+                'content'     => ['Replying to an h-cite'],
+                'in-reply-to' => [[
+                    'type'       => ['h-cite'],
+                    'properties' => [
+                        'url'  => ['https://other.example/their-post'],
+                        'name' => ['Their post'],
+                    ],
+                ]],
+            ],
+        ]);
+
+        $post = R::findOne('post', ' body LIKE ? ', ['%Replying to an h-cite%']);
+        $this->assertNotNull($post);
+        $this->assertSame('https://other.example/their-post', $post->in_reply_to);
+    }
+
+    public function testCreateCallbackDoesNotDumpInReplyToAsExtraProperties(): void
+    {
+        // in-reply-to is consumed into front matter, so it must not also land in
+        // the body as a JSON code block of "unrecognised" properties.
+        $adapter = new LambMicropubAdapter();
+        $adapter->createCallback([
+            'type'       => ['h-entry'],
+            'properties' => [
+                'content'     => ['No json block please'],
+                'in-reply-to' => ['https://other.example/their-post'],
+            ],
+        ]);
+
+        $post = R::findOne('post', ' body LIKE ? ', ['%No json block please%']);
+        $this->assertNotNull($post);
+        $this->assertStringNotContainsString('```json', $post->body);
+        $this->assertSame('https://other.example/their-post', $post->in_reply_to);
+    }
+
+    public function testSourceQueryReturnsInReplyTo(): void
+    {
+        $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nSource reply content");
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->sourceQueryCallback(ROOT_URL . '/status/' . $bean->id);
+
+        $this->assertSame(['https://other.example/post'], $result['properties']['in-reply-to']);
+    }
+
+    public function testSourceQueryOmitsInReplyToForNormalPost(): void
+    {
+        $bean = $this->storeReply('An ordinary post');
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->sourceQueryCallback(ROOT_URL . '/status/' . $bean->id);
+
+        $this->assertArrayNotHasKey('in-reply-to', $result['properties']);
+    }
+
+    public function testUpdateReplaceInReplyToSetsTarget(): void
+    {
+        $bean = $this->storeReply('Turning this into a reply');
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['replace' => ['in-reply-to' => ['https://other.example/post']]]
+        );
+
+        $this->assertTrue($result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('https://other.example/post', $updated->in_reply_to);
+        $this->assertStringContainsString('Turning this into a reply', $updated->body);
+    }
+
+    public function testUpdateReplaceInReplyToAcceptsHCiteObject(): void
+    {
+        $bean = $this->storeReply('Reply target as h-cite');
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['replace' => ['in-reply-to' => [[
+                'type'       => ['h-cite'],
+                'properties' => ['url' => ['https://other.example/post']],
+            ]]]]
+        );
+
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('https://other.example/post', $updated->in_reply_to);
+    }
+
+    public function testUpdateReplaceInReplyToPreservesUnrelatedFrontMatter(): void
+    {
+        $bean = $this->storeReply("---\ntitle: Kept Title\nslug: kept-slug\n---\nBody stays");
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->updateCallback(
+            ROOT_URL . '/kept-slug',
+            ['replace' => ['in-reply-to' => ['https://other.example/post']]]
+        );
+
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('https://other.example/post', $updated->in_reply_to);
+        $this->assertSame('Kept Title', $updated->title);
+        $this->assertSame('kept-slug', $updated->slug);
+        $this->assertStringContainsString('Body stays', $updated->body);
+    }
+
+    public function testUpdateReplaceInReplyToRejectsValueCarryingNoUrl(): void
+    {
+        // An h-cite with no url is not a reply target; accepting it would either
+        // clear the existing one or report a change that never happened.
+        $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nHi");
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['replace' => ['in-reply-to' => [[
+                'type'       => ['h-cite'],
+                'properties' => ['name' => ['No url here']],
+            ]]]]
+        );
+
+        $this->assertSame('invalid_request', $result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('https://other.example/post', $updated->in_reply_to);
+    }
+
+    public function testUpdateReplaceInReplyToWithEmptyValueClearsTarget(): void
+    {
+        $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nNo longer a reply");
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['replace' => ['in-reply-to' => []]]
+        );
+
+        $this->assertTrue($result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('', (string) $updated->in_reply_to);
+    }
+
+    public function testUpdateDeletePropertyRemovesInReplyTo(): void
+    {
+        $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nPlain post now");
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['delete' => ['in-reply-to']]
+        );
+
+        $this->assertTrue($result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('', (string) $updated->in_reply_to);
+        $this->assertStringContainsString('Plain post now', $updated->body);
+    }
+
+    public function testUpdateDeleteInReplyToValueRemovesMatchingTarget(): void
+    {
+        $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nHi");
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['delete' => ['in-reply-to' => ['https://other.example/post']]]
+        );
+
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('', (string) $updated->in_reply_to);
+    }
+
+    public function testUpdateDeleteInReplyToValueLeavesDifferentTargetIntact(): void
+    {
+        $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nHi");
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['delete' => ['in-reply-to' => ['https://unrelated.example/post']]]
+        );
+
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('https://other.example/post', $updated->in_reply_to);
+    }
+
+    public function testUpdateAddInReplyToSetsTargetWhenAbsent(): void
+    {
+        $bean = $this->storeReply('Not yet a reply');
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['add' => ['in-reply-to' => ['https://other.example/post']]]
+        );
+
+        $this->assertTrue($result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('https://other.example/post', $updated->in_reply_to);
+    }
+
+    public function testUpdateAddSecondInReplyToIsRejected(): void
+    {
+        // Storage holds one reply target, so a second one cannot be honoured:
+        // Micropub requires an unsupported operation to fail rather than return
+        // success the client will read as "saved".
+        $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nHi");
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['add' => ['in-reply-to' => ['https://second.example/post']]]
+        );
+
+        $this->assertSame('invalid_request', $result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('https://other.example/post', $updated->in_reply_to);
+    }
+
     // --- has_micropub_scope ---
 
     public function testHasMicropubScopeTrueWhenScopePresent(): void

--- a/tests/Unit/ReplyContextTest.php
+++ b/tests/Unit/ReplyContextTest.php
@@ -7,6 +7,7 @@ use RedBeanPHP\R;
 
 use function Lamb\parse_bean;
 use function Lamb\Post\populate_bean;
+use function Lamb\Post\set_reply_to;
 use function Lamb\Theme\the_reply_context;
 
 class ReplyContextTest extends TestCase
@@ -115,6 +116,65 @@ class ReplyContextTest extends TestCase
         $this->assertSame('', the_reply_context($bean));
     }
 
+    // set_reply_to helper ----------------------------------------------------
+
+    public function testSetReplyToAddsFrontMatterBlockToPlainBody(): void
+    {
+        $body = set_reply_to('Just a status', 'https://other.example/post');
+        $bean = populate_bean($body);
+        $this->assertSame('https://other.example/post', $bean->in_reply_to);
+        $this->assertStringContainsString('Just a status', $bean->body);
+    }
+
+    public function testSetReplyToPreservesOtherFrontMatter(): void
+    {
+        $body = set_reply_to("---\nslug: keep-me\ndraft: true\n---\nBody text", 'https://other.example/post');
+        $this->assertStringContainsString('slug: keep-me', $body);
+        $this->assertStringContainsString('draft: true', $body);
+
+        $bean = populate_bean($body);
+        $this->assertSame('https://other.example/post', $bean->in_reply_to);
+        $this->assertSame('keep-me', $bean->slug);
+        $this->assertSame(1, (int) $bean->draft);
+    }
+
+    public function testSetReplyToReplacesUnderscoreSpelledKey(): void
+    {
+        // One key survives, whichever spelling the author used: two lines both
+        // matching parse_matter()'s normalisation would race for the value.
+        $body = set_reply_to("---\nin_reply_to: https://old.example/post\n---\nHi", 'https://new.example/post');
+        $this->assertStringNotContainsString('old.example', $body);
+        $this->assertSame('https://new.example/post', populate_bean($body)->in_reply_to);
+    }
+
+    public function testSetReplyToRemovesKeyWhenValueEmpty(): void
+    {
+        $body = set_reply_to("---\ntitle: Kept\nin-reply-to: https://other.example/post\n---\nHi", '');
+        $this->assertStringNotContainsString('in-reply-to', $body);
+        $this->assertStringContainsString('title: Kept', $body);
+        $this->assertSame('', (string) populate_bean($body)->in_reply_to);
+    }
+
+    public function testSetReplyToRemovesListValueAndEmptyBlock(): void
+    {
+        // A YAML list spans continuation lines; leaving them behind would make
+        // the block unparseable, and an emptied block must go entirely.
+        $body = set_reply_to(
+            "---\nin-reply-to:\n  - https://first.example/post\n  - https://second.example/post\n---\nHi",
+            ''
+        );
+        $this->assertSame('Hi', trim($body));
+    }
+
+    public function testSetReplyToQuotesValueWithNewlineInjection(): void
+    {
+        // The value arrives from a Micropub request: a newline must not be able
+        // to inject further front-matter keys (as build_matter() guards too).
+        $body = set_reply_to('Status', "https://other.example/post\ndraft: true");
+        $bean = populate_bean($body);
+        $this->assertSame(0, (int) $bean->draft);
+    }
+
     // Atom feed -------------------------------------------------------------
 
     /**
@@ -156,6 +216,78 @@ class ReplyContextTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
+    public function testAtomFeedContentCarriesReplyContextMarkup(): void
+    {
+        // thr:in-reply-to is invisible to most readers, and services that thread
+        // replies (micro.blog) look for u-in-reply-to in the item HTML — so the
+        // reply context has to travel inside <content>, not only in the theme.
+        require_once __DIR__ . '/../../vendor/autoload.php';
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        $bean = R::dispense('post');
+        $bean->title = '';
+        $bean->transformed = '<p>A reply</p>';
+        $bean->in_reply_to = 'https://other.example/post';
+        $bean->created = '2024-01-01 12:00:00';
+        $bean->updated = '2024-01-01 12:00:00';
+
+        global $config, $data;
+        $config = ['site_title' => 'Blog', 'author_name' => 'Author'];
+        $data = ['posts' => [$bean], 'title' => 'Blog', 'feed_url' => 'http://localhost/feed', 'updated' => '2024-01-01 12:00:00'];
+
+        ob_start();
+        require __DIR__ . '/../../src/themes/base/feed.php';
+        $output = ob_get_clean();
+
+        $content = (string) (new \SimpleXMLElement($output))->entry->content;
+        $this->assertStringContainsString('u-in-reply-to', $content);
+        $this->assertStringContainsString('https://other.example/post', $content);
+        $this->assertStringContainsString('<p>A reply</p>', $content);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testAtomFeedContentUnchangedForNonReply(): void
+    {
+        require_once __DIR__ . '/../../vendor/autoload.php';
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        $bean = R::dispense('post');
+        $bean->title = '';
+        $bean->transformed = '<p>Not a reply</p>';
+        $bean->created = '2024-01-01 12:00:00';
+        $bean->updated = '2024-01-01 12:00:00';
+
+        global $config, $data;
+        $config = ['site_title' => 'Blog', 'author_name' => 'Author'];
+        $data = ['posts' => [$bean], 'title' => 'Blog', 'feed_url' => 'http://localhost/feed', 'updated' => '2024-01-01 12:00:00'];
+
+        ob_start();
+        require __DIR__ . '/../../src/themes/base/feed.php';
+        $output = ob_get_clean();
+
+        $content = (string) (new \SimpleXMLElement($output))->entry->content;
+        $this->assertSame('<p>Not a reply</p>', $content);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testJsonFeedIncludesMicroblogInReplyTo(): void
     {
         require_once __DIR__ . '/../../vendor/autoload.php';
@@ -184,5 +316,9 @@ class ReplyContextTest extends TestCase
 
         $json = json_decode($output, true);
         $this->assertSame('https://other.example/post', $json['items'][0]['_microblog']['in_reply_to_url']);
+        // `_microblog` is a JSON Feed extension no plain reader looks at: the
+        // same relationship has to be visible in content_html as well.
+        $this->assertStringContainsString('u-in-reply-to', $json['items'][0]['content_html']);
+        $this->assertStringContainsString('<p>A reply</p>', $json['items'][0]['content_html']);
     }
 }

--- a/tests/Unit/ReplyContextTest.php
+++ b/tests/Unit/ReplyContextTest.php
@@ -175,6 +175,21 @@ class ReplyContextTest extends TestCase
         $this->assertSame(0, (int) $bean->draft);
     }
 
+    public function testSetReplyToLeavesNestedKeysAlone(): void
+    {
+        // Only a top-level `in-reply-to` is this function's business. An indented
+        // one belongs to whatever block encloses it, and treating it as the key
+        // took the rest of that block's lines with it as "continuations".
+        $body = set_reply_to(
+            "---\nmeta:\n  in-reply-to: https://old.example/x\n  other: keep-me\ntitle: T\n---\nHi",
+            'https://new.example/post'
+        );
+
+        $this->assertStringContainsString('other: keep-me', $body);
+        $this->assertStringContainsString('in-reply-to: https://old.example/x', $body);
+        $this->assertSame('https://new.example/post', populate_bean($body)->in_reply_to);
+    }
+
     // Atom feed -------------------------------------------------------------
 
     /**


### PR DESCRIPTION
A reply's target only ever reached the theme and two feed metadata fields,
and the Micropub side of it was read-only:

- q=source omitted `in-reply-to` entirely, so a client doing
  read-modify-write on a reply saw a normal post.
- update replace/add/delete for `in-reply-to` fell through the property
  checks and returned 200, so a client believed an edit it never got had
  been saved. `set_reply_to()` now edits the front-matter key surgically,
  carrying every other key (including a hand-written `slug:` or `draft:`)
  over untouched. Adding a second target is refused with invalid_request
  rather than overwritten or dropped, since storage holds one.
- an `in-reply-to` h-cite object — which Micropub allows, and which a
  client sends when it has the parent's name to hand — reached
  matter_string() as an array, came back null, and the reply target was
  dropped. It was also missing from buildExtraProperties()'s known list,
  so the same object was dumped into the post body as a visible JSON code
  block.
- both feeds carried the relationship only in `thr:in-reply-to` and
  `_microblog.in_reply_to_url`, extensions ordinary readers ignore and
  which are not what services threading replies look for: the
  u-in-reply-to markup now travels inside the item HTML too.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011gB9uvJWJnc9EMkxFp13aF