### PR TITLE
Render set_matter()'s value as YAML instead of interpolating it

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -701,7 +701,7 @@ function visible_clause(): array
  */
 function persist_resolved_created(string $body, string $resolved): string
 {
-    return set_matter($body, 'created', $resolved, quote: true, append: false);
+    return set_matter($body, 'created', $resolved, append: false);
 }
 
 /**

--- a/src/post.php
+++ b/src/post.php
@@ -413,42 +413,62 @@ function build_matter(array $matter, string $content): string
  * key already holds the target value, are returned unchanged (no cosmetic
  * churn).
  *
+ * The value is rendered through the YAML writer rather than interpolated, for
+ * the reason build_matter() already documents: a slug carrying a colon
+ * (`slug: a: b`) is not valid YAML, so parse_matter() returned nothing and the
+ * *whole* front-matter block — title, draft, created — silently vanished on the
+ * next read; one carrying a `#` had everything from it treated as a comment.
+ * finalize_slug() reaches both by appending an id suffix to an explicit slug
+ * that collides or names a reserved route, and then pinning the result here.
+ * Yaml::dump() already quotes anything that needs it, including the
+ * `Y-m-d H:i:s` created stamp, so no caller has to ask for quoting.
+ *
  * @param string $body The raw post body.
  * @param string $key The front-matter key to set.
  * @param string $value The value to write.
- * @param bool $quote When true, the value is wrapped in single quotes.
  * @param bool $append When true, the key is appended if absent (otherwise the
  *                     body is returned unchanged when the key is missing).
  * @return string The body with the front-matter key set.
  */
-function set_matter(string $body, string $key, string $value, bool $quote = false, bool $append = true): string
+function set_matter(string $body, string $key, string $value, bool $append = true): string
 {
     // Only touch a front-matter block at the very start of the body.
     if (!preg_match('/\A(\s*---\s*\n)(.*?\n)(---\s*\n?)/s', $body, $m)) {
         return $body;
     }
 
-    $rendered = $quote ? "'" . $value . "'" : $value;
-
+    $rendered = Yaml::dump($value);
+    // A browser submits a <textarea> with CRLF line endings, so most bodies
+    // reaching here carry them. The `\r` is matched and carried over rather
+    // than swept into the value: as part of $line[2] it made $current differ
+    // from $value on every save, so the no-churn contract above never held for
+    // an edit-form body and each save rewrote the line (and re-stored the post).
     $new_yaml = preg_replace_callback(
-        '/^([ \t]*' . preg_quote($key, '/') . '[ \t]*:)[ \t]*(.*?)[ \t]*$/mi',
+        '/^([ \t]*' . preg_quote($key, '/') . '[ \t]*:)[ \t]*(.*?)[ \t]*(\r?)$/mi',
         function (array $line) use ($value, $rendered): string {
             $current = trim($line[2], " \t'\"");
             if ($current === $value) {
                 return $line[0];
             }
-            return $line[1] . ' ' . $rendered;
+            return $line[1] . ' ' . $rendered . $line[3];
         },
         $m[2],
         1,
         $count
     );
+    // preg_replace_callback() returns null on a PCRE failure (a backtrack limit
+    // on a long block). Concatenating that would drop the entire YAML block, so
+    // leave the body alone instead.
+    if ($new_yaml === null) {
+        return $body;
+    }
 
     if ($count === 0) {
         if (!$append) {
             return $body;
         }
-        $new_yaml = $m[2] . "$key: $rendered\n";
+        $eol = str_ends_with($m[1], "\r\n") ? "\r\n" : "\n";
+        $new_yaml = $m[2] . "$key: $rendered" . $eol;
     }
 
     return $m[1] . $new_yaml . $m[3] . substr($body, strlen($m[0]));

--- a/tests/Unit/FrontMatterTest.php
+++ b/tests/Unit/FrontMatterTest.php
@@ -180,7 +180,7 @@ class FrontMatterTest extends TestCase
         $body = "---\ncreated: 2020-01-01 00:00:00\n---\nContent.";
         $this->assertSame(
             "---\ncreated: '2024-06-05 12:00:00'\n---\nContent.",
-            set_matter($body, 'created', '2024-06-05 12:00:00', quote: true, append: false)
+            set_matter($body, 'created', '2024-06-05 12:00:00', append: false)
         );
     }
 
@@ -189,7 +189,7 @@ class FrontMatterTest extends TestCase
         $body = "---\ntitle: Hi\n---\nContent.";
         $this->assertSame(
             $body,
-            set_matter($body, 'created', '2024-06-05 12:00:00', quote: true, append: false)
+            set_matter($body, 'created', '2024-06-05 12:00:00', append: false)
         );
     }
 
@@ -198,7 +198,71 @@ class FrontMatterTest extends TestCase
         $body = "---\ncreated: '2024-06-05 12:00:00'\n---\nContent.";
         $this->assertSame(
             $body,
-            set_matter($body, 'created', '2024-06-05 12:00:00', quote: true, append: false)
+            set_matter($body, 'created', '2024-06-05 12:00:00', append: false)
         );
+    }
+
+    // set_matter — the value is YAML, not interpolated text
+
+    public function testSetMatterQuotesASlugCarryingAColon(): void
+    {
+        // finalize_slug() appends an id suffix to an explicit slug that
+        // collides or names a reserved route, then pins the result back here.
+        // Interpolated, `slug: a: b-12` is not valid YAML, so parse_matter()
+        // returned nothing and the whole block — title and draft included —
+        // silently vanished on the next read.
+        $body = "---\ntitle: My Post\ndraft: true\nslug: 'a: b'\n---\n\nBody.\n";
+
+        $result = set_matter($body, 'slug', 'a: b-12');
+
+        $this->assertSame(
+            ['title' => 'My Post', 'draft' => true, 'slug' => 'a: b-12'],
+            parse_matter($result)
+        );
+    }
+
+    public function testSetMatterQuotesASlugCarryingAHash(): void
+    {
+        // Unquoted, everything from the `#` is a YAML comment, so the pinned
+        // slug read back as `y` and never matched the stored one.
+        $body = "---\ntitle: T\nslug: x\n---\n\nBody.\n";
+
+        $this->assertSame('y #z', parse_matter(set_matter($body, 'slug', 'y #z'))['slug']);
+    }
+
+    public function testSetMatterQuotesAnAppendedValueToo(): void
+    {
+        $body = "---\ntitle: T\n---\n\nBody.\n";
+
+        $this->assertSame('a: b', parse_matter(set_matter($body, 'slug', 'a: b'))['slug']);
+    }
+
+    // set_matter — CRLF bodies (what a browser submits from a <textarea>)
+
+    public function testSetMatterDoesNotChurnACrlfBodyWhoseValueIsUnchanged(): void
+    {
+        $body = "---\r\nslug: my-slug\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n";
+
+        $this->assertSame($body, set_matter($body, 'slug', 'my-slug'));
+    }
+
+    public function testSetMatterKeepsCrlfWhenRewritingAValue(): void
+    {
+        $body = "---\r\nslug: my-slug\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n";
+
+        $this->assertSame(
+            "---\r\nslug: other\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n",
+            set_matter($body, 'slug', 'other')
+        );
+    }
+
+    public function testSetMatterKeepsCrlfWhenAppendingAKey(): void
+    {
+        $body = "---\r\ntitle: Hi\r\n---\r\n\r\nBody.\r\n";
+
+        $result = set_matter($body, 'slug', 'new');
+
+        $this->assertSame("---\r\ntitle: Hi\r\nslug: new\r\n---\r\n\r\nBody.\r\n", $result);
+        $this->assertSame(['title' => 'Hi', 'slug' => 'new'], parse_matter($result));
     }
 }


### PR DESCRIPTION
## The bug

There are three functions that write a value into a post's front matter. Two of them dump through the YAML writer and say why:

`build_matter()`:
> `Yaml::dump()` rather than `"$key: $value"`: … an unescaped newline in one … injected extra front-matter keys … It also fixes the mirror-image bug — a title containing a colon produced invalid YAML, so `parse_matter()` returned nothing and the title was silently dropped.

`set_frontmatter_key()`:
> the value is dumped through the YAML writer rather than interpolated, so a newline in it cannot inject further keys.

`set_matter()` — the third — still interpolated:

```php
$rendered = $quote ? "'" . $value . "'" : $value;
…
return $line[1] . ' ' . $rendered;
```

so it still carries the bug the other two were fixed for.

### How it is reached

`finalize_slug()` appends an id suffix to an explicit front-matter slug that collides with another post or names a reserved route, then pins the result back into the body via `persist_slug()` → `set_matter()`. The slug column holds slugs that never went through `slugify()` — `sanitize_explicit_slug()` only strips `/` and `\`, and the column also holds slugs pinned by an importer from a foreign permalink — so `:` and `#` both get there.

**A colon destroys the whole block.** Given `slug: 'a: b'` on a post that then collides:

```
---                          ---
title: My Post               title: My Post
draft: true          →       draft: true
slug: 'a: b'                 slug: a: b-12
---                          ---
```

`slug: a: b-12` is not valid YAML. `parse_matter()` catches the `ParseException` and returns `[]`, so the entire block goes with it — measured before the fix:

```
array()
```

The title clears, and in `apply_frontmatter()`:

```php
$bean->draft = !empty($front_matter['draft']) ? 1 : 0;
```

**the draft is published.** `created:` and `in-reply-to:` go the same way.

**A `#` truncates the value.** `slug: y #z` is a YAML comment from the `#` on, so the slug reads back as `y`, never matches the stored `y #z`, and `finalize_slug()` re-pins it on every save forever.

## Two more ways the same function damaged the block

**CRLF churn.** A browser normalises a `<textarea>` to CRLF on submit, so most bodies reaching `set_matter()` carry `\r`. With `/m` but not `/s`, `$` matches before the `\n`, so the `\r` landed inside the captured value:

```php
$current = trim($line[2], " \t'\"");   // "my-slug\r"
if ($current === $value) {             // never true
```

The docblock's "Bodies … whose slug already equals the actual value, are returned unchanged (no cosmetic churn)" therefore never held for an edit-form body. Every save rewrote the line (converting only that line to LF, leaving the block mixed) and made `finalize_slug()` report a change, costing an extra `R::store()` per save. The `\r` is now matched into its own group and carried over, and the append path uses the block's own line ending instead of a hard-coded `\n`.

**Silent total loss on a PCRE failure.** `preg_replace_callback()` returns `null` on a backtrack-limit failure, and `$m[1] . null . $m[3] . …` would have dropped the entire YAML block. The body is now returned untouched instead.

## The `$quote` parameter

`Yaml::dump()` already quotes anything that needs it, including the one value that asked for quoting:

```
'2024-06-05 12:00:00'  =>  "'2024-06-05 12:00:00'"
'plain-slug'           =>  "plain-slug"
```

so the output of the `created` path is byte-identical and `$quote` has nothing left to do. It is removed, and `persist_resolved_created()` updated.

## Verification

Ran the nine existing `set_matter` cases from `FrontMatterTest` plus the new ones against a standalone harness; all nine produce byte-identical output to before, including `testSetMatterPreservesKeyWhitespacePrefixOnReplace` and the three `created` cases. Six new tests added:

- `testSetMatterQuotesASlugCarryingAColon` — asserts the full block (`title`, `draft`, `slug`) survives
- `testSetMatterQuotesASlugCarryingAHash`
- `testSetMatterQuotesAnAppendedValueToo` — the append path had the same hole
- `testSetMatterDoesNotChurnACrlfBodyWhoseValueIsUnchanged`
- `testSetMatterKeepsCrlfWhenRewritingAValue`
- `testSetMatterKeepsCrlfWhenAppendingAKey`

This environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite could not be executed here — the assertions above were run directly against `src/post.php` with `symfony/yaml` at the locked v7.4.15.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_