### PR TITLE
Carry feed_locked through export and restore

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -48,6 +48,7 @@ The filename comes from the post's slug. A post with no slug is named after its 
       "draft": false,
       "deleted": false,
       "deleted_at": null,
+      "feed_locked": false,
       "post_version": 3,
       "feed_name": null,
       "feeditem_uuid": null,
@@ -68,6 +69,7 @@ Each entry in `posts` points at a file in the archive and records the things a M
 | `created` / `updated` | Local timestamps, `Y-m-d H:i:s`. A `created` date in the future means the post is [scheduled]({{ site.baseurl }}{% link scheduling.md %}). |
 | `draft` | `true` for an unpublished [draft]({{ site.baseurl }}{% link drafts.md %}). |
 | `deleted` / `deleted_at` | `true` and a timestamp for a post in the [trash]({{ site.baseurl }}{% link trash.md %}). |
+| `feed_locked` | `true` when you have edited a feed-sourced post through the edit form, which stops later crawls of that [feed]({{ site.baseurl }}{% link feeds.md %}) overwriting your version. |
 | `post_version` | Which revision of Lamb's post pipeline last rendered the post. |
 | `feed_name`, `feeditem_uuid`, `source_url` | Set when the post came from a subscribed feed rather than being written locally. Locally authored posts have `null` in all three. |
 | `site.url` (in the top-level `site` block, not per-post) | The origin the [Lamb importer]({{ site.baseurl }}{% link lamb-import.md %}) uses to namespace restored post ids, so archives from two different sites never collide on id. |

--- a/src/export.php
+++ b/src/export.php
@@ -64,6 +64,10 @@ function collect_posts(): array
             'draft'          => (bool) $bean->draft,
             'deleted'        => (bool) $bean->deleted,
             'deleted_at'     => $bean->deleted_at === null ? null : (string) $bean->deleted_at,
+            // Author-owned state, not feed provenance: it says the author took
+            // this post over through the edit form, which is why the next crawl
+            // leaves it alone. Losing it means the feed reclaims the post.
+            'feed_locked'    => (bool) $bean->feed_locked,
             'version'        => $bean->version === null ? null : (int) $bean->version,
             'feed_name'      => $bean->feed_name === null ? null : (string) $bean->feed_name,
             'feeditem_uuid'  => $bean->feeditem_uuid === null ? null : (string) $bean->feeditem_uuid,
@@ -195,7 +199,8 @@ function asset_source_path(string $assets_root, string $relative): ?string
  * Deliberately carries no title and no body: those live in the `.md` file at
  * `path`, and duplicating them here would create two sources of truth that can
  * drift. What is recorded instead is the state the front matter cannot express
- * — the row's identity, timestamps, draft/deleted flags and feed provenance.
+ * — the row's identity, timestamps, draft/deleted/feed-locked flags and feed
+ * provenance.
  *
  * The field list is an explicit allowlist so a future column added to the post
  * bean cannot start appearing in exports (and leaking, in the case of another
@@ -215,6 +220,7 @@ function manifest_post_entry(array $post, string $path): array
         'draft'         => (bool) ($post['draft'] ?? false),
         'deleted'       => (bool) ($post['deleted'] ?? false),
         'deleted_at'    => $post['deleted_at'] ?? null,
+        'feed_locked'   => (bool) ($post['feed_locked'] ?? false),
         'post_version'  => $post['version'] ?? null,
         'feed_name'     => $post['feed_name'] ?? null,
         'feeditem_uuid' => $post['feeditem_uuid'] ?? null,

--- a/src/restore.php
+++ b/src/restore.php
@@ -368,6 +368,11 @@ function import_post(array $item, callable $_downloader, bool $dry_run = false, 
  * non-empty — a slugless status post keeps the empty slug and its
  * /status/<id> permalink.
  *
+ * `feed_locked` travels with `feeditem_uuid` for the same reason: the uuid is
+ * what a later crawl matches a post on, and `feed_locked` is what stops that
+ * crawl overwriting the author's own edits. Restoring one without the other
+ * hands the post back to the feed.
+ *
  * @param array<string, mixed> $item
  */
 function apply_manifest_state(OODBBean $bean, array $item): void
@@ -388,6 +393,10 @@ function apply_manifest_state(OODBBean $bean, array $item): void
 
     $bean->draft = empty($item['draft']) ? 0 : 1;
     $bean->deleted = empty($item['deleted']) ? 0 : 1;
+    // Absent from an archive written before the manifest carried it, which
+    // reads as 0 — the value such an install would have had for any post whose
+    // author never took it over.
+    $bean->feed_locked = empty($item['feed_locked']) ? 0 : 1;
     $bean->deleted_at = $item['deleted_at'] ?? null;
     $bean->feed_name = $item['feed_name'] ?? null;
     $bean->feeditem_uuid = $item['feeditem_uuid'] ?? null;

--- a/tests/Unit/ExportTest.php
+++ b/tests/Unit/ExportTest.php
@@ -72,6 +72,7 @@ class ExportTest extends TestCase
             'draft'         => false,
             'deleted'       => false,
             'deleted_at'    => null,
+            'feed_locked'   => false,
             'version'       => 3,
             'feed_name'     => null,
             'feeditem_uuid' => null,
@@ -174,6 +175,22 @@ class ExportTest extends TestCase
         $this->assertTrue($entry['draft']);
         $this->assertTrue($entry['deleted']);
         $this->assertSame('2026-07-20 10:00:00', $entry['deleted_at']);
+    }
+
+    public function testManifestEntryRecordsTheFeedLock(): void
+    {
+        // feed_locked is author-owned state, not feed provenance: it records
+        // that the author took a feed-sourced post over through the edit form,
+        // which is the only thing stopping the next crawl overwriting it. An
+        // archive that drops it hands the post back to the feed on restore.
+        $locked = manifest_post_entry(
+            $this->post(['feeditem_uuid' => 'abc123', 'feed_locked' => true]),
+            'posts/2026/07/hello-world.md'
+        );
+        $unlocked = manifest_post_entry($this->post(), 'posts/2026/07/hello-world.md');
+
+        $this->assertTrue($locked['feed_locked']);
+        $this->assertFalse($unlocked['feed_locked']);
     }
 
     public function testManifestEntryRecordsFeedProvenance(): void

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -413,6 +413,7 @@ class LambRestoreTest extends TestCase
             'draft'         => false,
             'deleted'       => false,
             'deleted_at'    => null,
+            'feed_locked'   => false,
             'version'       => 3,
             'feed_name'     => null,
             'feeditem_uuid' => null,
@@ -451,6 +452,15 @@ class LambRestoreTest extends TestCase
                 'id'   => 5,
                 'slug' => 'with-a-photo',
                 'body' => "---\nslug: with-a-photo\n---\n\n![](/assets/2026/07/photo.png)\n",
+            ]),
+            $this->post([
+                'id'            => 6,
+                'slug'          => 'taken-over',
+                'body'          => "---\ntitle: Taken over\nslug: taken-over\n---\n\nMy words now.\n",
+                'feed_name'     => 'example',
+                'feeditem_uuid' => 'abc123',
+                'source_url'    => 'https://example.test/post',
+                'feed_locked'   => true,
             ]),
         ];
     }
@@ -553,7 +563,7 @@ class LambRestoreTest extends TestCase
     {
         $this->importArchive($this->buildArchive());
 
-        $this->assertSame(5, R::count('post'));
+        $this->assertSame(6, R::count('post'));
 
         $hello = R::findOne('post', ' slug = ? ', ['hello-world']);
         $this->assertNotNull($hello);
@@ -576,6 +586,15 @@ class LambRestoreTest extends TestCase
 
         $photo = R::findOne('post', ' slug = ? ', ['with-a-photo']);
         $this->assertStringContainsString('/assets/2026/07/photo.png', (string) $photo->body);
+
+        // feed_locked has to travel with feeditem_uuid: the uuid is what the
+        // next crawl matches the post on, and feed_locked is the only thing
+        // stopping that crawl overwriting the author's own edits.
+        $taken_over = R::findOne('post', ' slug = ? ', ['taken-over']);
+        $this->assertNotNull($taken_over);
+        $this->assertSame('abc123', (string) $taken_over->feeditem_uuid);
+        $this->assertSame(1, (int) $taken_over->feed_locked);
+        $this->assertEmpty($hello->feed_locked);
     }
 
     public function testReimportingTheSameArchiveChangesNothing(): void
@@ -584,8 +603,8 @@ class LambRestoreTest extends TestCase
         $this->importArchive($archive);
         $output = $this->importArchive($archive);
 
-        $this->assertSame(5, R::count('post'));
-        $this->assertStringContainsString('created=0 existed=5', $output);
+        $this->assertSame(6, R::count('post'));
+        $this->assertStringContainsString('created=0 existed=6', $output);
     }
 
     public function testReplaceOverwritesLocalEditsAndRestoresTrashState(): void
@@ -603,8 +622,8 @@ class LambRestoreTest extends TestCase
 
         $output = $this->importArchive($archive, true);
 
-        $this->assertStringContainsString('replaced=5', $output);
-        $this->assertSame(5, R::count('post'));
+        $this->assertStringContainsString('replaced=6', $output);
+        $this->assertSame(6, R::count('post'));
         $this->assertSame(
             "---\ntitle: Hello World\nslug: hello-world\n---\n\nBody text.\n",
             R::load('post', $edited->id)->body
@@ -700,7 +719,7 @@ class LambRestoreTest extends TestCase
 
         $this->importArchive("$this->tmp_dir/unpacked");
 
-        $this->assertSame(5, R::count('post'));
+        $this->assertSame(6, R::count('post'));
         $this->assertSame('2026-07-14 09:30:00', R::findOne('post', ' slug = ? ', ['hello-world'])->created);
     }
 
@@ -828,7 +847,7 @@ class LambRestoreTest extends TestCase
         $process->run();
 
         $this->assertSame(0, $process->getExitCode(), $process->getErrorOutput());
-        $this->assertStringContainsString('[dry-run] Done. created=5', $process->getOutput());
+        $this->assertStringContainsString('[dry-run] Done. created=6', $process->getOutput());
     }
 
     public function testTheCliScriptRefusesWhenExperimentalFeaturesDisabled(): void


### PR DESCRIPTION
## The bug

`feed_locked` records that the author took a feed-sourced post over through the edit form. It is the only thing that stops the next `/_cron` crawl re-syncing the item over their version — `src/network/ingest.php`:

```php
if (!$existing->feed_locked && (int) $item->get_updated_date('U') > $synced_at) {
    update_item($item, $name);
```

and `src/response/posts.php` sets it precisely so that "later crawls stop overwriting it".

The export/restore round trip dropped it:

| | `feeditem_uuid` | `feed_locked` |
| --- | --- | --- |
| `collect_posts()` | ✅ read off the bean | ❌ not read |
| `manifest_post_entry()` | ✅ recorded | ❌ not recorded |
| `apply_manifest_state()` | ✅ restored | ❌ not restored |

The uuid is what a crawl *matches* a post on and the lock is what stops it *writing*, so restoring one without the other is worse than restoring neither: the post comes back fully identified as that feed item and fully unprotected. After a restore from backup, the first `/_cron` run silently replaces the author's edited body, title and slug with the feed's version.

`apply_manifest_state()`'s own docblock states the contract this breaks:

> This is deliberately total rather than additive: a restore that leaves a post published when the backup says it was trashed, or dated today when the backup says 2019, has not restored anything.

## The fix

The flag travels with the uuid at all three points:

- `collect_posts()` — `'feed_locked' => (bool) $bean->feed_locked` (read off the bean, not named in SQL, for the fluid-mode reason the docblock already gives)
- `manifest_post_entry()` — `'feed_locked' => (bool) ($post['feed_locked'] ?? false)`
- `apply_manifest_state()` — `$bean->feed_locked = empty($item['feed_locked']) ? 0 : 1;`

An archive written before the manifest carried the key restores as `0`, which is what such an install held for any post whose author never took it over. That makes it a purely additive field, so `EXPORT_FORMAT` stays at `lamb-export/1` — matching the constant's own rule ("additive fields keep version 1").

## Tests

- `ExportTest::testManifestEntryRecordsTheFeedLock` — locked and unlocked entries
- `LambRestoreTest` — the round-trip sample gains a sixth post that is feed-sourced *and* locked; `testRoundTripRestoresEveryPostState` now asserts `feeditem_uuid` and `feed_locked` both come back, and that an unlocked post stays unlocked. The dependent counts in `testReimportingTheSameArchiveChangesNothing`, `testReplaceOverwritesLocalEditsAndRestoresTrashState`, `testAnUnpackedDirectoryImportsLikeTheZip` and `testTheCliScriptRunsAnArchiveEndToEnd` are updated from 5 to 6.
- Both fixtures (`ExportTest::post()`, `LambRestoreTest::post()`) gain the field so they keep mirroring `collect_posts()`, which is what their docblocks say they are for.

`docs/export.md` gains the field in the sample manifest and in the field table.

Note: this environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here — the change is a three-point addition to an existing allowlist, verified by reading, with the test updates written to match.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_