### PR TITLE
Sanitise attributes, not just tags, in Micropub content HTML

### DIFF
--- a/src/LambDown.php
+++ b/src/LambDown.php
@@ -227,6 +227,29 @@ class LambDown extends Parsedown
     }
 
     /**
+     * Neutralises a disallowed URL scheme in a content attribute, exactly as
+     * safe mode does for a Markdown link or image.
+     *
+     * The Micropub `content.html` path stores its HTML straight into the post's
+     * `transformed` column and never goes through Parsedown, so nothing applied
+     * the scheme allowlist the Markdown path gets for free. This exposes
+     * Parsedown's own filterUnsafeUrlInAttribute() rather than restating the
+     * allowlist, so the two content paths cannot drift: a `mailto:` link is
+     * kept in both, a `javascript:` one becomes `javascript%3A` in both, and a
+     * root-relative `/assets/…` (what asset_url() writes) carries no colon and
+     * is untouched.
+     *
+     * @param string $url The attribute's raw value.
+     * @return string The value with a disallowed scheme neutralised.
+     */
+    public function filterContentUrl(string $url): string
+    {
+        $element = $this->filterUnsafeUrlInAttribute(['attributes' => ['url' => $url]], 'url');
+
+        return (string) $element['attributes']['url'];
+    }
+
+    /**
      * Supplies the lookup used to stamp intrinsic `width`/`height` on images.
      *
      * Injected rather than looked up here so the parser stays a pure

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1014,20 +1014,109 @@ class LambMicropubAdapter extends MicropubAdapter
     }
 
     /**
-     * Strip disallowed tags from HTML content, keeping safe formatting elements.
+     * Tags kept in Micropub `content.html`. Everything else is unwrapped by
+     * strip_tags(), which keeps the text inside it.
+     */
+    private const HTML_TAGS = [
+        'a', 'abbr', 'b', 'blockquote', 'br', 'caption',
+        'code', 'del', 'em', 'figcaption', 'figure', 'h1', 'h2', 'h3',
+        'h4', 'h5', 'h6', 'hr', 'i', 'img', 'ins', 'li', 'ol', 'p',
+        'pre', 'q', 's', 'small', 'strong', 'sub', 'sup',
+        'table', 'tbody', 'td', 'th', 'thead', 'tr', 'u', 'ul',
+    ];
+
+    /**
+     * Attributes kept on a surviving element, by lower-case tag name. `*`
+     * applies to every tag. An allowlist rather than a denylist of `on*`: a
+     * denylist has to keep pace with every attribute that can run script or
+     * reposition the page, and `style` alone is enough to cover the viewport.
+     */
+    private const HTML_ATTRIBUTES = [
+        '*'          => ['title'],
+        'a'          => ['href'],
+        'blockquote' => ['cite'],
+        'img'        => ['src', 'alt', 'width', 'height'],
+        'ol'         => ['start'],
+        'q'          => ['cite'],
+        'td'         => ['colspan', 'rowspan'],
+        'th'         => ['colspan', 'rowspan', 'scope'],
+    ];
+
+    /** Kept attributes whose value is a URL and must clear the scheme allowlist. */
+    private const HTML_URL_ATTRIBUTES = ['href', 'src', 'cite'];
+
+    /**
+     * Sanitise the HTML of a Micropub `content.html` create.
+     *
+     * The result is written straight to the post's `transformed` column, which
+     * every theme echoes raw into the page (`<?= anchor_headings($bean->transformed, …) ?>`)
+     * and which is syndicated verbatim inside the Atom `<content type="html">`
+     * and the JSON Feed's `content_html`. It never passes through Parsedown, so
+     * safe mode does not apply to it.
+     *
+     * strip_tags() alone was not a sanitiser for that: it drops disallowed
+     * *tags* and keeps every attribute of the ones it allows, so
+     * `<img src=x onerror=…>`, `<p onmouseover=…>` and `<a href="javascript:…">`
+     * all survived intact — stored XSS reachable by any token holding only
+     * `create` scope, running in the author's logged-in session. The codebase
+     * already treats that scope as a limited-trust principal (see
+     * apply_frontmatter()'s note on `id:`/`deleted:`, and syndication_links()).
+     *
+     * Import\sanitize_html_in_dom() scrubs `on*` off imported HTML for the same
+     * reason; this does the equivalent for the Micropub path, as an attribute
+     * allowlist, and hands every URL attribute to LambDown::filterContentUrl()
+     * so a link here is filtered exactly as the Markdown path filters one.
      *
      * @param string $html
      * @return string
      */
     private function sanitizeHtml(string $html): string
     {
-        return strip_tags($html, [
-            'a', 'abbr', 'b', 'blockquote', 'br', 'caption',
-            'code', 'del', 'em', 'figcaption', 'figure', 'h1', 'h2', 'h3',
-            'h4', 'h5', 'h6', 'hr', 'i', 'img', 'ins', 'li', 'ol', 'p',
-            'pre', 'q', 's', 'small', 'strong', 'sub', 'sup',
-            'table', 'tbody', 'td', 'th', 'thead', 'tr', 'u', 'ul',
-        ]);
+        $html = strip_tags($html, self::HTML_TAGS);
+        if (trim($html) === '') {
+            return '';
+        }
+
+        $filter = new \Lamb\LambDown();
+        $dom = \Lamb\Import\load_html_fragment($html);
+        foreach ((new \DOMXPath($dom))->query('//*') ?: [] as $element) {
+            if (!$element instanceof \DOMElement) {
+                continue;
+            }
+            $this->sanitizeAttributes($element, $filter);
+        }
+
+        return \Lamb\Import\dump_html_fragment($dom);
+    }
+
+    /**
+     * Reduces one element's attributes to the allowlisted set, with any URL
+     * among them run through the same filter Parsedown's safe mode applies.
+     */
+    private function sanitizeAttributes(\DOMElement $element, \Lamb\LambDown $filter): void
+    {
+        $allowed = array_merge(
+            self::HTML_ATTRIBUTES['*'],
+            self::HTML_ATTRIBUTES[strtolower($element->tagName)] ?? []
+        );
+
+        // The names are snapshotted first: DOMNamedNodeMap is live, and removing
+        // while iterating it skips the entry that shuffles into the freed slot.
+        $names = [];
+        foreach ($element->attributes as $attribute) {
+            $names[] = $attribute->nodeName;
+        }
+
+        foreach ($names as $name) {
+            $lower = strtolower($name);
+            if (!in_array($lower, $allowed, true)) {
+                $element->removeAttribute($name);
+                continue;
+            }
+            if (in_array($lower, self::HTML_URL_ATTRIBUTES, true)) {
+                $element->setAttribute($name, $filter->filterContentUrl($element->getAttribute($name)));
+            }
+        }
     }
 
     /**

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -427,6 +427,78 @@ class MicropubAdapterTest extends TestCase
         $this->assertStringNotContainsString('<iframe', $post->transformed);
     }
 
+    public function testCreateCallbackHtmlEventHandlerAttributesAreStripped(): void
+    {
+        // strip_tags() drops disallowed *tags* and keeps every attribute of the
+        // ones it allows, so an `on*` handler on an allowed element survived
+        // into `transformed` — which every theme echoes raw and both feeds
+        // syndicate verbatim. Reachable by a token holding only `create` scope.
+        $adapter = new LambMicropubAdapter();
+        $adapter->createCallback([
+            'type' => ['h-entry'],
+            'properties' => [
+                'content' => [['html' =>
+                    '<p>Handlers</p><img src="/assets/2026/01/a.webp" onerror="alert(1)">'
+                    . '<p onmouseover="alert(2)">hover</p><b OnClick="alert(3)">mixed case</b>',
+                ]],
+            ],
+        ]);
+
+        $post = R::findOne('post', ' body LIKE ? ', ['%Handlers%']);
+        $this->assertNotNull($post);
+        $this->assertStringNotContainsString('onerror', $post->transformed);
+        $this->assertStringNotContainsString('onmouseover', $post->transformed);
+        $this->assertStringNotContainsString('OnClick', $post->transformed);
+        $this->assertStringNotContainsString('onclick', $post->transformed);
+        // The elements and their allowed attributes survive.
+        $this->assertStringContainsString('src="/assets/2026/01/a.webp"', $post->transformed);
+        $this->assertStringContainsString('<b>mixed case</b>', $post->transformed);
+    }
+
+    public function testCreateCallbackHtmlStyleAttributeIsStripped(): void
+    {
+        // `style` alone is enough to cover the viewport with an element that
+        // links somewhere else, so the attribute allowlist drops it too.
+        $adapter = new LambMicropubAdapter();
+        $adapter->createCallback([
+            'type' => ['h-entry'],
+            'properties' => [
+                'content' => [['html' => '<p style="position:fixed;inset:0">Overlay</p>']],
+            ],
+        ]);
+
+        $post = R::findOne('post', ' body LIKE ? ', ['%Overlay%']);
+        $this->assertNotNull($post);
+        $this->assertStringNotContainsString('style=', $post->transformed);
+        $this->assertStringContainsString('<p>Overlay</p>', $post->transformed);
+    }
+
+    public function testCreateCallbackHtmlLinkSchemeIsFilteredLikeMarkdown(): void
+    {
+        // The HTML path never goes through Parsedown, so nothing applied the
+        // scheme allowlist safe mode gives the Markdown path. It now defers to
+        // Parsedown's own filter, so both paths neutralise the same way.
+        $adapter = new LambMicropubAdapter();
+        $adapter->createCallback([
+            'type' => ['h-entry'],
+            'properties' => [
+                'content' => [['html' =>
+                    '<p>Schemes</p><a href="javascript:alert(1)">bad</a>'
+                    . '<a href="https://example.test/ok">good</a>'
+                    . '<a href="mailto:a@b.test">mail</a>',
+                ]],
+            ],
+        ]);
+
+        $post = R::findOne('post', ' body LIKE ? ', ['%Schemes%']);
+        $this->assertNotNull($post);
+        $this->assertStringNotContainsString('href="javascript:', $post->transformed);
+        $this->assertStringContainsString('javascript%3Aalert', $post->transformed);
+        // Everything Parsedown's safe mode allows in a Markdown link is kept here too.
+        $this->assertStringContainsString('href="https://example.test/ok"', $post->transformed);
+        $this->assertStringContainsString('href="mailto:a@b.test"', $post->transformed);
+    }
+
     public function testCreateCallbackPlainTextContentIsStillMarkdownProcessed(): void
     {
         $adapter = new LambMicropubAdapter();


### PR DESCRIPTION
## The bug

A Micropub create carrying `content: {html: …}` takes a path that bypasses Parsedown entirely:

```php
$bean = populate_bean($body);
if ($isHtml) {
    $bean->transformed = $this->sanitizeHtml($content);
}
```

`transformed` is then echoed **raw** by all three themes —

```php
<div class="e-content"><?= anchor_headings($bean->transformed, …) ?></div>
```

— and syndicated verbatim inside the Atom `<content type="html">` and the JSON Feed's `content_html`. Safe mode never touches it, so `sanitizeHtml()` is the only guard. It was:

```php
private function sanitizeHtml(string $html): string
{
    return strip_tags($html, ['a', 'abbr', 'b', … 'img', … ]);
}
```

`strip_tags()` drops disallowed **tags** and keeps **every attribute** of the ones it allows. Measured against that exact allowlist:

```
``&lt;img src=x onerror=alert(document.cookie)&gt;``    => ``&lt;img src=x onerror=alert(document.cookie)&gt;``
<a href="javascript:alert(1)">click</a>       => <a href="javascript:alert(1)">click</a>
<p onmouseover="alert(1)">hover</p>           => <p onmouseover="alert(1)">hover</p>
<b onclick=alert(1)>x</b>                     => <b onclick=alert(1)>x</b>
<p style="position:fixed;inset:0">overlay</p> => <p style="position:fixed;inset:0">overlay</p>
```

Stored XSS, reachable by a token holding **only `create` scope**, running in the author's logged-in session — which is enough to drive `/settings`, `/delete`, and everything else behind the session cookie.

`create` scope is already a trust boundary in this codebase, in its own words:

- `apply_frontmatter()`: "A Micropub client holding only `create` scope could reach it … `id:` overwrote an arbitrary post and `deleted:` trashed one, both bypassing the scope checks that correctly refuse update and delete."
- `syndication_links()`: "`syndicated_to` is not author-only — a Micropub client holding just `create` scope sets it via `mp-syndicate-to` — so require a real http(s) URL before linking it."

And the sibling path already does the scrub. `Import\sanitize_html_in_dom()`, for HTML out of a WXR file:

> Removes executable / styling tags and **any `on*` event-handler attributes**. Imported body HTML is untrusted enough to warrant a defensive scrub … event-handler attributes are walked off every element regardless of case.

The Micropub path never got the equivalent.

## The fix

Attributes are reduced to a per-tag allowlist. An allowlist rather than a denylist of `on*`: a denylist has to keep pace with every attribute that can run script or reposition the page, and `style` alone is enough to cover the viewport with an element that links somewhere else.

Every surviving URL attribute (`href`, `src`, `cite`) goes through a new `LambDown::filterContentUrl()` — a thin wrapper over Parsedown's *own* `filterUnsafeUrlInAttribute()`, rather than a restated allowlist, so the HTML path and the Markdown path cannot drift:

```php
public function filterContentUrl(string $url): string
{
    $element = $this->filterUnsafeUrlInAttribute(['attributes' => ['url' => $url]], 'url');

    return (string) $element['attributes']['url'];
}
```

Measured after the change, running the real `sanitizeHtml()`:

```
``&lt;img src=x onerror=alert(document.cookie)&gt;``      => ``&lt;img src="x"&gt;``
<p onmouseover="alert(1)">hover</p>             => <p>hover</p>
<b OnClick=alert(1)>x</b>                       => <b>x</b>
<p style="position:fixed;inset:0;…">overlay</p> => <p>overlay</p>
<a href="javascript:alert(1)">click</a>         => <a href="javascript%3Aalert(1)">click</a>
<a href="mailto:a@b.test">mail</a>              => <a href="mailto:a@b.test">mail</a>
<a href="tel:+123">call</a>                     => <a href="tel:+123">call</a>
<a href="https://example.test/a?b=1&c=2" title="t">ok</a> => <a href="https://example.test/a?b=1&amp;c=2" title="t">ok</a>
``&lt;img src="/assets/2026/01/a.webp" alt="pic" width="10" height="20"&gt;`` => unchanged
<table><thead><tr><th scope="col">h</th></tr>…  => unchanged
<blockquote cite="https://e.test/x"><p>q</p></blockquote> => unchanged
bare text — Café ünïcøde                        => unchanged
```

Note there is **no functional regression on links**: because the check defers to Parsedown's list, `mailto:` and `tel:` are kept here exactly as they are in a Markdown link, and `javascript:` is neutralised the same way (`:` → `%3A`) rather than dropped — so an author sees the same result whichever content type their client sends.

`DOMDocument` adds no new dependency: `ext-dom` is already a hard transitive requirement via `league/html-to-markdown` (`"require": {"ext-dom": "*", …}` in the lock), and `themes/base/feed.php` already calls `dom_import_simplexml()` on the web feed path. The two DOM helpers are the ones `import.php` already exports for exactly this purpose.

## Verification

Ran the real `sanitizeHtml()`/`sanitizeAttributes()` and the new `filterContentUrl()` against the five inputs the existing `MicropubAdapterTest` HTML cases use, checking each test's own assertions:

```
ok   <p>Rich content</p>                              -> <p>Rich content</p>
ok   <p>This has <b>bold</b> text.</p>                -> <p>This has <b>bold</b> text.</p>
ok   <p>Sanitise script</p><script>alert(1)</script>  -> <p>Sanitise script</p>alert(1)
ok   <p>Sanitise style</p><style>…</style>            -> <p>Sanitise style</p>body{display:none}
ok   <p>Sanitise iframe</p><iframe …></iframe>        -> <p>Sanitise iframe</p>
```

All five still hold. Three tests added to `MicropubAdapterTest`:

- `testCreateCallbackHtmlEventHandlerAttributesAreStripped` — `onerror`, `onmouseover` and a mixed-case `OnClick`, while asserting the elements and their allowed attributes survive
- `testCreateCallbackHtmlStyleAttributeIsStripped`
- `testCreateCallbackHtmlLinkSchemeIsFilteredLikeMarkdown` — `javascript:` neutralised, `https:` and `mailto:` kept

This environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here; the tables above were produced by running the extracted methods against a clone of `erusev/parsedown` at the locked 1.8.0. CI will run the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_