### PR TITLE
Keep the OpenGraph image sizer inside the web root

### DIFF
--- a/src/theme/meta.php
+++ b/src/theme/meta.php
@@ -150,11 +150,28 @@ function image_dimensions(string $url): array
 }
 
 /**
- * Maps a same-origin image URL to its filesystem path under ROOT_DIR, or null for remote
- * URLs (which can't be measured locally).
+ * Maps a same-origin image URL to a real file inside ROOT_DIR, or null for a
+ * remote URL (which can't be measured locally) and for anything that resolves
+ * outside the web root.
+ *
+ * The URL is the `src` of the first `<img>` in a post's rendered body, so it is
+ * whatever the Markdown said — and the body is not always the author's: a
+ * subscribed feed's item description reaches here (strip_tags() removes HTML
+ * tags but leaves Markdown `![](…)` for Parsedown to render), as does a
+ * Micropub client holding only `create` scope, and both importers. `![](/../..
+ * /etc/whatever.png)` therefore built a path straight out of the web root, and
+ * image_dimensions() published whether it exists — plus its pixel size and MIME
+ * type — into the page's og:image meta tags for anyone to read.
+ *
+ * Response\asset_dimensions() already resolves the same class of body-supplied
+ * `src` and documents why: "Post bodies are hand-written Markdown, so
+ * /assets/../../etc/passwd … is reachable input; realpath() containment rejects
+ * it, and covers symlinks out of the tree too." The containment here is against
+ * ROOT_DIR rather than src/assets/, because the site default (og-image.png) and
+ * the shipped card both legitimately live outside the uploads tree.
  *
  * @param string $url Image URL.
- * @return string|null
+ * @return string|null The resolved path inside ROOT_DIR, or null.
  */
 function og_local_path(string $url): ?string
 {
@@ -162,12 +179,20 @@ function og_local_path(string $url): ?string
         return null;
     }
     if (str_starts_with($url, ROOT_URL . '/')) {
-        return ROOT_DIR . substr($url, strlen(ROOT_URL));
+        $path = ROOT_DIR . substr($url, strlen(ROOT_URL));
+    } elseif (str_starts_with($url, '/')) {
+        $path = ROOT_DIR . $url;
+    } else {
+        return null;
     }
-    if (str_starts_with($url, '/')) {
-        return ROOT_DIR . $url;
+
+    $root = realpath(ROOT_DIR);
+    $real = realpath($path);
+    if ($root === false || $real === false) {
+        return null;
     }
-    return null;
+
+    return str_starts_with($real, $root . DIRECTORY_SEPARATOR) ? $real : null;
 }
 
 /**

--- a/tests/Unit/ThemeMetaTest.php
+++ b/tests/Unit/ThemeMetaTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\Theme\image_dimensions;
+use function Lamb\Theme\og_local_path;
 use function Lamb\Theme\the_meta_description;
 use function Lamb\Theme\the_opengraph;
 
@@ -353,6 +355,50 @@ class ThemeMetaTest extends TestCase
             @unlink($dir . '/og-image.' . $ext);
         }
         return $dir;
+    }
+
+    // -------------------------------------------------------------------------
+    // og_local_path — a body-supplied src must not escape the web root
+    // -------------------------------------------------------------------------
+
+    public function testOgLocalPathRefusesAnImageOutsideTheWebRoot(): void
+    {
+        // The src is the first <img> in a post's rendered body, and the body is
+        // not always the author's: a subscribed feed's item description reaches
+        // here as Markdown, so `![](/../../secret.png)` is remote input. Sizing
+        // it published the existence, pixel size and MIME type of a file
+        // outside the web root into the page's og:image meta tags.
+        $webRoot = $this->resetWebRoot();
+        file_put_contents($webRoot . '/og-image.png', $this->onePixelPng());
+
+        $outside = sys_get_temp_dir() . '/lamb_og_outside_' . getmypid() . '.png';
+        file_put_contents($outside, $this->onePixelPng());
+        // Enough `..` segments to climb out of ROOT_DIR wherever it points.
+        $climb = str_repeat('/..', substr_count(trim(str_replace('\\', '/', (string) realpath(ROOT_DIR)), '/'), '/') + 1);
+
+        try {
+            // Positive control: a file genuinely inside the web root still resolves.
+            $this->assertNotNull(og_local_path(ROOT_URL . '/og-image.png'));
+            $this->assertNotSame([], image_dimensions(ROOT_URL . '/og-image.png'));
+
+            // The same file, reached by climbing out of the root, does not.
+            $this->assertSame($outside, realpath($outside));
+            $this->assertNull(og_local_path(ROOT_URL . $climb . $outside));
+            $this->assertSame([], image_dimensions(ROOT_URL . $climb . $outside));
+            // The root-relative spelling (no ROOT_URL prefix) is the same path.
+            $this->assertNull(og_local_path($climb . $outside));
+        } finally {
+            @unlink($webRoot . '/og-image.png');
+            @unlink($outside);
+        }
+    }
+
+    /** A real 1x1 PNG, so getimagesize() can read its dimensions and type. */
+    private function onePixelPng(): string
+    {
+        return (string) base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+        );
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

`Theme\og_local_path()` mapped an image URL to a filesystem path by concatenation, and never checked where it landed:

```php
if (str_starts_with($url, ROOT_URL . '/')) {
    return ROOT_DIR . substr($url, strlen(ROOT_URL));
}
if (str_starts_with($url, '/')) {
    return ROOT_DIR . $url;
}
```

That URL is the `src` of the first `<img>` in a post's rendered body (`og_image()` → `first_embedded_image($bean->transformed)`), so it is whatever the Markdown said — **and the body is not always the author's**:

- a subscribed feed's item description reaches here: `attributed_content()` runs `strip_tags()`, which removes HTML tags but leaves Markdown `[](…)` for Parsedown to render into an `<img>`;
- a Micropub client holding only `create` scope;
- both CLI importers.

`image_dimensions()` then runs `is_file()` and `getimagesize()` on the result and puts what it finds into the page's meta tags:

```php
$og_tags['og:image:width']  = $image['width'];
$og_tags['og:image:height'] = $image['height'];
$og_tags['og:image:type']   = $image['type'];
```

So a post body containing `[](/../../../../tmp/whatever.png)` publishes the **existence, pixel dimensions and MIME type** of an arbitrary readable path on the host, into public HTML, for anyone to read. Reproduced against the pre-fix logic with `ROOT_DIR = src/`:

```
src=/assets/2026/07/a.webp   path=…/lamb/src/assets/2026/07/a.webp   is_file=false
src=/../composer.json        path=…/lamb/src/../composer.json        is_file=true
```

and with a real PNG placed outside the root:

```php
image_dimensions(ROOT_URL . '/../../../../..' . $secret)
// => ['width' => '1234', 'height' => '567', 'type' => 'image/png']
```

## The fix

`Response\asset_dimensions()` resolves exactly this class of body-supplied `src` and already guards it, for the reason its own docblock gives:

> Anything that escapes `src/assets/` once resolved. Post bodies are hand-written Markdown, so `/assets/../../etc/passwd` (percent-encoded or not) is reachable input; `realpath()` containment rejects it, and covers symlinks out of the tree too.

The same containment is applied here — against `ROOT_DIR` rather than `src/assets/`, because the site default (`og-image.png` in the web root) and the shipped card (`/images/og-image-lamb.webp`) legitimately live outside the uploads tree:

```php
$root = realpath(ROOT_DIR);
$real = realpath($path);
if ($root === false || $real === false) {
    return null;
}

return str_starts_with($real, $root . DIRECTORY_SEPARATOR) ? $real : null;
```

This also covers symlinks out of the tree, and a missing file now returns `null` where it previously returned a path that `image_dimensions()`'s `is_file()` rejected a line later — same outcome, one step earlier.

Behaviour for every legitimate case is unchanged (verified against the patched source):

```
inside  path    = '…/webroot/og-image.png'
inside  dims    = {"width":"1","height":"1","type":"image\/png"}
escape  path    = NULL
escape  dims    = []
escape  rootrel = NULL
remote          = NULL
missing         = NULL
```

## Test

`ThemeMetaTest::testOgLocalPathRefusesAnImageOutsideTheWebRoot` writes the same 1×1 PNG both inside the web root and in `sys_get_temp_dir()`, then reaches the outside copy with enough `..` segments to climb out of `ROOT_DIR` wherever the suite has pointed it (computed from `realpath(ROOT_DIR)`, since the helper's own comment notes ROOT_DIR is process-wide and another test may have set it). It asserts the positive control still resolves and still sizes, and that the escaping spelling — with and without the `ROOT_URL` prefix — returns `null` and no dimensions. Both files are cleaned up in a `finally`.

Note: this environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here; the before/after tables above were produced by running `src/theme/meta.php` directly against a temporary web root. CI will run the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_