### PR TITLE
Ignore local agent tooling and scratch paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ node_modules/
 
 # Local runtime data (db is covered by *.db above)
 /data/sessions/
+
+# Local agent tooling and scratch
+/.agents/
+/.calibrate/
+/.workshop.lock
+/tmp/


### PR DESCRIPTION
Adds `.agents/`, `.calibrate/`, `.workshop.lock` and `tmp/` to `.gitignore`. These are local agent tooling and scratch state that kept showing up as untracked noise in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LLKgGyXqqhBbdbShiA9hr