### PR TITLE
Keep the front matter when a CRLF body's heading becomes the title

### DIFF
--- a/src/post.php
+++ b/src/post.php
@@ -356,6 +356,15 @@ function consume_leading_heading(string $body): string
  * matter, so the stored title is migrated into the body before re-parsing.
  * The result matches the format modern feed ingestion writes.
  *
+ * An existing block is recognised by the same fence split_frontmatter() reads,
+ * not by a literal `---\n`: a browser normalises a <textarea> to CRLF on
+ * submit, so every body saved from the edit form arrives with `---\r\n`
+ * fences. Matching only the LF spelling took those bodies down the
+ * create-a-block branch and prepended a *second* front-matter block — the
+ * author's real one (with its `draft:`, `slug:` and `created:` lines) became
+ * body text, so parse_bean() saw no `draft` key and published the post.
+ * The block's own line ending is reused for the inserted line.
+ *
  * @param string $body The post body, with or without existing front matter.
  * @param string $title The title to write into the front matter.
  * @return string The body with the title present in its front matter.
@@ -363,11 +372,28 @@ function consume_leading_heading(string $body): string
 function inject_title_matter(string $body, string $title): string
 {
     $title_line = rtrim(Yaml::dump(['title' => $title]), "\n");
-    if (str_starts_with($body, "---\n")) {
-        return "---\n" . $title_line . "\n" . substr($body, strlen("---\n"));
+    // has_frontmatter(), not a non-empty YAML block: `---\n---\n` is an empty
+    // block, and adding a second one above it is the bug this guards against.
+    if (has_frontmatter($body) && preg_match('/\A---[ \t]*(\R)/', $body, $m) === 1) {
+        return $m[0] . $title_line . $m[1] . substr($body, strlen($m[0]));
     }
 
     return "---\n" . $title_line . "\n---\n\n" . $body;
+}
+
+/**
+ * Whether the body opens with a complete front-matter block.
+ *
+ * split_frontmatter() cannot answer this on its own: it reports an empty YAML
+ * string both for a body with no block at all and for one whose block is empty
+ * (`---\n---\n`). The content it returns is the discriminator — it is the body
+ * itself only when nothing was split off.
+ *
+ * @param string $body The raw post body.
+ */
+function has_frontmatter(string $body): bool
+{
+    return split_frontmatter($body)[1] !== $body;
 }
 
 function slugify(string $text): string

--- a/tests/Unit/ConsumeLeadingHeadingTest.php
+++ b/tests/Unit/ConsumeLeadingHeadingTest.php
@@ -7,6 +7,7 @@ use RedBeanPHP\R;
 
 use function Lamb\parse_bean;
 use function Lamb\Post\consume_leading_heading;
+use function Lamb\Post\parse_matter;
 use function Lamb\Theme\anchor_headings;
 
 class ConsumeLeadingHeadingTest extends TestCase
@@ -73,6 +74,47 @@ class ConsumeLeadingHeadingTest extends TestCase
         $this->assertStringContainsString('My Post', $result);
         $this->assertStringContainsString('created: 2020-01-01', $result);
         $this->assertStringContainsString('Body.', $result);
+    }
+
+    public function testPreservesCrlfFrontMatterWhenPromotingHeading()
+    {
+        // A browser normalises a <textarea> to CRLF on submit, so this is what
+        // every body saved from the edit form looks like. The existing block
+        // must gain the title, not be pushed below a second one — otherwise
+        // `draft: true` stops being front matter and the post publishes.
+        $body = "---\r\ndraft: true\r\n---\r\n\r\n# My Post\r\n\r\nBody.\r\n";
+
+        $result = consume_leading_heading($body);
+
+        $this->assertSame(2, substr_count($result, '---'));
+        $matter = parse_matter($result);
+        $this->assertSame('My Post', $matter['title'] ?? null);
+        $this->assertTrue($matter['draft'] ?? false);
+        $this->assertStringNotContainsString('# My Post', $result);
+        $this->assertSame($result, consume_leading_heading($result));
+    }
+
+    public function testPreservesFrontMatterFenceWithTrailingWhitespace()
+    {
+        // split_frontmatter() accepts trailing spaces on a fence line, so the
+        // title injection has to recognise the same block it reads.
+        $body = "---  \ncreated: 2020-01-01\n---  \n\n# My Post\n\nBody.";
+
+        $result = consume_leading_heading($body);
+
+        $this->assertSame(2, substr_count($result, '---'));
+        $this->assertStringContainsString('created: 2020-01-01', $result);
+        $this->assertSame('My Post', parse_matter($result)['title'] ?? null);
+    }
+
+    public function testFillsAnEmptyFrontMatterBlockRatherThanAddingAnother()
+    {
+        $body = "---\n---\n\n# My Post\n\nBody.";
+
+        $result = consume_leading_heading($body);
+
+        $this->assertSame(2, substr_count($result, '---'));
+        $this->assertSame('My Post', parse_matter($result)['title'] ?? null);
     }
 
     public function testIsIdempotent()


### PR DESCRIPTION
## The bug

`inject_title_matter()` recognised an existing front-matter block only by a literal `---\n` opening fence:

```php
if (str_starts_with($body, "---\n")) {
```

But `split_frontmatter()` — the function that decides what a front-matter block *is* everywhere else in the codebase — accepts any line ending and trailing whitespace on the fence:

```php
preg_match('/\A---[ \t]*\R(.*?)\R?---[ \t]*(?:\R|\z)/s', $body, $m)
```

The two disagreed, and a browser normalises a `<textarea>` to CRLF on submit, so **every body saved from the edit form arrives with `---\r\n` fences**.

`consume_leading_heading()` splits the block off with `split_frontmatter()` (which happily matches CRLF), then hands the reassembled body to `inject_title_matter()` (which does not). So the CRLF body took the create-a-block branch and a **second** front-matter block was prepended above the author's real one, which became body text:

```
input:   ---\r\ndraft: true\r\n---\r\n\r\n# My Title\r\n\r\nSome body.\r\n

output:  ---
         title: 'My Title'
         ---

         ---
         draft: true
         ---
         Some body.
```

`parse_matter()` then sees only the injected `title`, so downstream in `apply_frontmatter()`:

- `$bean->draft = !empty($front_matter['draft']) ? 1 : 0;` → **a draft is published on save**
- an explicit `slug:` is dropped, so the post moves URL and picks up a slug-change redirect
- `created:` is dropped, so a scheduled post is re-dated to now
- `in-reply-to:` is dropped
- the orphaned block renders into the page as a horizontal rule plus stray `draft: true` text

Reproducing the pre-fix behaviour, `draft` is gone from the parsed matter entirely:

```
array('title' => 'My Title', 'slug' => 'my-title')
```

## The fix

Recognise the same fence `split_frontmatter()` reads, and reuse the block's own line ending for the inserted line so the block stays internally consistent:

```php
if (has_frontmatter($body) && preg_match('/\A---[ \t]*(\R)/', $body, $m) === 1) {
    return $m[0] . $title_line . $m[1] . substr($body, strlen($m[0]));
}
```

`has_frontmatter()` is added because `split_frontmatter()` cannot answer the question on its own: it returns an empty YAML string both for a body with no block and for one whose block is empty (`---\n---\n`). The returned *content* is the discriminator — it is the body itself only when nothing was split off. Without this, an empty block would also gain a duplicate.

As a side effect this also fixes the unterminated-fence case (`---\nfoo\n`), which previously produced a block with no closing fence and so lost the title entirely.

## Verification

Three regression tests added to `tests/Unit/ConsumeLeadingHeadingTest.php`, each asserting exactly one fence pair survives, the title lands, and the pre-existing keys are still front matter:

- `testPreservesCrlfFrontMatterWhenPromotingHeading` — the edit-form case; also asserts `draft` is still `true` and that the result is idempotent
- `testPreservesFrontMatterFenceWithTrailingWhitespace` — `---  \n` fences
- `testFillsAnEmptyFrontMatterBlockRatherThanAddingAnother` — `---\n---\n`

Ran against a standalone harness (this environment could not complete `composer install` — the proxy refuses `api.github.com` zipball downloads, so the Codeception suite could not be executed here). All three cases produce two fence lines, the correct title, and are idempotent; the pre-existing LF, no-front-matter and CRLF-without-front-matter paths are byte-identical to before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_