### PR TITLE
Release 0.13.0-rc1 (image scan fix)

### DIFF
--- a/.docker/Dockerfile.release
+++ b/.docker/Dockerfile.release
@@ -16,6 +16,13 @@ LABEL org.opencontainers.image.source="https://github.com/svandragt/lamb"
 # gd powers WebP upload conversion
 RUN install-php-extensions gettext pdo_mysql gd
 
+# The base image ships a C/C++ toolchain so install-php-extensions can compile;
+# nothing needs it once the extensions are built. Dropping it also drops
+# linux-libc-dev, whose kernel CVEs blocked every release scan — the container
+# runs the host's kernel, so those headers were never the thing at risk.
+RUN apt-get purge -y --auto-remove linux-libc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 # Images are converted to WebP and resized server-side, so large photo

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,23 @@
+# Advisories the release image scan (.github/workflows/release-artifacts.yml)
+# should not block on. Keep this list short and dated: every entry is a CVE
+# nobody has fixed for us yet, not a CVE that stopped mattering.
+#
+# Both entries below are Go modules linked into the FrankenPHP binary that ships
+# in the base image. Lamb cannot patch them — they go away when FrankenPHP
+# rebuilds against newer dependencies. Neither is reachable through the Caddyfile
+# Lamb ships (.docker/Caddyfile.release): it serves static files and PHP, and
+# turns on no OpenAPI validation, no gRPC, and no xDS.
+#
+# Re-check on each release: drop the line, re-run the scan, and if it passes the
+# base image has caught up.
+
+# ponytail: suppression, not a fix — remove once dunglas/frankenphp:php8.4 ships
+# kin-openapi >= 0.144.0 and grpc >= 1.82.1.
+
+# kin-openapi ValidationHandler.Load() fail-open authentication bypass.
+# Added 2026-08-16, seen in frankenphp's kin-openapi v0.140.0.
+GHSA-r277-6w6q-xmqw
+
+# gRPC-Go xDS RBAC and HTTP/2 vulnerabilities.
+# Added 2026-08-16, seen in frankenphp's grpc v1.81.1.
+GHSA-hrxh-6v49-42gf


### PR DESCRIPTION
Promote main to release so 0.13.0-rc1 can be re-tagged with a Docker image that builds.

The first promotion (#614) tagged 0.13.0-rc1 fine, but the `Release artifacts` Trivy gate failed and no image reached ghcr.io. #615 fixes the scan. After this merges the tag moves to the new release tip and the artifacts workflow re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CeZkmJnKHa8tgLV6X9xJcj