### PR TITLE
Bug sweep: fifteen silent failures

### DIFF
--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -63,6 +63,8 @@ Editing the `slug:` line (or the title, when no explicit slug is set) reslugs th
 
 Slugs are unique. If a slug is already taken by another post (or matches a built-in route like `/search`), Lamb appends the post's id to keep the URL distinct, and writes the final slug back into the post's front-matter so you can see — and edit — the slug the post is actually served under.
 
+A slug is a single URL segment: Lamb serves posts at `/<slug>`, so a slash in a slug is turned into a hyphen (`archive/2024` becomes `archive-2024`). Spaces and non-ASCII characters are fine — `slug: café` is served at `/café`, which your browser sends (and Lamb reads) percent-encoded.
+
 You can also set a `created:` date in the front-matter. A future date schedules the post — see [Scheduling]({{ site.baseurl }}{% link scheduling.md %}).
 
 By default Lamb derives a post's description from its first line. Set a `summary:` in the front-matter to write that description yourself — it is used for the post's [social-embed]({{ site.baseurl }}{% link social-embeds.md %}) description (the OpenGraph/Twitter `description` tag) and its feed summary. `description:` works as an alias.

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -29,6 +29,8 @@ Write GitHub-style task lists with `- [ ]` for an open item and `- [x]` for a do
 - [x] walk the dog
 ```
 
+A numbered list (`1. [ ] …`) works too, as does a marker with no list bullet at all (`[ ] buy milk` on its own line). A marker inside a code block stays code, so you can write about task lists without turning them into checkboxes.
+
 These render as real checkboxes. When you are logged in the checkboxes are interactive: tick or untick one straight on the page and Lamb saves it as an edit, rewriting the `[ ]`/`[x]` in the post source for you. Visitors see the checkboxes as read-only.
 
 ## Page

--- a/src/LambDown.php
+++ b/src/LambDown.php
@@ -14,6 +14,14 @@ class LambDown extends Parsedown
     private $imageSizeResolver = null;
 
     /**
+     * The checked state of each checkbox the last text() call rendered, in
+     * document order.
+     *
+     * @var list<bool>
+     */
+    private array $checkboxStates = [];
+
+    /**
      * Registers the GitHub-style task-list checkbox block.
      *
      * Internalised from leblanc-simon/parsedown-checkbox (which targets
@@ -40,14 +48,33 @@ class LambDown extends Parsedown
     {
         $html = parent::text($text);
 
+        $this->checkboxStates = [];
         $index = 0;
         return preg_replace_callback(
-            '/<input type="checkbox"/',
-            static function (array $m) use (&$index): string {
-                return $m[0] . ' data-checkbox-index="' . $index++ . '"';
+            '/<input type="checkbox"( checked)?/',
+            function (array $m) use (&$index): string {
+                $checked = $m[1] ?? '';
+                $this->checkboxStates[] = $checked !== '';
+                return '<input type="checkbox" data-checkbox-index="' . $index++ . '"' . $checked;
             },
             $html
         ) ?? $html;
+    }
+
+    /**
+     * The checked state of every checkbox the last text() call rendered, in the
+     * same order as their `data-checkbox-index` values.
+     *
+     * Recorded by the renderer itself so callers that need to map a rendered
+     * checkbox back to the source (the task-list toggle endpoint) can check
+     * their own reading of the Markdown against what was actually rendered,
+     * rather than re-deriving it from the HTML.
+     *
+     * @return list<bool>
+     */
+    public function renderedCheckboxStates(): array
+    {
+        return $this->checkboxStates;
     }
 
     /**

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -37,6 +37,28 @@ function load_dotenv(string $root): void
 }
 
 /**
+ * The directory holding this install's mutable state: the SQLite database, the
+ * session files, the SimplePie cache and the /_cron lock.
+ *
+ * `LAMB_DATA_DIR` moves all of it (the release-verify workflow and the
+ * acceptance suite both do), so anything writing under `data/` has to ask here
+ * rather than hardcode the default. A hardcoded `../data` was how the /_cron
+ * lock ended up in a directory that, on an install with LAMB_DATA_DIR set, does
+ * not exist at all — the lock could never be opened, and every run reported
+ * "Already running" forever.
+ *
+ * The default is relative to the web root, which is the working directory of a
+ * request (php-fpm and `php -S -t src` both chdir there). CLI entry points pass
+ * their own absolute path.
+ *
+ * @return string The data directory path.
+ */
+function data_dir(): string
+{
+    return getenv('LAMB_DATA_DIR') ?: '../data';
+}
+
+/**
  * Initializes the database by configuring the SQLite connection and setting up the writer cache.
  *
  * @param string $data_dir The directory path where the database file will be stored.

--- a/src/config.php
+++ b/src/config.php
@@ -514,6 +514,10 @@ function get_ini_text(): string
  */
 function save_ini_text(string $ini_text): void
 {
+    // Valid UTF-8, like a post body (see Lamb\normalize_utf8): a stray byte
+    // pasted into a setting reaches json_encode() through the JSON feed and the
+    // export manifest, and json_encode() refuses the whole document over it.
+    $ini_text = \Lamb\normalize_utf8($ini_text);
     $option = get_option('site_config_ini', '');
     // Stamp the edit time so conditional-GET validators invalidate cached pages
     // immediately on a settings change (see Response\latest_content_timestamp).

--- a/src/export.php
+++ b/src/export.php
@@ -299,9 +299,14 @@ function build_export_archive(
     sort($assets);
 
     $manifest = build_manifest($entries, $assets, $exported_at, $site);
+    // JSON_INVALID_UTF8_SUBSTITUTE: one stray byte in a slug or the site title
+    // used to abort the whole export with "Malformed UTF-8 characters", leaving
+    // the author unable to back up at all. Post bodies are stored as raw files
+    // in the archive, so they are unaffected either way.
     $json = json_encode(
         $manifest,
-        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR
     );
     $zip->addFromString('manifest.json', $json . "\n");
 

--- a/src/http.php
+++ b/src/http.php
@@ -124,6 +124,35 @@ function request_root_url(array $server): ?string
 }
 
 /**
+ * Reads a request value as a string, or null when it carries none.
+ *
+ * Every superglobal is attacker-shaped: `?s=x` arrives as a string, `?s[]=x` as
+ * an array, and the same is true of every POST field and cookie. PHP 8 turns
+ * that mismatch into an uncaught TypeError at the first string-typed sink, so a
+ * single bracket in a query string was a 500 any visitor could ask for —
+ * including one that told them a hidden post exists, since the crash only
+ * happened on the branch that checks a preview token.
+ *
+ * An array or object is reported as absent rather than coerced: "Array" is not
+ * a search term, a password, or a preview token, and every caller already has a
+ * sensible answer for "not supplied".
+ *
+ * @param mixed $value The raw superglobal value (e.g. `$_GET['s'] ?? null`).
+ * @return string|null The value as text, or null when it has none.
+ */
+function request_string(mixed $value): ?string
+{
+    if (is_string($value)) {
+        return $value;
+    }
+    if (is_int($value) || is_float($value)) {
+        return (string) $value;
+    }
+
+    return null;
+}
+
+/**
  * Sanitises a value bound for a `Location:` header.
  *
  * Any request-derived value interpolated into a redirect target (the request

--- a/src/import.php
+++ b/src/import.php
@@ -708,6 +708,10 @@ function prepare_imported_html(string $html, string $created, callable $download
  */
 function store_redirect(string $from, string $to): void
 {
+    // The key is matched against the *decoded* request path (the router decodes
+    // before looking a redirect up), while an imported path arrives encoded as
+    // the source site wrote it.
+    $from = rawurldecode($from);
     $redirect = R::findOneOrDispense('redirect', ' from_slug = ? ', [$from]);
     $redirect->from_slug = $from;
     $redirect->to_url = $to;

--- a/src/index.php
+++ b/src/index.php
@@ -9,7 +9,7 @@ define('ROOT_DIR', __DIR__);
 
 require '../vendor/autoload.php';
 
-$data_dir = getenv('LAMB_DATA_DIR') ?: '../data';
+$data_dir = Bootstrap\data_dir();
 Bootstrap\bootstrap_db($data_dir);
 Bootstrap\bootstrap_session($data_dir);
 

--- a/src/index.php
+++ b/src/index.php
@@ -87,7 +87,12 @@ $sublookup = strtok('/');
 
 $request_uri_with_query = $_SERVER['REQUEST_URI'] ?? '';
 
-$redirect_path = trim((string) $request_uri, '/');
+# Lookups against stored slugs and redirect keys run on the decoded path: the
+# request arrives percent-encoded, while a slug is stored as the author wrote it
+# (`café`, `my post`). Matching the two without decoding meant such a post 404ed
+# at the very permalink every link on the site — and its own feed entry — points
+# at. Route names are matched on the raw segment, as before.
+$redirect_path = rawurldecode(trim((string) $request_uri, '/'));
 if (str_contains($redirect_path, '/')) {
     $redirect_url = find_redirect($redirect_path);
     if ($redirect_url !== null) {
@@ -105,11 +110,14 @@ if (Response\should_noindex($action, $_GET)) {
 }
 
 $template = $action;
-if (post_has_slug($action) === $action) {
-    Route\register_route($action, __NAMESPACE__ . '\\Response\respond_post', $action);
+# Empty when the request has no first segment at all (e.g. `//`), which must not
+# be looked up: every status post has an empty slug, so it would match one.
+$slug_lookup = is_string($action) ? rawurldecode($action) : '';
+if ($slug_lookup !== '' && post_has_slug($slug_lookup) !== null) {
+    Route\register_route($action, __NAMESPACE__ . '\\Response\respond_post', $slug_lookup);
     $template = 'status';
 } elseif ($action !== false && !Route\is_reserved_route($action)) {
-    $redirect_url = find_redirect($action);
+    $redirect_url = find_redirect($slug_lookup);
     if ($redirect_url !== null) {
         header('Location: ' . Http\sanitize_location($redirect_url), true, 301);
         exit;

--- a/src/known.php
+++ b/src/known.php
@@ -132,7 +132,10 @@ function extract_items(SimpleXMLElement $rss): array
             $path = parse_url($link, PHP_URL_PATH);
             if (is_string($path) && trim($path, '/') !== '') {
                 $segments = explode('/', trim($path, '/'));
-                $slug = (string) end($segments);
+                // Decoded: the slug column holds the text, and permalink_path()
+                // re-encodes it for the URL. Keeping the encoded form would
+                // double-encode the imported post's permalink.
+                $slug = rawurldecode((string) end($segments));
             }
         } else {
             $bookmark_url = $link;

--- a/src/known.php
+++ b/src/known.php
@@ -380,14 +380,18 @@ function import_item(array $item, callable $downloader, bool $dry_run = false, ?
  */
 function store_source_redirects(array $item, OODBBean $bean): void
 {
-    $to = $bean->slug ? '/' . $bean->slug : '/status/' . $bean->id;
+    $to = \Lamb\permalink_path($bean);
+    // store_redirect() keys on the decoded path; compare in the same space so a
+    // source path that merely differs by encoding is still recognised as the
+    // post's own new URL (and skipped) rather than stored as a self-redirect.
+    $to_slug = rawurldecode(ltrim($to, '/'));
 
     $bookmark_url = trim((string) ($item['bookmark_url'] ?? ''));
     if ($bookmark_url === '') {
         $link_path = parse_url((string) ($item['link'] ?? ''), PHP_URL_PATH);
         if (is_string($link_path) && $link_path !== '') {
             $from = trim($link_path, '/');
-            if ($from !== '' && $from !== ltrim($to, '/')) {
+            if ($from !== '' && rawurldecode($from) !== $to_slug) {
                 store_redirect($from, $to);
             }
         }

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -805,7 +805,7 @@ function post_has_slug(string $lookup): string|null
     if ($post === null || $post->id === 0) {
         return null;
     }
-    if (!is_viewable($post) && !preview_token_valid($post, $_GET['preview'] ?? null)) {
+    if (!is_viewable($post) && !preview_token_valid($post, Http\request_string($_GET['preview'] ?? null))) {
         return null;
     }
 

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -916,7 +916,8 @@ function redirect_target_slug(string $to_url): ?string
     if (!str_starts_with($to_url, '/')) {
         return null;
     }
-    $slug = ltrim($to_url, '/');
+    // Stored encoded (permalink_path()); slugs and from_slug values are not.
+    $slug = rawurldecode(ltrim($to_url, '/'));
     if ($slug === '' || str_contains($slug, '/')) {
         return null;
     }

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -112,17 +112,31 @@ function parse_tags(string $html): string
  * Counterpart of get_tags(): used by Micropub category `add` updates, where
  * categories live in the body as hashtags rather than in a column.
  *
+ * "Already carries" is case-insensitive, and a tag repeated in $tags is added
+ * once: `#PHP` and `#php` are one tag everywhere else (the link parse_tags()
+ * writes, the lookup posts_by_tag() runs), so appending the other spelling
+ * just prints the same tag twice.
+ *
  * @param string       $body The raw post body.
  * @param list<string> $tags Tag names (without `#`).
  * @return string The body with missing tags appended.
  */
 function add_body_tags(string $body, array $tags): string
 {
-    $to_add = array_diff($tags, get_tags($body));
-    if (empty($to_add)) {
+    $present = array_map('mb_strtolower', get_tags($body));
+    $to_add = [];
+    foreach ($tags as $tag) {
+        $key = mb_strtolower($tag);
+        if ($tag === '' || in_array($key, $present, true)) {
+            continue;
+        }
+        $present[] = $key;
+        $to_add[] = $tag;
+    }
+    if ($to_add === []) {
         return $body;
     }
-    $hashtags = implode(' ', array_map(fn($tag) => '#' . $tag, $to_add));
+    $hashtags = implode(' ', array_map(fn(string $tag): string => '#' . $tag, $to_add));
 
     return rtrim($body) . ' ' . $hashtags;
 }

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -158,6 +158,23 @@ function remove_body_tags(string $body, array $tags): string
 }
 
 /**
+ * Escapes the wildcards in a value that is about to be embedded in a SQL `LIKE`
+ * pattern. The query that uses it must say `ESCAPE '\'`.
+ *
+ * `%` and `_` are wildcards, so a search for "100%" matched every post and one
+ * for "a_pha" matched "alpha" — the visitor's literal text has to stay literal.
+ * The escape character itself is escaped first, or a trailing backslash in the
+ * search term would escape the closing wildcard instead of itself.
+ *
+ * @param string $value The literal text to match.
+ * @return string The text with LIKE wildcards escaped.
+ */
+function like_escape(string $value): string
+{
+    return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $value);
+}
+
+/**
  * The root-relative URL path a post is served at: `/<slug>`, or `/status/<id>`
  * for a slug-less status post.
  *

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -158,6 +158,36 @@ function remove_body_tags(string $body, array $tags): string
 }
 
 /**
+ * Repairs a body that is not valid UTF-8.
+ *
+ * Everything downstream assumes UTF-8, and the failure is silent rather than
+ * loud: htmlspecialchars() (inside Parsedown, and inside escape()) returns an
+ * empty string for input it cannot decode, so one stray byte rendered the whole
+ * paragraph containing it as `<p></p>` — the text was still in the `body`
+ * column, but the post, its description, its feed entry and its search text
+ * were blank. Symfony's YAML parser refuses such a block outright, so the front
+ * matter went with it.
+ *
+ * A body that is already valid UTF-8 is returned untouched. Otherwise it is
+ * read as Windows-1252, which is where a stray byte almost always comes from
+ * (a Latin-1 feed, a smart quote pasted from a word processor) and which maps
+ * every byte value, so the result is always valid UTF-8. That turns a blank
+ * post into a readable one, and a genuinely different encoding into visible
+ * mojibake the author can see and fix rather than silent emptiness.
+ *
+ * @param string $text The raw post body.
+ * @return string The body as valid UTF-8.
+ */
+function normalize_utf8(string $text): string
+{
+    if ($text === '' || mb_check_encoding($text, 'UTF-8')) {
+        return $text;
+    }
+
+    return mb_convert_encoding($text, 'UTF-8', 'Windows-1252');
+}
+
+/**
  * Escapes the wildcards in a value that is about to be embedded in a SQL `LIKE`
  * pattern. The query that uses it must say `ESCAPE '\'`.
  *
@@ -308,6 +338,11 @@ function absolute_url(string $url, ?string $base = null): string
  */
 function parse_bean(OODBBean $bean): void
 {
+    // Repair a body that is not valid UTF-8 first: every step below (the YAML
+    // parser, Parsedown's escaping) treats such a body as empty rather than
+    // reporting it.
+    $bean->body = normalize_utf8((string) $bean->body);
+
     // Restore an iOS Smart-Punctuation front-matter fence (e.g. a single em
     // dash for a typed `---`) before parsing, and persist the normalised body.
     // This is the single choke point every save path runs through — web

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -184,7 +184,9 @@ function normalize_utf8(string $text): string
         return $text;
     }
 
-    return mb_convert_encoding($text, 'UTF-8', 'Windows-1252');
+    $converted = mb_convert_encoding($text, 'UTF-8', 'Windows-1252');
+
+    return is_string($converted) ? $converted : $text;
 }
 
 /**

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -158,6 +158,61 @@ function remove_body_tags(string $body, array $tags): string
 }
 
 /**
+ * The root-relative URL path a post is served at: `/<slug>`, or `/status/<id>`
+ * for a slug-less status post.
+ *
+ * The slug is percent-encoded where a path needs it (see
+ * encode_path_segment()). It is stored as the author wrote it — an explicit
+ * front-matter `slug:` can carry a space or a non-ASCII character — and a path
+ * is not a place to put those raw: the router decodes the request before
+ * matching a slug, so the encoded form is the one that round-trips.
+ *
+ * @param OODBBean $bean The post. It should have the 'slug' and 'id' properties.
+ * @return string The post's URL path.
+ */
+function permalink_path(OODBBean $bean): string
+{
+    if ($bean->slug) {
+        return '/' . encode_path_segment((string) $bean->slug);
+    }
+
+    return '/status/' . $bean->id;
+}
+
+/**
+ * Percent-encodes a string for use as a single URL path segment.
+ *
+ * rawurlencode() over-encodes for this: RFC 3986 lets a path segment carry the
+ * sub-delimiters (`&`, `+`, `,`, `=`, …) plus `:` and `@` verbatim, and those
+ * already resolve today. A post's permalink is also its Atom entry id, so
+ * re-encoding a character that never needed it would show every subscriber the
+ * post again as new. They are put back, leaving exactly what a path cannot hold
+ * encoded: whitespace, `?`, `#`, `%`, the brackets, the slashes, and anything
+ * non-ASCII.
+ *
+ * @param string $segment The raw segment text (e.g. a slug).
+ * @return string The segment, safe to place in a URL path.
+ */
+function encode_path_segment(string $segment): string
+{
+    return strtr(rawurlencode($segment), [
+        '%21' => '!',
+        '%24' => '$',
+        '%26' => '&',
+        '%27' => "'",
+        '%28' => '(',
+        '%29' => ')',
+        '%2A' => '*',
+        '%2B' => '+',
+        '%2C' => ',',
+        '%3A' => ':',
+        '%3B' => ';',
+        '%3D' => '=',
+        '%40' => '@',
+    ]);
+}
+
+/**
  * Generates a permalink for the given item.
  *
  * This method creates a permalink for the given item based on its slug or ID.
@@ -171,11 +226,7 @@ function remove_body_tags(string $body, array $tags): string
  */
 function permalink(OODBBean $bean): string
 {
-    if ($bean->slug) {
-        return ROOT_URL . "/$bean->slug";
-    }
-
-    return ROOT_URL . '/status/' . $bean->id;
+    return ROOT_URL . permalink_path($bean);
 }
 
 /**
@@ -779,7 +830,9 @@ function find_post_by_path(string $path): ?OODBBean
         return $bean->id ? $bean : null;
     }
 
-    $slug = trim($path, '/');
+    // The path comes from a URL, so its slug is percent-encoded (permalink_path()
+    // encodes it); the column holds the decoded text.
+    $slug = rawurldecode(trim($path, '/'));
     if ($slug !== '') {
         return R::findOne('post', ' slug = ? ', [$slug]);
     }

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -184,9 +184,7 @@ function normalize_utf8(string $text): string
         return $text;
     }
 
-    $converted = mb_convert_encoding($text, 'UTF-8', 'Windows-1252');
-
-    return is_string($converted) ? $converted : $text;
+    return mb_convert_encoding($text, 'UTF-8', 'Windows-1252');
 }
 
 /**

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1097,7 +1097,7 @@ function mp_log_path(): string
     if (!empty($GLOBALS['lamb_mp_log_path'])) {
         return (string) $GLOBALS['lamb_mp_log_path'];
     }
-    return ROOT_DIR . '/../data/micropub.log';
+    return \Lamb\Bootstrap\data_dir() . '/micropub.log';
 }
 
 /**

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -550,7 +550,7 @@ class LambMicropubAdapter extends MicropubAdapter
     private function applyAdd(OODBBean $bean, string $property, array $values): bool
     {
         if ($property === 'category') {
-            $bean->body = add_body_tags($bean->body ?? '', array_map('strval', $values));
+            $bean->body = add_body_tags($bean->body ?? '', self::textValues($values));
             return true;
         }
 
@@ -628,7 +628,7 @@ class LambMicropubAdapter extends MicropubAdapter
     private function applyDeleteValues(OODBBean $bean, string $property, array $values): bool
     {
         if ($property === 'category') {
-            $bean->body = remove_body_tags($bean->body ?? '', array_map('strval', $values));
+            $bean->body = remove_body_tags($bean->body ?? '', self::textValues($values));
             return true;
         }
 
@@ -670,7 +670,7 @@ class LambMicropubAdapter extends MicropubAdapter
             // set, so the hashtags already on the body go first.
             $bean->body = add_body_tags(
                 strip_trailing_body_tags($bean->body ?? ''),
-                array_map('strval', $values)
+                self::textValues($values)
             );
             return true;
         }
@@ -1018,20 +1018,25 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     private function buildPhotos(array $photos): string
     {
-        if (empty($photos)) {
-            return '';
-        }
-
-        return implode("\n", array_map(function ($photo) {
+        $markdown = [];
+        foreach ($photos as $photo) {
             if (is_array($photo)) {
-                $url = $photo['value'] ?? '';
-                $alt = $photo['alt'] ?? '';
+                $url = matter_string($photo['value'] ?? null);
+                $alt = matter_string($photo['alt'] ?? null) ?? '';
             } else {
-                $url = $photo;
+                $url = matter_string($photo);
                 $alt = '';
             }
-            return '![' . $alt . '](' . $url . ')';
-        }, $photos));
+            // A photo with no usable URL is dropped rather than written as
+            // `![](Array)`: the value has no faithful text, and an image link
+            // to it is worse than no image link.
+            if ($url === null || trim($url) === '') {
+                continue;
+            }
+            $markdown[] = '![' . $alt . '](' . $url . ')';
+        }
+
+        return implode("\n", $markdown);
     }
 
     /**
@@ -1042,11 +1047,36 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     private function buildTags(array $categories): string
     {
-        if (empty($categories)) {
-            return '';
+        $tags = self::textValues($categories);
+
+        return $tags === [] ? '' : implode(' ', array_map(fn(string $c) => '#' . $c, $tags));
+    }
+
+    /**
+     * The text values of a Micropub property, dropping anything with no
+     * faithful textual form.
+     *
+     * Microformats properties are arrays of values, and a value is not
+     * necessarily a string. Casting one with (string) or strval() stored the
+     * literal "Array" — as a hashtag, as an image URL — and raised an
+     * "Array to string conversion" warning on the way. matter_string() applies
+     * the same rule front matter already uses: a list collapses to its first
+     * entry, and anything else with no text is absent.
+     *
+     * @param list<mixed> $values
+     * @return list<string>
+     */
+    private static function textValues(array $values): array
+    {
+        $texts = [];
+        foreach ($values as $value) {
+            $text = matter_string($value);
+            if ($text !== null && trim($text) !== '') {
+                $texts[] = $text;
+            }
         }
 
-        return implode(' ', array_map(fn($c) => '#' . $c, $categories));
+        return $texts;
     }
 }
 

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1063,7 +1063,7 @@ class LambMicropubAdapter extends MicropubAdapter
      * the same rule front matter already uses: a list collapses to its first
      * entry, and anything else with no text is absent.
      *
-     * @param list<mixed> $values
+     * @param array<array-key, mixed> $values
      * @return list<string>
      */
     private static function textValues(array $values): array

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1376,7 +1376,7 @@ function respond_micropub_media(): void
         micropub_error(400, 'invalid_request', 'File upload failed.');
     }
 
-    $ext = \Lamb\Response\safe_upload_extension($file['name'] ?? '');
+    $ext = \Lamb\Response\safe_upload_extension(\Lamb\Http\request_string($file['name'] ?? null) ?? '');
     if ($ext === null) {
         micropub_error(400, 'invalid_request', 'Unsupported file type.');
     }
@@ -1389,7 +1389,7 @@ function respond_micropub_media(): void
 
     $sub_path  = \Lamb\Response\upload_subpath();
     $uploadDir = \Lamb\Response\get_upload_dir($sub_path);
-    $seed      = sha1(($file['name'] ?? '') . uniqid('', true));
+    $seed      = sha1((\Lamb\Http\request_string($file['name'] ?? null) ?? '') . uniqid('', true));
 
     // Re-encode JPEG/PNG to WebP, falling back to the original bytes on failure.
     $filename = \Lamb\Response\store_webp_copy($file['tmp_name'], $ext, $uploadDir, $seed);

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -24,6 +24,7 @@ use function Lamb\remove_body_tags;
 use function Lamb\strip_trailing_body_tags;
 use function Lamb\Post\build_matter;
 use function Lamb\Post\finalize_and_store_post;
+use function Lamb\Post\finalize_slug;
 use function Lamb\Post\matter_string;
 use function Lamb\Post\normalize_frontmatter_fence;
 use function Lamb\Post\parse_matter;
@@ -488,6 +489,10 @@ class LambMicropubAdapter extends MicropubAdapter
             return $rejection;
         }
 
+        // Captured before any operation runs: whether this update *mints* a
+        // slug decides whether it is finalised below.
+        $slug_before = (string) ($bean->slug ?? '');
+
         foreach ($actions['replace'] ?? [] as $property => $values) {
             if (!is_array($values) || !array_is_list($values)) {
                 return 'invalid_request';
@@ -531,6 +536,20 @@ class LambMicropubAdapter extends MicropubAdapter
 
         parse_bean($bean);
         $bean->updated = \Lamb\now();
+        // An update can mint a slug where there was none: naming a titleless
+        // status post derives one from the title. Without finalize_slug() that
+        // slug skipped the uniqueness and reserved-route checks every other
+        // save path applies, so two posts could end up sharing a URL — one of
+        // them unreachable at its own permalink, with its feed entry pointing
+        // at the other's content.
+        //
+        // Only a freshly minted slug is finalised. A post that already had one
+        // keeps it untouched (pinSlug() writes it into the front matter before
+        // a rename): moving a live permalink — the URL the client just used to
+        // address the post — is worse than leaving a pre-existing duplicate be.
+        if ($slug_before === '') {
+            finalize_slug($bean);
+        }
         R::store($bean);
 
         notify_post_subscribers($bean);

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -815,10 +815,11 @@ class LambMicropubAdapter extends MicropubAdapter
         $currentBody = (string) ($bean->body ?? '');
         [$yaml] = split_frontmatter(normalize_frontmatter_fence($currentBody));
 
-        $tags       = get_tags($currentBody);
-        $hashtagStr = empty($tags) ? '' : ' ' . implode(' ', array_map(fn($t) => '#' . $t, $tags));
-
-        $content = $newContent . $hashtagStr;
+        // add_body_tags() rather than appending the old body's tags outright:
+        // a tag the replacement content already carries must not be appended a
+        // second time, or every content update grows the trailing run
+        // (`goodbye #php #php`).
+        $content = add_body_tags($newContent, get_tags($currentBody));
 
         return $yaml === '' ? $content : "---\n" . $yaml . "\n---\n" . $content;
     }

--- a/src/network.php
+++ b/src/network.php
@@ -114,6 +114,10 @@ function webmention_line(array $sent): string
     // webmention sends (no atomic claim on a queued row). Acquiring a
     // non-blocking exclusive lock first serializes overlapping runs instead.
     $lock = acquire_cron_lock();
+    if ($lock === false) {
+        http_response_code(500);
+        die('Cannot open the cron lock at ' . cron_lock_path() . ' — is the data directory writable?');
+    }
     if ($lock === null) {
         die('Already running, try again later.');
     }
@@ -152,6 +156,15 @@ function webmention_line(array $sent): string
 }
 
 /**
+ * The path of the lock file serializing /_cron runs. Lives in the install's
+ * data directory, wherever that is — see Bootstrap\data_dir().
+ */
+function cron_lock_path(): string
+{
+    return \Lamb\Bootstrap\data_dir() . '/cron.lock';
+}
+
+/**
  * Acquires an exclusive, non-blocking lock serializing /_cron runs.
  *
  * The returned handle must be kept referenced for the remainder of the
@@ -160,16 +173,22 @@ function webmention_line(array $sent): string
  * needed as long as the caller never returns normally before then (every
  * process_feeds() exit path terminates the request via die()/exit()).
  *
- * @param string $path Lock file path; created if absent.
- * @return resource|null The open lock-file handle, or null when the lock is
- *                        already held (another run is in progress) or the
- *                        lock file itself couldn't be opened.
+ * The two ways this can fail are kept apart. A lock file that cannot be opened
+ * at all is not another run in progress — it is a broken install, and reporting
+ * it as contention is what let a mislocated lock file silently stop every cron
+ * run (feeds, the webmention queue, the purge) while the endpoint kept
+ * answering "Already running, try again later."
+ *
+ * @param string|null $path Lock file path; defaults to cron_lock_path().
+ * @return resource|false|null The open lock-file handle; null when another run
+ *                             holds the lock; false when the lock file cannot
+ *                             be opened.
  */
-function acquire_cron_lock(string $path = '../data/cron.lock')
+function acquire_cron_lock(?string $path = null)
 {
-    $handle = @fopen($path, 'c');
+    $handle = @fopen($path ?? cron_lock_path(), 'c');
     if ($handle === false) {
-        return null;
+        return false;
     }
     if (!flock($handle, LOCK_EX | LOCK_NB)) {
         fclose($handle);

--- a/src/network/sources.php
+++ b/src/network/sources.php
@@ -141,7 +141,7 @@ function ensure_feed_cache(string $dir): string|false
 function configure_simplepie_feed(SimplePie $feed, string $url): void
 {
     $feed->get_registry()->register(SimplePieFile::class, SafeFile::class, true);
-    $cache_dir = ensure_feed_cache('../data/cache/simplepie');
+    $cache_dir = ensure_feed_cache(\Lamb\Bootstrap\data_dir() . '/cache/simplepie');
     if ($cache_dir === false) {
         $feed->enable_cache(false);
     } else {

--- a/src/post.php
+++ b/src/post.php
@@ -745,7 +745,7 @@ function checkbox_marker_offsets(string $body): array
         $blank = false;
 
         if (preg_match(TASK_MARKER_PATTERN, $line, $m, PREG_OFFSET_CAPTURE) === 1) {
-            $offsets[] = $position + $m[2][1];
+            $offsets[] = $position + (int) $m[2][1];
         }
 
         $position += $advance;

--- a/src/post.php
+++ b/src/post.php
@@ -253,24 +253,33 @@ function normalize_matter_values(array $matter): array
 }
 
 /**
- * Strips leading slashes/backslashes from an explicit front-matter `slug:`
- * value.
+ * Reduces an explicit front-matter `slug:` value to the single URL path
+ * segment a post is served under.
  *
- * An explicit slug (unlike a title-derived one, which goes through
- * slugify()) is stored verbatim and later feeds an automatic redirect's
- * `to_url` on a subsequent slug change (`'/' . $slug`, in redirect_edited()).
- * A slug beginning with `/` (or `\`, which some browsers normalise to `/` in
- * a URL) would make that concatenation a protocol-relative `//host/...` (or
- * `/\host/...`) URL — an open redirect off the site. Stripped rather than
- * rejected outright so a legitimate custom slug that merely has redundant
- * leading slashes still saves.
+ * An explicit slug (unlike a title-derived one, which goes through slugify())
+ * is stored close to verbatim, and two things then read it as a path:
+ *
+ * - It feeds an automatic redirect's `to_url` on a subsequent slug change
+ *   (`'/' . $slug`, in redirect_edited()). A slug beginning with `/` (or `\`,
+ *   which some browsers normalise to `/` in a URL) would make that
+ *   concatenation a protocol-relative `//host/...` (or `/\host/...`) URL — an
+ *   open redirect off the site. Hence the leading separators go first.
+ * - permalink() serves the post at `/<slug>`, and the router matches a post
+ *   against the request's *first* path segment. A slug with a separator inside
+ *   it (`archive/2024`) therefore names a URL that can never route back to the
+ *   post: it saves, every link on the site points at it, and it 404s. The
+ *   remaining separators become hyphens so the stored slug is the URL the post
+ *   actually answers on.
+ *
+ * Sanitised rather than rejected outright so a post with a stray slash in its
+ * slug still saves.
  *
  * @param string $slug
  * @return string
  */
 function sanitize_explicit_slug(string $slug): string
 {
-    return ltrim($slug, "/\\");
+    return str_replace(['/', '\\'], '-', ltrim($slug, "/\\"));
 }
 
 /**

--- a/src/post.php
+++ b/src/post.php
@@ -609,14 +609,171 @@ function finalize_and_store_post(OODBBean $bean): void
 }
 
 /**
+ * Matches a task-list marker the renderer turns into a checkbox: optional
+ * blockquote markers, an optional bullet or ordered list marker, then
+ * `[ ]`/`[x]`/`[X]` followed by whitespace and a non-empty label.
+ *
+ * Capture 2 is the state character, so its byte offset locates the single
+ * character a toggle rewrites.
+ */
+const TASK_MARKER_PATTERN = '/^([ \t]*(?:>[ \t]?)*[ \t]*(?:(?:[-*+]|\d{1,9}[.)])[ \t]+)?\[)([ xX])(\][ \t]+\S)/';
+
+/**
+ * Matches any list item line (task or not), used to track whether the scanner
+ * is inside a list — where an indented line is nested content rather than an
+ * indented code block.
+ */
+const LIST_ITEM_PATTERN = '/^[ \t]*(?:>[ \t]?)*[ \t]*(?:[-*+]|\d{1,9}[.)])[ \t]+/';
+
+/**
+ * Matches the opening line of a fenced code block, capturing the fence itself
+ * so a closing fence can be required to use the same character and be at least
+ * as long — the rule Parsedown applies, so a longer fence can quote a shorter
+ * one inside it.
+ */
+const CODE_FENCE_PATTERN = '/^[ \t]*(?:>[ \t]?)*[ \t]*(`{3,}|~{3,})/';
+
+/**
+ * The width of a line's leading indentation, with tabs expanded to the next
+ * multiple of four (the tab stop Markdown's four-space code indent assumes).
+ *
+ * @param string $line A single source line.
+ * @return int The indentation width in columns.
+ */
+function indent_width(string $line): int
+{
+    $width = 0;
+    for ($i = 0, $len = strlen($line); $i < $len; $i++) {
+        if ($line[$i] === ' ') {
+            $width++;
+        } elseif ($line[$i] === "\t") {
+            $width += 4 - ($width % 4);
+        } else {
+            break;
+        }
+    }
+
+    return $width;
+}
+
+/**
+ * The byte offsets, within $body, of the state character of every task marker
+ * the renderer turns into a checkbox — in the order the checkboxes appear.
+ *
+ * The toggle endpoint addresses a checkbox by its rendered position
+ * (`data-checkbox-index`, numbered in document order by LambDown::text()), so
+ * this has to recognise a marker exactly where the renderer does, or a click
+ * flips somebody else's box. That means mirroring LambDown/Parsedown, not just
+ * matching `- [ ] ` lines:
+ *
+ * - a marker needs no list bullet at all (`[ ] task` is a checkbox block on its
+ *   own, which is why LambDown registers one), and an ordered bullet
+ *   (`1. [ ] task`) counts as much as `-`/`*`/`+`;
+ * - blockquoted markers render too, which every feed-ingested post is made of
+ *   (Network\attributed_content() quotes the source with `> `);
+ * - a marker inside a fenced or indented code block renders as code, not a
+ *   checkbox, so it must not be counted;
+ * - a marker with no label after it (`- [ ] `) is not a checkbox either;
+ * - front matter is not rendered at all, so markers there are invisible.
+ *
+ * @param string $body The raw post body (front matter included).
+ * @return list<int> Byte offsets of each rendered marker's state character.
+ */
+function checkbox_marker_offsets(string $body): array
+{
+    [, $content] = split_frontmatter($body);
+    $position = strlen($body) - strlen($content);
+
+    $offsets = [];
+    /** @var string|null $fence The opening fence (e.g. '```') while inside a code block. */
+    $fence   = null;
+    $in_list = false;
+    $blank   = true;
+
+    foreach (preg_split('/(\R)/', $content, -1, PREG_SPLIT_DELIM_CAPTURE) ?: [] as $index => $piece) {
+        // Odd indices are the captured line endings.
+        if ($index % 2 === 1) {
+            $position += strlen($piece);
+            continue;
+        }
+
+        $line = $piece;
+        $advance = strlen($line);
+
+        if ($fence !== null) {
+            $closing = '/^[ \t]*(?:>[ \t]?)*[ \t]*' . $fence[0] . '{' . strlen($fence) . ',}[ \t]*$/';
+            if (preg_match($closing, $line) === 1) {
+                $fence = null;
+            }
+            $position += $advance;
+            continue;
+        }
+        if (trim($line) === '') {
+            $blank = true;
+            $position += $advance;
+            continue;
+        }
+        // An indented code block, but only outside a list: inside one the same
+        // indentation marks nested list content, which does render checkboxes.
+        if (indent_width($line) >= 4 && !$in_list) {
+            $blank = false;
+            $position += $advance;
+            continue;
+        }
+        if (preg_match(CODE_FENCE_PATTERN, $line, $m) === 1) {
+            $fence = $m[1];
+            $blank = false;
+            $position += $advance;
+            continue;
+        }
+
+        if (preg_match(LIST_ITEM_PATTERN, $line) === 1) {
+            $in_list = true;
+        } elseif ($blank && indent_width($line) === 0) {
+            // A fresh, unindented block after a blank line closes the list.
+            $in_list = false;
+        }
+        $blank = false;
+
+        if (preg_match(TASK_MARKER_PATTERN, $line, $m, PREG_OFFSET_CAPTURE) === 1) {
+            $offsets[] = $position + $m[2][1];
+        }
+
+        $position += $advance;
+    }
+
+    return $offsets;
+}
+
+/**
+ * The checked state of every task checkbox the renderer emits for a body, in
+ * the order the toggle endpoint's `data-checkbox-index` counts them.
+ *
+ * The renderer is the authority on which markers become checkboxes, so this is
+ * what checkbox_marker_offsets()'s reading of the source is checked against
+ * before a toggle is stored (see Response\apply_checkbox_toggle).
+ *
+ * @param string $body The raw post body (front matter included).
+ * @return list<bool> True for each checked box, in document order.
+ */
+function rendered_checkbox_states(string $body): array
+{
+    [, $content] = split_frontmatter($body);
+    $parser = new \Lamb\LambDown();
+    $parser->setSafeMode(true);
+    $parser->text(trim($content));
+
+    return $parser->renderedCheckboxStates();
+}
+
+/**
  * Toggles the checked state of the Nth GitHub-style task-list marker in a body.
  *
- * Task markers are list lines of the form `- [ ] ` / `* [x] ` / `+ [X] `. They
- * are counted in document order (the same order LambDown numbers the rendered
- * checkboxes with `data-checkbox-index`), so the Nth rendered checkbox maps to
- * the Nth source marker. Only the target marker's state character is rewritten;
- * every other marker and all surrounding text is preserved verbatim. An index
- * past the last marker returns the body unchanged.
+ * Markers are counted exactly as the renderer numbers the checkboxes it emits
+ * (see checkbox_marker_offsets()), so the Nth rendered checkbox maps to the Nth
+ * source marker. Only the target marker's state character is rewritten; every
+ * other marker and all surrounding text is preserved verbatim. An index past
+ * the last marker returns the body unchanged.
  *
  * @param string $body    The raw post body.
  * @param int    $index   Zero-based index of the marker to toggle.
@@ -625,19 +782,12 @@ function finalize_and_store_post(OODBBean $bean): void
  */
 function toggle_checkbox(string $body, int $index, bool $checked): string
 {
-    $seen = 0;
-    return preg_replace_callback(
-        '/^(\s*[-*+]\s+\[)[ xX](\]\s)/m',
-        function (array $m) use (&$seen, $index, $checked): string {
-            $state = $seen === $index ? ($checked ? 'x' : ' ') : null;
-            $seen++;
-            if ($state === null) {
-                return $m[0];
-            }
-            return $m[1] . $state . $m[2];
-        },
-        $body
-    ) ?? $body;
+    $offsets = checkbox_marker_offsets($body);
+    if ($index < 0 || !isset($offsets[$index])) {
+        return $body;
+    }
+
+    return substr_replace($body, $checked ? 'x' : ' ', $offsets[$index], 1);
 }
 
 /**

--- a/src/post.php
+++ b/src/post.php
@@ -813,8 +813,8 @@ function toggle_checkbox(string $body, int $index, bool $checked): string
 function get_tag_search_conditions(string $tag): array
 {
     return [
-        'sql'    => 'body LIKE ?',
-        'params' => ["%#$tag%"],
+        'sql'    => "body LIKE ? ESCAPE '\\'",
+        'params' => ['%#' . \Lamb\like_escape($tag) . '%'],
     ];
 }
 

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -547,7 +547,15 @@ function respond_settings(): array
             redirect_uri('/settings');
         }
 
-        $submitted_ini = \Lamb\Http\request_string($_POST['ini_text'] ?? null) ?? '';
+        // A submission carrying no configuration text at all is not an author
+        // clearing the box (that posts an empty string) — it is a malformed
+        // request, and saving '' for it would wipe every setting.
+        $submitted_ini = \Lamb\Http\request_string($_POST['ini_text'] ?? null);
+        if ($submitted_ini === null) {
+            $_SESSION['flash'][] = 'Settings not saved: the form did not include the configuration text.';
+            redirect_uri('/settings');
+        }
+
         $validation = Config\validate_ini($submitted_ini);
 
         if ($validation['valid']) {

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -77,7 +77,7 @@ function redirect_login(): array
         return login_page_data('Login is not configured on this site.');
     }
 
-    $user_pass = $_POST['password'] ?? '';
+    $user_pass = \Lamb\Http\request_string($_POST['password'] ?? null) ?? '';
     if (!password_verify($user_pass, base64_decode(LOGIN_PASSWORD))) {
         log_failed_login();
         record_login_failure($ip, $now);
@@ -540,14 +540,14 @@ function respond_settings(): array
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         Security\require_csrf();
 
-        if (isset($_POST['action']) && $_POST['action'] === 'reset') {
+        if (\Lamb\Http\request_string($_POST['action'] ?? null) === 'reset') {
             $default_ini = Config\get_default_ini_text();
             Config\save_ini_text($default_ini);
             $_SESSION['flash'][] = "Settings reset to defaults.";
             redirect_uri('/settings');
         }
 
-        $submitted_ini = $_POST['ini_text'] ?? '';
+        $submitted_ini = \Lamb\Http\request_string($_POST['ini_text'] ?? null) ?? '';
         $validation = Config\validate_ini($submitted_ini);
 
         if ($validation['valid']) {

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -134,7 +134,11 @@ function count_scheduled(): int
 #[NoReturn]
 function redirect_search(string $query): void
 {
-    $location = \Lamb\Http\sanitize_location("/search/$query");
+    // Percent-encoded: the term becomes a path segment, and an unencoded `#`
+    // made the browser read the rest as a fragment (so searching for a hashtag
+    // from the box searched for nothing at all), while `/` split the term and
+    // a space made an invalid Location header.
+    $location = \Lamb\Http\sanitize_location('/search/' . \Lamb\encode_path_segment($query));
     header("Location: $location", true, 301);
     die();
 }
@@ -205,7 +209,9 @@ function sanitize_tag_arg(array $args): string
 {
     [$tag] = $args;
 
-    return htmlspecialchars(urldecode($tag));
+    // rawurldecode(), not urldecode(): a `+` is a legal tag character, not a
+    // space (see Lamb\parse_tags, which encodes the link the same way).
+    return htmlspecialchars(rawurldecode($tag));
 }
 
 /**
@@ -316,7 +322,7 @@ function respond_tag_feed_json(array $args): void
  */
 function respond_search(array $args): array
 {
-    $query = urldecode((string) ($args[0] ?? ''));
+    $query = rawurldecode((string) ($args[0] ?? ''));
     if (empty($query)) {
         $query = request_string($_GET['s'] ?? null) ?? '';
         if (empty($query)) {
@@ -384,7 +390,7 @@ function get_results(array $data, array $posts, array $pagination): array
 function respond_tag(array $args): array
 {
     [$tag] = $args;
-    $tag = urldecode($tag);
+    $tag = rawurldecode((string) $tag);
     // Keep $tag raw: matching, URL-encoding and the page title each handle it
     // correctly, and the title is escaped at render time (so no double-encoding).
 

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -333,8 +333,10 @@ function respond_search(array $args): array
     $where_clauses = [];
     $params = [];
     foreach ($words as $word) {
-        $where_clauses[] = 'body LIKE ?';
-        $params[] = "%$word%";
+        // The search term is literal text: without escaping, a `%` in it matched
+        // every post and an `_` matched any character.
+        $where_clauses[] = "body LIKE ? ESCAPE '\\'";
+        $params[] = '%' . \Lamb\like_escape($word) . '%';
     }
     $public = public_posts_clause();
     $where_sql = '(' . implode(' AND ', $where_clauses) . ') AND' . $public['sql'];

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -9,6 +9,7 @@ use Lamb\Config;
 use Lamb\Security;
 use RedBeanPHP\R;
 
+use function Lamb\Http\request_string;
 use function Lamb\Post\posts_by_tag;
 use function Lamb\Theme\part;
 
@@ -315,9 +316,9 @@ function respond_tag_feed_json(array $args): void
  */
 function respond_search(array $args): array
 {
-    $query = urldecode($args[0] ?? '');
+    $query = urldecode((string) ($args[0] ?? ''));
     if (empty($query)) {
-        $query = $_GET['s'] ?? '';
+        $query = request_string($_GET['s'] ?? null) ?? '';
         if (empty($query)) {
             return [];
         }

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -12,6 +12,7 @@ use RedBeanPHP\R;
 use RedBeanPHP\RedException\SQL;
 
 use function Lamb\delete_redirect_for_slug;
+use function Lamb\Http\request_string;
 use function Lamb\notify_post_subscribers;
 use function Lamb\parse_bean;
 use function Lamb\Post\finalize_and_store_post;
@@ -34,10 +35,10 @@ function redirect_created(): void
 {
     Security\require_login();
     Security\require_csrf();
-    if ($_POST['submit'] !== SUBMIT_CREATE) {
+    if (request_string($_POST['submit'] ?? null) !== SUBMIT_CREATE) {
         return;
     }
-    $contents = trim($_POST['contents'] ?? '');
+    $contents = trim(request_string($_POST['contents'] ?? null) ?? '');
     if (empty($contents)) {
         return;
     }
@@ -81,8 +82,10 @@ function warn_if_manual_redirect(string $slug): void
         return;
     }
 
-    $_SESSION['flash'][] = 'A manual redirect for <code>' . $slug
-        . '</code> still exists in Settings → [redirections]. You may want to remove it.';
+    // Plain text: the themes escape a flash before printing it, so markup here
+    // reaches the author as literal tags.
+    $_SESSION['flash'][] = 'A manual redirect for "' . $slug
+        . '" still exists in Settings → [redirections]. You may want to remove it.';
 }
 
 /**
@@ -264,11 +267,11 @@ function redirect_edited(): void
     Security\require_login();
     Security\require_csrf();
     $validSubmits = [SUBMIT_EDIT];
-    if (!in_array($_POST['submit'], $validSubmits, true)) {
+    if (!in_array(request_string($_POST['submit'] ?? null), $validSubmits, true)) {
         return;
     }
 
-    $contents = trim(($_POST['contents']));
+    $contents = trim(request_string($_POST['contents'] ?? null) ?? '');
     $id = trim(filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT) ?: '');
     if (empty($contents) || empty($id)) {
         return;
@@ -287,7 +290,7 @@ function redirect_edited(): void
     $bean->updated = \Lamb\now();
 
     if (is_reserved_route($bean->slug)) {
-        $_SESSION['flash'][] = 'Failed to save, slug is in use <code>' . $bean->slug . '</code>';
+        $_SESSION['flash'][] = 'Failed to save, slug is in use: "' . $bean->slug . '"';
 
         return;
     }
@@ -441,7 +444,7 @@ function respond_status(array $args): array
 {
     [$id] = $args;
     $bean = R::load('post', (int)$id);
-    if (!\Lamb\is_viewable($bean) && !\Lamb\preview_token_valid($bean, $_GET['preview'] ?? null)) {
+    if (!\Lamb\is_viewable($bean) && !\Lamb\preview_token_valid($bean, request_string($_GET['preview'] ?? null))) {
         return respond_404([], true);
     }
 
@@ -485,7 +488,7 @@ function respond_post(array $args): array
 {
     [$slug] = $args;
     $post = R::findOne('post', ' slug = ? ', [$slug]);
-    if ($post === null || (!\Lamb\is_viewable($post) && !\Lamb\preview_token_valid($post, $_GET['preview'] ?? null))) {
+    if ($post === null || (!\Lamb\is_viewable($post) && !\Lamb\preview_token_valid($post, request_string($_GET['preview'] ?? null)))) {
         return respond_404([]);
     }
     $data['posts'] = [$post];

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -107,7 +107,10 @@ function store_slug_change_redirect(string $old_slug, string $new_slug): void
 
     $auto_redirect = R::dispense('redirect');
     $auto_redirect->from_slug = $old_slug;
-    $auto_redirect->to_url    = '/' . sanitize_explicit_slug($new_slug);
+    // Encoded the same way permalink_path() encodes it, so the 301 lands on a
+    // URL the router can read back (a slug may carry a space or a non-ASCII
+    // character).
+    $auto_redirect->to_url    = '/' . \Lamb\encode_path_segment(sanitize_explicit_slug($new_slug));
     R::store($auto_redirect);
 }
 

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -17,6 +17,7 @@ use function Lamb\parse_bean;
 use function Lamb\Post\finalize_and_store_post;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\populate_bean;
+use function Lamb\Post\rendered_checkbox_states;
 use function Lamb\Post\sanitize_explicit_slug;
 use function Lamb\Post\toggle_checkbox;
 use function Lamb\Route\is_reserved_route;
@@ -394,7 +395,26 @@ function apply_checkbox_toggle(int $id, int $index, bool $checked): bool
         return false;
     }
 
-    $bean->body = toggle_checkbox((string) $bean->body, $index, $checked);
+    // The index names a *rendered* checkbox, so the rewrite is checked against
+    // the renderer rather than trusted: no such checkbox, or a rewrite that
+    // moves any other box, is refused. The client then reverts the tick instead
+    // of the author silently finding a different task crossed off — which is
+    // what a document the source scan reads differently from the renderer
+    // (see Post\checkbox_marker_offsets) used to do.
+    $body   = (string) $bean->body;
+    $before = rendered_checkbox_states($body);
+    if (!isset($before[$index])) {
+        return false;
+    }
+
+    $toggled  = toggle_checkbox($body, $index, $checked);
+    $expected = $before;
+    $expected[$index] = $checked;
+    if (rendered_checkbox_states($toggled) !== $expected) {
+        return false;
+    }
+
+    $bean->body = $toggled;
     parse_bean($bean);
     $bean->updated = \Lamb\now();
 

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -281,6 +281,14 @@ function persist_image_bytes(string $bytes, string $ext, string $dest_dir, strin
         @unlink($tmp);
         return null;
     }
+    // tempnam() creates its file 0600, and rename() carries that mode to the
+    // published asset — every other upload path (move_uploaded_file(),
+    // imagewebp(), the restore's file_put_contents()) lands on the usual
+    // 0666 & ~umask. A 0600 asset is readable by the PHP user alone, so a
+    // separate static-file server user, a backup, or the author's own account
+    // cannot read an image the site is serving.
+    @chmod("$dest_dir/$filename", 0666 & ~umask());
+
     return $filename;
 }
 

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -83,7 +83,10 @@ function respond_upload(array $_args): void
         $out .= sprintf("![%s](%s)", $f['name'], asset_url($sub_path, $new_fn));
     }
 
-    echo json_encode($out, JSON_THROW_ON_ERROR);
+    // The markdown carries the client's filename, which need not be valid
+    // UTF-8; without substitution json_encode() throws and the upload 500s
+    // after the file has already been stored.
+    echo json_encode($out, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
     die();
 }
 

--- a/src/restore.php
+++ b/src/restore.php
@@ -379,8 +379,10 @@ function apply_manifest_state(OODBBean $bean, array $item): void
     }
     $bean->updated = $updated !== '' ? $updated : $bean->created;
 
-    $slug = (string) ($item['slug'] ?? '');
+    $slug = Post\sanitize_explicit_slug((string) ($item['slug'] ?? ''));
     if ($slug !== '') {
+        // Sanitised like any explicit slug: an archive from an older Lamb can
+        // carry one with a separator in it, which the router cannot serve.
         $bean->slug = $slug;
     }
 

--- a/src/security.php
+++ b/src/security.php
@@ -53,8 +53,8 @@ function require_login(): void
  */
 function require_csrf(): void
 {
-    $token = $_POST[HIDDEN_CSRF_NAME] ?? '';
-    $csrf = $_SESSION[HIDDEN_CSRF_NAME] ?? '';
+    $token = \Lamb\Http\request_string($_POST[HIDDEN_CSRF_NAME] ?? null) ?? '';
+    $csrf = \Lamb\Http\request_string($_SESSION[HIDDEN_CSRF_NAME] ?? null) ?? '';
     if (! $token || ! hash_equals($csrf, $token)) {
         $txt = $_SERVER['SERVER_PROTOCOL'] . ' 405 Method Not Allowed';
         header($txt);

--- a/src/theme.php
+++ b/src/theme.php
@@ -18,6 +18,7 @@ use function Lamb\get_tags;
 use function Lamb\Http\is_valid_http_url;
 use function Lamb\Network\get_feeds;
 use function Lamb\permalink;
+use function Lamb\permalink_path;
 use function Lamb\Post\body_has_tag;
 use function Lamb\Post\get_tag_search_conditions;
 use function Lamb\visible_clause;
@@ -137,14 +138,9 @@ function date_created(OODBBean $bean): string
 
     $human_created = human_time(strtotime($bean->created));
 
-    $slug = "/status/$bean->id";
-    if (!empty($bean->slug)) {
-        $slug = $bean->slug;
-    }
-
     return sprintf(
-        '<a href="/%1$s" class="u-url" title="Timestamp: %2$s"><time class="dt-published" datetime="%2$s">%3$s</time></a>',
-        escape(ltrim($slug, '/')),
+        '<a href="%1$s" class="u-url" title="Timestamp: %2$s"><time class="dt-published" datetime="%2$s">%3$s</time></a>',
+        escape(permalink_path($bean)),
         escape((string) $bean->created),
         $human_created
     );

--- a/src/theme/formatting.php
+++ b/src/theme/formatting.php
@@ -100,7 +100,7 @@ function og_escape(string $html): string
  */
 function preload_text(): string
 {
-    return htmlspecialchars($_GET['text'] ?? '', ENT_QUOTES, 'UTF-8');
+    return htmlspecialchars(\Lamb\Http\request_string($_GET['text'] ?? null) ?? '', ENT_QUOTES, 'UTF-8');
 }
 
 /**

--- a/src/themes/2024/parts/_items.php
+++ b/src/themes/2024/parts/_items.php
@@ -14,6 +14,7 @@ use function Lamb\Theme\anchor_headings;
 use function Lamb\Theme\escape;
 use function Lamb\Config\is_menu_item;
 use function Lamb\Theme\link_source;
+use function Lamb\Theme\syndication_links;
 use function Lamb\Theme\the_reply_context;
 use function Lamb\Theme\title_link;
 
@@ -51,6 +52,7 @@ else :
             <?= the_reply_context($bean) ?>
             <?php // List view renders the post title at h2, so the body's top heading sits at h3; otherwise h2 under the site h1. ?>
             <div class="e-content"><?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
+            <?= syndication_links($bean) ?>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
                 <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>

--- a/src/themes/2026/html.php
+++ b/src/themes/2026/html.php
@@ -82,6 +82,12 @@ global $template;
         endif;
         part($template);
         part("_related");
+        // Received webmentions: the part itself renders nothing unless the
+        // visitor is the logged-in author and the post has any (they are a
+        // private notification, per docs/webmentions.md). A theme that omits
+        // the call hides them from the author entirely — this one did, and it
+        // is the default theme.
+        part("_webmentions");
         ?>
     </main>
 </div>

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -14,6 +14,7 @@ use function Lamb\Theme\anchor_headings;
 use function Lamb\Theme\escape;
 use function Lamb\Config\is_menu_item;
 use function Lamb\Theme\link_source;
+use function Lamb\Theme\syndication_links;
 use function Lamb\Theme\the_reply_context;
 use function Lamb\Theme\title_link;
 
@@ -52,6 +53,7 @@ else :
             <?= the_reply_context($bean) ?>
             <?php // List view renders the post title at h2, so the body's top heading sits at h3; otherwise h2 under the site h1. ?>
             <div class="e-content"><?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
+            <?= syndication_links($bean) ?>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
                 <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>

--- a/src/themes/2026/parts/_related.php
+++ b/src/themes/2026/parts/_related.php
@@ -44,7 +44,7 @@ $primary_tag = $tags[0] ?? null;
     <ul class="related-list">
         <?php foreach ($shown as $bean) : ?>
             <?php
-            $permalink = '/' . ltrim(!empty($bean->slug) ? $bean->slug : "status/{$bean->id}", '/');
+            $permalink = \Lamb\permalink_path($bean);
             $title = trim(strip_tags($bean->title ?? ''));
             $excerpt = trim(strip_tags($bean->description ?? ''));
             // If the post has no title, promote a short excerpt to the title slot.

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -62,12 +62,21 @@ foreach ($data['posts'] as $bean) {
     // The reply context travels inside <content>, not only in the theme: thr:
     // below is invisible to readers that ignore the extension, and services that
     // thread replies (micro.blog) look for the u-in-reply-to microformat in the
-    // item's HTML. Its markup is already escaped, so addChild() is safe here.
-    $Content = $Entry->addChild(
-        'content',
+    // item's HTML.
+    //
+    // Written through a DOM text node rather than addChild(): addChild() escapes
+    // `<` but not `&`, which strips exactly one layer of escaping off the post's
+    // HTML. Text the author (or an ingested feed) wrote as `<script>` is stored
+    // as `&lt;script&gt;` by Parsedown's safe mode, and the feed handed it to
+    // subscribers as live markup inside a type="html" element. A text node
+    // escapes `&` and `<` alike, so the content arrives exactly as stored.
+    $Content = $Entry->addChild('content');
+    $Content->addAttribute('type', 'html');
+    $content_html = Lamb\normalize_utf8(
         Lamb\Theme\the_reply_context($bean) . Lamb\absolute_urls($bean->transformed)
     );
-    $Content->addAttribute('type', 'html');
+    $content_node = dom_import_simplexml($Content);
+    $content_node->appendChild($content_node->ownerDocument->createTextNode($content_html));
     if (!empty($bean->in_reply_to)) {
         // Raw URL: SimpleXML escapes attribute values itself, so pre-escaping
         // would double-encode any query-string ampersands.

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -76,7 +76,10 @@ foreach ($data['posts'] as $bean) {
         Lamb\Theme\the_reply_context($bean) . Lamb\absolute_urls($bean->transformed)
     );
     $content_node = dom_import_simplexml($Content);
-    $content_node->appendChild($content_node->ownerDocument->createTextNode($content_html));
+    $content_document = $content_node->ownerDocument;
+    if ($content_document !== null) {
+        $content_node->appendChild($content_document->createTextNode($content_html));
+    }
     if (!empty($bean->in_reply_to)) {
         // Raw URL: SimpleXML escapes attribute values itself, so pre-escaping
         // would double-encode any query-string ampersands.

--- a/src/themes/base/feed_json.php
+++ b/src/themes/base/feed_json.php
@@ -51,4 +51,12 @@ foreach ($data['posts'] as $bean) {
     $feed['items'][] = $item;
 }
 
-echo json_encode($feed, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+// JSON_INVALID_UTF8_SUBSTITUTE: json_encode() returns false for the whole
+// document if any one string is not valid UTF-8, which served subscribers an
+// empty 200 with no clue why. A post stored before parse_bean() started
+// repairing bodies can still hold such a byte, so the feed degrades that one
+// character to U+FFFD instead of vanishing.
+echo json_encode(
+    $feed,
+    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE
+);

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -54,7 +54,10 @@ function respond_webmention(array $_args): void
         die();
     }
 
-    $result = verify_and_store((string) ($_POST['source'] ?? ''), (string) ($_POST['target'] ?? ''));
+    $result = verify_and_store(
+        \Lamb\Http\request_string($_POST['source'] ?? null) ?? '',
+        \Lamb\Http\request_string($_POST['target'] ?? null) ?? ''
+    );
 
     http_response_code($result['status']);
     header('Content-Type: text/plain; charset=utf-8');

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -290,8 +290,9 @@ function store_source_redirect(array $item, OODBBean $bean): void
         return;
     }
 
-    $to = $bean->slug ? '/' . $bean->slug : '/status/' . $bean->id;
-    if ($from === ltrim($to, '/')) {
+    $to = \Lamb\permalink_path($bean);
+    // Compared in the decoded space store_redirect() keys on.
+    if (rawurldecode($from) === rawurldecode(ltrim($to, '/'))) {
         return;
     }
 

--- a/tests/Acceptance/EncodedSlugCest.php
+++ b/tests/Acceptance/EncodedSlugCest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Acceptance;
+
+use Tests\Support\AcceptanceTester;
+
+/**
+ * A post is served at the URL its own permalink names. An explicit
+ * front-matter slug is stored as the author wrote it, so a slug carrying a
+ * space or a non-ASCII character reaches the router percent-encoded — it used
+ * to 404 at the very URL every link on the site pointed at.
+ */
+class EncodedSlugCest
+{
+    private function login(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', $_ENV['LAMB_TEST_PASSWORD']);
+        $I->click('Log in');
+    }
+
+    private function createPost(AcceptanceTester $I, string $contents): void
+    {
+        $I->amOnPage('/');
+        $I->fillField('contents', $contents);
+        $I->click('Create post');
+    }
+
+    public function aSlugWithASpaceIsReachable(AcceptanceTester $I)
+    {
+        $this->login($I);
+        $this->createPost($I, "---\ntitle: Spaced Slug\nslug: my spaced slug\n---\nBody of the spaced post.");
+
+        $I->amOnPage('/my%20spaced%20slug');
+        $I->seeResponseCodeIs(200);
+        $I->see('Body of the spaced post.');
+        $I->dontSee('Fatal error');
+    }
+
+    public function aNonAsciiSlugIsReachable(AcceptanceTester $I)
+    {
+        $this->login($I);
+        $this->createPost($I, "---\ntitle: Unicode Slug\nslug: café\n---\nBody of the unicode post.");
+
+        $I->amOnPage('/caf%C3%A9');
+        $I->seeResponseCodeIs(200);
+        $I->see('Body of the unicode post.');
+    }
+
+    public function aSlugWithASlashIsFlattenedToOneSegment(AcceptanceTester $I)
+    {
+        $this->login($I);
+        $this->createPost($I, "---\ntitle: Nested Slug\nslug: archive/2024\n---\nBody of the nested post.");
+
+        $I->amOnPage('/archive-2024');
+        $I->seeResponseCodeIs(200);
+        $I->see('Body of the nested post.');
+    }
+
+    public function anUnknownSlugStill404s(AcceptanceTester $I)
+    {
+        $I->amOnPage('/no%20such%20post');
+        $I->seeResponseCodeIs(404);
+    }
+}

--- a/tests/Acceptance/MalformedParamsCest.php
+++ b/tests/Acceptance/MalformedParamsCest.php
@@ -82,4 +82,18 @@ class MalformedParamsCest
         $I->seeResponseCodeIs(200);
         $I->dontSee('Fatal error');
     }
+    public function aMissingSettingsFieldDoesNotWipeTheConfiguration(AcceptanceTester $I)
+    {
+        $this->login($I);
+        $I->amOnPage('/settings');
+        $token = $I->grabAttributeFrom('input[name=csrf]', 'value');
+
+        // An array is not "the author cleared the box" (that posts an empty
+        // string) — saving '' for it would drop every setting.
+        $I->sendAjaxPostRequest('/settings', ['csrf' => $token, 'ini_text' => ['x']]);
+
+        $I->amOnPage('/settings');
+        $I->seeResponseCodeIs(200);
+        $I->see('site_title');
+    }
 }

--- a/tests/Acceptance/MalformedParamsCest.php
+++ b/tests/Acceptance/MalformedParamsCest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Acceptance;
+
+use Tests\Support\AcceptanceTester;
+
+/**
+ * Every request parameter can arrive as an array (`?s[]=x`), and PHP 8 turns
+ * the mismatch into an uncaught TypeError at the first string-typed sink. Each
+ * of these used to be a 500 an anonymous visitor could ask for — one of them
+ * only on the branch that checks a preview token, which made it an oracle for
+ * whether a hidden post exists.
+ */
+class MalformedParamsCest
+{
+    private function login(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', $_ENV['LAMB_TEST_PASSWORD']);
+        $I->click('Log in');
+    }
+
+    public function anArraySearchTermDoesNotCrash(AcceptanceTester $I)
+    {
+        $I->amOnPage('/search?s[]=x');
+        $I->seeResponseCodeIs(200);
+        $I->dontSee('Fatal error');
+    }
+
+    public function anArrayPreviewTokenLooksLikeNoToken(AcceptanceTester $I)
+    {
+        $this->login($I);
+        $I->amOnPage('/');
+        $I->fillField('contents', "---\ntitle: Hidden Draft\nslug: hidden-draft\ndraft: true\n---\nSecret body.");
+        $I->click('Create post');
+        $I->amOnPage('/logout');
+
+        // A hidden post and a nonexistent one must answer identically: the
+        // crash used to happen only for the one that exists.
+        $I->amOnPage('/hidden-draft?preview[]=x');
+        $I->seeResponseCodeIs(404);
+        $I->dontSee('Secret body.');
+
+        $I->amOnPage('/no-such-post?preview[]=x');
+        $I->seeResponseCodeIs(404);
+    }
+
+    public function anArrayPreviewTokenOnAStatusUrlDoesNotCrash(AcceptanceTester $I)
+    {
+        $this->login($I);
+        $I->amOnPage('/');
+        $I->fillField('contents', "---\ncreated: 2099-01-01 00:00:00\n---\n\nScheduled body.");
+        $I->click('Create post');
+        $I->amOnPage('/logout');
+
+        // Whatever /status/1 turns out to be here, an array token must read as
+        // "no token" rather than fataling.
+        $I->amOnPage('/status/1?preview[]=x');
+        $I->seeResponseCodeIs(404);
+        $I->dontSee('Fatal error');
+    }
+
+    public function anArrayPasswordDoesNotCrashTheLogin(AcceptanceTester $I)
+    {
+        $I->amOnPage('/login');
+        $token = $I->grabAttributeFrom('input[name=csrf]', 'value');
+
+        $I->sendAjaxPostRequest('/login', [
+            'csrf'     => $token,
+            'submit'   => 'Log in',
+            'password' => ['x'],
+        ]);
+
+        $I->seeResponseCodeIs(200);
+        $I->dontSee('Fatal error');
+    }
+
+    public function anArrayPreloadTextDoesNotCrashTheEntryForm(AcceptanceTester $I)
+    {
+        $this->login($I);
+        $I->amOnPage('/?text[]=x');
+        $I->seeResponseCodeIs(200);
+        $I->dontSee('Fatal error');
+    }
+}

--- a/tests/Acceptance/SearchRedirectCest.php
+++ b/tests/Acceptance/SearchRedirectCest.php
@@ -39,4 +39,25 @@ class SearchRedirectCest
         $I->amOnPage('/search?s=xyzzy_unique_no_match_99');
         $I->see('No results found.');
     }
+    // SQL LIKE wildcards in a search term are literal text, not wildcards.
+
+    public function testWildcardCharactersInASearchTermAreLiteral(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', $_ENV['LAMB_TEST_PASSWORD']);
+        $I->click('Log in');
+        $I->amOnPage('/');
+        $I->fillField('contents', 'alpha bravo charlie');
+        $I->click('Create post');
+
+        // A bare `%` matched every post, and `_` matched any character.
+        $I->amOnPage('/search/%25');
+        $I->see('No results found.');
+
+        $I->amOnPage('/search/a_pha');
+        $I->see('No results found.');
+
+        $I->amOnPage('/search/alpha');
+        $I->see('1 result found.');
+    }
 }

--- a/tests/Acceptance/SearchRedirectCest.php
+++ b/tests/Acceptance/SearchRedirectCest.php
@@ -60,4 +60,20 @@ class SearchRedirectCest
         $I->amOnPage('/search/alpha');
         $I->see('1 result found.');
     }
+    public function testSearchingForAHashtagFromTheBoxFindsIt(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', $_ENV['LAMB_TEST_PASSWORD']);
+        $I->click('Log in');
+        $I->amOnPage('/');
+        $I->fillField('contents', 'Deploying with #ansible today');
+        $I->click('Create post');
+        $I->amOnPage('/logout');
+
+        // Unencoded, the `#` made the browser read the rest of the redirect as
+        // a fragment, so the search ran with no term at all.
+        $I->amOnPage('/search?s=%23ansible');
+        $I->seeCurrentUrlMatches('~/search/%23ansible~');
+        $I->see('1 result found.');
+    }
 }

--- a/tests/Acceptance/TagFeedCest.php
+++ b/tests/Acceptance/TagFeedCest.php
@@ -65,4 +65,21 @@ class TagFeedCest
         // SimpleXMLElement encodes emoji as XML character entities
         $I->seeInSource('&#x1F411;');
     }
+    public function tryTagLinkWithAPlusResolves(AcceptanceTester $I)
+    {
+        $I->amOnPage('/login');
+        $I->fillField('password', $_ENV['LAMB_TEST_PASSWORD']);
+        $I->click('Log in');
+        $I->amOnPage('/');
+        $I->fillField('contents', 'Learning #c++ today');
+        $I->click('Create post');
+
+        // Follow the link the post itself renders: `+` is a legal tag
+        // character, and the route used to read it back as a space.
+        $I->amOnPage('/');
+        $I->seeInSource('href="/tag/c++"');
+        $I->click('#c++');
+        $I->seeResponseCodeIs(200);
+        $I->see('Learning');
+    }
 }

--- a/tests/Unit/CheckboxRenderParityTest.php
+++ b/tests/Unit/CheckboxRenderParityTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Unit;
+
+use Lamb\LambDown;
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Post\checkbox_marker_offsets;
+use function Lamb\Post\split_frontmatter;
+use function Lamb\Post\toggle_checkbox;
+
+/**
+ * The toggle endpoint addresses a checkbox by its *rendered* position
+ * (`data-checkbox-index`), so the markers checkbox_marker_offsets() counts in
+ * the source have to be exactly the checkboxes LambDown renders — same count,
+ * same order, same states. Where the two disagreed, clicking one box silently
+ * rewrote a different one.
+ */
+class CheckboxRenderParityTest extends TestCase
+{
+    /**
+     * The `checked` state of every checkbox LambDown renders, in document order.
+     *
+     * @return list<bool>
+     */
+    private function renderedStates(string $body): array
+    {
+        $parser = new LambDown();
+        $parser->setSafeMode(true);
+        [, $content] = split_frontmatter($body);
+        $html = $parser->text(trim($content));
+
+        preg_match_all('/<input type="checkbox" data-checkbox-index="\d+"( checked)?/', $html, $matches);
+
+        return array_map(static fn(string $checked): bool => $checked !== '', $matches[1]);
+    }
+
+    /**
+     * The `checked` state of every marker the toggle scanner finds, in order.
+     *
+     * @return list<bool>
+     */
+    private function scannedStates(string $body): array
+    {
+        return array_map(
+            static fn(int $offset): bool => strtolower($body[$offset]) === 'x',
+            checkbox_marker_offsets($body)
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function bodyProvider(): array
+    {
+        return [
+            'bullet list'              => ["- [ ] one\n- [x] two\n"],
+            'bare markers'             => ["[ ] alpha\n\n- [ ] beta\n- [x] gamma\n"],
+            'ordered list'             => ["1. [ ] one\n2. [x] two\n"],
+            'ordered list with parens' => ["1) [x] paren\n"],
+            'blockquoted list'         => ["> - [ ] q1\n> - [x] q2\n"],
+            'blockquoted bare'         => ["> [x] quoted\n"],
+            'backtick fenced code'     => ["```\n- [x] code\n```\n\n- [ ] real\n"],
+            'tilde fenced code'        => ["~~~\n- [x] code\n~~~\n\n- [ ] real\n"],
+            'fenced code with info'    => ["```php\n- [x] code\n```\n\n- [ ] real\n"],
+            'indented code block'      => ["para\n\n    - [x] indented\n\n- [ ] real\n"],
+            'labelless marker'         => ["- [ ] \n- [x] labelled\n"],
+            'nested list'              => ["- [ ] a\n  - [x] b\n"],
+            'nested list four spaces'  => ["- [ ] a\n    - [x] b\n"],
+            'front matter'             => ["---\ntitle: t\n---\n\n- [x] one\n"],
+            'paragraph then bare'      => ["text\n[x] task\n"],
+            'crlf line endings'        => ["- [ ] one\r\n- [x] two\r\n"],
+            'escaped bracket'          => ["\\[ ] not a task\n\n- [x] real\n"],
+            'tab after bullet'         => ["-\t[x] tabbed\n"],
+            'paragraph closes list'    => ["- [x] a\n\ntext\n\n    [ ] indented\n"],
+            'mixed shapes'             => ["1. [ ] one\n\n> [x] quoted\n\n```\n[ ] code\n```\n\n[x] bare\n"],
+        ];
+    }
+
+    /**
+     * @dataProvider bodyProvider
+     */
+    public function testScannerMatchesRenderer(string $body): void
+    {
+        $this->assertSame($this->renderedStates($body), $this->scannedStates($body));
+    }
+
+    /**
+     * @dataProvider bodyProvider
+     */
+    public function testTogglingEveryIndexFlipsThatCheckbox(string $body): void
+    {
+        $states = $this->renderedStates($body);
+
+        foreach ($states as $index => $state) {
+            $expected = $states;
+            $expected[$index] = !$state;
+
+            $toggled = toggle_checkbox($body, $index, !$state);
+
+            $this->assertSame($expected, $this->renderedStates($toggled), "index $index");
+            $this->assertSame(strlen($body), strlen($toggled), 'only the state character changes');
+        }
+    }
+
+    public function testBareMarkerIsCountedBeforeListMarkers(): void
+    {
+        $body = "[ ] alpha\n\n- [ ] beta\n";
+
+        $this->assertSame("[x] alpha\n\n- [ ] beta\n", toggle_checkbox($body, 0, true));
+        $this->assertSame("[ ] alpha\n\n- [x] beta\n", toggle_checkbox($body, 1, true));
+    }
+
+    public function testMarkerInFencedCodeIsNotCounted(): void
+    {
+        $body = "```\n- [ ] code\n```\n\n- [ ] real\n";
+
+        $this->assertSame("```\n- [ ] code\n```\n\n- [x] real\n", toggle_checkbox($body, 0, true));
+    }
+
+    public function testLabellessMarkerIsNotCounted(): void
+    {
+        $body = "- [ ] \n- [ ] real\n";
+
+        $this->assertSame("- [ ] \n- [x] real\n", toggle_checkbox($body, 0, true));
+    }
+
+    public function testFrontMatterMarkerIsNotCounted(): void
+    {
+        $body = "---\ntags:\n  - [ ] odd\n---\n\n- [ ] real\n";
+
+        $this->assertSame("---\ntags:\n  - [ ] odd\n---\n\n- [x] real\n", toggle_checkbox($body, 0, true));
+    }
+
+    public function testOrderedAndBlockquotedMarkersAreCounted(): void
+    {
+        $body = "1. [ ] one\n\n> - [ ] two\n";
+
+        $this->assertSame("1. [x] one\n\n> - [ ] two\n", toggle_checkbox($body, 0, true));
+        $this->assertSame("1. [ ] one\n\n> - [x] two\n", toggle_checkbox($body, 1, true));
+    }
+
+    public function testNegativeIndexIsNoOp(): void
+    {
+        $body = "- [ ] one\n";
+
+        $this->assertSame($body, toggle_checkbox($body, -1, true));
+    }
+}

--- a/tests/Unit/ConfigLoadTest.php
+++ b/tests/Unit/ConfigLoadTest.php
@@ -155,6 +155,18 @@ class ConfigLoadTest extends TestCase
         $this->assertStringNotContainsString('First', $text);
     }
 
+    public function testSaveIniTextRepairsAStrayByte(): void
+    {
+        // A byte pasted from a word processor reached json_encode() through the
+        // JSON feed and the export manifest, and json_encode() refuses the whole
+        // document over one — the feed came back empty and the export 500ed.
+        save_ini_text('theme = 2024' . "\n" . 'site_title = Caf' . chr(0xE9) . " Blog\n");
+
+        $text = get_ini_text();
+        $this->assertTrue(mb_check_encoding($text, 'UTF-8'));
+        $this->assertStringContainsString("Caf\u{e9} Blog", $text);
+    }
+
     // config_modified_timestamp
 
     public function testConfigModifiedTimestampIsZeroWhenNoConfigStored(): void

--- a/tests/Unit/CronLockTest.php
+++ b/tests/Unit/CronLockTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Bootstrap\data_dir;
+use function Lamb\Network\acquire_cron_lock;
+use function Lamb\Network\cron_lock_path;
+
+/**
+ * The /_cron lock has to live in the install's own data directory. It used to
+ * be hardcoded to `../data`, so an install with LAMB_DATA_DIR set had no such
+ * directory, the lock file could never be opened, and every run was reported as
+ * "Already running" — feeds, the webmention queue and the purge silently never
+ * ran again.
+ */
+class CronLockTest extends TestCase
+{
+    private string $tmp;
+    private string|false $previous_env;
+
+    protected function setUp(): void
+    {
+        $this->previous_env = getenv('LAMB_DATA_DIR');
+        $this->tmp = sys_get_temp_dir() . '/lamb-cron-lock-' . bin2hex(random_bytes(6));
+        mkdir($this->tmp, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previous_env === false) {
+            putenv('LAMB_DATA_DIR');
+        } else {
+            putenv('LAMB_DATA_DIR=' . $this->previous_env);
+        }
+        array_map('unlink', glob($this->tmp . '/*') ?: []);
+        @rmdir($this->tmp);
+    }
+
+    public function testDataDirDefaultsToTheWebRootSibling(): void
+    {
+        putenv('LAMB_DATA_DIR');
+        $this->assertSame('../data', data_dir());
+    }
+
+    public function testDataDirHonoursTheEnvironmentOverride(): void
+    {
+        putenv('LAMB_DATA_DIR=' . $this->tmp);
+        $this->assertSame($this->tmp, data_dir());
+    }
+
+    public function testCronLockLivesInTheConfiguredDataDir(): void
+    {
+        putenv('LAMB_DATA_DIR=' . $this->tmp);
+        $this->assertSame($this->tmp . '/cron.lock', cron_lock_path());
+    }
+
+    public function testLockIsAcquiredThenContended(): void
+    {
+        putenv('LAMB_DATA_DIR=' . $this->tmp);
+
+        $first = acquire_cron_lock();
+        $this->assertIsResource($first);
+        $this->assertFileExists(cron_lock_path());
+
+        // A second run while the first still holds it: contention, not failure.
+        $this->assertNull(acquire_cron_lock());
+
+        fclose($first);
+        $second = acquire_cron_lock();
+        $this->assertIsResource($second);
+        fclose($second);
+    }
+
+    public function testUnopenableLockFileIsNotReportedAsContention(): void
+    {
+        $missing = $this->tmp . '/no-such-directory/cron.lock';
+
+        $this->assertFalse(acquire_cron_lock($missing));
+    }
+}

--- a/tests/Unit/ExportTest.php
+++ b/tests/Unit/ExportTest.php
@@ -330,4 +330,43 @@ class ExportTest extends TestCase
         $this->assertNotFalse($zip->locateName('manifest.json'));
         $zip->close();
     }
+    public function testExportSurvivesAnInvalidUtf8ByteInTheManifest(): void
+    {
+        // One stray byte in a slug or the site title used to abort the whole
+        // export with "Malformed UTF-8 characters" — the author could not back
+        // the site up at all.
+        $dir = sys_get_temp_dir() . '/lamb_export_utf8_' . uniqid('', true);
+        mkdir($dir, 0777, true);
+        $zip_path = "$dir/export.zip";
+
+        try {
+            $manifest = build_export_archive(
+                [[
+                    'id'      => 1,
+                    'slug'    => 'caf' . chr(0xE9) . '-notes',
+                    'body'    => "Body text.\n",
+                    'created' => '2026-01-02 03:04:05',
+                    'updated' => '2026-01-02 03:04:05',
+                ]],
+                $dir,
+                $zip_path,
+                '2026-01-02T03:04:05+00:00',
+                ['title' => 'Caf' . chr(0xE9) . ' Blog', 'url' => 'https://example.com'],
+            );
+
+            $this->assertSame(1, $manifest['counts']['posts']);
+            $zip = new ZipArchive();
+            $this->assertTrue($zip->open($zip_path));
+            $json = $zip->getFromName('manifest.json');
+            $zip->close();
+            $this->assertIsString($json);
+            $decoded = json_decode($json, true);
+            $this->assertIsArray($decoded);
+            // The byte degrades to U+FFFD; the post file itself is stored raw.
+            $this->assertStringContainsString("\u{FFFD}", $decoded['site']['title']);
+        } finally {
+            array_map('unlink', glob("$dir/*") ?: []);
+            rmdir($dir);
+        }
+    }
 }

--- a/tests/Unit/FeedJsonTemplateTest.php
+++ b/tests/Unit/FeedJsonTemplateTest.php
@@ -141,6 +141,25 @@ class FeedJsonTemplateTest extends TestCase
         $this->assertStringNotContainsString('src="/assets', $html);
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedJsonSurvivesAnInvalidUtf8Byte(): void
+    {
+        // json_encode() returns false for the whole document if one string is
+        // not valid UTF-8, so a single stray byte — in a setting, or in a post
+        // stored before bodies were repaired on save — served every subscriber
+        // an empty 200.
+        $json = $this->renderJsonFeedWithPost(
+            ['title' => 'Caf' . chr(0xE9), 'transformed' => '<p>Body</p>'],
+            ['site_title' => 'Caf' . chr(0xE9) . ' Blog'],
+        );
+
+        $this->assertCount(1, $json['items']);
+        $this->assertStringContainsString("\u{FFFD}", $json['items'][0]['title']);
+    }
+
     private function renderJsonFeedWithPost(array $fields, array $extraConfig = []): array
     {
         require_once __DIR__ . '/../../vendor/autoload.php';

--- a/tests/Unit/FeedTemplateTest.php
+++ b/tests/Unit/FeedTemplateTest.php
@@ -286,6 +286,37 @@ class FeedTemplateTest extends TestCase
      * @param array $conventionFiles Names of web-root convention files to create (e.g. favicon.png).
      * @param array $extraConfig   Extra config keys merged into $config.
      */
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedContentKeepsTheEscapingTheStoredHtmlHas(): void
+    {
+        // addChild() escapes `<` but not `&`, which strips exactly one layer
+        // off the stored HTML: `&lt;script&gt;` — text the author typed, and
+        // what Parsedown's safe mode produces for an ingested feed item —
+        // reached subscribers as live markup in a type="html" element.
+        $stored = '<p>Escaping demo &lt;script&gt;alert(1)&lt;/script&gt; &amp; more</p>';
+
+        $xml = $this->renderFeedWithPost(['transformed' => $stored]);
+
+        $this->assertSame($stored, (string) $xml->entry[0]->content);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFeedContentStillCarriesRealMarkup(): void
+    {
+        $stored = '<p>Hello <a href="http://localhost/tag/php">#php</a></p>';
+
+        $xml = $this->renderFeedWithPost(['transformed' => $stored]);
+
+        $this->assertSame($stored, (string) $xml->entry[0]->content);
+        $this->assertSame('html', (string) $xml->entry[0]->content['type']);
+    }
+
     private function renderFeedWithPost(array $fields, array $conventionFiles = [], array $extraConfig = []): \SimpleXMLElement
     {
         require_once __DIR__ . '/../../vendor/autoload.php';

--- a/tests/Unit/HttpTest.php
+++ b/tests/Unit/HttpTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use function Lamb\Http\extract_page_segment;
 use function Lamb\Http\get_request_uri;
 use function Lamb\Http\page_path;
+use function Lamb\Http\request_string;
 use function Lamb\Http\requested_path;
 
 class HttpTest extends TestCase
@@ -147,5 +148,33 @@ class HttpTest extends TestCase
     public function testPagePathStripsExistingPageSegment(): void
     {
         $this->assertSame('/tag/foo/page/4', page_path('/tag/foo/page/2', 4));
+    }
+    // request_string — a request value can always arrive as an array, and PHP 8
+    // fatals at the first string-typed sink rather than coercing it.
+
+    public function testRequestStringPassesStringsThrough(): void
+    {
+        $this->assertSame('needle', request_string('needle'));
+        $this->assertSame('', request_string(''));
+    }
+
+    public function testRequestStringReportsAnArrayAsAbsent(): void
+    {
+        $this->assertNull(request_string(['x']));
+        $this->assertNull(request_string(['a' => 'b']));
+        $this->assertNull(request_string([]));
+    }
+
+    public function testRequestStringReportsMissingAndNonTextValuesAsAbsent(): void
+    {
+        $this->assertNull(request_string(null));
+        $this->assertNull(request_string(true));
+        $this->assertNull(request_string(new \stdClass()));
+    }
+
+    public function testRequestStringRendersNumbersAsText(): void
+    {
+        $this->assertSame('42', request_string(42));
+        $this->assertSame('1.5', request_string(1.5));
     }
 }

--- a/tests/Unit/LambHelpersTest.php
+++ b/tests/Unit/LambHelpersTest.php
@@ -8,6 +8,7 @@ use RedBeanPHP\R;
 use function Lamb\encode_path_segment;
 use function Lamb\find_post_by_path;
 use function Lamb\get_option;
+use function Lamb\like_escape;
 use function Lamb\now;
 use function Lamb\permalink;
 use function Lamb\permalink_path;
@@ -168,6 +169,23 @@ class LambHelpersTest extends TestCase
         $found = find_post_by_path('/my%20post');
         $this->assertNotNull($found);
         $this->assertSame((int) $bean->id, (int) $found->id);
+    }
+
+    // like_escape — a visitor's literal text must stay literal inside a LIKE.
+
+    public function testLikeEscapeEscapesWildcards(): void
+    {
+        $this->assertSame('100\\%', like_escape('100%'));
+        $this->assertSame('a\\_b', like_escape('a_b'));
+        $this->assertSame('plain', like_escape('plain'));
+    }
+
+    public function testLikeEscapeEscapesTheEscapeCharacterFirst(): void
+    {
+        // Otherwise a trailing backslash in the term escapes the pattern's own
+        // closing wildcard instead of itself.
+        $this->assertSame('back\\\\slash', like_escape('back\\slash'));
+        $this->assertSame('\\\\\\%', like_escape('\\%'));
     }
 
     // get_option

--- a/tests/Unit/LambHelpersTest.php
+++ b/tests/Unit/LambHelpersTest.php
@@ -5,10 +5,12 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\encode_path_segment;
 use function Lamb\find_post_by_path;
 use function Lamb\get_option;
 use function Lamb\now;
 use function Lamb\permalink;
+use function Lamb\permalink_path;
 use function Lamb\post_has_slug;
 use function Lamb\set_option;
 
@@ -105,6 +107,67 @@ class LambHelpersTest extends TestCase
         R::store($bean);
         $bean->slug = null;
         $this->assertSame(ROOT_URL . '/status/' . $bean->id, permalink($bean));
+    }
+
+    // permalink_path / encode_path_segment — a post's URL has to survive the
+    // round trip back through the router, which matches the *decoded* request
+    // path against the stored slug.
+
+    public function testPermalinkEncodesWhatAPathCannotHold(): void
+    {
+        $bean = R::dispense('post');
+
+        $bean->slug = 'my post';
+        $this->assertSame('/my%20post', permalink_path($bean));
+
+        $bean->slug = 'café';
+        $this->assertSame('/caf%C3%A9', permalink_path($bean));
+
+        $bean->slug = 'a?b#c';
+        $this->assertSame('/a%3Fb%23c', permalink_path($bean));
+    }
+
+    public function testPermalinkLeavesPathLegalCharactersAlone(): void
+    {
+        // These already resolve, and a permalink is also the post's Atom entry
+        // id — re-encoding one would show every subscriber the post as new.
+        $bean = R::dispense('post');
+
+        $bean->slug = 'tea-&-cake';
+        $this->assertSame('/tea-&-cake', permalink_path($bean));
+
+        $bean->slug = 'c++,notes;x=1:2@3';
+        $this->assertSame('/c++,notes;x=1:2@3', permalink_path($bean));
+
+        $bean->slug = 'hello-world';
+        $this->assertSame('/hello-world', permalink_path($bean));
+    }
+
+    public function testEncodePathSegmentEncodesSeparatorsAndPercent(): void
+    {
+        $this->assertSame('a%2Fb', encode_path_segment('a/b'));
+        $this->assertSame('a%5Cb', encode_path_segment('a\\b'));
+        $this->assertSame('100%25', encode_path_segment('100%'));
+    }
+
+    public function testPermalinkPathFallsBackToStatusId(): void
+    {
+        $bean = R::dispense('post');
+        R::store($bean);
+        $bean->slug = '';
+        $this->assertSame('/status/' . $bean->id, permalink_path($bean));
+    }
+
+    public function testFindPostByPathDecodesTheSlug(): void
+    {
+        $bean = R::dispense('post');
+        $bean->slug = 'my post';
+        $bean->body = 'Spaced.';
+        R::store($bean);
+
+        $found = find_post_by_path('/my%20post');
+        $this->assertNotNull($found);
+        $this->assertSame((int) $bean->id, (int) $found->id);
     }
 
     // get_option

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -11,6 +11,7 @@ use ZipArchive;
 use function Lamb\Bootstrap\ensure_post_columns;
 use function Lamb\Export\build_export_archive;
 use function Lamb\Import\run_import;
+use function Lamb\Restore\apply_manifest_state;
 use function Lamb\Restore\import_post;
 use function Lamb\Restore\item_skip_reason;
 use function Lamb\Restore\manifest_items;
@@ -873,5 +874,15 @@ class LambRestoreTest extends TestCase
         );
         $this->assertSame(['backup.zip', false, false, null], parse_restore_args(['x', 'backup.zip']));
         $this->assertSame([null, false, false, null], parse_restore_args(['x', '--help']));
+    }
+    public function testApplyManifestStateFlattensASeparatorInTheSlug(): void
+    {
+        // An archive from an older Lamb can carry a slug with a separator in
+        // it; the router serves a post at one path segment, so restoring it
+        // verbatim would put the post at a URL that 404s.
+        $bean = R::dispense('post');
+        apply_manifest_state($bean, ['slug' => 'archive/2024', 'created' => '2024-01-01 00:00:00']);
+
+        $this->assertSame('archive-2024', $bean->slug);
     }
 }

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -152,6 +152,16 @@ class LambTest extends TestCase
         $this->assertStringContainsString('<a href="/tag/🐑">#🐑</a>', $result);
     }
 
+    public function testParseTagsLinksATagContainingAPlus()
+    {
+        // `+` is a legal tag character and a legal path character, so the link
+        // carries it verbatim — the tag route reads the path with
+        // rawurldecode(), which leaves it alone. urldecode() turned it into a
+        // space, so a post's own tag link 404ed.
+        $result = parse_tags('<p>Learning #c++ today</p>');
+        $this->assertStringContainsString('<a href="/tag/c++">#c++</a>', $result);
+    }
+
     public function testParseTagsDoesNotAlterTextWithNoTags()
     {
         $input = '<p>No tags here.</p>';

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -36,6 +36,18 @@ class LambTest extends TestCase
         $this->assertSame('Hello #new', add_body_tags("Hello \n", ['new']));
     }
 
+    public function testAddBodyTagsSkipsATagPresentInAnotherCase()
+    {
+        // `#PHP` and `#php` are one tag everywhere else — the link parse_tags()
+        // writes and the lookup posts_by_tag() runs are both case-insensitive.
+        $this->assertSame('Hello #PHP', add_body_tags('Hello #PHP', ['php']));
+    }
+
+    public function testAddBodyTagsAddsARepeatedTagOnce()
+    {
+        $this->assertSame('Hello #foo', add_body_tags('Hello', ['foo', 'foo', 'FOO']));
+    }
+
     // strip_trailing_body_tags
 
     public function testStripTrailingBodyTagsRemovesTrailingRun()

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
 
 use function Lamb\add_body_tags;
 use function Lamb\get_tags;
@@ -183,5 +184,69 @@ class LambTest extends TestCase
         $result = parse_tags('<p>#foo&amp;bar</p>');
         $this->assertStringNotContainsString('href="/tag/foo&amp"', $result);
         $this->assertStringContainsString('href="/tag/foo"', $result);
+    }
+    private function connect(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+    }
+
+    // normalize_utf8 — a body that is not valid UTF-8 rendered as nothing at
+    // all, because htmlspecialchars() returns '' for input it cannot decode.
+
+    public function testNormalizeUtf8LeavesValidTextUntouched(): void
+    {
+        $text = "Caf\u{e9} \u{1F411} notes";
+        $this->assertSame($text, \Lamb\normalize_utf8($text));
+        $this->assertSame('', \Lamb\normalize_utf8(''));
+    }
+
+    public function testNormalizeUtf8RecoversALatin1Byte(): void
+    {
+        $latin1 = 'Caf' . chr(0xE9) . ' notes';
+
+        $repaired = \Lamb\normalize_utf8($latin1);
+
+        $this->assertSame("Caf\u{e9} notes", $repaired);
+        $this->assertTrue(mb_check_encoding($repaired, 'UTF-8'));
+    }
+
+    public function testNormalizeUtf8RecoversAWindows1252SmartQuote(): void
+    {
+        // 0x92 is a right single quote in Windows-1252 and invalid in UTF-8 —
+        // the byte a word processor pastes in.
+        $repaired = \Lamb\normalize_utf8('It' . chr(0x92) . 's here');
+
+        $this->assertSame("It\u{2019}s here", $repaired);
+    }
+
+    public function testParseBeanRendersABodyWithAStrayByte(): void
+    {
+        $this->connect();
+        $bean = R::dispense('post');
+        $bean->body = 'Caf' . chr(0xE9) . " notes\n\nsecond paragraph";
+
+        \Lamb\parse_bean($bean);
+
+        // Every paragraph containing a stray byte used to render as `<p></p>`.
+        $this->assertStringContainsString("Caf\u{e9} notes", (string) $bean->transformed);
+        $this->assertStringContainsString('second paragraph', (string) $bean->transformed);
+        $this->assertSame("Caf\u{e9} notes", (string) $bean->description);
+    }
+
+    public function testParseBeanKeepsFrontMatterOnABodyWithAStrayByte(): void
+    {
+        $this->connect();
+        $bean = R::dispense('post');
+        $bean->body = "---\ntitle: Caf" . chr(0xE9) . "\n---\n\nBody text.";
+
+        \Lamb\parse_bean($bean);
+
+        // The YAML parser refuses a block it cannot decode, so the title (and
+        // the slug derived from it) went missing along with the rendering.
+        $this->assertSame("Caf\u{e9}", (string) $bean->title);
+        $this->assertStringContainsString('Body text.', (string) $bean->transformed);
     }
 }

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -2250,4 +2250,29 @@ class MicropubAdapterTest extends TestCase
         $this->assertStringContainsString('#nested', $updated->body);
         $this->assertStringNotContainsString('#Array', $updated->body);
     }
+    public function testContentReplaceKeepsEachTagOnce(): void
+    {
+        // The old body's tags are carried across a content replace so
+        // categories survive it — but a tag the new content already carries
+        // must not be appended again, or every update grows the trailing run.
+        $post = R::dispense('post');
+        $post->body = 'hello #php world';
+        $post->slug = 'replace-tags';
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $adapter = new LambMicropubAdapter();
+        $this->assertTrue($adapter->updateCallback(
+            'http://localhost/replace-tags',
+            ['replace' => ['content' => ['goodbye #php']]]
+        ));
+        $this->assertSame('goodbye #php', R::load('post', $post->id)->body);
+
+        // And a replacement that drops the tag from its text keeps it.
+        $this->assertTrue($adapter->updateCallback(
+            'http://localhost/replace-tags',
+            ['replace' => ['content' => ['again']]]
+        ));
+        $this->assertSame('again #php', R::load('post', $post->id)->body);
+    }
 }

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -2275,4 +2275,51 @@ class MicropubAdapterTest extends TestCase
         ));
         $this->assertSame('again #php', R::load('post', $post->id)->body);
     }
+    public function testNamingAStatusPostMintsAUniqueSlug(): void
+    {
+        // Naming a titleless status post derives a slug from the title. That
+        // slug used to skip the uniqueness check every other save path
+        // applies, so two posts could end up sharing a URL — one of them
+        // unreachable at its own permalink.
+        $taken = R::dispense('post');
+        $taken->body = "---\ntitle: Shared Name\nslug: shared-name\n---\n\ntaken";
+        $taken->slug = 'shared-name';
+        $taken->created = date('Y-m-d H:i:s');
+        R::store($taken);
+
+        $post = R::dispense('post');
+        $post->body = 'a status post';
+        $post->slug = '';
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $adapter = new LambMicropubAdapter();
+        $this->assertTrue($adapter->updateCallback(
+            'http://localhost/status/' . $post->id,
+            ['replace' => ['name' => ['Shared Name']]]
+        ));
+
+        $renamed = R::load('post', $post->id);
+        $this->assertNotSame('shared-name', $renamed->slug);
+        $this->assertSame(1, R::count('post', ' slug = ? ', ['shared-name']));
+    }
+
+    public function testRenamingAPostKeepsItsExistingSlug(): void
+    {
+        $post = R::dispense('post');
+        $post->body = "---\ntitle: Original\n---\n\nbody";
+        $post->slug = 'original';
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $adapter = new LambMicropubAdapter();
+        $this->assertTrue($adapter->updateCallback(
+            'http://localhost/original',
+            ['replace' => ['name' => ['Renamed Entirely']]]
+        ));
+
+        $renamed = R::load('post', $post->id);
+        $this->assertSame('original', $renamed->slug);
+        $this->assertSame('Renamed Entirely', $renamed->title);
+    }
 }

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -2184,4 +2184,70 @@ class MicropubAdapterTest extends TestCase
     {
         $this->assertFalse(has_micropub_scope(false, 'create'));
     }
+    // Microformats values are not necessarily strings, and casting one stored
+    // the literal "Array" (with an "Array to string conversion" warning).
+
+    public function testCreateCallbackDropsCategoriesWithNoText(): void
+    {
+        $adapter = new LambMicropubAdapter();
+        $adapter->createCallback([
+            'type'       => ['h-entry'],
+            'properties' => [
+                'content'  => ['Categories of every shape'],
+                // A nested list collapses to its first entry, as front matter
+                // does; a boolean and an empty list carry no text at all.
+                'category' => ['ok', ['nested'], true, []],
+            ],
+        ]);
+
+        $post = R::findOne('post', ' body LIKE ? ', ['%Categories of every shape%']);
+        $this->assertNotNull($post);
+        $this->assertStringContainsString('#ok', $post->body);
+        $this->assertStringContainsString('#nested', $post->body);
+        $this->assertStringNotContainsString('#Array', $post->body);
+        $this->assertStringNotContainsString('#1', $post->body);
+    }
+
+    public function testCreateCallbackDropsAPhotoWithNoUsableUrl(): void
+    {
+        $adapter = new LambMicropubAdapter();
+        $adapter->createCallback([
+            'type'       => ['h-entry'],
+            'properties' => [
+                'content' => ['Photos of every shape'],
+                'photo'   => [
+                    ['value' => ['/one.jpg'], 'alt' => 'first'],
+                    ['value' => [], 'alt' => 'nothing'],
+                    '/two.jpg',
+                ],
+            ],
+        ]);
+
+        $post = R::findOne('post', ' body LIKE ? ', ['%Photos of every shape%']);
+        $this->assertNotNull($post);
+        $this->assertStringContainsString('![first](/one.jpg)', $post->body);
+        $this->assertStringContainsString('![](/two.jpg)', $post->body);
+        $this->assertStringNotContainsString('(Array)', $post->body);
+        $this->assertStringNotContainsString('nothing', $post->body);
+    }
+
+    public function testUpdateCallbackDropsCategoriesWithNoText(): void
+    {
+        $post = R::dispense('post');
+        $post->body = "Tagged post\n";
+        $post->slug = 'tagged-post';
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback('http://localhost/tagged-post', [
+            'add' => ['category' => ['real', ['nested'], false]],
+        ]);
+
+        $this->assertTrue($result);
+        $updated = R::load('post', $post->id);
+        $this->assertStringContainsString('#real', $updated->body);
+        $this->assertStringContainsString('#nested', $updated->body);
+        $this->assertStringNotContainsString('#Array', $updated->body);
+    }
 }

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -239,6 +239,22 @@ class PostTest extends TestCase
         $this->assertSame('normal-slug', sanitize_explicit_slug('normal-slug'));
     }
 
+    public function testSanitizeExplicitSlugFlattensInnerSeparators()
+    {
+        // A slug is one path segment: the router matches a post against the
+        // request's first segment, so `archive/2024` named a URL that could
+        // never route back to the post it was stored on.
+        $this->assertSame('archive-2024', sanitize_explicit_slug('archive/2024'));
+        $this->assertSame('a-b-c', sanitize_explicit_slug('a/b\\c'));
+        $this->assertSame('evil.com-x', sanitize_explicit_slug('//evil.com/x'));
+    }
+
+    public function testParseMatterFlattensInnerSlashInExplicitSlug()
+    {
+        $body = "---\nslug: archive/2024\n---\nContent.";
+        $this->assertSame('archive-2024', parse_matter($body)['slug']);
+    }
+
     // parse_matter — front matter is a *leading* fence only
 
     public function testParseMatterIgnoresKeyValueLineAfterBodyContent()

--- a/tests/Unit/RedirectTest.php
+++ b/tests/Unit/RedirectTest.php
@@ -8,6 +8,7 @@ use RedBeanPHP\R;
 use function Lamb\delete_redirect_for_slug;
 use function Lamb\find_redirect;
 use function Lamb\get_all_redirects;
+use function Lamb\redirect_target_slug;
 
 class RedirectTest extends TestCase
 {
@@ -24,6 +25,26 @@ class RedirectTest extends TestCase
 
         // Clean redirect table before each test
         R::exec('DELETE FROM redirect WHERE 1');
+    }
+
+    // Redirect keys live in the decoded space the router looks them up in,
+    // while the targets they point at are encoded like any other permalink.
+
+    public function testRedirectTargetSlugDecodesItsTarget(): void
+    {
+        $this->assertSame('my post', redirect_target_slug('/my%20post'));
+        $this->assertSame('café', redirect_target_slug('/caf%C3%A9'));
+        $this->assertSame('plain', redirect_target_slug('/plain'));
+        $this->assertNull(redirect_target_slug('https://example.com/x'));
+        $this->assertNull(redirect_target_slug('/a/b'));
+    }
+
+    public function testStoreRedirectKeysOnTheDecodedPath(): void
+    {
+        \Lamb\Import\store_redirect('2020/caf%C3%A9', '/caf%C3%A9');
+
+        // Looked up the way the router looks it up: with the decoded path.
+        $this->assertSame('/caf%C3%A9', find_redirect('2020/café'));
     }
 
     // find_redirect — config-based

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -414,6 +414,60 @@ class ResponsePostsTest extends TestCase
         $this->assertFalse(apply_checkbox_toggle($post->id, -1, true));
     }
 
+    public function testApplyCheckboxToggleUsesRenderedIndex(): void
+    {
+        // The first rendered checkbox is the bare marker, not the list item —
+        // the index the client sends counts every checkbox on the page.
+        $post          = R::dispense('post');
+        $post->body    = "[ ] bare\n\n- [ ] listed\n";
+        $post->version = 1;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $this->assertTrue(apply_checkbox_toggle($post->id, 0, true));
+        $this->assertSame("[x] bare\n\n- [ ] listed\n", R::load('post', $post->id)->body);
+    }
+
+    public function testApplyCheckboxToggleSkipsMarkersInFencedCode(): void
+    {
+        $post          = R::dispense('post');
+        $post->body    = "```\n- [ ] sample\n```\n\n- [ ] real\n";
+        $post->version = 1;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $this->assertTrue(apply_checkbox_toggle($post->id, 0, true));
+        $this->assertSame("```\n- [ ] sample\n```\n\n- [x] real\n", R::load('post', $post->id)->body);
+    }
+
+    public function testApplyCheckboxToggleFailsForIndexPastLastCheckbox(): void
+    {
+        $post          = R::dispense('post');
+        $post->body    = "- [ ] one\n";
+        $post->version = 1;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $this->assertFalse(apply_checkbox_toggle($post->id, 3, true));
+        // Refused, not silently accepted with the body left as it was.
+        $this->assertSame("- [ ] one\n", R::load('post', $post->id)->body);
+    }
+
+    public function testApplyCheckboxToggleRefusesWhenRewriteWouldMoveAnotherBox(): void
+    {
+        // A body whose markers the source scan and the renderer read
+        // differently: the fence is swallowed by the preceding list item, so
+        // the renderer shows three checkboxes where the scan sees two.
+        $post          = R::dispense('post');
+        $post->body    = "- [ ] one\n+ [ ] two\n```\n- [ ] three\n";
+        $post->version = 1;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $this->assertFalse(apply_checkbox_toggle($post->id, 2, true));
+        $this->assertSame("- [ ] one\n+ [ ] two\n```\n- [ ] three\n", R::load('post', $post->id)->body);
+    }
+
     // -------------------------------------------------------------------------
     // lock_if_feed_sourced
     // -------------------------------------------------------------------------

--- a/tests/Unit/ThemeSyndicationPartTest.php
+++ b/tests/Unit/ThemeSyndicationPartTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+/**
+ * Every bundled theme has to render a post's syndication targets.
+ *
+ * docs/micropub.md promises that a post carrying `syndicated-to` shows
+ * "Also on: …" links with the `u-syndication` microformat — the markup Bridgy
+ * and other IndieWeb consumers read. Only the base theme did, so on a default
+ * install (theme = 2026) the recorded targets were never shown at all.
+ */
+class ThemeSyndicationPartTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    private function renderItem(string $theme): string
+    {
+        $bean = R::dispense('post');
+        $bean->title = 'Syndicated';
+        $bean->transformed = '<p>body</p>';
+        $bean->created = '2024-01-01 12:00:00';
+        $bean->deleted = false;
+        $bean->syndicated_to = 'https://bsky.app/profile/me';
+        R::store($bean);
+
+        global $data, $template, $config;
+        $config = ['menu_items' => [], 'syndicate_to' => ['https://bsky.app/profile/me' => 'Bluesky']];
+        $data = ['posts' => [$bean]];
+        $template = 'status';
+
+        ob_start();
+        include dirname(__DIR__, 2) . "/src/themes/$theme/parts/_items.php";
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function themeProvider(): array
+    {
+        return [
+            'base' => ['base'],
+            '2026' => ['2026'],
+            '2024' => ['2024'],
+        ];
+    }
+
+    /**
+     * @dataProvider themeProvider
+     */
+    public function testThemeRendersSyndicationLinks(string $theme): void
+    {
+        $html = $this->renderItem($theme);
+
+        $this->assertStringContainsString('Also on:', $html);
+        $this->assertStringContainsString('u-syndication', $html);
+        $this->assertStringContainsString('Bluesky', $html);
+    }
+}

--- a/tests/Unit/ThemeWebmentionsPartTest.php
+++ b/tests/Unit/ThemeWebmentionsPartTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every bundled theme layout has to include the received-webmentions part.
+ *
+ * The part decides for itself whether to render anything (author only, status
+ * pages only, and only when the post has mentions — see
+ * docs/webmentions.md). A layout that never calls it hides them from the
+ * author entirely, which is what the default theme did: mentions were
+ * received, verified and stored, and then shown nowhere.
+ */
+class ThemeWebmentionsPartTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function layoutProvider(): array
+    {
+        // The 2024 theme ships no html.php of its own, so it renders through
+        // the base layout (Theme\part() falls back per file).
+        return [
+            'base' => ['base'],
+            '2026' => ['2026'],
+        ];
+    }
+
+    /**
+     * @dataProvider layoutProvider
+     */
+    public function testLayoutIncludesTheWebmentionsPart(string $theme): void
+    {
+        $layout = file_get_contents(dirname(__DIR__, 2) . "/src/themes/$theme/html.php");
+
+        $this->assertIsString($layout);
+        $this->assertMatchesRegularExpression('/part\(\s*[\'"]_webmentions[\'"]\s*\)/', $layout);
+    }
+}

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -1050,6 +1050,25 @@ XML;
         }
     }
 
+    public function testPersistImageBytesWritesAReadableAsset(): void
+    {
+        // tempnam() creates 0600 and rename() carries that mode to the
+        // published file, leaving an asset the site serves that a separate
+        // static-file user (or the author's own account) cannot read. Every
+        // other upload path lands on the usual 0666 & ~umask.
+        $dir = sys_get_temp_dir() . '/lamb_persist_' . uniqid('', true);
+        mkdir($dir, 0777, true);
+        try {
+            $filename = persist_image_bytes('GIF89a' . str_repeat("\0", 32), 'gif', $dir, 'seed');
+
+            $this->assertNotNull($filename);
+            $this->assertSame(0666 & ~umask(), fileperms("$dir/$filename") & 0777);
+        } finally {
+            array_map('unlink', glob("$dir/*") ?: []);
+            rmdir($dir);
+        }
+    }
+
     public function testPersistImageBytesReturnsNullWhenDirMissing(): void
     {
         $filename = persist_image_bytes('xx', 'gif', '/does/not/exist', 'seed');


### PR DESCRIPTION
A coarse sweep of the codebase, then a deep sweep of everything each finding touched. Fifteen bugs, every one of them silently doing the wrong thing rather than failing. One commit per bug; each test added here was run against the pre-fix code to confirm it goes red.

### Data the author loses or never sees

**Toggling a task checkbox rewrote a different task.** `/checkbox` addresses a checkbox by its *rendered* position (`data-checkbox-index`), but the source rewrite counted only `- [ ] ` lines. The renderer counts more (a bare `[ ] task` is a checkbox block of its own, so is `1. [ ] task`, so is anything blockquoted — which every feed-ingested post is) and fewer (markers in fenced or indented code, a marker with no label, front matter). `[ ] alpha` + `- [ ] beta` + `- [x] gamma` renders three boxes; clicking "beta" rewrote "gamma". The scan now reads the source the way Parsedown does, and the rewrite is *verified* — LambDown records what it rendered, and a rewrite that moves any other box is refused rather than stored.

**A stray non-UTF-8 byte blanked the post.** `htmlspecialchars()` returns `''` for input it cannot decode, so one Latin-1 byte rendered the whole paragraph as `<p></p>` — post, description, feed entry and search text empty, body column intact, nothing to explain it. Symfony's YAML parser refuses such a block outright, so a byte in front matter took the title and slug too. `parse_bean()` repairs the body first, reading it as Windows-1252 (where a stray byte almost always comes from).

**One bad byte emptied the JSON feed and broke the backup.** `json_encode()` refuses the whole document over any invalid string, so a byte pasted into `site_title` served subscribers an empty 200 and made `/export` answer 500. Settings text is repaired on save, and both outputs substitute rather than vanish.

**A post could 404 at the URL its own permalink named.** An explicit `slug:` is stored verbatim and the router matched the raw request segment, so `slug: café` and `slug: my post` saved fine, every link pointed at them, and each 404ed; a slug with a slash could not route back at all. Fixed at all three ends — `sanitize_explicit_slug()` keeps a slug to one segment, `permalink_path()` encodes only what a path cannot hold (sub-delimiters stay verbatim: a permalink is also a feed entry id), and the router decodes before matching. Redirect keys/targets and the Known/restore importers follow the same convention now.

**A Micropub rename could put two posts on one URL.** Naming a titleless status post derives a slug from the title, and that was the one save path that skipped `finalize_slug()` — so the new slug went in without the uniqueness or reserved-route check. The loser of the collision is unreachable at its own permalink while its feed entry points at the other post's content. Only a slug the update *mints* is finalised; a post that already has one keeps it.

**Received webmentions and syndication links never showed** on the 2026 theme — the default. Both are documented (docs/webmentions.md, docs/micropub.md); the base theme rendered them, the default one didn't call the part at all. Tests now cover every bundled theme.

### Things any visitor could trigger

**A bracket in a request parameter 500ed the site.** `?s[]=x`, `?preview[]=x` and `password[]=x` each hit a string-typed sink and fataled. The preview one only crashed for a post that *exists but is hidden* — a draft slug 500ed where an unknown slug 404ed, so it answered "does this draft exist?". `Http\request_string()` closes the class, not just the three instances.

**`/_cron` could never run again.** The lock file was hardcoded to `../data/cron.lock`; with `LAMB_DATA_DIR` set that directory does not exist, `fopen()` failed, and the failure was reported exactly like a lock held by another run — so the endpoint answered "Already running, try again later." forever while feeds, the webmention queue, the purge and scheduled hub pings all stopped. `Bootstrap\data_dir()` is now the single answer, and the two failures are told apart.

**The Atom feed stripped one layer of escaping** from every post body: `addChild()` escapes `<` but not `&`, so text stored as `&lt;script&gt;` reached subscribers as live markup in a `type="html"` element. The JSON feed was correct all along, so the two disagreed about the same post.

**Searching for a hashtag from the search box searched for nothing** — the term went into the redirect path unencoded, so `#` became a fragment. A `/` split the term; a space made an invalid Location header. And a tag containing `+` (`#c++`) linked to a tag page that 404ed, because the route read `+` as a space.

**`%` and `_` in a search term were SQL wildcards**: searching "100%" matched every post, "a_pha" matched "alpha".

### Smaller

- A Micropub content replace duplicated any tag the new content already carried (`goodbye #php #php`), growing the run on every update.
- Micropub stored the literal `"Array"` as a hashtag and as an image URL when a client sent a nested value (with an "Array to string conversion" warning behind it).
- Assets written by `persist_image_bytes()` (WordPress import images, Micropub inline photos not re-encoded) landed 0600, because `tempnam()` creates them that way and `rename()` keeps the mode — unreadable to a separate static-file user, a backup, or the author, while the site links to them.
- A settings POST with no `ini_text` saved an empty INI over every setting.
- Two flash messages carried `<code>` markup that the themes escape, so the author saw the raw tags.

### Verification

1762 unit tests and 89 acceptance tests green locally; `phpcs` clean. CI is green on the head commit: phpcs, phpstan level 8, PHP 8.4 and 8.5, js-test and playwright.