### PR TITLE
Apply safe mode to a task-list checkbox label

### DIFF
--- a/src/LambDown.php
+++ b/src/LambDown.php
@@ -167,45 +167,40 @@ class LambDown extends Parsedown
     /**
      * Renders a disabled task checkbox followed by its inline-formatted label.
      *
+     * The label goes through line() with safe mode left ON, and is not escaped
+     * beforehand. The upstream extension this was internalised from pre-escaped
+     * the text and then switched safe mode off around the inline pass — which
+     * turned off more than the escaping it was compensating for. Safe mode is
+     * also what applies Parsedown's URL-scheme allowlist (sanitiseElement()),
+     * so with it off a link or image *inside a label* kept whatever scheme it
+     * was given:
+     *
+     *     [ ] [click](javascript:alert(1))
+     *     → <input type="checkbox" disabled> <a href="javascript:alert(1)">click</a>
+     *
+     * while the same link outside a label correctly became `javascript%3A`.
+     * That is not only the author's own body: a subscribed feed's item
+     * description reaches the renderer (attributed_content() strips HTML tags
+     * but leaves Markdown, and prefixes each line with `> `, which still parses
+     * as a task item inside the blockquote), as does a Micropub client holding
+     * only `create` scope — so it was remotely triggerable stored XSS, served
+     * to every visitor from the post's cached `transformed` column.
+     *
+     * Dropping the pre-escape also fixes what it broke on the way past: `&` in
+     * a label's link URL was escaped once by hand and once more as an attribute
+     * value, so `?b=1&c=2` was emitted as `?b=1&amp;amp;c=2` and the link
+     * pointed at a URL with a literal `&amp;` in it. line() escapes the label's
+     * own text by itself, exactly once, the way every other inline text does.
+     *
      * @param string $text    The label text.
      * @param bool   $checked Whether the box is ticked.
      * @return string The checkbox HTML.
      */
     protected function renderCheckbox($text, $checked)
     {
-        if ($this->markupEscaped || $this->safeMode) {
-            $text = self::escape($text);
-        }
-
         $checkedAttr = $checked ? ' checked' : '';
 
-        return '<input type="checkbox"' . $checkedAttr . ' disabled> ' . $this->formatLabel($text);
-    }
-
-    /**
-     * Inline-formats a checkbox label without double-escaping.
-     *
-     * The label has already been escaped under safe mode, so markup escaping and
-     * safe mode are toggled off around the inline pass (then restored), exactly
-     * as the upstream extension does.
-     *
-     * @param string $text The (already escaped) label text.
-     * @return string The inline-formatted label.
-     */
-    protected function formatLabel($text)
-    {
-        $markupEscaped = $this->markupEscaped;
-        $safeMode      = $this->safeMode;
-
-        $this->setMarkupEscaped(false);
-        $this->setSafeMode(false);
-
-        $text = $this->line($text);
-
-        $this->setMarkupEscaped($markupEscaped);
-        $this->setSafeMode($safeMode);
-
-        return $text;
+        return '<input type="checkbox"' . $checkedAttr . ' disabled> ' . $this->line($text);
     }
 
     /**

--- a/tests/Unit/LambDownTest.php
+++ b/tests/Unit/LambDownTest.php
@@ -117,6 +117,59 @@ class LambDownTest extends TestCase
         $this->assertStringContainsString('<strong>the</strong>', $html);
     }
 
+    public function testCheckboxLabelLinkGetsTheSafeModeSchemeAllowlist(): void
+    {
+        // The label used to be rendered with safe mode switched off, so
+        // Parsedown's URL-scheme allowlist never ran on a link inside it —
+        // while the same link outside a label was correctly neutralised.
+        $inLabel  = $this->parser->text('[ ] [click](javascript:alert(1))');
+        $outside  = $this->parser->text('[click](javascript:alert(1))');
+
+        $this->assertStringNotContainsString('href="javascript:', $inLabel);
+        $this->assertStringContainsString('javascript%3Aalert', $inLabel);
+        // Both spellings of the same link are neutralised the same way.
+        $this->assertStringContainsString('javascript%3Aalert', $outside);
+    }
+
+    public function testCheckboxLabelImageGetsTheSafeModeSchemeAllowlist(): void
+    {
+        $html = $this->parser->text('[x] ![a](javascript:alert(2))');
+
+        $this->assertStringNotContainsString('src="javascript:', $html);
+        $this->assertStringContainsString('javascript%3Aalert', $html);
+    }
+
+    public function testBlockquotedCheckboxLabelIsAlsoFiltered(): void
+    {
+        // The shape feed ingestion produces: attributed_content() strips HTML
+        // tags but leaves Markdown, and prefixes every line with `> `, which
+        // still parses as a task item inside the blockquote. That made this
+        // remotely triggerable by any subscribed feed.
+        $html = $this->parser->text('> [ ] [click](javascript:alert(4))');
+
+        $this->assertStringNotContainsString('href="javascript:', $html);
+        $this->assertStringContainsString('javascript%3Aalert', $html);
+    }
+
+    public function testCheckboxLabelStillEscapesRawHtml(): void
+    {
+        $html = $this->parser->text('[ ] <img src=x onerror=alert(3)>');
+
+        $this->assertStringNotContainsString('<img src=x', $html);
+        $this->assertStringContainsString('&lt;img src=x onerror=alert(3)&gt;', $html);
+    }
+
+    public function testCheckboxLabelLinkUrlIsNotDoubleEscaped(): void
+    {
+        // The label was escaped by hand and then again as an attribute value,
+        // so `?b=1&c=2` was emitted as `?b=1&amp;amp;c=2` — a link pointing at
+        // a URL with a literal `&amp;` in it.
+        $html = $this->parser->text('[x] [l](https://example.test/a?b=1&c=2)');
+
+        $this->assertStringContainsString('href="https://example.test/a?b=1&amp;c=2"', $html);
+        $this->assertStringNotContainsString('&amp;amp;', $html);
+    }
+
     public function testVideoExtensionRendersVideoTag(): void
     {
         $html = $this->parser->text('![clip](video.mp4)');


### PR DESCRIPTION
## The bug

`LambDown::renderCheckbox()` pre-escaped the label text and then switched safe mode **off** around the inline pass, the way the upstream extension it was internalised from does:

```php
protected function renderCheckbox($text, $checked)
{
    if ($this->markupEscaped || $this->safeMode) {
        $text = self::escape($text);
    }
    …
    return '<input type="checkbox"' . $checkedAttr . ' disabled> ' . $this->formatLabel($text);
}

protected function formatLabel($text)
{
    …
    $this->setMarkupEscaped(false);
    $this->setSafeMode(false);
    $text = $this->line($text);
    …
}
```

That turns off more than the escaping it is compensating for. Safe mode is also what applies Parsedown's URL-scheme allowlist (`sanitiseElement()` → `filterUnsafeUrlInAttribute()`), so a link or image **inside a label** kept whatever scheme it was given — while the identical link outside a label was correctly neutralised. Measured against `erusev/parsedown` 1.8.0 with `setSafeMode(true)`:

```
plain link (control):    <p><a href="javascript%3Aalert(1)">click</a></p>
checkbox label link:     <input type="checkbox" … disabled> <a href="javascript:alert(1)">click</a>
checkbox label image:    <input type="checkbox" … disabled> ``&lt;img src="javascript:alert(2)" …&gt;``
in a blockquote (feed):  <blockquote><input type="checkbox" … disabled> <a href="javascript:alert(4)">click</a></blockquote>
```

### Why it is remotely triggerable

This is not only the author's own body. `Network\attributed_content()` builds a feed-ingested post like this:

```php
$contents = strip_tags($item->get_description() ?? '');
$lines = explode(PHP_EOL, $contents);
…
$line = "> $line";
```

`strip_tags()` removes HTML tags but leaves Markdown untouched, and the `> ` prefix does not stop a task marker parsing — the blockquote's contents go back through full block parsing, custom block types included (last line of the table above).

So a subscribed feed whose item description contains

```
[ ] [click me](javascript:…)
```

is rendered once at ingest, cached in the post's `transformed` column, and served to **every visitor** of the site. A Micropub client holding only `create` scope reaches the same path. `src/lamb.php` already documents this exact class of finding for `parse_tags()` ("Feed ingestion reaches here with remote content, which is then stored and served to every visitor, so that was remotely triggerable stored XSS") — this is the same hole in a different renderer.

Raw HTML in a label was *not* affected: `self::escape()` handled that. It is specifically the URL-scheme allowlist that got switched off.

### The double-escape it also caused

The hand-escape ran before Parsedown escaped the same value again as an attribute:

```
[x] [l](https://example.test/a?b=1&c=2)
→ <a href="https://example.test/a?b=1&amp;amp;c=2">
```

The browser decodes that to `?b=1&amp;c=2` — the link points at the wrong URL.

## The fix

Drop the pre-escape and leave safe mode on: `line()` escapes the label's own text by itself, exactly once, the way every other inline text is escaped, and — because safe mode is still on — runs the scheme allowlist. `formatLabel()` has nothing left to do and is removed.

```php
protected function renderCheckbox($text, $checked)
{
    $checkedAttr = $checked ? ' checked' : '';

    return '<input type="checkbox"' . $checkedAttr . ' disabled> ' . $this->line($text);
}
```

After:

```
js link in label       <input type="checkbox" … disabled> <a href="javascript%3Aalert(1)">click</a>
js image in label      <input type="checkbox" … disabled> ``&lt;img src="javascript%3Aalert(2)" …&gt;``
js link in blockquote  <blockquote><input type="checkbox" … disabled> <a href="javascript%3Aalert(4)">click</a></blockquote>
data: uri in label     <a href="data%3Atext/html;base64,…">x</a>
ampersand in label url <a href="https://e.test/a?b=1&amp;c=2">l</a>
raw html escaped       &lt;img src=x onerror=alert(3)&gt;
bold formatted         read <strong>the</strong> docs
image in label sized   ``&lt;img src="/assets/2026/01/a.webp" alt="i" loading="lazy" decoding="async" /&gt;``
```

`markupEscaped` on its own is still honoured — `inlineMarkup()` returns early for it independently of safe mode — so a caller using that flag rather than safe mode is unaffected, as is a parser with both off.

## Verification

Rendered all 19 `CheckboxRenderParityTest::bodyProvider()` fixtures through the old and new renderer side by side: **byte-identical output on every one**, and `renderedCheckboxStates()` matches for all of them — so the rendered checkbox count, order and states that the toggle endpoint's `data-checkbox-index` relies on are unchanged.

Five tests added to `LambDownTest`:

- `testCheckboxLabelLinkGetsTheSafeModeSchemeAllowlist` — asserts the in-label and outside-label spellings of the same link are neutralised the same way
- `testCheckboxLabelImageGetsTheSafeModeSchemeAllowlist`
- `testBlockquotedCheckboxLabelIsAlsoFiltered` — the feed-ingestion shape
- `testCheckboxLabelStillEscapesRawHtml` — the behaviour that already worked
- `testCheckboxLabelLinkUrlIsNotDoubleEscaped`

This environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here; the tables above were produced by running `src/LambDown.php` against a clone of `erusev/parsedown` at the locked 1.8.0. CI will run the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_