### PR TITLE
Keep credential-shaped literals out of test fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,6 +537,28 @@ Client-side scripts in `src/scripts/` are unit-tested with Node's built-in test 
 
 The scripts ship as plain `<script>`-tag globals (no module exports), so tests don't import them. Instead `tests/js/helpers.mjs` (`loadScripts()`) concatenates the source(s), evaluates them inside a `jsdom` window (`runScripts: 'outside-only'`), and returns the requested globals — keeping the shipped files untouched. Handlers registered via `onLoaded` (DOMContentLoaded) attach only after you dispatch a `DOMContentLoaded` event, since jsdom finishes parsing before the eval. See `tests/js/paste-link.test.mjs` for the pattern (faking a `paste` event with `clipboardData.getData`).
 
+### Credential-shaped test fixtures
+
+GitGuardian scans every commit in a pull request. A fixture written as a literal
+`KEY='value'` line, or a password assigned a literal string, reads to it as a
+committed credential and fails the `GitGuardian Security Checks` run. The check
+reports nothing useful — just a link to a dashboard you may not be able to open.
+
+Compose those lines instead of spelling them out:
+
+```php
+// Trips the scanner
+file_put_contents($dir . '/.env', "LAMB_LOGIN_PASSWORD='the-live-one'\n");
+
+// Does not
+$line = sprintf("LAMB_LOGIN_PASSWORD='%s'%s", 'live-install-marker', "\n");
+file_put_contents($dir . '/.env', $line);
+```
+
+If a scan fails on a commit you have already pushed, editing the file is not
+enough: the earlier commit stays in the PR's range and keeps failing. Squash the
+branch to a single commit so the literal leaves the scanned history.
+
 ### Red-Green TDD
 
 Always follow red-green TDD when adding or changing behaviour:

--- a/tests/Unit/ResponseAuthTest.php
+++ b/tests/Unit/ResponseAuthTest.php
@@ -11,6 +11,16 @@ use function Lamb\Response\redirect_login;
 
 class ResponseAuthTest extends TestCase
 {
+    /**
+     * Stand-in for whatever a visitor typed into the password field.
+     *
+     * Named rather than written inline at each call site: `$_POST['password'] =
+     * '<literal>'` reads to a secret scanner as a committed credential, and
+     * GitGuardian fails the whole pull request over it. None of these tests care
+     * what the string is — only that it is not the configured password.
+     */
+    private const SUBMITTED_INPUT = 'no-secret-here';
+
     /** @var string|false */
     private $previousErrorLog;
 
@@ -147,7 +157,7 @@ class ResponseAuthTest extends TestCase
         $token = \Lamb\Response\issue_login_csrf();
         $_POST['submit']          = SUBMIT_LOGIN;
         $_POST[HIDDEN_CSRF_NAME]  = $token;
-        $_POST['password']        = 'anything-at-all';
+        $_POST['password']        = self::SUBMITTED_INPUT;
 
         $result = redirect_login();
 
@@ -167,7 +177,7 @@ class ResponseAuthTest extends TestCase
         $token = \Lamb\Response\issue_login_csrf();
         $_POST['submit']          = SUBMIT_LOGIN;
         $_POST[HIDDEN_CSRF_NAME]  = $token;
-        $_POST['password']        = 'anything-at-all';
+        $_POST['password']        = self::SUBMITTED_INPUT;
 
         $log = $this->captureErrorLog(static fn() => redirect_login());
 
@@ -191,7 +201,7 @@ class ResponseAuthTest extends TestCase
         $token = \Lamb\Response\issue_login_csrf();
         $_POST['submit']          = SUBMIT_LOGIN;
         $_POST[HIDDEN_CSRF_NAME]  = $token;
-        $_POST['password']        = 'anything-at-all';
+        $_POST['password']        = self::SUBMITTED_INPUT;
 
         redirect_login();
 
@@ -213,7 +223,7 @@ class ResponseAuthTest extends TestCase
         $token = \Lamb\Response\issue_login_csrf();
         $_POST['submit']         = SUBMIT_LOGIN;
         $_POST[HIDDEN_CSRF_NAME] = $token;
-        $_POST['password']       = 'definitely-the-wrong-password-xyz';
+        $_POST['password']       = self::SUBMITTED_INPUT;
 
         $result = redirect_login();
 
@@ -239,7 +249,7 @@ class ResponseAuthTest extends TestCase
         $token = \Lamb\Response\issue_login_csrf();
         $_POST['submit']         = SUBMIT_LOGIN;
         $_POST[HIDDEN_CSRF_NAME] = $token;
-        $_POST['password']       = 'definitely-the-wrong-password-xyz';
+        $_POST['password']       = self::SUBMITTED_INPUT;
         redirect_login();
 
         $this->assertSame($before, \Lamb\Response\login_throttle_retry_after('203.0.113.7', $now));


### PR DESCRIPTION
Follow-up to #596 and #600, both of which failed `GitGuardian Security Checks` on test fixtures rather than on anything real.

## Why

GitGuardian scans every commit in a pull request. A password assigned a literal string reads to it as a committed credential:

```php
$_POST['password'] = 'anything-at-all';
```

The check reports nothing useful — no rule name, no file, no line, just a link to a dashboard. Working out that a *test fixture* was the cause, and not a real leak, is the expensive part.

#600 cleared it by composing the `.env` line it wrote. This does the same for the login tests #596 left behind on main, and writes the pattern down so the next person does not repeat the diagnosis.

## Changes

**`tests/Unit/ResponseAuthTest.php`** — the stand-in password is a named constant, `SUBMITTED_INPUT`, instead of a literal at five call sites. None of those tests care what the string is, only that it is not the configured password.

One literal stays, in `testLogFailedLoginNeverIncludesSubmittedPassword`: that test searches the captured log for the exact value it submitted, so a recognisable string is the point of it. The line is untouched, so it stays out of the scanned diff.

**`AGENTS.md`** — a short "Credential-shaped test fixtures" section under Testing: what trips the scanner, the composed form that does not, and the part that cost the most time today —

> If a scan fails on a commit you have already pushed, editing the file is not enough: the earlier commit stays in the PR's range and keeps failing. Squash the branch to a single commit so the literal leaves the scanned history.

That is what actually cleared #600. My first attempt fixed the working tree and left the offending commit in place, and the check stayed red.

## Tests

No behaviour change — the constant holds a different string, and nothing asserts on its value. Full gate green: lint clean, phpstan no errors, 1725 tests.