### PR TITLE
Trim the Trivy suppression comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,8 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: '0'
+          # Trivy auto-discovers only a plain .trivyignore, so drop this line
+          # and every suppression in the YAML file silently stops applying.
           trivyignores: .trivyignore.yaml
 
   # Browser end-to-end suite. Only runs when e2e-relevant files change

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -93,6 +93,8 @@ jobs:
           image-ref: ghcr.io/${{ github.repository }}:${{ env.TAG }}
           severity: HIGH,CRITICAL
           ignore-unfixed: true
+          # Trivy auto-discovers only a plain .trivyignore, so drop this line
+          # and every suppression in the YAML file silently stops applying.
           trivyignores: .trivyignore.yaml
           exit-code: '1'
 

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,38 +1,19 @@
-# Advisories the image scans should not block on, with the date each
-# suppression stops applying. Trivy drops an entry once `expired_at` passes, so
-# the scan fails again and someone has to look — a parked CVE cannot quietly
-# become permanent.
-#
-# Read by both scans via the action's `trivyignores` input:
-#   .github/workflows/ci.yml              (advisory, does not block a PR)
-#   .github/workflows/release-artifacts.yml  (blocks the image push)
-#
-# Trivy only auto-discovers the plain-text `.trivyignore`, never this file, so
-# an entry added here without the `trivyignores` input does nothing.
-#
-# When an entry expires: rebuild the image and re-run the scan without the
-# entry. If it passes, the base image has caught up — delete the lines. If not,
-# push the date out and say what still blocks it.
+# Advisories the image scans must not block on, each with the date its
+# suppression lapses. Trivy reads this file only when a scan names it in
+# `trivyignores`; see AGENTS.md for what to do when an entry expires.
 
 vulnerabilities:
-  # Both are Go modules linked into the FrankenPHP binary that ships in
-  # dunglas/frankenphp:php8.4. Lamb cannot patch them; they clear when
-  # FrankenPHP rebuilds against newer dependencies. Neither is reachable
-  # through .docker/Caddyfile.release, which serves static files and PHP and
-  # turns on no OpenAPI validation, no gRPC and no xDS.
-
-  # ponytail: suppression, not a fix — drop once the base image ships
-  # kin-openapi >= 0.144.0 and grpc >= 1.82.1.
-
   - id: GHSA-r277-6w6q-xmqw
     statement: >-
-      kin-openapi ValidationHandler.Load() fail-open authentication bypass,
-      in frankenphp's kin-openapi v0.140.0. Lamb's Caddyfile enables no
-      OpenAPI validation, so the handler is never constructed.
+      kin-openapi ValidationHandler.Load() fail-open authentication bypass, in
+      frankenphp's kin-openapi v0.140.0. Lamb's Caddyfile enables no OpenAPI
+      validation, so the handler is never constructed. Clears when the base
+      image ships kin-openapi 0.144.0 or newer.
     expired_at: 2026-10-15
 
   - id: GHSA-hrxh-6v49-42gf
     statement: >-
       gRPC-Go xDS RBAC and HTTP/2 vulnerabilities, in frankenphp's grpc
-      v1.81.1. Lamb's Caddyfile enables no gRPC or xDS listeners.
+      v1.81.1. Lamb's Caddyfile enables no gRPC or xDS listeners. Clears when
+      the base image ships grpc 1.82.1 or newer.
     expired_at: 2026-10-15

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,10 +69,16 @@ Dependabot (`.github/dependabot.yml`) watches all five ecosystems weekly —
 composer, npm, github-actions, docker, devcontainers — and
 `dependabot-auto-merge.yml` merges patch and minor bumps once CI is green.
 Vulnerabilities are caught by `composer audit` (quality job), `pnpm audit`
-(js-test job), and a Trivy scan of the release image before it is pushed. An
-advisory in the base image that Lamb cannot patch goes in `.trivyignore.yaml`
-with an `expired_at` date, so the suppression lapses on its own and the scan
-asks again — see the file for what to do when one expires.
+(js-test job), and a Trivy scan of the release image before it is pushed.
+
+An advisory in the base image that Lamb cannot patch goes in
+`.trivyignore.yaml` with an `expired_at` date, so the suppression lapses on its
+own and the scan asks again. When one expires, rebuild the release image and
+scan it with the entry removed. If the scan passes, the base image has caught
+up — delete the entry. If it still fails, push the date out and say in the
+`statement` what is still blocking it. Both scans have to name the file in the
+action's `trivyignores` input: Trivy auto-discovers only a plain-text
+`.trivyignore`, so an entry it is not pointed at does nothing.
 
 Two things that automation deliberately does **not** handle, so they need a
 human:


### PR DESCRIPTION
`.trivyignore.yaml` carries three lines of comment: what the file is, that Trivy reads it only when a scan names it, and a pointer to `AGENTS.md`. Each entry's own `statement` field carries the rest — why the advisory cannot reach Lamb, and the version that clears it.

The expiry runbook lives in the `Dependencies` section of `AGENTS.md`: rebuild, re-scan without the entry, delete it if the scan passes, push the date out and record what still blocks it if not.

Both workflows now warn, above the `trivyignores` input, that removing the line disables every suppression in the file. That is the one thing a future editor cannot see from where they are standing, and it was previously stated only in the file they would not be reading.

## Verified

Scanned `ghcr.io/svandragt/lamb:0.13.0-rc1` with the settings the release workflow uses: all three targets clean, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CeZkmJnKHa8tgLV6X9xJcj