### PR TITLE
Unwrap a content object on the Micropub update path

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -679,8 +679,29 @@ class LambMicropubAdapter extends MicropubAdapter
     private function applyReplace(OODBBean $bean, string $property, array $values): bool
     {
         if ($property === 'content') {
-            $newContent = (string) ($values[0] ?? '');
-            $bean->body = $this->rebuildBody($bean, $newContent);
+            // An empty value list is Micropub's "replace with nothing".
+            if ($values === []) {
+                $bean->body = $this->rebuildBody($bean, '');
+                return true;
+            }
+            // extractContent(), not (string) $values[0]: a content value is
+            // legitimately `{"html": …}` or `{"value": …}`, which the create
+            // path has always unwrapped. Cast here instead, that object became
+            // the literal string "Array" (with an "Array to string conversion"
+            // warning) and rebuildBody() wrote it over the entire post — a
+            // spec-legal update from the same client that created the post
+            // destroyed its content.
+            ['content' => $newContent, 'is_html' => $isHtml] = $this->extractContent(['content' => $values]);
+            if ($newContent === null) {
+                // A value carrying no text at all (an object with neither key)
+                // is a replace the storage cannot honour; reporting success for
+                // it reads to the client as "saved", as applyAdd() notes.
+                return false;
+            }
+            // strip_tags() for the html shape, matching what createCallback()
+            // stores in the body. `transformed` is regenerated from the body by
+            // the parse_bean() at the end of updateCallback() either way.
+            $bean->body = $this->rebuildBody($bean, $isHtml ? strip_tags($newContent) : $newContent);
             return true;
         }
 

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -1118,6 +1118,74 @@ class MicropubAdapterTest extends TestCase
         $this->assertStringContainsString('New body text', $updated->body);
     }
 
+    public function testUpdateCallbackReplaceContentAcceptsAnHtmlObject(): void
+    {
+        // A content value is legitimately `{"html": …}` — the shape
+        // createCallback() has always unwrapped, and the one a client that
+        // created the post with rich content sends back. Cast with (string),
+        // the object became the literal "Array" and overwrote the whole post.
+        $bean = R::dispense('post');
+        $bean->body = 'Original content';
+        $bean->slug = '';
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['replace' => ['content' => [['html' => '<p>New <b>rich</b> body</p>']]]]
+        );
+
+        $this->assertTrue($result);
+        $updated = R::load('post', $bean->id);
+        $this->assertStringNotContainsString('Array', $updated->body);
+        $this->assertStringContainsString('New rich body', $updated->body);
+    }
+
+    public function testUpdateCallbackReplaceContentAcceptsAValueObject(): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = 'Original content';
+        $bean->slug = '';
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['replace' => ['content' => [['value' => 'Plain from an object']]]]
+        );
+
+        $this->assertTrue($result);
+        $updated = R::load('post', $bean->id);
+        $this->assertStringNotContainsString('Array', $updated->body);
+        $this->assertStringContainsString('Plain from an object', $updated->body);
+    }
+
+    public function testUpdateCallbackRefusesContentWithNoText(): void
+    {
+        // An object carrying neither `html` nor `value` has no content to
+        // store; reporting success for it reads to the client as "saved".
+        $bean = R::dispense('post');
+        $bean->body = 'Original content';
+        $bean->slug = '';
+        $bean->created = date('Y-m-d H:i:s');
+        $bean->updated = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['replace' => ['content' => [['alt' => 'no text here']]]]
+        );
+
+        $this->assertSame('invalid_request', $result);
+        // Nothing is stored when an operation is refused.
+        $this->assertSame('Original content', R::load('post', $bean->id)->body);
+    }
+
     public function testUpdateCallbackReplaceContentPreservesHashtags(): void
     {
         $bean = R::dispense('post');


### PR DESCRIPTION
## The bug

A Micropub `content` value is legitimately an object — `{"html": …}` or `{"value": …}` — and `createCallback()` has always unwrapped it:

```php
private function extractContent(array $props): array
{
    …
    if (is_array($raw)) {
        if (isset($raw['html'])) {
            return ['content' => $raw['html'], 'is_html' => true];
        }
        return ['content' => $raw['value'] ?? null, 'is_html' => false];
    }
    …
}
```

`applyReplace()`'s content branch cast it instead:

```php
if ($property === 'content') {
    $newContent = (string) ($values[0] ?? '');
    $bean->body = $this->rebuildBody($bean, $newContent);
    return true;
}
```

Measured:

```
[{"html":"<p>new</p>"}]  => 'Array'      (+ PHP Warning: Array to string conversion)
[{"value":"plain"}]      => 'Array'      (+ PHP Warning: Array to string conversion)
["plain string"]         => 'plain string'
[]                       => ''
```

`rebuildBody()` writes that straight over the body:

```php
$content = add_body_tags($newContent, get_tags($currentBody));
return $yaml === '' ? $content : "---\n" . $yaml . "\n---\n" . $content;
```

So **`replace: {content: [{"html": "…"}]}` replaces the entire post body with the literal string `"Array"`** — from the same client that created the post with rich content in the first place. Total content loss on a spec-legal update, and it returns `true`, so the client is told it saved.

Every other value in the same method already handles the object shape:

- `matterValue()` runs every value through `matter_string()`
- both `in-reply-to` branches go through `replyTargetUrl()`, which unwraps an embedded `h-cite`

and `buildBody()`'s docblock records the create-path version of exactly this fix:

> Microformats properties are arrays of values, and a value is not necessarily a string: `in-reply-to` is legitimately an embedded h-cite object, and a client is free to send a nested array for `name`. **Both reached the `?string` parameters of `assembleFrontMatter()` as arrays and 500ed the create.**

The content branch was the one left casting.

## The fix

Route it through `extractContent()` — the same unwrapper the create path uses — and store the tag-stripped text for the html shape, exactly as `createCallback()` does for the body. (`transformed` is regenerated from the body by the `parse_bean()` at the end of `updateCallback()` either way, so the update path has no separate rendering to preserve.)

After:

```
html object:   [{"html":"<p>new <b>body</b></p>"}]  => 'new body'
value object:  [{"value":"plain from object"}]      => 'plain from object'
plain string:  ["plain string"]                     => 'plain string'
empty list:    []                                   => ''
empty object:  [[]]                                 => <REFUSED>
```

Behaviour preserved: a plain string is unchanged, and an empty value list still means Micropub's "replace with nothing". A value carrying no text at all (an object with neither key) is now refused as `invalid_request` rather than silently written as `"Array"` — the reason `applyAdd()` already gives for its own refusals:

> reporting success for it reads to the client as "saved"

and `updateCallback()` stores nothing until every operation has succeeded, so a refused update leaves the post exactly as it was.

## Tests

Three added to `MicropubAdapterTest`, in the style of the existing `testUpdateCallbackReplaceContent*` cases:

- `testUpdateCallbackReplaceContentAcceptsAnHtmlObject` — asserts the body does not contain `Array` and does contain the text
- `testUpdateCallbackReplaceContentAcceptsAValueObject`
- `testUpdateCallbackRefusesContentWithNoText` — asserts `invalid_request` **and** that the original body is untouched

The existing `testUpdateCallbackReplaceContentUpdatesBody`, `…PreservesTitle` and `…PreservesHashtags` all use plain-string values and are unaffected.

Note: this environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here; the before/after tables were produced by running the real `extractContent()` and the patched content branch extracted from `src/micropub.php`. CI will run the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_