### PR TITLE
Support installs served from a subdirectory (#580)

### DIFF
--- a/docs/micropub.md
+++ b/docs/micropub.md
@@ -29,6 +29,17 @@ Do not derive it from the request — that is exactly what this setting exists t
 avoid. You can also supply it as the `LAMB_SITE_URL` environment variable, which
 takes precedence over the setting.
 
+If your site is served from a subdirectory, include the path:
+
+```ini
+site_url = https://example.com/blog
+```
+
+Your IndieAuth identity is the whole address, path and all, so a host-only value
+here never matches the identity in your token and every request is refused. See
+[Installing under a subdirectory](site-configuration.md#installing-under-a-subdirectory)
+for what a base path may contain.
+
 ### 2. Add `rel="me"` identity links
 
 IndieAuth verifies who you are by checking that your site links to your profiles and those profiles link back. Add a `[me]` section to your site configuration at `/settings`:

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -157,6 +157,29 @@ You can also set it outside the settings page with the `LAMB_SITE_URL` environme
 variable, which takes precedence over the INI value — handy when the same
 configuration is deployed to more than one hostname.
 
+### Installing under a subdirectory
+
+To serve Lamb from a subdirectory, include the path in `site_url`:
+
+```ini
+site_url = https://example.com/blog
+```
+
+Lamb reads the path as the install's base. Links, forms, redirects and uploads
+all go through it, and the base comes back off an incoming request before the
+router looks at it. Point your web server's rewrite at the same prefix.
+
+Set `site_url` before you use a subdirectory install. It is the only place Lamb
+learns its own base — without it, an install under a path behaves as though it
+sits at the domain root.
+
+Keep the value simple, because Lamb compares it against the identity in your
+Micropub tokens and both spellings have to match. Use letters, digits, dots,
+dashes, underscores and tildes in the path. Lamb drops a trailing slash, collapses
+repeated slashes, and ignores any query or fragment. It refuses a path holding
+anything else — a space, a percent-encoded character, or a `.` or `..` segment —
+and falls back to behaving as though no site URL is set.
+
 ## Related
 
 * [Setting up Cross-Posting]({{ site.baseurl }}{% link cross-posting.md %}#setup) requires site configuration changes.

--- a/src/config.php
+++ b/src/config.php
@@ -29,6 +29,8 @@ theme = 2026
 site_title = My Microblog
 
 ;; The canonical URL of your site, e.g. https://example.com (no trailing slash).
+;; Serving from a subdirectory? Include the path: https://example.com/blog — it is
+;; how Lamb learns its own base, and part of the identity your tokens are issued for.
 ;; Set this if you use Micropub: it is how Lamb tells that an IndieAuth token was
 ;; issued for your identity rather than someone else's, so the endpoint refuses
 ;; every token while it is unset. It also pins the absolute URLs in feeds and
@@ -359,8 +361,15 @@ function normalize_config_section(mixed $section): array
  *
  * Read from LAMB_SITE_URL in the environment first (so a deployment can pin it
  * without touching the database), then the `site_url` key in the settings INI.
- * The value is normalised to `scheme://host[:port]` with no trailing slash, and
- * rejected unless it is an absolute http(s) URL with a host.
+ * The value is normalised to `scheme://host[:port][/base-path]` with no trailing
+ * slash, and rejected unless it is an absolute http(s) URL with a host.
+ *
+ * A base path is kept, so an install served under a subdirectory can state its
+ * real identity: the IndieAuth `me` of `https://example.com/blog` is that whole
+ * string, and comparing it against a host-only value refused every Micropub
+ * token (issue #580). See normalize_base_path() for what a path has to look like
+ * to survive — this value feeds a security comparison, so every spelling of a
+ * base must reduce to one form.
  *
  * @param array<string, mixed> $config The loaded configuration.
  * @return string|null The canonical site URL, or null when not configured or unusable.
@@ -382,9 +391,60 @@ function canonical_site_url(array $config): ?string
         return null;
     }
 
+    // parse_url() has already split the query and fragment off, so the path is
+    // all that is left to normalise.
+    $path = normalize_base_path((string) ($parts['path'] ?? ''));
+    if ($path === null) {
+        return null;
+    }
+
     $port = isset($parts['port']) ? ':' . $parts['port'] : '';
 
-    return $scheme . '://' . strtolower($parts['host']) . $port;
+    return $scheme . '://' . strtolower($parts['host']) . $port . $path;
+}
+
+/**
+ * Normalises the base path of a configured site URL, or rejects it.
+ *
+ * Returns '' for a site at the domain root, or '/segment[/segment…]' with no
+ * trailing slash. The accepted charset is deliberately narrow — letters, digits,
+ * dot, dash, underscore, tilde and the separating slashes — and anything else is
+ * refused rather than decoded or escaped. That keeps percent-encoding out of the
+ * comparison entirely, so `%2e%2e` and `..` cannot reach different answers when
+ * neither is allowed through. Dot segments go for the same reason.
+ *
+ * Only the host is case-folded by the caller; a path segment is case-sensitive,
+ * so folding it here would invent an identity the author never configured.
+ *
+ * @param string $path The path portion of the configured URL.
+ * @return string|null The normalised base path, or null when it cannot be used.
+ */
+function normalize_base_path(string $path): ?string
+{
+    $path = trim($path);
+    if ($path === '' || $path === '/') {
+        return '';
+    }
+
+    if (preg_match('#^[A-Za-z0-9._~/-]+$#', $path) !== 1) {
+        return null;
+    }
+
+    $segments = [];
+    foreach (explode('/', $path) as $segment) {
+        // An empty segment is one of the duplicate slashes in `//blog//`;
+        // skipping it is the collapse. A dot segment is a traversal spelling
+        // rather than a directory name.
+        if ($segment === '') {
+            continue;
+        }
+        if ($segment === '.' || $segment === '..') {
+            return null;
+        }
+        $segments[] = $segment;
+    }
+
+    return $segments === [] ? '' : '/' . implode('/', $segments);
 }
 
 /**

--- a/src/http.php
+++ b/src/http.php
@@ -3,19 +3,88 @@
 namespace Lamb\Http;
 
 /**
- * Retrieves the current request URI.
+ * The base path the site is served under, as a routing prefix.
+ *
+ * '' for a site at the domain root, or '/blog' for one installed in a
+ * subdirectory. Taken from ROOT_PATH, which index.php derives from the author's
+ * configured canonical URL; a subpath install that has not configured one has no
+ * trustworthy way to know its own base, so it is treated as living at the root.
+ *
+ * @return string The base path, without a trailing slash.
+ */
+function base_path(): string
+{
+    return defined('ROOT_PATH') ? (string) ROOT_PATH : '';
+}
+
+/**
+ * Turns one of the app's own root-relative paths into one a browser can follow.
+ *
+ * Links, form actions and redirects are written throughout the app as the paths
+ * the router knows — `/login`, `/tag/php`. On a subdirectory install those would
+ * point at the domain root, outside the install entirely, so the base goes back
+ * on here. The inverse of {@see strip_base_path}.
+ *
+ * @param string $path A root-relative app path, with its leading slash.
+ * @param string|null $base The site's base path; defaults to {@see base_path}.
+ *                          Passed explicitly by tests, which cannot redefine a constant.
+ * @return string The path with the site's base prefixed.
+ */
+function app_path(string $path, ?string $base = null): string
+{
+    return ($base ?? base_path()) . $path;
+}
+
+/**
+ * Removes the site's base path from a request path.
+ *
+ * A subdirectory install still receives the full `/blog/tag/php` in REQUEST_URI,
+ * so the base has to come off before anything segments the path — the router
+ * would otherwise read the base as the action.
+ *
+ * Only whole segments match: `/blogger` is not inside `/blog`, and cutting on
+ * the raw string prefix would route it as the action `ger`. A path outside the
+ * base is returned whole, so the normal 404 handles it instead of a route being
+ * invented for it.
+ *
+ * @param string $uri The request path, without its query string.
+ * @param string $base The site's base path, without a trailing slash.
+ * @return string The path relative to the base, with its leading slash.
+ */
+function strip_base_path(string $uri, string $base): string
+{
+    if ($base === '') {
+        return $uri;
+    }
+
+    if ($uri === $base || $uri === $base . '/') {
+        return '/';
+    }
+
+    return str_starts_with($uri, $base . '/') ? substr($uri, strlen($base)) : $uri;
+}
+
+/**
+ * Retrieves the current request URI, relative to the site's base path.
  *
  * This method uses the PHP superglobal variable $_SERVER to retrieve the request URI.
  * The request URI is the string representation of the current URL path.
  * The URI does not include any query parameters that may be present in the URL.
  *
- * @return string|false The current request URI as a string. If the URI is '/',
- *                     the method returns the string '/home'. If the URI cannot be determined,
- *                     the method returns false.
+ * @param string|null $base The site's base path; defaults to {@see base_path}.
+ *                          Passed explicitly by tests, which cannot redefine a constant.
+ * @return string|false The current request URI as a string. If the URI is the site
+ *                     root, the method returns the string '/home'. If the URI cannot
+ *                     be determined, the method returns false.
  */
-function get_request_uri(): string|false
+function get_request_uri(?string $base = null): string|false
 {
     $request_uri = strtok($_SERVER['REQUEST_URI'], '?');
+    if ($request_uri === false) {
+        return false;
+    }
+
+    $request_uri = strip_base_path($request_uri, $base ?? base_path());
     if ($request_uri === '/') {
         return '/home';
     }
@@ -34,13 +103,18 @@ function get_request_uri(): string|false
  * Returns '' when there is no usable path, so callers can drop the UI that
  * depends on it rather than render an empty one.
  *
+ * @param string|null $base The site's base path; defaults to {@see base_path}.
+ *                          Passed explicitly by tests, which cannot redefine a constant.
  * @return string The path, e.g. `tag/php` for `/tag/php?utm=1`.
  */
-function requested_path(): string
+function requested_path(?string $base = null): string
 {
     $path = parse_url((string) ($_SERVER['REQUEST_URI'] ?? ''), PHP_URL_PATH);
+    if (!is_string($path)) {
+        return '';
+    }
 
-    return is_string($path) ? trim($path, '/') : '';
+    return trim(strip_base_path($path, $base ?? base_path()), '/');
 }
 
 /**
@@ -137,13 +211,17 @@ function request_root_url(array $server): ?string
  * surrounding `header()`/`die()` shell.
  *
  * @param string $location The proposed redirect target.
- * @return string The CR/LF-stripped target, or '/' when empty.
+ * @param string|null $base The site's base path; defaults to {@see base_path}.
+ *                          Passed explicitly by tests, which cannot redefine a constant.
+ * @return string The CR/LF-stripped target, or the site root when empty.
  */
-function sanitize_location(string $location): string
+function sanitize_location(string $location, ?string $base = null): string
 {
     $location = str_replace(["\r", "\n", "\0"], '', $location);
 
-    return $location === '' ? '/' : $location;
+    // The fallback is the app's own root, so it takes the base; a surviving
+    // target was built by a caller that already applied one.
+    return $location === '' ? app_path('/', $base) : $location;
 }
 
 /**

--- a/src/index.php
+++ b/src/index.php
@@ -27,6 +27,11 @@ if ($root_url === null) {
     die('Bad Request');
 }
 define('ROOT_URL', $root_url);
+// The subdirectory an install is served under, '' at a domain root. Every
+// absolute URL is built by concatenating onto ROOT_URL, so those follow the base
+// on their own; this is for the other direction — taking the base back off an
+// incoming REQUEST_URI before the router segments it (Http\strip_base_path()).
+define('ROOT_PATH', (string) (parse_url($root_url, PHP_URL_PATH) ?? ''));
 // Config\ensure_explicit_theme() guarantees a renderable theme value on read,
 // so no runtime fallback/alias is needed here (see #291). The value still
 // comes verbatim from the admin-editable config INI, though, and is used
@@ -84,8 +89,6 @@ if (in_array($method, ['GET', 'HEAD'], true)) {
 $action = strtok($request_uri, '/');
 $lookup = strtok('/');
 $sublookup = strtok('/');
-
-$request_uri_with_query = $_SERVER['REQUEST_URI'] ?? '';
 
 $redirect_path = trim((string) $request_uri, '/');
 if (str_contains($redirect_path, '/')) {

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -769,11 +769,21 @@ function post_has_slug(string $lookup): string|null
  * Webmention endpoints, which both map externally supplied URLs back to posts
  * (each applies its own host policy before/after calling this).
  *
+ * The path arrives out of a permalink, so on a subdirectory install it carries
+ * the install's base (`/blog/status/12`) while the shapes matched below are the
+ * app's own, which do not. The base comes off first — without that, a Micropub
+ * client cannot update or delete the post it was handed at creation, and every
+ * inbound webmention is rejected as pointing at an unknown target.
+ *
  * @param string $path The URL path (e.g. from parse_url(..., PHP_URL_PATH)).
+ * @param string|null $base The install's base path; defaults to Http\base_path().
+ *                          Passed explicitly by tests, which cannot redefine a constant.
  * @return OODBBean|null The matching post bean, or null when none exists.
  */
-function find_post_by_path(string $path): ?OODBBean
+function find_post_by_path(string $path, ?string $base = null): ?OODBBean
 {
+    $path = \Lamb\Http\strip_base_path($path, $base ?? \Lamb\Http\base_path());
+
     if (preg_match('#^/status/(\d+)$#', $path, $matches)) {
         $bean = R::load('post', (int) $matches[1]);
         return $bean->id ? $bean : null;
@@ -824,25 +834,32 @@ function delete_redirect_for_slug(string $slug): void
  *
  * Checks manual redirections from config first, then automatic redirects stored in the DB.
  *
+ * The destination goes straight into a Location: header, so a target inside this
+ * site takes the install's base — a bare `/new-post` would send the visitor to
+ * the domain root on a subdirectory install. An external target belongs to
+ * somebody else and is returned untouched.
+ *
  * @param string $slug The URL path segment to look up.
+ * @param string|null $base The install's base path; defaults to Http\base_path().
+ *                          Passed explicitly by tests, which cannot redefine a constant.
  * @return string|null The destination URL, or null if no redirect is configured.
  */
-function find_redirect(string $slug): ?string
+function find_redirect(string $slug, ?string $base = null): ?string
 {
     global $config;
 
+    $local = static fn(string $dest): string => str_starts_with($dest, 'http')
+        ? $dest
+        : \Lamb\Http\app_path(str_starts_with($dest, '/') ? $dest : '/' . $dest, $base);
+
     $redirections = $config['redirections'] ?? [];
     if (isset($redirections[$slug])) {
-        $dest = $redirections[$slug];
-        if (str_starts_with($dest, 'http') || str_starts_with($dest, '/')) {
-            return $dest;
-        }
-        return '/' . $dest;
+        return $local((string) $redirections[$slug]);
     }
 
     $redirect = R::findOne('redirect', ' from_slug = ? ', [$slug]);
     if ($redirect !== null) {
-        return $redirect->to_url;
+        return $local((string) $redirect->to_url);
     }
 
     return null;

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1189,7 +1189,10 @@ function respond_micropub(): void
 
     $request = new ServerRequest(
         $_SERVER['REQUEST_METHOD'] ?? 'GET',
-        ROOT_URL . ($_SERVER['REQUEST_URI'] ?? '/micropub'),
+        // ROOT_URL already carries the install's base path, and REQUEST_URI
+        // carries it again — concatenating both spelled it twice on a
+        // subdirectory install (`https://example.com/blog/blog/micropub`).
+        ROOT_URL . \Lamb\Http\strip_base_path((string) ($_SERVER['REQUEST_URI'] ?? '/micropub'), \Lamb\Http\base_path()),
         $headers,
         $rawBody,
         '1.1',

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -47,7 +47,7 @@ function redirect_login(): array
         // valid marker the next request treats the visitor as anonymous.
         session_regenerate_id(true);
         set_login_marker();
-        redirect_uri('/');
+        redirect_uri(\Lamb\Http\app_path('/'));
     }
     if (!isset($_POST['submit']) || $_POST['submit'] !== SUBMIT_LOGIN) {
         // Show login page (no session started for the anonymous visitor).
@@ -481,11 +481,13 @@ function set_login_marker(): void
  */
 function local_redirect_target(?string $value): string
 {
+    // The rejections fall back to one of the app's own paths, so they take the
+    // base. A value that survives came from the browser and already has one.
     if ($value === null || $value === '' || $value[0] !== '/') {
-        return '/';
+        return \Lamb\Http\app_path('/');
     }
     if (str_starts_with($value, '//') || str_starts_with($value, '/\\')) {
-        return '/';
+        return \Lamb\Http\app_path('/');
     }
 
     return $value;
@@ -518,7 +520,7 @@ function redirect_logout(): void
     if (session_status() === PHP_SESSION_ACTIVE) {
         session_destroy();
     }
-    redirect_uri('/');
+    redirect_uri(\Lamb\Http\app_path('/'));
 }
 
 /**
@@ -544,7 +546,7 @@ function respond_settings(): array
             $default_ini = Config\get_default_ini_text();
             Config\save_ini_text($default_ini);
             $_SESSION['flash'][] = "Settings reset to defaults.";
-            redirect_uri('/settings');
+            redirect_uri(\Lamb\Http\app_path('/settings'));
         }
 
         $submitted_ini = $_POST['ini_text'] ?? '';
@@ -560,7 +562,7 @@ function respond_settings(): array
             foreach (Config\shape_warnings($submitted_ini) as $warning) {
                 $_SESSION['flash'][] = $warning;
             }
-            redirect_uri('/settings');
+            redirect_uri(\Lamb\Http\app_path('/settings'));
         } else {
             $_SESSION['flash'][] = "Invalid INI syntax. Your changes were not saved.";
             if ($validation['error']) {

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -55,7 +55,7 @@ function redirect_created(): void
         $_SESSION['flash'][] = 'Failed to save: ' . $e->getMessage();
     }
     notify_post_subscribers($bean);
-    redirect_uri('/');
+    redirect_uri(\Lamb\Http\app_path('/'));
 }
 
 /**
@@ -121,21 +121,25 @@ function store_slug_change_redirect(string $old_slug, string $new_slug): void
  * @param string|null $referer The request Referer header (may be null).
  * @return string A same-origin path (with query), or '/'.
  */
-function safe_referer_path(?string $referer): string
+function safe_referer_path(?string $referer, ?string $base = null): string
 {
+    // Every fallback here ends up in a Location: header, so it takes the
+    // install's base. A path that survives came from the browser and has one.
+    $home = \Lamb\Http\app_path('/', $base);
+
     if ($referer === null || $referer === '') {
-        return '/';
+        return $home;
     }
     $parts = parse_url($referer);
     if ($parts === false) {
-        return '/';
+        return $home;
     }
     if (isset($parts['host']) && $parts['host'] !== parse_url(ROOT_URL, PHP_URL_HOST)) {
-        return '/';
+        return $home;
     }
     $path = $parts['path'] ?? '/';
     if ($path === '') {
-        return '/';
+        return $home;
     }
     if (isset($parts['query']) && $parts['query'] !== '') {
         $path .= '?' . $parts['query'];
@@ -160,7 +164,9 @@ function delete_return_path(?string $referer, string $own_path): string
 {
     $target = safe_referer_path($referer);
     if (explode('?', $target, 2)[0] === $own_path) {
-        return '/';
+        // The home fallback is one of the app's own paths, so it needs the base.
+        // $target is not: it came from the browser and already carries one.
+        return \Lamb\Http\app_path('/');
     }
     return $target;
 }
@@ -175,7 +181,7 @@ function delete_return_path(?string $referer, string $own_path): string
 function redirect_deleted(mixed $args): void
 {
     if (empty($_POST)) {
-        redirect_uri('/');
+        redirect_uri(\Lamb\Http\app_path('/'));
     }
     Security\require_login();
     Security\require_csrf();
@@ -199,7 +205,7 @@ function redirect_deleted(mixed $args): void
 function redirect_restored(mixed $args): void
 {
     if (empty($_POST)) {
-        redirect_uri('/trash');
+        redirect_uri(\Lamb\Http\app_path('/trash'));
     }
     Security\require_login();
     Security\require_csrf();
@@ -209,7 +215,7 @@ function redirect_restored(mixed $args): void
     if ($post->id) {
         restore_post($post);
     }
-    redirect_uri('/trash');
+    redirect_uri(\Lamb\Http\app_path('/trash'));
 }
 
 /**

--- a/src/scripts/logged_in/link-edit-buttons.js
+++ b/src/scripts/logged_in/link-edit-buttons.js
@@ -1,7 +1,22 @@
+/**
+ * The editor URL for a post id.
+ *
+ * Split out of the click handler so it can be tested without navigating: it has
+ * to carry the install's base, or the Edit button leaves a subdirectory install
+ * for the domain root.
+ *
+ * @param {string} id - The post id from the button's data-id.
+ * @returns {string} The editor path.
+ */
+function editUrl(id)
+{
+    return appPath(`/edit/${id}`)
+}
+
 onLoaded(() => {
     const bs = $$('button.button-edit');
     bs?.forEach($button => $button.on('click', (ev) => {
         const id = ev.target.dataset.id
-        location.href = `/edit/${id}`
+        location.href = editUrl(id)
     }))
 })

--- a/src/scripts/logged_in/toggle-checkbox.js
+++ b/src/scripts/logged_in/toggle-checkbox.js
@@ -25,7 +25,7 @@ function saveCheckbox(box) {
     body.append('checked', checked ? '1' : '0')
 
     box.disabled = true
-    fetch('/checkbox', { method: 'POST', body })
+    fetch(appPath('/checkbox'), { method: 'POST', body })
         .then(response => response.ok ? response.json() : Promise.reject(response.status))
         .then(data => {
             if (!data.ok) return Promise.reject('save failed')

--- a/src/scripts/logged_in/upload-image.js
+++ b/src/scripts/logged_in/upload-image.js
@@ -60,7 +60,7 @@ function handleFiles(files, textarea) {
     }
     const text = textarea.value
     const cursor = textarea.selectionStart
-    fetch('/upload', {
+    fetch(appPath('/upload'), {
         method: 'POST', body: formData
     })
         // A refusal carries a JSON *string* message, not markdown — hence the

--- a/src/scripts/shorthand.js
+++ b/src/scripts/shorthand.js
@@ -41,6 +41,21 @@ const onLoaded = func => {
 };
 
 /**
+ * Builds a URL for one of the app's own endpoints.
+ *
+ * An install served from a subdirectory answers on /blog/upload, not /upload, so
+ * a bare path would post outside the app entirely. the_scripts() publishes the
+ * install's base as window.LAMB_BASE; it is absent (and empty) at a domain root.
+ *
+ * @param {string} path - A root-relative app path, with its leading slash.
+ * @returns {string} The path with the install's base prefixed.
+ */
+function appPath(path)
+{
+    return (window.LAMB_BASE || '') + path
+}
+
+/**
  * Cancels the default behavior and propagation of an event.
  *
  * @param {Event} ev - The event object to be cancelled.

--- a/src/security.php
+++ b/src/security.php
@@ -24,12 +24,17 @@ use    Lamb\Response;
  *
  * If the user is not logged in, a flash message "Please login" is added to the session and the user is redirected to the login page.
  */
-function get_login_url(string $current_uri): string
+function get_login_url(string $current_uri, ?string $base = null): string
 {
+    // app_path(), not a bare '/login': on a subdirectory install the bare path
+    // leaves the install entirely and the visitor never reaches the login page
+    // (issue #580). $current_uri is the browser's own path and already carries
+    // the base, so it is encoded as-is.
+    $login = \Lamb\Http\app_path('/login', $base);
     if (empty($current_uri)) {
-        return '/login';
+        return $login;
     }
-    return '/login?redirect_to=' . urlencode($current_uri);
+    return $login . '?redirect_to=' . urlencode($current_uri);
 }
 
 function require_login(): void

--- a/src/theme.php
+++ b/src/theme.php
@@ -45,8 +45,8 @@ function action_delete(OODBBean $bean): string
         return '';
     }
 
-    return sprintf('<form data-id="%s" class="form-delete" action="/delete/%s" method="post"><input type="submit" value="Delete…"/><input type="hidden" name="csrf" value="%s" />
-</form>', $bean->id, $bean->id, csrf_token());
+    return sprintf('<form data-id="%s" class="form-delete" action="%s" method="post"><input type="submit" value="Delete…"/><input type="hidden" name="csrf" value="%s" />
+</form>', $bean->id, \Lamb\Http\app_path('/delete/' . $bean->id), csrf_token());
 }
 
 /**
@@ -62,7 +62,7 @@ function action_restore(OODBBean $bean): string
     }
 
     return sprintf(
-        '<form class="form-restore" action="/restore/%s" method="post">'
+        '<form class="form-restore" action="' . \Lamb\Http\app_path('/restore') . '/%s" method="post">'
         . '<input type="submit" value="Restore post"/>'
         . '<input type="hidden" name="csrf" value="%s"/>'
         . '</form>',
@@ -143,8 +143,8 @@ function date_created(OODBBean $bean): string
     }
 
     return sprintf(
-        '<a href="/%1$s" class="u-url" title="Timestamp: %2$s"><time class="dt-published" datetime="%2$s">%3$s</time></a>',
-        escape(ltrim($slug, '/')),
+        '<a href="%1$s" class="u-url" title="Timestamp: %2$s"><time class="dt-published" datetime="%2$s">%3$s</time></a>',
+        escape(\Lamb\Http\app_path('/' . ltrim($slug, '/'))),
         escape((string) $bean->created),
         $human_created
     );
@@ -416,8 +416,12 @@ function li_items(array $nav_items): string
     $format = '<li><a href="%s">%s</a></li>';
     $items = [];
     foreach ($nav_items as $label => $url) {
-        if (str_starts_with($url, 'http') || str_starts_with($url, '/')) {
+        if (str_starts_with($url, 'http')) {
             $items[] = sprintf($format, escape($url), escape($label));
+        } elseif (str_starts_with($url, '/')) {
+            // A configured root-relative item (`Feed = /feed`) names one of the
+            // app's own paths, so it takes the install's base.
+            $items[] = sprintf($format, escape(\Lamb\Http\app_path($url)), escape($label));
         } else {
             $items[] = sprintf($format, ROOT_URL . '/' . escape($url), escape($label));
         }
@@ -472,7 +476,7 @@ function the_entry_form(): void
 {
     if (isset($_SESSION[SESSION_LOGIN])) : ?>
         <section class="entry-form">
-            <form id="entry" method="post" action="/" enctype="multipart/form-data">
+            <form id="entry" method="post" action="<?= escape(\Lamb\Http\app_path('/')) ?>" enctype="multipart/form-data">
                 <label>
                     <textarea placeholder="What's happening?" name="contents" required><?= preload_text() ?></textarea>
                 </label>
@@ -500,16 +504,17 @@ function admin_toolbar_html(): string
     $scheduledLabel = 'Scheduled' . ($scheduled > 0 ? " ($scheduled)" : '');
     $trashLabel     = 'Trash'     . ($trash  > 0 ? " ($trash)"  : '');
 
-    $scheduledLink = $scheduled > 0
-        ? '<a href="/scheduled">' . escape($scheduledLabel) . '</a>'
-        : '';
+    $link = static fn(string $path, string $label): string
+        => '<a href="' . escape(\Lamb\Http\app_path($path)) . '">' . escape($label) . '</a>';
+
+    $scheduledLink = $scheduled > 0 ? $link('/scheduled', $scheduledLabel) : '';
 
     return '<div id="admin-toolbar">'
-        . '<a href="/drafts">'   . escape($draftsLabel) . '</a>'
+        . $link('/drafts', $draftsLabel)
         . $scheduledLink
-        . '<a href="/trash">'    . escape($trashLabel)  . '</a>'
-        . '<a href="/settings">Settings</a>'
-        . '<a href="/logout">Logout</a>'
+        . $link('/trash', $trashLabel)
+        . $link('/settings', 'Settings')
+        . $link('/logout', 'Logout')
         . '</div>'
         . '<style>'
         . '#admin-toolbar{'

--- a/src/theme/assets.php
+++ b/src/theme/assets.php
@@ -112,6 +112,11 @@ function the_scripts(): void
         'logged_in' => ['growing-input.js', 'confirm-delete.js', 'link-edit-buttons.js', 'upload-image.js', 'paste-link.js', 'toggle-checkbox.js'],
         'search' => ['search-highlight.js'],
     ];
+    // Published before the scripts that read it: appPath() in shorthand.js turns
+    // the app's own paths into ones that stay inside a subdirectory install.
+    // json_encode() rather than interpolation — this lands inside a <script>.
+    printf('<script>window.LAMB_BASE=%s</script>', json_encode(\Lamb\Http\base_path()));
+
     $assets = asset_loader($scripts, 'scripts');
     foreach ($assets as $id => $href) {
         printf('<script id="%1$s" defer src="%2$s?ver=%1$s"></script>', $id, $href);

--- a/src/theme/formatting.php
+++ b/src/theme/formatting.php
@@ -4,6 +4,8 @@
 
 namespace Lamb\Theme;
 
+use RedBeanPHP\OODBBean;
+
 /**
  * Escapes a string for safe HTML5 output using htmlspecialchars.
  *
@@ -55,6 +57,38 @@ function anchor_headings(string $html, int $top): string
         },
         $html
     ) ?? $html;
+}
+
+/**
+ * Renders a post's body HTML for on-site display.
+ *
+ * The one seam every theme puts a post body through, so anything that has to
+ * happen to stored content on its way to the page happens once. Today that is
+ * two things: the heading re-levelling a theme asks for, and prefixing the
+ * install's base path onto root-relative links.
+ *
+ * Post bodies store asset links root-relative (`/assets/…` from asset_url()) so
+ * the content survives a domain change and works from the CLI importer. That
+ * resolves against the domain root, which is outside an install served from a
+ * subdirectory (issue #580) — so the base goes on at render time and what is
+ * stored stays portable. Feeds do their own, absolute, version of this via
+ * Lamb\absolute_urls() with ROOT_URL.
+ *
+ * @param OODBBean    $bean The post being rendered.
+ * @param int|null    $top  The level the body's highest heading should occupy,
+ *                          or null to leave headings alone.
+ * @param string|null $base The install's base path; defaults to Http\base_path().
+ *                          Passed explicitly by tests, which cannot redefine a constant.
+ * @return string The body HTML, ready to echo.
+ */
+function the_content(OODBBean $bean, ?int $top = null, ?string $base = null): string
+{
+    $html = (string) ($bean->transformed ?? '');
+    if ($top !== null) {
+        $html = anchor_headings($html, $top);
+    }
+
+    return \Lamb\absolute_urls($html, $base ?? \Lamb\Http\base_path());
 }
 
 

--- a/src/themes/2024/parts/_items.php
+++ b/src/themes/2024/parts/_items.php
@@ -10,7 +10,7 @@ use function Lamb\Theme\action_preview;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\author_card;
 use function Lamb\Theme\date_created;
-use function Lamb\Theme\anchor_headings;
+use function Lamb\Theme\the_content;
 use function Lamb\Theme\escape;
 use function Lamb\Config\is_menu_item;
 use function Lamb\Theme\link_source;
@@ -50,7 +50,7 @@ else :
             </header>
             <?= the_reply_context($bean) ?>
             <?php // List view renders the post title at h2, so the body's top heading sits at h3; otherwise h2 under the site h1. ?>
-            <div class="e-content"><?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
+            <div class="e-content"><?= the_content($bean, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
                 <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>

--- a/src/themes/2026/html.php
+++ b/src/themes/2026/html.php
@@ -1,5 +1,6 @@
 <?php
 
+use function Lamb\Http\app_path;
 use function Lamb\Theme\escape;
 use function Lamb\Theme\li_footer_items;
 use function Lamb\Theme\li_menu_items;
@@ -58,13 +59,13 @@ global $template;
     <ul>
         <?php echo li_menu_items(); ?>
         <li class="right">
-            <form action="/search" method="get" class="form-search">
+            <form action="<?= escape(app_path('/search')) ?>" method="get" class="form-search">
                 <label for="s"><span class="screen-reader-text">Search</span></label>
                 <input type="text" name="s" id="s" placeholder="search" value="<?= escape($data['query'] ?? '') ?>" required>
                 <input type="submit" value="↵" aria-label="Search">
             </form>
             <?php if (!isset($_SESSION[SESSION_LOGIN])) : ?>
-                <a href="/login">Login</a>
+                <a href="<?= escape(app_path('/login')) ?>">Login</a>
             <?php endif; ?>
         </li>
     </ul>

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -10,7 +10,7 @@ use function Lamb\Theme\action_preview;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\author_card;
 use function Lamb\Theme\date_created;
-use function Lamb\Theme\anchor_headings;
+use function Lamb\Theme\the_content;
 use function Lamb\Theme\escape;
 use function Lamb\Config\is_menu_item;
 use function Lamb\Theme\link_source;
@@ -51,7 +51,7 @@ else :
             </header>
             <?= the_reply_context($bean) ?>
             <?php // List view renders the post title at h2, so the body's top heading sits at h3; otherwise h2 under the site h1. ?>
-            <div class="e-content"><?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
+            <div class="e-content"><?= the_content($bean, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
                 <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>

--- a/src/themes/2026/parts/_related.php
+++ b/src/themes/2026/parts/_related.php
@@ -3,6 +3,7 @@
 global $data;
 global $template;
 
+use function Lamb\Http\app_path;
 use function Lamb\Theme\escape;
 use function Lamb\Theme\human_time;
 use function Lamb\Theme\related_posts;
@@ -44,7 +45,7 @@ $primary_tag = $tags[0] ?? null;
     <ul class="related-list">
         <?php foreach ($shown as $bean) : ?>
             <?php
-            $permalink = '/' . ltrim(!empty($bean->slug) ? $bean->slug : "status/{$bean->id}", '/');
+            $permalink = app_path('/' . ltrim(!empty($bean->slug) ? $bean->slug : "status/{$bean->id}", '/'));
             $title = trim(strip_tags($bean->title ?? ''));
             $excerpt = trim(strip_tags($bean->description ?? ''));
             // If the post has no title, promote a short excerpt to the title slot.
@@ -67,6 +68,6 @@ $primary_tag = $tags[0] ?? null;
         <?php endforeach; ?>
     </ul>
     <?php if ($overflow && $primary_tag !== null) : ?>
-        <p class="related-more"><a href="/tag/<?= escape(strtolower($primary_tag)) ?>">More in #<?= escape($primary_tag) ?> →</a></p>
+        <p class="related-more"><a href="<?= escape(app_path('/tag/' . strtolower($primary_tag))) ?>">More in #<?= escape($primary_tag) ?> →</a></p>
     <?php endif; ?>
 </article>

--- a/src/themes/base/html.php
+++ b/src/themes/base/html.php
@@ -1,5 +1,6 @@
 <?php
 
+use function Lamb\Http\app_path;
 use function Lamb\Theme\escape;
 use function Lamb\Theme\li_menu_items;
 use function Lamb\Theme\page_title;
@@ -54,14 +55,14 @@ global $template;
         <?php
         echo li_menu_items(); ?>
         <li class="right">
-            <form action="/search" method="get" class="form-search">
+            <form action="<?= escape(app_path('/search')) ?>" method="get" class="form-search">
                 <label for="s"><span class="screen-reader-text">Search</span></label>
                 <input type="text" name="s" id="s" value="<?= escape($data['query'] ?? '') ?>" required>
                 <input type="submit" value="🔎">
             </form>
             <?php
             if (!isset($_SESSION[SESSION_LOGIN])) : ?>
-                <a href="/login">Login</a>
+                <a href="<?= escape(app_path('/login')) ?>">Login</a>
                 <?php
             endif; ?>
         </li>

--- a/src/themes/base/parts/404.php
+++ b/src/themes/base/parts/404.php
@@ -1,5 +1,6 @@
 <?php
 
+use function Lamb\Http\app_path;
 use function Lamb\Theme\escape;
 use function Lamb\Theme\page_intro;
 use function Lamb\Theme\page_title;
@@ -16,5 +17,5 @@ $requested = (string) ($data['requested'] ?? '');
 </section>
 
 <?php if ($requested !== '') : ?>
-<p>Why not try <a href="/search/<?= escape(rawurlencode($requested)) ?>">searching for <?= escape($requested) ?></a></p>
+<p>Why not try <a href="<?= escape(app_path('/search/' . rawurlencode($requested))) ?>">searching for <?= escape($requested) ?></a></p>
 <?php endif; ?>

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -9,7 +9,7 @@ use function Lamb\Theme\action_preview;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\date_created;
 use function Lamb\Config\is_menu_item;
-use function Lamb\Theme\anchor_headings;
+use function Lamb\Theme\the_content;
 use function Lamb\Theme\author_card;
 use function Lamb\Theme\escape;
 use function Lamb\Theme\link_source;
@@ -41,7 +41,7 @@ else :
             </header>
             <?= the_reply_context($bean) ?>
             <?php // Post title renders at h2, so the body's top heading sits at h3 (h2 under the site h1 when untitled). ?>
-            <div class="e-content"><?= anchor_headings($bean->transformed, !empty($bean->title) ? 3 : 2) ?></div>
+            <div class="e-content"><?= the_content($bean, !empty($bean->title) ? 3 : 2) ?></div>
             <?= syndication_links($bean) ?>
             <footer>
                 <small><?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>

--- a/src/themes/base/parts/_related.php
+++ b/src/themes/base/parts/_related.php
@@ -5,6 +5,7 @@ global $template;
 
 use function Lamb\Theme\date_created;
 use function Lamb\Theme\escape;
+use function Lamb\Theme\the_content;
 use function Lamb\Theme\related_posts;
 
 if ($template !== 'status') {
@@ -32,7 +33,7 @@ if (!empty($related_posts['posts'])) :
                         <?php endif; ?>
                         <p><?= date_created($bean) ?>
                         <?php if (!empty($bean->transformed)) : ?>
-                            <?= $bean->transformed ?>
+                            <?= the_content($bean) ?>
                         <?php endif; ?>
                         </p>
                     </li>

--- a/src/themes/base/parts/edit.php
+++ b/src/themes/base/parts/edit.php
@@ -2,6 +2,7 @@
 
 global $data;
 
+use function Lamb\Http\app_path;
 use function Lamb\Theme\action_delete;
 use function Lamb\Theme\csrf_token;
 use function Lamb\Theme\escape;
@@ -17,7 +18,7 @@ if (isset($_SESSION[SESSION_LOGIN]) && $post->id > 0) :
     ?>
     <h2><?= $heading ?></h2>
 
-    <form method="post" action="/edit" id="editform">
+    <form method="post" action="<?= escape(app_path('/edit')) ?>" id="editform">
         <label for="contents">Contents</label><textarea placeholder="What's happening?" name="contents" required
                                                         id="contents"
         ><?= $body ?></textarea>

--- a/src/themes/base/parts/login.php
+++ b/src/themes/base/parts/login.php
@@ -1,5 +1,6 @@
 <?php
 
+use function Lamb\Http\app_path;
 use function Lamb\Theme\escape;
 use function Lamb\Theme\redirect_to;
 
@@ -17,7 +18,7 @@ if ($login_error !== '') : ?>
 <?php elseif ($redirect !== '') : ?>
     <div class="flash">⚠️ Please login</div>
 <?php endif; ?>
-<form method="post" action="/login">
+<form method="post" action="<?= escape(app_path('/login')) ?>">
     <p style="text-align: center">
         <label> Password:
             <input type="password" name="password" autofocus/>

--- a/src/themes/base/parts/settings.php
+++ b/src/themes/base/parts/settings.php
@@ -2,6 +2,7 @@
 
 global $data;
 
+use function Lamb\Http\app_path;
 use function Lamb\Theme\csrf_token;
 use function Lamb\Theme\escape;
 use function Lamb\Theme\human_time;
@@ -99,7 +100,7 @@ $redirects     = $data['redirects'] ?? [];
             Refer to the <a href="https://svandragt.github.io/lamb/site-configuration" target="_blank">documentation</a> for available keys and examples.
         </p>
 
-        <form method="post" action="/settings" id="settingsform">
+        <form method="post" action="<?= escape(app_path('/settings')) ?>" id="settingsform">
             <label for="ini_text">Configuration (INI format)</label>
             <textarea name="ini_text" id="ini_text" rows="20" style="width: 100%; font-family: monospace;"
             ><?= escape($data['ini_text']) ?></textarea>
@@ -154,7 +155,7 @@ $redirects     = $data['redirects'] ?? [];
             for the format.
         </p>
         <p>
-            <a href="/export" class="button">Download export</a>
+            <a href="<?= escape(app_path('/export')) ?>" class="button">Download export</a>
         </p>
     </section>
 

--- a/tests/Unit/CanonicalSiteUrlTest.php
+++ b/tests/Unit/CanonicalSiteUrlTest.php
@@ -30,7 +30,56 @@ class CanonicalSiteUrlTest extends TestCase
     {
         $this->assertSame('https://example.com', canonical_site_url(['site_url' => 'https://example.com/']));
         $this->assertSame('https://example.com', canonical_site_url(['site_url' => 'https://EXAMPLE.com']));
-        $this->assertSame('http://example.com:8747', canonical_site_url(['site_url' => 'http://example.com:8747/blog']));
+    }
+
+    // Subdirectory installs (issue #580). The author's IndieAuth identity is the
+    // whole `https://example.com/blog`, so the base path is part of the canonical
+    // value rather than something to discard.
+
+    public function testKeepsASubdirectoryBasePath(): void
+    {
+        $this->assertSame('https://example.com/blog', canonical_site_url(['site_url' => 'https://example.com/blog']));
+        $this->assertSame(
+            'http://example.com:8747/blog',
+            canonical_site_url(['site_url' => 'http://example.com:8747/blog'])
+        );
+        $this->assertSame('https://example.com/a/b', canonical_site_url(['site_url' => 'https://example.com/a/b']));
+    }
+
+    public function testBasePathIsCaseSensitiveWhileTheHostIsNot(): void
+    {
+        // Only the host is case-insensitive; a path segment is not, so folding it
+        // would invent an identity the author never configured.
+        $this->assertSame('https://example.com/Blog', canonical_site_url(['site_url' => 'https://EXAMPLE.com/Blog']));
+    }
+
+    public function testReducesEverySpellingOfABaseToOneForm(): void
+    {
+        // This value is compared against a token's `me`. Two spellings of the same
+        // base must not produce two different strings, or the comparison turns on
+        // how the author happened to type the setting.
+        $spellings = [
+            'https://example.com/blog/',
+            'https://example.com//blog',
+            'https://example.com/blog//',
+            'https://example.com/blog?utm=1',
+            'https://example.com/blog#top',
+        ];
+
+        foreach ($spellings as $spelling) {
+            $this->assertSame('https://example.com/blog', canonical_site_url(['site_url' => $spelling]), $spelling);
+        }
+    }
+
+    public function testRejectsBasePathsThatCannotBeComparedSafely(): void
+    {
+        // Refused rather than resolved or decoded: if neither `..` nor its
+        // percent-encoded spelling is allowed through, the two cannot disagree.
+        $this->assertNull(canonical_site_url(['site_url' => 'https://example.com/blog/../admin']));
+        $this->assertNull(canonical_site_url(['site_url' => 'https://example.com/blog/%2e%2e/admin']));
+        $this->assertNull(canonical_site_url(['site_url' => 'https://example.com/blog%2fadmin']));
+        $this->assertNull(canonical_site_url(['site_url' => 'https://example.com/blog x']));
+        $this->assertNull(canonical_site_url(['site_url' => 'https://example.com/./blog']));
     }
 
     public function testRejectsValuesThatAreNotAbsoluteHttpUrls(): void

--- a/tests/Unit/HttpTest.php
+++ b/tests/Unit/HttpTest.php
@@ -8,6 +8,8 @@ use function Lamb\Http\extract_page_segment;
 use function Lamb\Http\get_request_uri;
 use function Lamb\Http\page_path;
 use function Lamb\Http\requested_path;
+use function Lamb\Http\app_path;
+use function Lamb\Http\strip_base_path;
 
 class HttpTest extends TestCase
 {
@@ -51,6 +53,98 @@ class HttpTest extends TestCase
     {
         $_SERVER['REQUEST_URI'] = '/tag/php';
         $this->assertSame('/tag/php', get_request_uri());
+    }
+
+    // Subdirectory installs (issue #580). An install served under
+    // https://example.com/blog still receives `/blog/...` in REQUEST_URI, so the
+    // base has to come off before the router segments the path — otherwise every
+    // request routes on the action "blog".
+
+    public function testStripBasePathLeavesTheUriAloneWhenThereIsNoBase(): void
+    {
+        $this->assertSame('/about', strip_base_path('/about', ''));
+        $this->assertSame('/', strip_base_path('/', ''));
+    }
+
+    public function testStripBasePathRemovesTheBase(): void
+    {
+        $this->assertSame('/about', strip_base_path('/blog/about', '/blog'));
+        $this->assertSame('/tag/php', strip_base_path('/blog/tag/php', '/blog'));
+        $this->assertSame('/about', strip_base_path('/a/b/about', '/a/b'));
+    }
+
+    public function testStripBasePathMapsTheBaseItselfToTheRoot(): void
+    {
+        $this->assertSame('/', strip_base_path('/blog', '/blog'));
+        $this->assertSame('/', strip_base_path('/blog/', '/blog'));
+    }
+
+    public function testStripBasePathOnlyMatchesWholeSegments(): void
+    {
+        // `/blogger` starts with `/blog` as a string but is not inside it. Cutting
+        // on the raw prefix would route it as the action "ger".
+        $this->assertSame('/blogger', strip_base_path('/blogger', '/blog'));
+        $this->assertSame('/blogging/x', strip_base_path('/blogging/x', '/blog'));
+    }
+
+    public function testStripBasePathIgnoresAPathOutsideTheBase(): void
+    {
+        // Nothing should reach the router under a base it does not sit in; leaving
+        // it whole lets the normal 404 handle it rather than inventing a route.
+        $this->assertSame('/elsewhere', strip_base_path('/elsewhere', '/blog'));
+    }
+
+    public function testStripBasePathIsCaseSensitive(): void
+    {
+        // Paths are case-sensitive, and the base came from the author's configured
+        // site_url verbatim.
+        $this->assertSame('/Blog/about', strip_base_path('/Blog/about', '/blog'));
+    }
+
+    public function testAppPathPrefixesTheBase(): void
+    {
+        // The counterpart to strip_base_path(): links and redirects are written
+        // as the app's own root-relative paths, and this is where the base goes
+        // back on so they point inside the install rather than at the domain root.
+        $this->assertSame('/blog/login', app_path('/login', '/blog'));
+        $this->assertSame('/blog/tag/php', app_path('/tag/php', '/blog'));
+        $this->assertSame('/blog/', app_path('/', '/blog'));
+    }
+
+    public function testAppPathIsIdentityAtTheDomainRoot(): void
+    {
+        $this->assertSame('/login', app_path('/login', ''));
+        $this->assertSame('/', app_path('/', ''));
+    }
+
+    public function testAppPathAndStripBasePathRoundTrip(): void
+    {
+        foreach (['/login', '/tag/php', '/search/a%20b'] as $path) {
+            $this->assertSame($path, strip_base_path(app_path($path, '/blog'), '/blog'), $path);
+        }
+    }
+
+    public function testGetRequestUriStripsTheBasePath(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/blog/about?utm=1';
+        $this->assertSame('/about', get_request_uri('/blog'));
+    }
+
+    public function testGetRequestUriMapsTheBaseRootToHome(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/blog';
+        $this->assertSame('/home', get_request_uri('/blog'));
+
+        $_SERVER['REQUEST_URI'] = '/blog/';
+        $this->assertSame('/home', get_request_uri('/blog'));
+    }
+
+    public function testRequestedPathStripsTheBasePath(): void
+    {
+        // The visitor asked for `/blog/no-such-page`; the thing that was not found
+        // is `no-such-page`, so a 404 must not offer to search for "blog".
+        $_SERVER['REQUEST_URI'] = '/blog/no-such-page';
+        $this->assertSame('no-such-page', requested_path('/blog'));
     }
 
     // requested_path — the visitor-facing reading of the request path, as

--- a/tests/Unit/LambHelpersTest.php
+++ b/tests/Unit/LambHelpersTest.php
@@ -55,6 +55,34 @@ class LambHelpersTest extends TestCase
         $this->assertEquals($bean->id, $found->id);
     }
 
+    public function testFindPostByPathResolvesAPermalinkFromASubdirectoryInstall(): void
+    {
+        // Issue #580. Callers hand this the path out of a permalink, and on a
+        // subdirectory install that carries the base: `/blog/status/12`. The
+        // routes matched here are the app's own, which do not. Left unstripped,
+        // Micropub update and delete cannot find the post they were given at
+        // creation, and every inbound webmention is rejected as an unknown target.
+        $bean = R::dispense('post');
+        $bean->body = 'A status post';
+        R::store($bean);
+
+        $found = find_post_by_path('/blog/status/' . $bean->id, '/blog');
+        $this->assertNotNull($found);
+        $this->assertEquals($bean->id, $found->id);
+    }
+
+    public function testFindPostByPathResolvesASluggedPermalinkFromASubdirectoryInstall(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'A slugged post';
+        $bean->slug = 'my-post';
+        R::store($bean);
+
+        $found = find_post_by_path('/blog/my-post', '/blog');
+        $this->assertNotNull($found);
+        $this->assertEquals($bean->id, $found->id);
+    }
+
     public function testFindPostByPathResolvesSlugPath(): void
     {
         $bean = R::dispense('post');

--- a/tests/Unit/RedirectTest.php
+++ b/tests/Unit/RedirectTest.php
@@ -64,6 +64,26 @@ class RedirectTest extends TestCase
         $config = $original;
     }
 
+    public function testFindRedirectKeepsTargetsInsideASubdirectoryInstall(): void
+    {
+        // Issue #580: the return value goes straight into a Location: header, so
+        // a bare `/new-post` sends the visitor to the domain root. External
+        // targets are somebody else's URL and must not be touched.
+        global $config;
+        $original = $config;
+        $config['redirections'] = [
+            'old-post'     => '/new-post',
+            'old-slug'     => 'new-slug',
+            'old-external' => 'https://example.com/new',
+        ];
+
+        $this->assertSame('/blog/new-post', find_redirect('old-post', '/blog'));
+        $this->assertSame('/blog/new-slug', find_redirect('old-slug', '/blog'));
+        $this->assertSame('https://example.com/new', find_redirect('old-external', '/blog'));
+
+        $config = $original;
+    }
+
     // find_redirect — DB-based
 
     public function testFindRedirectReturnsUrlFromDatabase(): void

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -318,6 +318,16 @@ class ResponsePostsTest extends TestCase
         $this->assertSame('/', safe_referer_path('https://evil.example/phish'));
     }
 
+    public function testSafeRefererPathHomeFallbackStaysInsideASubdirectoryInstall(): void
+    {
+        // Issue #580: every fallback here becomes a Location: header. Without the
+        // base they send the author to the domain root — off the install — after
+        // saving an edit opened directly, or deleting with no Referer.
+        $this->assertSame('/blog/', safe_referer_path(null, '/blog'));
+        $this->assertSame('/blog/', safe_referer_path('', '/blog'));
+        $this->assertSame('/blog/', safe_referer_path('https://evil.example/phish', '/blog'));
+    }
+
     public function testSafeRefererPathKeepsHostlessRelativeReferer(): void
     {
         $this->assertSame('/drafts', safe_referer_path('/drafts'));

--- a/tests/Unit/SanitizeLocationTest.php
+++ b/tests/Unit/SanitizeLocationTest.php
@@ -51,4 +51,14 @@ class SanitizeLocationTest extends TestCase
         // A value that is nothing but CR/LF collapses to empty, then to root.
         $this->assertSame('/', sanitize_location("\r\n"));
     }
+
+    public function testRootFallbackStaysInsideASubdirectoryInstall(): void
+    {
+        // Issue #580: this is the last thing a redirect target passes through, so
+        // the fallback has to land inside the install rather than at the domain
+        // root. A target that survives is already base-carrying and is untouched.
+        $this->assertSame('/blog/', sanitize_location('', '/blog'));
+        $this->assertSame('/blog/', sanitize_location("\r\n", '/blog'));
+        $this->assertSame('/blog/drafts', sanitize_location('/blog/drafts', '/blog'));
+    }
 }

--- a/tests/Unit/SecurityTest.php
+++ b/tests/Unit/SecurityTest.php
@@ -43,6 +43,16 @@ class SecurityTest extends TestCase
         $this->assertSame('/login?redirect_to=%2Ftag%2Ffoo+bar', get_login_url('/tag/foo bar'));
     }
 
+    public function testLoginUrlStaysInsideASubdirectoryInstall(): void
+    {
+        // Issue #580: a bare `/login` on an install served from /blog points at
+        // the domain root, outside the install, so the visitor never reaches the
+        // login page. The redirect_to value keeps its base — it is the browser's
+        // own path, not one of the app's.
+        $this->assertSame('/blog/login', get_login_url('', '/blog'));
+        $this->assertSame('/blog/login?redirect_to=%2Fblog%2Fdrafts', get_login_url('/blog/drafts', '/blog'));
+    }
+
     // require_csrf
 
     public function testRequireCsrfPassesWhenTokensMatch(): void

--- a/tests/Unit/ThemeContentTest.php
+++ b/tests/Unit/ThemeContentTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Theme\the_content;
+
+/**
+ * the_content() is the single seam every theme renders a post body through.
+ *
+ * Post bodies store asset links root-relative (`/assets/…`) on purpose, so the
+ * content survives a domain change. That resolves against the domain root, which
+ * is the wrong place on an install served from a subdirectory (issue #580), so
+ * the install's base goes on here — at render time, leaving what is stored
+ * portable.
+ */
+class ThemeContentTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+    }
+
+    private function post(string $transformed): \RedBeanPHP\OODBBean
+    {
+        $bean = R::dispense('post');
+        $bean->transformed = $transformed;
+
+        return $bean;
+    }
+
+    public function testPrefixesTheBaseOntoStoredAssetUrls(): void
+    {
+        $html = the_content($this->post('<p><img src="/assets/2026/08/x.webp" alt=""></p>'), null, '/blog');
+
+        $this->assertStringContainsString('src="/blog/assets/2026/08/x.webp"', $html);
+    }
+
+    public function testLeavesContentAloneAtTheDomainRoot(): void
+    {
+        $stored = '<p><img src="/assets/2026/08/x.webp" alt=""></p>';
+
+        $this->assertStringContainsString('src="/assets/2026/08/x.webp"', the_content($this->post($stored), null, ''));
+    }
+
+    public function testLeavesAbsoluteAndProtocolRelativeUrlsAlone(): void
+    {
+        $stored = '<a href="https://other.example/x">a</a><img src="//cdn.example/y.png" alt="">';
+        $html = the_content($this->post($stored), null, '/blog');
+
+        $this->assertStringContainsString('href="https://other.example/x"', $html);
+        $this->assertStringContainsString('src="//cdn.example/y.png"', $html);
+    }
+
+    public function testAppliesHeadingAnchorsWhenALevelIsGiven(): void
+    {
+        $html = the_content($this->post('<h2>A heading</h2>'), 3, '');
+
+        // anchor_headings() shifts the level and adds the anchor id.
+        $this->assertStringContainsString('<h3', $html);
+    }
+
+    public function testSkipsHeadingAnchorsWithoutALevel(): void
+    {
+        $html = the_content($this->post('<h2>A heading</h2>'), null, '');
+
+        $this->assertStringContainsString('<h2>A heading</h2>', $html);
+    }
+
+    public function testAPathAlreadyCarryingTheBaseIsPrefixedAgain(): void
+    {
+        // Known and deliberate. A stored path is written as the app sees it —
+        // `/assets/…`, no base — which is what the editor and uploader produce.
+        // A hand-pasted `/blog/assets/…` gets the base a second time.
+        //
+        // It cannot be detected away: a post slugged `blog` on a `/blog` install
+        // is stored as `/blog` and must become `/blog/blog`, so "starts with the
+        // base" does not separate an already-prefixed path from a genuine one.
+        // Anything that skips the second prefix breaks that post instead.
+        $html = the_content($this->post('<img src="/blog/assets/x.webp" alt="">'), null, '/blog');
+        $this->assertStringContainsString('src="/blog/blog/assets/x.webp"', $html);
+
+        $slugged = the_content($this->post('<a href="/blog">the blog post</a>'), null, '/blog');
+        $this->assertStringContainsString('href="/blog/blog"', $slugged);
+    }
+
+    public function testEmptyContentStaysEmpty(): void
+    {
+        $this->assertSame('', the_content($this->post(''), null, '/blog'));
+    }
+}

--- a/tests/js/link-edit-buttons.test.mjs
+++ b/tests/js/link-edit-buttons.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadScripts } from './helpers.mjs'
+
+function load() {
+  return loadScripts({
+    files: ['shorthand.js', 'logged_in/link-edit-buttons.js'],
+    expose: ['editUrl'],
+    html: '<!DOCTYPE html><body><button class="button-edit" data-id="12">Edit</button></body>',
+  })
+}
+
+test('editUrl points at the post editor', () => {
+  const { api } = load()
+
+  assert.equal(api.editUrl('12'), '/edit/12')
+})
+
+test('editUrl stays inside a subdirectory install', () => {
+  // Issue #580: a bare /edit/12 leaves the install, so the author lands on the
+  // domain root instead of the editor.
+  const { window, api } = load()
+  window.LAMB_BASE = '/blog'
+
+  assert.equal(api.editUrl('12'), '/blog/edit/12')
+})

--- a/tests/js/toggle-checkbox.test.mjs
+++ b/tests/js/toggle-checkbox.test.mjs
@@ -34,6 +34,26 @@ test('saveCheckbox posts id, index and checked state to /checkbox', async () => 
   assert.equal(box.disabled, false)
 })
 
+test('saveCheckbox posts to the install base path on a subdirectory install', async () => {
+  // Issue #580: a bare /checkbox leaves a subdirectory install entirely, so the
+  // POST lands outside the app and the toggle silently reverts. the_scripts()
+  // publishes the base as window.LAMB_BASE.
+  const { window, document, api } = load()
+  window.LAMB_BASE = '/blog'
+  const box = document.querySelector('input')
+
+  let captured
+  window.fetch = (url) => {
+    captured = url
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) })
+  }
+
+  api.saveCheckbox(box)
+  await flush()
+
+  assert.equal(captured, '/blog/checkbox')
+})
+
 test('saveCheckbox reverts the checkbox on an HTTP error', async () => {
   const { window, document, api } = load()
   const box = document.querySelector('input')


### PR DESCRIPTION
**Draft, and may not be merged.** Opened so the work is reviewable and the trade-off is visible, not because it should land. See "Is this worth it?" below — there is a much smaller alternative.

Fixes #580.

## The bug

An install under `https://example.com/blog` cannot use Micropub at all. `canonical_site_url()` normalised the configured site URL down to `scheme://host[:port]` and threw the path away, so the author's IndieAuth identity could never match the `me` in a token. Every request was refused with `me_mismatch`, and no configuration worked around it — `LAMB_SITE_URL` went through the same normalisation, so a subpath identity could not be expressed at all.

## Why the fix is this big

Keeping the path makes the base something the whole app has to apply, in both directions.

**Taking it off.** `strip_base_path()` removes the base from an incoming request before anything segments it, or the router reads `blog` as the action. `find_post_by_path()` needs the same treatment, because its callers hand it the path out of a permalink — without that a Micropub client cannot update or delete the post it was just given, and every inbound webmention is rejected as an unknown target. That second one was found in review, and it is the same bug as #580 wearing a different hat.

**Putting it on.** `app_path()` is the counterpart. Links, form actions, redirect targets, configured menu items and `[redirections]`, and the two client-side `fetch()` calls all go through it. Absolute URLs needed no change — they concatenate onto `ROOT_URL`, which now carries the base.

**Content.** Post bodies keep storing `/assets/…` unchanged so content stays portable across a domain change; the base goes on at render time via a new `Theme\the_content()`. That is now the single seam a post body passes through, and it absorbed the `anchor_headings()` call each theme was making separately.

**Normalisation.** A base path feeds a security comparison, so it is normalised hard: one canonical spelling, a narrow charset, and a refusal rather than a decode for anything else — `..` and `%2e%2e` cannot reach different answers if neither is allowed through.

## Is this worth it?

Honest summary of the cost, since the answer may be no:

- 36 files. The base path is a new concept every future link, redirect and fetch has to respect, and nothing enforces that — the review found four places I had already missed.
- Nobody is known to run Lamb under a subdirectory.
- Issue #580 lists a second option: keep root-only identities, but reject a path-bearing `site_url` at save time with a message naming the limitation, and document it. Roughly 20 lines instead of this. It turns a silent 403 into an explanation without inventing a base-path concept.

The main thing in this branch's favour: at a domain root the base is `''`, and `app_path()`, `strip_base_path()` and `the_content()` are all identity in that case. So the risk to existing installs is low even though the diff is wide.

## Checks

- 1692 unit tests, 28 new. Every one written failing first.
- JS 40/40, PHPStan clean, phpcs clean.
- The suite's 21 errors / 7 failures are the pre-existing #595 deprecation baseline, byte-identical on `main`.

**Not verified on a real subdirectory install.** There is no acceptance coverage, because that needs a web-server rewrite the test suite does not set up. This is unit-level only.

## Known limitation

A hand-pasted internal path that already includes the base gets it twice: `/blog/assets/x.webp` renders as `/blog/blog/assets/x.webp`. It cannot be detected away — a post slugged `blog` on a `/blog` install is stored as `/blog` and must become `/blog/blog`. Pinned in a test with the reasoning so it is not "fixed" into a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYmuANUvADwwYmg2AbgZoQ