### PR TITLE
Fix two Known import fidelity bugs: <wbr> hints and lost status slugs

### DIFF
--- a/docs/known-import.md
+++ b/docs/known-import.md
@@ -53,7 +53,7 @@ The importer writes directly to the same database your site uses, so the posts a
 
 A few things worth checking manually:
 
-- **Slugs and redirects.** Titled posts keep the slug from their original `<link>` path leaf, written into front matter as `slug:`. Status posts (synthetic-title detection above) get no `slug:`/`title:` front matter and fall through to their `/status/<id>` permalink instead. Either way, an automatic 301 redirect is created from **both** the old on-host `<link>` path (e.g. `/2020/old-slug`) and the old `<guid>` path (`/view/<hash>`) to the new local URL, so old links and any bookmarks to the `guid` permalink keep working.
+- **Slugs and redirects.** Every post keeps the slug from its original `<link>` path leaf, written into front matter as `slug:`, so imported posts stay on their old URL. Status posts (synthetic-title detection above) keep the slug but get no `title:`. A post whose `<link>` carries no usable slug — an offsite bookmark, for example — falls through to a `/status/<id>` permalink instead. Either way, an automatic 301 redirect is created from **both** the old on-host `<link>` path (e.g. `/2020/old-slug`) and the old `<guid>` path (`/view/<hash>`) to the new local URL, so old links and any bookmarks to the `guid` permalink keep working.
 - **Bookmarks.** The bookmarked page's title and URL appear as a markdown link line at the top of the post body — edit it if you'd rather present it differently.
 - **Media.** Run a quick `git status` on `src/assets/` to see what was downloaded.
 

--- a/src/import.php
+++ b/src/import.php
@@ -184,6 +184,15 @@ function normalize_html(string $html, array &$placeholders = [], array $unwrap_c
         $table->parentNode->replaceChild($dom->createTextNode("\n\n$key\n\n"), $table);
     }
 
+    // Known wraps long URLs in <wbr /> line-break hints. They carry no content
+    // and the Markdown converter would preserve them as visible tags.
+    $breaks = $xpath->query('//wbr') ?: [];
+    foreach ($breaks as $wbr) {
+        if ($wbr instanceof \DOMNode) {
+            $wbr->parentNode?->removeChild($wbr);
+        }
+    }
+
     $videos = $xpath->query('//video[@src]') ?: [];
     foreach ($videos as $video) {
         if (!$video instanceof DOMElement || $video->parentNode === null) {

--- a/src/known.php
+++ b/src/known.php
@@ -338,9 +338,12 @@ function import_item(array $item, callable $downloader, bool $dry_run = false, ?
         static fn(string $tag): bool => !body_has_tag($tag, $markdown)
     ));
 
+    // A synthetic title is Known's own truncation of the body, so it isn't worth
+    // importing — but the slug from the same permalink is a real, readable URL.
+    // Keeping it preserves the original link instead of minting /status/<id>.
     $title_is_synthetic = (bool) ($item['title_is_synthetic'] ?? false);
     $title = $title_is_synthetic ? '' : (string) ($item['title'] ?? '');
-    $slug = $title_is_synthetic ? '' : (string) ($item['slug'] ?? '');
+    $slug = (string) ($item['slug'] ?? '');
 
     $bookmark_url = trim((string) ($item['bookmark_url'] ?? ''));
     if ($bookmark_url !== '') {

--- a/tests/Unit/KnownImportTest.php
+++ b/tests/Unit/KnownImportTest.php
@@ -452,7 +452,7 @@ XML;
         $this->assertStringContainsString("title: 'Turn that frown upside down'", (string) $bean->body);
     }
 
-    public function testImportItemLeavesTitleAndSlugEmptyForSyntheticStatusPost(): void
+    public function testImportItemKeepsSlugButDropsTitleForSyntheticStatusPost(): void
     {
         $items = $this->sampleItems();
         $downloader = fn(): ?string => null;
@@ -460,9 +460,8 @@ XML;
         $bean = import_item($items[2], $downloader, false);
 
         $this->assertNotNull($bean);
-        $this->assertSame('', (string) $bean->slug);
+        $this->assertSame('if-you-send-email-using-noreply-then', (string) $bean->slug);
         $this->assertStringNotContainsString('title:', (string) $bean->body);
-        $this->assertStringNotContainsString('slug:', (string) $bean->body);
     }
 
     public function testImportItemPrependsBookmarkLinkLineToBody(): void

--- a/tests/Unit/KnownImportTest.php
+++ b/tests/Unit/KnownImportTest.php
@@ -280,6 +280,16 @@ XML;
         $this->assertStringContainsString("non-published status 'draft'", (string) skip_reason($items[4]));
     }
 
+    public function testHtmlToMarkdownDropsWordBreakHints(): void
+    {
+        $markdown = html_to_markdown(
+            '<p><a href="https://vandragt.com">https://<wbr />vandragt.com</a> changelog</p>',
+        );
+
+        $this->assertStringNotContainsString('wbr', $markdown);
+        $this->assertStringContainsString('https://vandragt.com', $markdown);
+    }
+
     public function testNormalizeKnownHtmlRemovesUnfurlBlockEntirely(): void
     {
         $items = $this->sampleItems();


### PR DESCRIPTION
Two fixes from importing a fresh Known RSS export.

**1. `<wbr>` hints leak into post bodies** — Known wraps long URLs in `<wbr />`. The HTML→Markdown converter keeps unknown HTML, so posts rendered a literal `<wbr></wbr>` inside link text (e.g. `https://<wbr></wbr>vandragt.com changelog`). Stripped in `normalize_html()` in `src/import.php`, so all three importers benefit.

**2. Status posts lost their slug** — Known synthesises a title from the body for status updates, so `import_item()` dropped the title. It dropped the slug from the same permalink too, moving every status post to `/status/<id>` and relying on a redirect. The slug is a real readable URL, so it is now kept; only the title is dropped. Docs updated.

Existing imports need a re-run with `--replace` to pick up either fix.

Tests: `testHtmlToMarkdownDropsWordBreakHints`, `testImportItemKeepsSlugButDropsTitleForSyntheticStatusPost`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsEdqfYUaafh7cgQzGrk29