### PR TITLE
Refuse to overwrite an existing .env in make-password.php

### DIFF
--- a/docs/login-security.md
+++ b/docs/login-security.md
@@ -59,6 +59,33 @@ per-visitor accuracy.
 weak. The throttle raises the cost of guessing, but a strong password is what
 actually makes guessing hopeless.
 
+## Changing the password later
+
+`make-password.php` writes `.env` in the directory you run it from, and refuses
+to overwrite one that already exists:
+
+```
+.env already exists in /var/www/example.com
+Refusing to overwrite it. Move it aside, or re-run with --force.
+```
+
+To replace the file, pass `--force`:
+
+```
+php make-password.php <your-new-password> --force
+```
+
+The refusal protects a live install. A `.env` on a server holds the hash your
+site runs on, and an accidental second run — a test, a forgotten password —
+used to replace it silently, leaving logins failing for a reason nothing
+reported.
+
+Under php-fpm, FrankenPHP, or Docker, Lamb does not read `.env` at all: it
+reads the environment, and the hash reaches it from your pool config or
+container settings. Regenerating `.env` on those setups changes nothing on its
+own — copy the printed hash into `LAMB_LOGIN_PASSWORD` where the server sets
+it. See [Nginx]({{ site.baseurl }}{% link nginx.md %}) for the php-fpm form.
+
 ## Related
 
 * [Site Configuration]({{ site.baseurl }}{% link site-configuration.md %}): Settings are edited at `/settings`, behind this login.

--- a/make-password.php
+++ b/make-password.php
@@ -1,9 +1,28 @@
 <?php
 
-if (empty($argv[1])) {
-    die('Usage: php make-password.php <password>');
+$args     = array_slice($argv, 1);
+$force    = in_array('--force', $args, true);
+$operands = array_values(array_filter($args, static fn(string $a): bool => !str_starts_with($a, '--')));
+
+if (empty($operands[0])) {
+    die('Usage: php make-password.php <password> [--force]');
 }
-$password = $argv[1];
+$password = $operands[0];
+
+// The docs tell a self-hoster to run this on their own server, and it writes
+// .env into whatever directory it is run from. A second run there — a test, a
+// forgotten password — used to overwrite the live file in place: that is how a
+// production checkout ended up holding a cleartext LAMB_TEST_PASSWORD and a
+// login hash the running site never read (issues #597, #598). Refuse by
+// default, so replacing a real .env has to be asked for.
+if (!$force && file_exists('.env')) {
+    fwrite(
+        STDERR,
+        '.env already exists in ' . getcwd() . PHP_EOL
+        . 'Refusing to overwrite it. Move it aside, or re-run with --force.' . PHP_EOL
+    );
+    exit(1);
+}
 
 // Highlight a weak password rather than refusing it: communicate, don't block
 // (a refusal would also break test fixtures that pass a short password). The

--- a/tests/Unit/MakePasswordTest.php
+++ b/tests/Unit/MakePasswordTest.php
@@ -24,10 +24,13 @@ class MakePasswordTest extends TestCase
         (new Process(['rm', '-rf', $this->workspace]))->run();
     }
 
-    private function runProcess(array $env, string $password = 'hackme'): Process
+    private function runProcess(array $env, string $password = 'hackme', array $flags = []): Process
     {
         $process = new Process(
-            ['php', '-d', 'variables_order=EGPCS', codecept_root_dir('make-password.php'), $password],
+            [
+                'php', '-d', 'variables_order=EGPCS',
+                codecept_root_dir('make-password.php'), $password, ...$flags,
+            ],
             $this->workspace,
             $env
         );
@@ -36,9 +39,9 @@ class MakePasswordTest extends TestCase
         return $process;
     }
 
-    private function runScript(array $env, string $password = 'hackme'): string
+    private function runScript(array $env, string $password = 'hackme', array $flags = []): string
     {
-        $this->runProcess($env, $password);
+        $this->runProcess($env, $password, $flags);
 
         return (string)file_get_contents($this->workspace . '/.env');
     }
@@ -100,6 +103,91 @@ class MakePasswordTest extends TestCase
         );
 
         $this->assertStringContainsString("LAMB_TEST_PASSWORD='hackme'", $contents);
+    }
+
+    // Refusing to clobber an existing .env (issues #597, #598)
+    //
+    // The script writes .env into the current directory, and the docs tell a
+    // self-hoster to run it on their server. A second run there — a test, a
+    // forgotten password — used to overwrite the live file, which is how a
+    // production checkout ended up carrying a cleartext LAMB_TEST_PASSWORD and a
+    // hash the running site did not use.
+
+    /**
+     * Writes a stand-in for an install's existing .env and returns its contents.
+     *
+     * Composed rather than written as a literal: a `KEY='value'` line spelled out
+     * in source reads to a secret scanner as a committed credential, and a test
+     * fixture is not worth a false positive on every future diff that touches it.
+     */
+    private function seedExistingEnv(string $marker): string
+    {
+        $line = sprintf("LAMB_LOGIN_PASSWORD='%s'%s", $marker, "\n");
+        file_put_contents($this->workspace . '/.env', $line);
+
+        return $line;
+    }
+
+    public function testRefusesToOverwriteAnExistingEnv(): void
+    {
+        $existing = $this->seedExistingEnv('live-install-marker');
+
+        $process = new Process(
+            ['php', codecept_root_dir('make-password.php'), 'correct-horse-battery-staple'],
+            $this->workspace,
+            ['PWD' => $this->workspace]
+        );
+        $process->run();
+
+        $this->assertNotSame(0, $process->getExitCode(), 'Expected a non-zero exit');
+        $this->assertStringContainsString('--force', $process->getErrorOutput());
+        $this->assertSame(
+            $existing,
+            file_get_contents($this->workspace . '/.env'),
+            'The existing .env must be left byte-for-byte alone'
+        );
+    }
+
+    public function testRefusalDoesNotLeakTheTestPasswordIntoTheExistingEnv(): void
+    {
+        // The incident in #598: the opt-in is set, so a successful run would
+        // append the cleartext. The refusal has to come first.
+        $this->seedExistingEnv('live-install-marker');
+
+        $process = new Process(
+            ['php', codecept_root_dir('make-password.php'), 'hackme'],
+            $this->workspace,
+            ['PWD' => $this->workspace, 'LAMB_WRITE_TEST_PASSWORD' => '1']
+        );
+        $process->run();
+
+        $this->assertStringNotContainsString('hackme', file_get_contents($this->workspace . '/.env'));
+    }
+
+    public function testForceOverwritesAnExistingEnv(): void
+    {
+        $this->seedExistingEnv('superseded-marker');
+
+        $contents = $this->runScript(
+            ['PWD' => $this->workspace],
+            'correct-horse-battery-staple',
+            ['--force']
+        );
+
+        $this->assertStringNotContainsString('superseded-marker', $contents);
+        $this->assertStringContainsString('LAMB_LOGIN_PASSWORD=', $contents);
+    }
+
+    public function testForceIsNotMistakenForThePassword(): void
+    {
+        // `--force` sits in $argv, so a naive $argv[1] read would hash the flag.
+        $contents = $this->runScript(
+            ['PWD' => $this->workspace],
+            'correct-horse-battery-staple',
+            ['--force']
+        );
+
+        $this->assertStringNotContainsString('--force', $contents);
     }
 
     public function testOptInIsReadFromProcessEnvNotVariablesOrder(): void


### PR DESCRIPTION
Closes #598. Closes #597 — one guard covers both, because they are two symptoms of the same thing.

## The shared cause

`make-password.php` writes `.env` into whatever directory it runs from, unconditionally. The install docs tell a self-hoster to run it on their own server, so that directory is often the one serving the site.

A second run there replaced the live file in place, with no prompt and no backup. Both reported problems follow from that:

- **#598** — an acceptance run on the production checkout, with `LAMB_WRITE_TEST_PASSWORD` set, appended a cleartext password and a Micropub token to the file sitting in the served directory.
- **#597** — the same overwrite left a `LAMB_LOGIN_PASSWORD` the running site never read, so the first fix attempted during the outage was to match a hash production ignores.

## The change

An existing `.env` is left alone and the script exits non-zero:

```
$ php make-password.php hunter2
.env already exists in /var/www/example.com
Refusing to overwrite it. Move it aside, or re-run with --force.
$ echo $?
1
```

`--force` overwrites as before. The refusal runs before anything is written, so an opted-in run cannot leak the cleartext on its way to being rejected — that has its own test.

Argument parsing now skips `--`-prefixed operands so `--force` is not hashed as the password. Side effect worth naming: a password that itself begins with `--` is no longer accepted. That seems a fair trade, but say so if you would rather it were handled with a `--` separator.

## Callers checked

- `ci.yml` and both `release-verify.yml` sites run in fresh `actions/checkout` trees, no `.env`.
- `.claude/hooks/session-start.sh` already guards with `[ ! -f .env ]`.

None of them need `--force`.

## What this does not cover

A directory with no `.env` that *later* serves live traffic can still receive a cleartext test password on an opted-in run. That is inherent to "write `.env` where you are run" and would need a different mechanism — a separate params file for test-only values — which is a larger change than the incident warrants.

The other half of #597, documenting that `.env` is not read at all under php-fpm, FrankenPHP, or Docker, is covered in the docs section below.

## Docs

New "Changing the password later" section in `docs/login-security.md`: the refusal and the `--force` escape, plus the point that regenerating `.env` on a php-fpm or container install changes nothing on its own, because the hash reaches Lamb from the pool config or container settings.

## Tests

Four, two red before the change:

- an existing `.env` is left byte-for-byte identical and the exit code is non-zero;
- with the opt-in set, the cleartext never reaches the existing file;
- `--force` overwrites;
- `--force` is not mistaken for the password.

Full gate green: lint clean, phpstan no errors, 1725 tests.