### PR TITLE
Exclude menu pages from search and tag listings in SQL

### DIFF
--- a/src/post.php
+++ b/src/post.php
@@ -664,11 +664,11 @@ function body_has_tag(string $tag, string $body): bool
 function posts_by_tag(string $tag): array
 {
     $conditions = get_tag_search_conditions($tag);
-    $visible = \Lamb\visible_clause();
+    $public = \Lamb\Response\public_posts_clause();
     $posts = R::find(
         'post',
-        '(' . $conditions['sql'] . ') AND' . $visible['sql'] . 'ORDER BY created DESC',
-        array_merge($conditions['params'], $visible['params'])
+        '(' . $conditions['sql'] . ') AND' . $public['sql'] . 'ORDER BY created DESC',
+        array_merge($conditions['params'], $public['params'])
     );
 
     return array_values(array_filter($posts, fn($post) => body_has_tag($tag, (string) $post->body)));

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -335,9 +335,9 @@ function respond_search(array $args): array
         $where_clauses[] = 'body LIKE ?';
         $params[] = "%$word%";
     }
-    $visible = \Lamb\visible_clause();
-    $where_sql = '(' . implode(' AND ', $where_clauses) . ') AND' . $visible['sql'];
-    $params = array_merge($params, $visible['params']);
+    $public = public_posts_clause();
+    $where_sql = '(' . implode(' AND ', $where_clauses) . ') AND' . $public['sql'];
+    $params = array_merge($params, $public['params']);
 
     $paginated = paginate_posts('post', 'created DESC', $where_sql, $params);
 

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -26,7 +26,8 @@ else :
     endif;
     foreach ($data['posts'] as $bean) :
         if ($template !== 'status' && is_menu_item($bean->slug ?? $bean->id)) :
-            # Hide from timeline
+            # Backstop for the owner-only views that query everything (drafts,
+            # trash, scheduled); public listings exclude menu pages in SQL.
             continue;
         endif;
         if (count($data['posts']) > 1) :

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -23,8 +23,9 @@ if (empty($data['posts'])) :
 else :
     foreach ($data['posts'] as $bean) :
         /** @var \RedBeanPHP\OODBBean $bean */
-        // Menu pages stay out of listings; tag and search have no SQL-level
-        // exclusion (unlike home and the feeds, via public_posts_clause). The
+        // Menu pages stay out of listings. Public listings already exclude them
+        // in SQL (public_posts_clause), so this is the backstop for the owner-only
+        // views that deliberately query everything — drafts, trash, scheduled. The
         // `status` guard is load-bearing: on a permalink the menu page *is* the
         // requested post, so skipping it there renders an empty page.
         if ($template !== 'status' && is_menu_item((string) ($bean->slug ?? ''))) :

--- a/tests/Unit/ResponseHandlersTest.php
+++ b/tests/Unit/ResponseHandlersTest.php
@@ -318,6 +318,48 @@ class ResponseHandlersTest extends TestCase
         $this->assertStringContainsString('hello', $result['title']);
     }
 
+    public function testRespondSearchExcludesMenuPagesFromResultsAndCount(): void
+    {
+        global $config;
+        $config['menu_items'] = ['About' => 'about'];
+
+        $ids = [];
+        foreach (['about', 'a-real-post'] as $slug) {
+            $post = R::dispense('post');
+            $post->body    = 'menuwordprobe in the body';
+            $post->slug    = $slug;
+            $post->created = '2020-01-01 00:00:00';
+            $ids[$slug] = R::store($post);
+        }
+
+        $result = respond_search(['menuwordprobe']);
+
+        $this->assertCount(1, $result['posts']);
+        $this->assertSame($ids['a-real-post'], (int) reset($result['posts'])->id);
+        $this->assertSame(1, (int) $result['pagination']['total_posts']);
+        $this->assertSame('1 result found.', $result['intro']);
+    }
+
+    public function testRespondTagExcludesMenuPages(): void
+    {
+        global $config;
+        $config['menu_items'] = ['About' => 'about'];
+
+        foreach (['about', 'a-real-post'] as $slug) {
+            $post = R::dispense('post');
+            $post->body    = 'tagged #menuprobe here';
+            $post->slug    = $slug;
+            $post->created = '2020-01-01 00:00:00';
+            R::store($post);
+        }
+
+        $result = respond_tag(['menuprobe']);
+
+        $this->assertCount(1, $result['posts']);
+        $this->assertSame('a-real-post', (string) $result['posts'][0]->slug);
+        $this->assertSame(1, (int) $result['pagination']['total_posts']);
+    }
+
     public function testRespondSearchFindsMatchingPost(): void
     {
         $post = R::dispense('post');


### PR DESCRIPTION
`/search/email log` on vandragt.com reported **7 results found** and rendered **6** articles. The 7th match was `/about`: a menu page, which `_items.php` skips in the render loop while `paginate_db()`'s `R::count()` still counted it. Tag pages had the same gap, and it also short-changed pagination (a page could render fewer than `posts_per_page` items).

Search (`respond_search`) and tag pages (`posts_by_tag`) now use `public_posts_clause()` — the allow-list the homepage and feeds already use — so count, list and pagination agree. Menu pages therefore also drop out of tag feeds, which is the intent: they're pages reachable from the nav, not timeline posts.

The theme-level skip stays as the backstop for owner-only views that deliberately query everything (drafts, trash, scheduled); its comment now says so instead of describing the gap this closes.

Tests: `testRespondSearchExcludesMenuPagesFromResultsAndCount`, `testRespondTagExcludesMenuPages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsEdqfYUaafh7cgQzGrk29