### PR TITLE
Refuse to link a reply target that is not an http(s) URL

### DIFF
--- a/src/theme/formatting.php
+++ b/src/theme/formatting.php
@@ -65,6 +65,16 @@ function anchor_headings(string $html, int $top): string
  * carries the `u-in-reply-to` microformats2 class so Webmention receivers
  * categorise the mention as a reply.
  *
+ * The same guard link_source() and syndication_links() already apply: escape()
+ * encodes HTML metacharacters, not URL schemes, so a `javascript:` target went
+ * into the href untouched. `in_reply_to` is not author-only — a Micropub client
+ * holding just `create` scope sets it, and replyTargetUrl() only unwraps the
+ * value, it does not validate it — and this markup is served on every page
+ * listing the post *and* inside the Atom and JSON feeds' content_html. A target
+ * that is not a real http(s) URL is shown as text instead of being linked: it
+ * cannot be a webmention target either (enqueue_outbound() filters on the same
+ * predicate), so there is nothing for the anchor to mean.
+ *
  * @param \RedBeanPHP\OODBBean $bean
  * @return string
  */
@@ -73,6 +83,10 @@ function the_reply_context(\RedBeanPHP\OODBBean $bean): string
     $url = trim((string) ($bean->in_reply_to ?? ''));
     if ($url === '') {
         return '';
+    }
+
+    if (!\Lamb\Http\is_valid_http_url($url)) {
+        return '<p class="reply-context">In reply to ' . escape($url) . '</p>';
     }
 
     $label = parse_url($url, PHP_URL_HOST) ?: $url;

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -80,7 +80,11 @@ foreach ($data['posts'] as $bean) {
     if ($content_document !== null) {
         $content_node->appendChild($content_document->createTextNode($content_html));
     }
-    if (!empty($bean->in_reply_to)) {
+    // Guarded like the reply context in <content> above: `ref`/`href` are a URL a
+    // reader may turn into a link, and in_reply_to is not author-only (a Micropub
+    // client with `create` scope sets it, unvalidated), so a non-http(s) scheme
+    // must not be syndicated as one.
+    if (!empty($bean->in_reply_to) && Lamb\Http\is_valid_http_url((string) $bean->in_reply_to)) {
         // Raw URL: SimpleXML escapes attribute values itself, so pre-escaping
         // would double-encode any query-string ampersands.
         $Thread = $Entry->addChild('in-reply-to', null, 'http://purl.org/syndication/thread/1.0');

--- a/src/themes/base/feed_json.php
+++ b/src/themes/base/feed_json.php
@@ -44,7 +44,10 @@ foreach ($data['posts'] as $bean) {
     if (!empty($bean->title)) {
         $item['title'] = $bean->title;
     }
-    if (!empty($bean->in_reply_to)) {
+    // Guarded like the reply context in content_html above: the consumer turns
+    // this into a link, and in_reply_to is not author-only (a Micropub client
+    // with `create` scope sets it, unvalidated).
+    if (!empty($bean->in_reply_to) && Lamb\Http\is_valid_http_url((string) $bean->in_reply_to)) {
         // micro.blog reply convention.
         $item['_microblog'] = ['in_reply_to_url' => $bean->in_reply_to];
     }

--- a/tests/Unit/ReplyContextTest.php
+++ b/tests/Unit/ReplyContextTest.php
@@ -110,6 +110,38 @@ class ReplyContextTest extends TestCase
         $this->assertStringContainsString('other.example', $html);
     }
 
+    public function testReplyContextRefusesToLinkANonHttpScheme(): void
+    {
+        // escape() encodes HTML metacharacters, not URL schemes — the same gap
+        // link_source() and syndication_links() already guard. in_reply_to is
+        // not author-only: a Micropub client holding just `create` scope sets
+        // it, and replyTargetUrl() only unwraps the value, it does not validate
+        // it. This markup is served on every page listing the post and inside
+        // both feeds' content_html.
+        foreach (['javascript:alert(1)', 'JaVaScRiPt:alert(1)', 'data:text/html;base64,eA==', 'vbscript:x'] as $url) {
+            $bean = R::dispense('post');
+            $bean->in_reply_to = $url;
+
+            $html = the_reply_context($bean);
+
+            $this->assertStringNotContainsString('href=', $html, $url);
+            $this->assertStringNotContainsString('<a ', $html, $url);
+            // The target is still shown, just not as a link.
+            $this->assertStringContainsString('In reply to', $html, $url);
+        }
+    }
+
+    public function testReplyContextStillLinksAnOrdinaryUrl(): void
+    {
+        $bean = R::dispense('post');
+        $bean->in_reply_to = 'https://e.test/a?b=1&c=2';
+
+        $html = the_reply_context($bean);
+
+        $this->assertStringContainsString('href="https://e.test/a?b=1&amp;c=2"', $html);
+        $this->assertStringContainsString('u-in-reply-to', $html);
+    }
+
     public function testReplyContextHelperEmptyWhenUnset(): void
     {
         $bean = R::dispense('post');


### PR DESCRIPTION
## The bug

Three theme helpers put a stored, non-author-controlled URL into an `href`. Two of them require `is_valid_http_url()` first, and both say why.

`Theme\link_source()`:
> `escape()` only encodes HTML metacharacters, not URL schemes: a `javascript:`-scheme URL passes through untouched into the href attribute.

`Theme\syndication_links()`:
> Same reasoning as `link_source()` above … `syndicated_to` is **not author-only** — a Micropub client holding just `create` scope sets it via `mp-syndicate-to` — so require a real http(s) URL before linking it.

`Theme\the_reply_context()` — the third — had no such guard:

```php
$url = trim((string) ($bean->in_reply_to ?? ''));
if ($url === '') {
    return '';
}
$label = parse_url($url, PHP_URL_HOST) ?: $url;
return '<p class="reply-context">In reply to <a class="u-in-reply-to" rel="in-reply-to" href="'
    . escape($url) . '">' . escape($label) . '</a></p>';
```

`in_reply_to` is not author-only either, for exactly the reason `syndication_links()` gives. Neither function on the way in validates it:

- `Micropub::replyTargetUrl()` unwraps the value (a bare string, or an embedded `h-cite` object) and returns it — its docblock is about *finding* the URL, not checking it;
- `normalize_in_reply_to()` only calls `matter_string()` and `trim()`.

So a Micropub client with only `create` scope, or a hand-written `in-reply-to:` line, produced:

```
<p class="reply-context">In reply to <a class="u-in-reply-to" rel="in-reply-to"
   href="javascript:alert(document.cookie)">javascript:alert(document.cookie)</a></p>
```

### Where it is served

`the_reply_context()` is not one page's markup:

- `themes/base/parts/_items.php`, `themes/2024/parts/_items.php`, `themes/2026/parts/_items.php` — every listing and status page that carries the post;
- `themes/base/feed.php` — prepended to the Atom `<content type="html">`;
- `themes/base/feed_json.php` — prepended to `content_html`.

So it reaches the site's own pages *and* every feed subscriber's reader.

## The fix

Apply the same predicate the two sibling helpers use. A target that is not a real http(s) URL is shown as text rather than linked — nothing is lost by that, because it cannot be a webmention target either (`Webmention\enqueue_outbound()` filters on `is_external_http_url()`), so there is nothing for the anchor to mean.

Measured after the change:

```
https URL:     …<a class="u-in-reply-to" rel="in-reply-to" href="https://other.example/post">other.example</a>…
javascript::   <p class="reply-context">In reply to javascript:alert(document.cookie)</p>
JaVaScRiPt::   <p class="reply-context">In reply to JaVaScRiPt:alert(1)</p>
data::         <p class="reply-context">In reply to data:text/html;base64,PHNjcmlwdD4=</p>
vbscript::     <p class="reply-context">In reply to vbscript:msgbox(1)</p>
schemeless:    <p class="reply-context">In reply to other.example/post</p>
url with amp:  …href="https://e.test/a?b=1&amp;c=2"…
unset:         ''
```

The two feed templates carry the same value in their own URL slots, so both get the same guard:

- `feed.php` — the Atom `thr:in-reply-to` `ref`/`href` attributes;
- `feed_json.php` — `_microblog.in_reply_to_url`, which micro.blog turns into a link.

Both templates run in the global namespace and already call `Lamb\permalink()` and `Lamb\Theme\the_reply_context()` fully qualified, so `Lamb\Http\is_valid_http_url()` resolves the same way.

## Tests

Two added to `ReplyContextTest`:

- `testReplyContextRefusesToLinkANonHttpScheme` — loops `javascript:`, a mixed-case `JaVaScRiPt:`, `data:` and `vbscript:`, asserting no `href=` and no `<a ` while "In reply to" is still shown
- `testReplyContextStillLinksAnOrdinaryUrl` — the positive control, including that a query-string `&` is escaped exactly once

No existing test asserts on a non-http reply target: `MicropubAdapterTest`'s fourteen `in_reply_to` assertions all use `https://` URLs and check the stored column rather than the rendering, and neither feed template test touches `in_reply_to`.

Note: this environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here; the table above was produced by running `src/theme/formatting.php` and `src/http.php` directly. CI will run the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_