### PR TITLE
Tell the operator why bin/upgrade stopped on a foreign-owned checkout

### DIFF
--- a/bin/upgrade
+++ b/bin/upgrade
@@ -10,6 +10,33 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# git refuses to work in a repository owned by another user ("detected dubious
+# ownership"), which is the normal shape of a deploy: the checkout owned by the
+# webserver user, the cron job running as a human. Every git command below then
+# fails under `set -e`, so the script exits having done nothing — every 15
+# minutes, with cron mail that reads like every other cron mail, while the site
+# quietly stops updating. Fail with something a reader can act on instead.
+if ! git_err=$(git rev-parse --is-inside-work-tree 2>&1); then
+    echo "bin/upgrade: cannot use the git checkout at $(pwd)" >&2
+    echo "${git_err}" >&2
+    if [[ "${git_err}" == *"dubious ownership"* ]]; then
+        cat >&2 <<EOF
+
+The user running this script must own the checkout, or be trusted for it.
+Either align ownership:
+
+    sudo chown -R \$(id -un) "$(pwd)"
+
+or, if the webserver must keep owning it, mark it safe for the deploying user:
+
+    git config --global --add safe.directory "$(pwd)"
+
+Run that as the user the cron job runs as, not as root.
+EOF
+    fi
+    exit 1
+fi
+
 git fetch origin
 
 if [ -n "${1:-}" ]; then

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -26,6 +26,30 @@ To upgrade automatically every night, add it to cron:
 
 Cron will email you the output if the health check fails (when your system is set up to deliver mail).
 
+### The deploying user must own the checkout
+
+Run the script as a user that owns the checkout. If the webserver user owns it and your cron job runs as someone else, git refuses to touch the repository at all:
+
+```
+fatal: detected dubious ownership in repository at '/var/www/example.com/html'
+```
+
+The script stops there and tells you how to fix it. You have two options. Align ownership:
+
+```
+sudo chown -R $(id -un) /var/www/example.com/html
+```
+
+Or, if the webserver must keep owning the files, mark the checkout as trusted for the deploying user:
+
+```
+git config --global --add safe.directory /var/www/example.com/html
+```
+
+Run that command as the user the cron job runs as, not as root — `--global` writes to that user's own git config.
+
+Watch for this after moving to a new server, where ownership often differs from the old one. Nothing else reports it: the upgrade simply stops running, and the site keeps serving the version it already has.
+
 ## Tarball install
 
 Download the latest `lamb-<version>.tar.gz` from the [releases page](https://github.com/svandragt/lamb/releases) and extract it over your existing installation:


### PR DESCRIPTION
Closes #599 — the Lamb-side half. The fix itself is server-side; this makes the cause legible.

## The failure

Where the working tree is owned by `www-data` and the deploy cron runs as a human user, git refuses:

```
fatal: detected dubious ownership in repository at '/var/www/example.com/html'
```

`git fetch origin` is the first real command in `bin/upgrade`, and `set -euo pipefail` is in force, so the script died there — every 15 minutes, having done nothing. Nobody noticed, because cron mail for a silent failure looks like every other cron mail. The site kept serving the version it already had.

## The change

Check the repository is usable before touching it. On the dubious-ownership case, print both ways out:

```
bin/upgrade: cannot use the git checkout at /var/www/example.com/html
fatal: detected dubious ownership in repository at '/var/www/example.com/html'

The user running this script must own the checkout, or be trusted for it.
Either align ownership:

    sudo chown -R $(id -un) "/var/www/example.com/html"

or, if the webserver must keep owning it, mark it safe for the deploying user:

    git config --global --add safe.directory "/var/www/example.com/html"

Run that as the user the cron job runs as, not as root.
```

Any other git failure still surfaces git's own message, with the directory named.

`docs/upgrading.md` gains a matching section, including the point that a server migration is where ownership usually starts to differ — nothing else reports it, the upgrade just stops running.

## Testing

Verified by hand, two ways: run outside a repository (generic branch, exit 1), and run against a stub `git` on PATH reproducing the dubious-ownership failure (guidance branch, exit 1). Both print the directory and exit non-zero.

No automated test. The repo has no harness for shell scripts, and reproducing the real case needs a checkout owned by a different user, which means root. Adding a bash test framework for one diagnostic message did not seem a fair trade — say so if you would rather have one.

Full gate green: lint clean, 1725 tests.