### PR TITLE
Stop imported hashtags arriving escaped and duplicated

### DIFF
--- a/src/import.php
+++ b/src/import.php
@@ -145,6 +145,11 @@ function html_to_markdown(string $html, array $unwrap_class_prefixes = []): stri
     ]);
     $markdown = strtr(trim($converter->convert($html)), $placeholders);
     $markdown = html_entity_decode($markdown, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    // The converter escapes a line-leading `#` so Markdown won't read it as a
+    // heading. In Lamb a `#word` is a hashtag, and `\#word` is neither: it
+    // renders with a stray backslash and hides the tag from body_has_tag(), so
+    // an importer appends the same tag a second time (issue: duplicate tags).
+    $markdown = preg_replace('/(^|\s)\\\\#(?=\S)/m', '$1#', $markdown) ?? $markdown;
     return separate_images_from_following_text($markdown);
 }
 

--- a/tests/Unit/KnownImportTest.php
+++ b/tests/Unit/KnownImportTest.php
@@ -464,6 +464,38 @@ XML;
         $this->assertStringNotContainsString('title:', (string) $bean->body);
     }
 
+    public function testHtmlToMarkdownLeavesALineLeadingHashtagUnescaped(): void
+    {
+        $markdown = html_to_markdown('<p>Signed up.</p><p>#web</p>');
+
+        $this->assertStringNotContainsString('\#web', $markdown);
+        $this->assertStringEndsWith('#web', $markdown);
+    }
+
+    public function testImportItemDoesNotAppendATagAlreadyEndingTheBody(): void
+    {
+        $item = [
+            'title'              => 'How to sign up without a mobile number',
+            'guid'               => 'https://known.example/view/dddd4444',
+            'link'               => 'https://example.test/2016/how-to-sign-up',
+            'content'            => '<div class="e-content"><p>Signed up.</p>'
+                . '<p><a href="https://example.test/tag/web" class="p-category" rel="tag">#web</a></p></div>',
+            'post_type'          => 'post',
+            'status'             => 'publish',
+            'created'            => '2016-09-07 12:10:55',
+            'updated'            => '2016-09-07 12:10:55',
+            'tags'               => ['web'],
+            'slug'               => 'how-to-sign-up',
+            'bookmark_url'       => '',
+            'title_is_synthetic' => false,
+        ];
+
+        $bean = import_item($item, fn(): ?string => null, false);
+
+        $this->assertNotNull($bean);
+        $this->assertSame(1, substr_count((string) $bean->body, '#web'));
+    }
+
     public function testImportItemPrependsBookmarkLinkLineToBody(): void
     {
         $items = $this->sampleItems();


### PR DESCRIPTION
Reported on https://vandragt.com/how-to-signup-for-flickr-without-disclosing-your-mobile-number and /bugzscoutlogwriter-10: the same hashtag renders twice.

Root cause is not the `<category>`/body overlap itself — the importer already filters a `<category>` tag out when the body carries it (`body_has_tag()`). It's Markdown escaping. Known ends each post with its tags in their own paragraph:

```html
<p><a href="…/tag/web" class="p-category" rel="tag">#web</a></p>
```

The converter turns that into a line-leading `#`, which it escapes as `\#web` so Markdown won't read it as a heading. Two consequences: the body renders with a stray backslash, and `body_has_tag('web', …)` no longer matches, so the `<category>` tag gets appended a second time.

`html_to_markdown()` now unescapes `\#` back to `#` — in Lamb a `#word` is a hashtag, and `\#word` is neither a heading nor a tag. Applies to all three importers.

Re-run affected imports with `--replace`.

Tests: `testHtmlToMarkdownLeavesALineLeadingHashtagUnescaped`, `testImportItemDoesNotAppendATagAlreadyEndingTheBody`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsEdqfYUaafh7cgQzGrk29