### PR TITLE
Say when LAMB_LOGIN_PASSWORD is unset instead of failing as a bad password

### DIFF
--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -65,6 +65,18 @@ function redirect_login(): array
         return throttled_login_response($retry_after);
     }
 
+    // An install with no LAMB_LOGIN_PASSWORD can never authenticate anyone, and
+    // password_verify() against an empty hash fails exactly like a wrong
+    // password — so the operator goes looking for a forgotten password instead
+    // of an unset variable (php-fpm clears the environment; the pool config has
+    // to declare it). Say which it is, in the log and on the page, and do not
+    // record a failure: the server is at fault, and throttling the operator
+    // out of their own diagnosis makes it worse.
+    if (LOGIN_PASSWORD === '') {
+        error_log('LAMB_LOGIN_PASSWORD is not set; admin logins cannot succeed');
+        return login_page_data('Login is not configured on this site.');
+    }
+
     $user_pass = $_POST['password'] ?? '';
     if (!password_verify($user_pass, base64_decode(LOGIN_PASSWORD))) {
         log_failed_login();

--- a/tests/Unit/ResponseAuthTest.php
+++ b/tests/Unit/ResponseAuthTest.php
@@ -134,25 +134,68 @@ class ResponseAuthTest extends TestCase
     }
 
     /**
-     * Wrong password re-renders the login page in place with the error rather
-     * than redirecting through a session flash (issue #462): the flash carrier
-     * is gone now that /login is sessionless, so the message must travel in the
-     * returned data. The visitor must remain anonymous (no session started).
+     * An install with no LAMB_LOGIN_PASSWORD cannot authenticate anyone, and
+     * saying "password is incorrect" sends the operator hunting for a password
+     * that was never the problem. The unit suite runs without the variable set,
+     * so LOGIN_PASSWORD is '' here — the misconfigured install itself.
+     *
+     * The visitor must still end up anonymous, and the reply must not hint at
+     * whether the submitted password was close to anything.
      */
-    public function testRedirectLoginWrongPasswordRendersErrorWithoutSession(): void
+    public function testRedirectLoginSaysSoWhenNoLoginPasswordIsConfigured(): void
     {
         $token = \Lamb\Response\issue_login_csrf();
         $_POST['submit']          = SUBMIT_LOGIN;
         $_POST[HIDDEN_CSRF_NAME]  = $token;
-        $_POST['password']        = 'definitely-the-wrong-password-xyz';
+        $_POST['password']        = 'anything-at-all';
 
         $result = redirect_login();
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('login_error', $result);
-        $this->assertSame('Password is incorrect, please try again.', $result['login_error']);
+        $this->assertStringContainsString('not configured', $result['login_error']);
         $this->assertArrayHasKey('login_csrf', $result);
         $this->assertArrayNotHasKey(SESSION_LOGIN, $_SESSION);
+    }
+
+    /**
+     * The operator's copy of that message: named variable, and a statement that
+     * logins cannot succeed, so a search of the error log lands on it.
+     */
+    public function testRedirectLoginLogsTheMissingLoginPassword(): void
+    {
+        $token = \Lamb\Response\issue_login_csrf();
+        $_POST['submit']          = SUBMIT_LOGIN;
+        $_POST[HIDDEN_CSRF_NAME]  = $token;
+        $_POST['password']        = 'anything-at-all';
+
+        $log = $this->captureErrorLog(static fn() => redirect_login());
+
+        $this->assertStringContainsString('LAMB_LOGIN_PASSWORD', $log);
+        $this->assertStringContainsString('cannot succeed', $log);
+    }
+
+    /**
+     * The misconfiguration is the server's fault, not the visitor's, so it must
+     * not burn an attempt from the throttle budget (issue #443) — otherwise an
+     * operator testing their own fix locks themselves out of the diagnosis.
+     */
+    public function testRedirectLoginDoesNotRecordAFailureWhenUnconfigured(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.9';
+        // One short of the limit, so recording a single failure would trip it.
+        for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES - 1; $i++) {
+            \Lamb\Response\record_login_failure('203.0.113.9', time());
+        }
+
+        $token = \Lamb\Response\issue_login_csrf();
+        $_POST['submit']          = SUBMIT_LOGIN;
+        $_POST[HIDDEN_CSRF_NAME]  = $token;
+        $_POST['password']        = 'anything-at-all';
+
+        redirect_login();
+
+        $this->assertSame(0, \Lamb\Response\login_throttle_retry_after('203.0.113.9', time()));
     }
 
     /**


### PR DESCRIPTION
From the puffin server migration handover: the finding its author marked as the one worth fixing.

## The problem

`src/response.php` captures the hash at include time:

```php
define('LOGIN_PASSWORD', getenv("LAMB_LOGIN_PASSWORD") ?: '');
```

Unset, that leaves `LOGIN_PASSWORD` as `''`, and `password_verify($pass, base64_decode(''))` fails exactly the way a wrong password does. The visitor sees "Password is incorrect, please try again." Nothing reaches the error log. From outside, a server that cannot authenticate anyone is indistinguishable from an operator who forgot their password — which is the wrong conclusion to reach, and the expensive one.

On the migrated server this cost hours, and the only way to confirm the cause was reading `/proc/<fpm-master>/environ`. The root cause is that php-fpm clears the environment and the new pool config never declared `env[LAMB_LOGIN_PASSWORD]`. `docs/nginx.md` documents that correctly — the docs were right, the deployment was wrong, and the app had no way to say so.

## The change

A login attempt against an unconfigured install now:

- logs `LAMB_LOGIN_PASSWORD is not set; admin logins cannot succeed` — the variable by name, so a search of the error log lands on it from a cold start;
- renders "Login is not configured on this site." in place of the wrong-password error;
- records no throttle failure. The fault is the server's, and throttling the operator out of their own diagnosis after five attempts makes the original problem worse.

The guard sits after the CSRF check and the throttle check, so neither is weakened, and before `password_verify()`, so bcrypt does not run for an attempt that cannot succeed.

## On the visitor-facing message

The handover asked for an admin-visible message "provided it doesn't leak anything to an anonymous visitor". This one names configuration state, not credentials: a visitor learns the install cannot authenticate anyone. That is not a secret, and it is not something an attacker can act on — there is no account to compromise while the hash is empty. Happy to drop it to log-only if you would rather say nothing on the page.

## Tests

Three, red before the change:

- unconfigured install renders a message containing "not configured", visitor stays anonymous;
- the log line carries both `LAMB_LOGIN_PASSWORD` and "cannot succeed";
- with the throttle one short of its limit, an unconfigured attempt does not trip it.

The unit suite runs without `LAMB_LOGIN_PASSWORD` set, so `LOGIN_PASSWORD` is `''` throughout — the misconfigured install itself. Worth knowing: that means the old `testRedirectLoginWrongPasswordRendersErrorWithoutSession` was never exercising a wrong password against a real hash, only an empty one. It is replaced here by the unconfigured-install test that describes what that state actually is. Testing a genuinely wrong password against a configured hash needs `LOGIN_PASSWORD` to stop being an autoload-time constant, which is a larger change than this fix.

Full gate green: lint clean, phpstan no errors, 1721 tests.

Handover findings 2-4 (`.env` present in production, cleartext test password on a production checkout, `bin/upgrade` aborting on dubious ownership) are untouched and still unfiled.