### PR TITLE
Store devbox.lock verbatim so git stops seeing phantom changes

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -7,6 +7,7 @@
     },
     "nodejs@24": {
       "last_modified": "2025-12-29T16:45:58Z",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/346dd96ad74dc4457a9db9de4f4f57dab2e5731d#nodejs_24",
       "source": "devbox-search",
       "version": "24.12.0",
@@ -259,6 +260,7 @@
     },
     "php@8.2": {
       "last_modified": "2024-03-22T11:26:23Z",
+      "plugin_version": "0.0.3",
       "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#php",
       "source": "devbox-search",
       "version": "8.2.17",
@@ -391,6 +393,7 @@
     },
     "ruby@3.3": {
       "last_modified": "2026-01-23T17:20:52Z",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#ruby",
       "source": "devbox-search",
       "version": "3.3.10",


### PR DESCRIPTION
## Problem

`devbox.lock` showed as modified in `git status` permanently, in a tree with no real changes. Worse, it blocked branch operations:

```
$ git rebase main
error: cannot rebase: You have unstaged changes.

$ git checkout other-branch
error: Your local changes to the following files would be overwritten by checkout:
	devbox.lock
```

Meanwhile `git diff devbox.lock` printed nothing.

## Cause

A global clean filter in `~/.config/git/attributes` strips `plugin_version` from the lock:

```
devbox.lock filter=devbox-lock
```
```
filter.devbox-lock.clean = jq '.packages |= map_values(del(.plugin_version))'
```

Git does not re-run clean filters for `git status` — it compares stat data and reports the file as modified without hashing the filtered content. `git diff` does run the filter, finds the content identical, and prints nothing. The two commands disagree, and the operations that guard on "is the tree dirty" side with `status`.

## Fix

Override the filter to `cat` in this repo's local config and commit the lock exactly as devbox writes it, `plugin_version` keys and all. Devbox rewriting those keys is now a no-op rather than permanent phantom dirt.

Local config, so nothing changes for other checkouts or for the global filter in other projects.

## Test

```
$ devbox run -- php -v && git status --porcelain devbox.lock
(no output)
```

Before this change the same command printed ` M devbox.lock`.