### PR TITLE
Stop an imported post slug shadowing a route

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -113,7 +113,13 @@ $template = $action;
 # Empty when the request has no first segment at all (e.g. `//`), which must not
 # be looked up: every status post has an empty slug, so it would match one.
 $slug_lookup = is_string($action) ? rawurldecode($action) : '';
-if ($slug_lookup !== '' && post_has_slug($slug_lookup) !== null) {
+# A reserved name is never re-registered as a post: register_route() overwrites,
+# and this runs after register_app_routes(), so a post slugged `login` used to
+# replace the login route and lock the author out of their own site. finalize_slug()
+# suffixes such a slug at save time, but a database can carry one that predates
+# that guard or came in through an importer, and the site has to keep working.
+# The post is still served at its /status/<id> permalink.
+if ($slug_lookup !== '' && !Route\is_reserved_route($action) && post_has_slug($slug_lookup) !== null) {
     Route\register_route($action, __NAMESPACE__ . '\\Response\respond_post', $slug_lookup);
     $template = 'status';
 } elseif ($action !== false && !Route\is_reserved_route($action)) {

--- a/src/routes.php
+++ b/src/routes.php
@@ -148,6 +148,21 @@ function call_route(bool|string $action): array
 /**
  * Checks if a given route is reserved.
  *
+ * The registry is built on demand when it is empty. A CLI importer
+ * (import-lamb.php, import-wordpress.php, import-known.php) bootstraps the
+ * database and the config but never the router, so $routes was empty there and
+ * this answered "not reserved" for every name — silently disabling the guard on
+ * exactly the path that pins a foreign permalink as a slug. A WordPress page at
+ * /login/ therefore imported as slug `login`, and index.php registers a matching
+ * post's route *after* register_app_routes(), overwriting it: /login served the
+ * post and the author could no longer reach the login form. `feed`, `search`,
+ * `settings` and `_cron` shadow the same way.
+ *
+ * A web request has already called register_app_routes(), so the rebuild never
+ * fires there. The `false` action picks the same key set as any other — the
+ * action-dependent branches choose a handler for `home` and `tag`, not whether
+ * those names exist.
+ *
  * @param string $name The name of the route to check.
  *
  * @return bool True if the route is reserved, false otherwise.
@@ -155,6 +170,10 @@ function call_route(bool|string $action): array
 function is_reserved_route(string $name): bool
 {
     global $routes;
+
+    if (empty($routes)) {
+        register_app_routes(false);
+    }
 
     return isset($routes[$name]);
 }

--- a/tests/Unit/RouteTest.php
+++ b/tests/Unit/RouteTest.php
@@ -53,6 +53,21 @@ class RouteTest extends TestCase
         $this->assertSame(['y', 'x'], $result);
     }
 
+    public function testIsReservedRouteKnowsTheAppRoutesWithoutARequest(): void
+    {
+        // setUp() emptied $routes, which is the state a CLI importer runs in:
+        // it bootstraps the database and the config but never the router. The
+        // guard used to answer "free" for every name there, so an imported
+        // post could take `login` and shadow the login page.
+        global $routes;
+        $this->assertSame([], $routes);
+
+        $this->assertTrue(is_reserved_route('login'));
+        $this->assertTrue(is_reserved_route('feed'));
+        $this->assertTrue(is_reserved_route('_cron'));
+        $this->assertFalse(is_reserved_route('an-ordinary-slug'));
+    }
+
     public function testCallRouteReturns404ArrayForUnregisteredRoute(): void
     {
         global $config;

--- a/tests/Unit/SlugFinalizeTest.php
+++ b/tests/Unit/SlugFinalizeTest.php
@@ -98,6 +98,24 @@ class SlugFinalizeTest extends TestCase
         $this->assertSame('my-page', $bean->slug);
     }
 
+    public function testFinalizeSuffixesReservedRouteSlugWithNoRouterRegistered(): void
+    {
+        // No register_route() call: this is the state a CLI importer runs in,
+        // and is_reserved_route() has to answer the same there as it does in a
+        // request. An importer pins a foreign permalink verbatim, so a
+        // WordPress page at /login/ arrives with slug `login`.
+        global $routes;
+        $routes = [];
+
+        $text = "---\nslug: login\n---\nContent.";
+        $bean = populate_bean($text);
+        R::store($bean);
+        finalize_slug($bean);
+        R::store($bean);
+
+        $this->assertSame('login-' . $bean->id, $bean->slug);
+    }
+
     public function testFinalizeSuffixesReservedRouteSlug(): void
     {
         // Routes are registered by index.php at runtime; register one here so


### PR DESCRIPTION
## The bug

`is_reserved_route()` answers from the global `$routes` registry:

```php
function is_reserved_route(string $name): bool
{
    global $routes;
    return isset($routes[$name]);
}
```

Only `index.php` ever fills that registry. The three CLI importers — `import-lamb.php`, `import-wordpress.php`, `import-known.php` — bootstrap the database and the config but never call `Route\register_app_routes()`, so `$routes` is empty and the guard answers "not reserved" for **every** name. Measured directly against `src/routes.php`:

```
before register_app_routes():        after register_app_routes():
  login          reserved=false        login          reserved=true
  feed           reserved=false        feed           reserved=true
  search         reserved=false        search         reserved=true
  _cron          reserved=false        _cron          reserved=true
  …
```

That is precisely the path that pins a foreign permalink verbatim as a slug — `wordpress.php` takes `wp:post_name`, `known.php` takes the permalink's last segment — so a WordPress page at `/login/` imports with slug `login`.

**Nothing downstream catches it.** `register_route()` overwrites, and `index.php` registers the matching post's route *after* `register_app_routes()`:

```php
Route\register_app_routes($action, $lookup, $sublookup);   // line 104
…
if ($slug_lookup !== '' && post_has_slug($slug_lookup) !== null) {
    Route\register_route($action, …\Response\respond_post, $slug_lookup);   // line 117
```

so the post replaces the route outright. `/login` serves the post and **the author can no longer reach the login form**. `feed`, `feed.json`, `search`, `settings`, `export`, `robots.txt`, `sitemap.xml` and `_cron` shadow the same way — a post slugged `_cron` silently stops feed ingestion and the outbound webmention queue.

`src/import.php` documents the opposite as the contract:

> An explicit `slug:` line — sourced from the CMS's own permalink leaf — pins the post's URL to its original permalink. … **finalize_slug() still suffixes `-id` on a reserved-route or collision**, so a duplicate imported slug can't override an existing post.

The collision half works (it is a DB query); the reserved-route half never ran.

## The fix

Two changes, one at each end.

**`is_reserved_route()` builds the registry on demand when it is empty**, so it gives the same answer in a CLI import as in a request:

```php
if (empty($routes)) {
    register_app_routes(false);
}
```

A web request has already registered the routes, so the rebuild never fires there. Passing `false` as the action is safe: the action-dependent branches in `register_app_routes()` pick a *handler* for `home` and `tag`, not whether those names exist, so the key set is identical for any action.

**`index.php` no longer registers a post route over a reserved name.** A database can already carry such a slug — imported before this fix, or from before the guard existed — and the site has to keep working. That post is still served at its `/status/<id>` permalink (`respond_status` loads by id regardless of slug), and its next save through the edit form suffixes the slug and restores its own URL.

## Tests

- `RouteTest::testIsReservedRouteKnowsTheAppRoutesWithoutARequest` — asserts `$routes` is empty (the class's `setUp()` empties it, which is the CLI state) and that `login`, `feed` and `_cron` still come back reserved while an ordinary slug does not.
- `SlugFinalizeTest::testFinalizeSuffixesReservedRouteSlugWithNoRouterRegistered` — the importer case end to end: no `register_route()` call, `slug: login` in the front matter, expects `login-<id>`. Its neighbour `testFinalizeSuffixesReservedRouteSlug` keeps its explicit registration and still passes.

I checked the rest of the suite for tests that would newly see a name as reserved: the only route-named slug or title anywhere in `tests/` is `SlugFinalizeTest`'s own `slug: search` (which already expects the suffix) and `UpgradePostsTest`'s `slug: search-1` (already suffixed, and `upgrade_posts()` never calls `finalize_slug()`). `RobotsTest`, `NoIndexTest` and `RouteVisibilityTest` all reset and register the routes explicitly, so the on-demand build never fires for them.

Note: this environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here. The `is_reserved_route()` before/after table above was produced by running `src/routes.php` directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_