### PR TITLE
Warn when site_url carries a path instead of failing silently (#580)

### DIFF
--- a/docs/micropub.md
+++ b/docs/micropub.md
@@ -29,6 +29,10 @@ Do not derive it from the request — that is exactly what this setting exists t
 avoid. You can also supply it as the `LAMB_SITE_URL` environment variable, which
 takes precedence over the setting.
 
+Give the domain on its own, with no path. Lamb serves from the root of a domain,
+so a value like `https://example.com/blog` cannot work — see
+[Troubleshooting](#troubleshooting).
+
 ### 2. Add `rel="me"` identity links
 
 IndieAuth verifies who you are by checking that your site links to your profiles and those profiles link back. Add a `[me]` section to your site configuration at `/settings`:
@@ -75,6 +79,8 @@ Posts created with `post-status: draft` or a future `published` date are not pub
 If a client can't connect — for example it reports "something went wrong setting up your Micropub endpoint" — you can turn on diagnostic logging to see exactly what the client sent and why Lamb responded as it did.
 
 The first thing to check is that `site_url` is set (see [Set your site URL](#1-set-your-site-url)); without it every token is refused, with a `no_site_url` reason in the log below.
+
+The second is that your site is served from the root of a domain. Lamb does not support an install under a subdirectory such as `https://example.com/blog`: it reads `site_url` as the domain alone, while your IndieAuth identity is the whole address including the path, so no token can ever match and every request is refused with a `me_mismatch` reason. The settings page warns you if you save a `site_url` with a path in it. Serve the site from its own domain or subdomain instead.
 
 Add this to your site configuration at `/settings`:
 

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -157,6 +157,18 @@ You can also set it outside the settings page with the `LAMB_SITE_URL` environme
 variable, which takes precedence over the INI value — handy when the same
 configuration is deployed to more than one hostname.
 
+### Serve from the root of a domain
+
+Give `site_url` the domain on its own, with no path. Lamb does not support an
+install under a subdirectory, so `https://example.com/blog` cannot work: Lamb
+reads the domain and drops the path, while your IndieAuth identity is the whole
+address. Micropub then refuses every token, because the identity it compares
+against is not the one your tokens were issued for.
+
+The settings page warns you if you save a `site_url` with a path. To run Lamb at
+`example.com/blog` today, give it its own subdomain — `blog.example.com` — and
+point `site_url` at that.
+
 ## Related
 
 * [Setting up Cross-Posting]({{ site.baseurl }}{% link cross-posting.md %}#setup) requires site configuration changes.

--- a/src/config.php
+++ b/src/config.php
@@ -581,6 +581,11 @@ function validate_ini(string $ini_text): array
  * Only shape is reported. Whether a value is a usable timezone, URL or theme
  * name is each reader's business and each already has its own fallback.
  *
+ * The one exception is a path in `site_url` (see site_url_warning), because that
+ * value has no fallback the author can observe — it is silently narrowed and the
+ * damage surfaces somewhere else entirely, as a Micropub endpoint refusing every
+ * token.
+ *
  * @param string $ini_text The raw INI text as the author submitted it.
  * @return list<string> Human-readable warnings, empty when every value fits.
  */
@@ -588,6 +593,15 @@ function shape_warnings(string $ini_text): array
 {
     $defaults = parse_ini_safe(get_default_ini_text());
     $warnings = [];
+
+    $parsed = parse_ini_safe($ini_text);
+    $site_url = $parsed['site_url'] ?? null;
+    if (is_scalar($site_url)) {
+        $site_url_warning = site_url_warning((string) $site_url);
+        if ($site_url_warning !== null) {
+            $warnings[] = $site_url_warning;
+        }
+    }
 
     foreach (parse_ini_safe($ini_text) as $key => $value) {
         $expects_section = is_config_section((string) $key, $defaults);
@@ -617,6 +631,40 @@ function shape_warnings(string $ini_text): array
     }
 
     return $warnings;
+}
+
+/**
+ * Warns when a configured site URL carries a path, or null when it is fine.
+ *
+ * Lamb serves from the root of a domain. canonical_site_url() narrows the
+ * configured value to `scheme://host[:port]`, so a path is dropped — and because
+ * that value is the author's IndieAuth identity, an install at
+ * `https://example.com/blog` ends up comparing `https://example.com` against a
+ * token issued for `https://example.com/blog`. Every Micropub token is refused
+ * with `me_mismatch`, and nothing on the settings page suggests why (issue #580).
+ *
+ * A value canonical_site_url() cannot read at all is left alone: it already has
+ * its own handling and its own message, and a second one here is noise.
+ *
+ * @param string $site_url The `site_url` value as the author wrote it.
+ * @return string|null The warning, or null when the value has no path.
+ */
+function site_url_warning(string $site_url): ?string
+{
+    $site_url = trim($site_url);
+    if ($site_url === '' || canonical_site_url(['site_url' => $site_url]) === null) {
+        return null;
+    }
+
+    $path = trim((string) (parse_url($site_url, PHP_URL_PATH) ?? ''), '/');
+    if ($path === '') {
+        return null;
+    }
+
+    return "`site_url` has a path (`/{$path}`), and Lamb serves from the root of a domain. "
+        . 'The path is ignored, so Micropub refuses every token: your identity is the whole '
+        . "address including `/{$path}`, and Lamb compares tokens against the domain alone. "
+        . 'Serve the site from its own domain or subdomain.';
 }
 
 /**

--- a/tests/Unit/ConfigTypesTest.php
+++ b/tests/Unit/ConfigTypesTest.php
@@ -219,6 +219,35 @@ class ConfigTypesTest extends TestCase
         $this->assertStringContainsString('ignored', $warnings[0]);
     }
 
+    public function testShapeWarningsNamesAPathInTheSiteUrl(): void
+    {
+        // Issue #580: Lamb serves from the domain root only. A path in site_url
+        // is dropped on read, which leaves Micropub comparing the author's
+        // identity against the wrong URL and refusing every token, with the
+        // settings page reporting a clean save.
+        $warnings = shape_warnings("site_url = https://example.com/blog\n");
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('site_url', $warnings[0]);
+        $this->assertStringContainsString('/blog', $warnings[0]);
+        $this->assertStringContainsString('Micropub', $warnings[0]);
+    }
+
+    public function testShapeWarningsAcceptsARootSiteUrl(): void
+    {
+        $this->assertSame([], shape_warnings("site_url = https://example.com\n"));
+        $this->assertSame([], shape_warnings("site_url = https://example.com/\n"));
+        $this->assertSame([], shape_warnings("site_url = http://example.com:8747\n"));
+    }
+
+    public function testShapeWarningsIgnoresASiteUrlItCannotRead(): void
+    {
+        // canonical_site_url() already refuses these and Micropub already says so;
+        // a second, differently-worded complaint here would just be noise.
+        $this->assertSame([], shape_warnings("site_url = not-a-url\n"));
+        $this->assertSame([], shape_warnings("site_url =\n"));
+    }
+
     public function testShapeWarningsNamesASectionWrittenAsAScalar(): void
     {
         $warnings = shape_warnings("feeds = https://example.com/rss\n");


### PR DESCRIPTION
**Draft.** This is the small alternative to #611 — the two are mutually exclusive answers to the same issue. Pick one and close the other.

Refs #580.

## The problem, unchanged

An install at `https://example.com/blog` cannot use Micropub. `canonical_site_url()` narrows the configured value to `scheme://host[:port]`, so the path is dropped. That value is the author's IndieAuth identity, so Lamb compares `https://example.com` against a token issued for `https://example.com/blog`, and refuses every one with `me_mismatch`.

The worst part is not the refusal. It is that the settings page says "Settings saved successfully", and the failure appears somewhere else entirely, in a client that will not connect.

## What this does

Says so at the point of saving, and documents the limitation. It does not add subdirectory support — an install under a path still cannot work.

`shape_warnings()` already exists for exactly this shape of problem: a setting that saved and will be ignored, reported back to the author on the settings page. The new warning names the path, says it is dropped, says Micropub will refuse every token as a result, and points at the fix — serve the site from its own domain or subdomain.

A `site_url` that `canonical_site_url()` cannot read at all is left alone. That case already has its own handling and its own message, and a second differently-worded complaint is noise.

## One judgement call

This widens `shape_warnings()` past pure shape, which its own docblock had ruled out: "Whether a value is a usable timezone, URL or theme name is each reader's business and each already has its own fallback."

`site_url` is the exception, and the docblock now says why. Every other narrowed value degrades where the author can see it. This one is silently narrowed and the damage surfaces in a different subsystem, with nothing connecting the two.

## Compared with #611

| | This PR | #611 |
|---|---|---|
| Files | 4 | 36 |
| Lines | +95, −0 | +593, −76 |
| Subdirectory installs | Still unsupported, but explained | Supported |
| New concepts | None | A base path every future link, redirect and fetch must respect |
| Ongoing cost | None | The review found four places already missed |

#611 is the real fix if subdirectory installs are in scope for Lamb. This one is the right answer if they are not, and it is worth noting that nobody is known to run one.

Whichever way it goes, one thing from #611 is worth keeping either way: `find_post_by_path()` has the same base-path bug, so on a subpath install Micropub update and delete, and every inbound webmention, fail to resolve their target. That is moot if subdirectories stay unsupported, but it is the same root cause wearing a different hat.

## Checks

- 3 new unit tests, written failing first.
- PHPStan clean, phpcs clean.
- The suite's 21 errors / 7 failures are the pre-existing #595 deprecation baseline, byte-identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYmuANUvADwwYmg2AbgZoQ