### PR TITLE
Make body_has_tag() end a tag where the renderer does

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -40,7 +40,14 @@ function now(): string
 // parse_tags() builds around it — quotes, angle brackets, a backtick, `=`, and
 // the slashes — on top of the punctuation that merely ends a tag. Emoji and other
 // non-Latin scripts stay valid in a tag name.
-const TAG_PATTERN = '/(^|[\s>])#([^\s#&.,!?;:()\[\]{}<>"\'`=\/\\\\]+)/u';
+// The character class itself, so the one other place that has to agree on where
+// a tag ends — Post\body_has_tag(), which decides whether a post belongs on the
+// /tag/ page the link below points at — can be built from it instead of
+// restating it. The two had drifted: body_has_tag() was missing `>`, `"`, `'`,
+// a backtick, `=` and the slashes, so `#php/8` rendered a link to /tag/php and
+// then the tag page left the post out.
+const TAG_TERMINATORS = '\s#&.,!?;:()\[\]{}<>"\'`=\/\\\\';
+const TAG_PATTERN = '/(^|[\s>])#([^' . TAG_TERMINATORS . ']+)/u';
 
 // Bean fields front matter is allowed to set. Anything else in a front-matter
 // block is metadata for the author's own use, not a column to write; see the

--- a/src/post.php
+++ b/src/post.php
@@ -824,13 +824,21 @@ function get_tag_search_conditions(string $tag): array
  * start of the string, whitespace, or `>`, and be followed by whitespace, the
  * end of the string, or one of the tag-terminating punctuation characters.
  *
+ * The terminator set is Lamb\TAG_TERMINATORS, the same class TAG_PATTERN
+ * excludes from a tag name, rather than a second copy of it. The copy had
+ * drifted: it was missing `>`, `"`, `'`, a backtick, `=` and both slashes, so a
+ * body reading `#php/8` rendered a link to /tag/php — TAG_PATTERN ends the tag
+ * at the slash — while this said the post carried no such tag. posts_by_tag()
+ * and Theme\get_posts_by_tags() both filter on it, so the tag page and the
+ * related-posts list left out the very post whose link led there.
+ *
  * @param string $tag  The tag to look for (without the leading `#`).
  * @param string $body The raw post body.
  * @return bool
  */
 function body_has_tag(string $tag, string $body): bool
 {
-    $pattern = '/(^|[\s>])#' . preg_quote($tag, '/') . '(?=[\s#&.,!?;:()\[\]{}<]|$)/iu';
+    $pattern = '/(^|[\s>])#' . preg_quote($tag, '/') . '(?=[' . \Lamb\TAG_TERMINATORS . ']|$)/iu';
     return (bool) preg_match($pattern, $body);
 }
 

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\get_tags;
 use function Lamb\Post\body_has_tag;
 use function Lamb\Post\get_tag_search_conditions;
 use function Lamb\Post\parse_matter;
@@ -81,6 +82,48 @@ class PostTest extends TestCase
     public function testBodyHasTagDoesNotMatchMidWordHash()
     {
         $this->assertFalse(body_has_tag('php', 'colour#php inline'));
+    }
+
+    /**
+     * body_has_tag() has to end a tag exactly where TAG_PATTERN does, because
+     * TAG_PATTERN decides which /tag/ link is rendered and body_has_tag()
+     * decides whether that page lists the post. It was missing `>`, `"`, `'`,
+     * a backtick, `=` and both slashes, so `#php/8` linked to /tag/php and the
+     * tag page then left the post out.
+     *
+     * @dataProvider terminatorProvider
+     */
+    public function testBodyHasTagAgreesWithTheRendererOnWhereATagEnds(string $body): void
+    {
+        $tags = get_tags($body);
+
+        $this->assertSame(['php'], $tags, $body);
+        $this->assertTrue(body_has_tag('php', $body), $body);
+    }
+
+    /**
+     * One body per character TAG_PATTERN treats as ending a tag name.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function terminatorProvider(): array
+    {
+        return [
+            'slash'       => ['Learn #php/8 today'],
+            'backslash'   => ['Path #php\\win'],
+            'double quote' => ['Read #php"quoted"'],
+            'single quote' => ["It is #php' s"],
+            'backtick'    => ['Tag #php`code`'],
+            'equals'      => ['Query #php=1 here'],
+            'gt'          => ['Markup #php> arrow'],
+            // Already agreed before, kept so a future narrowing is caught too.
+            'space'       => ['Plain #php here'],
+            'end'         => ['End of line #php'],
+            'full stop'   => ['Punctuated #php.'],
+            'ampersand'   => ['Amp #php&more'],
+            'colon'       => ['Colon #php: yes'],
+            'hash'        => ['Hash #php#two'],
+        ];
     }
 
     // slugify


### PR DESCRIPTION
## The bug

Two functions decide where a hashtag ends, and they have to agree:

- `Lamb\TAG_PATTERN` — used by `get_tags()` and `parse_tags()`, so it decides **which `/tag/` link a body renders**
- `Post\body_has_tag()` — used by `posts_by_tag()` and `Theme\get_posts_by_tags()` to refine the SQL prefilter, so it decides **whether that page lists the post**

`body_has_tag()`'s docblock says they do:

> Returns true if $body contains $tag as a hashtag, **using the same boundary rules as the inline tag renderer (Lamb\parse_tags)**

They did not. The terminator set was a second, shorter copy:

```php
// TAG_PATTERN
'/(^|[\s>])#([^\s#&.,!?;:()\[\]{}<>"\'`=\/\\\\]+)/u'

// body_has_tag
'/(^|[\s>])#' . preg_quote($tag, '/') . '(?=[\s#&.,!?;:()\[\]{}<]|$)/iu'
```

`>`, `"`, `'`, a backtick, `=`, `/` and `\` are missing from the second. Measured against the two patterns verbatim:

```
BODY                       get_tags()     body_has_tag(first tag)
Learn #php/8 today         ["php"]        false   <-- DISAGREE
Read #php"quoted"          ["php"]        false   <-- DISAGREE
It is #php' s              ["php"]        false   <-- DISAGREE
Tag #php`code`             ["php"]        false   <-- DISAGREE
Query #php=1 here          ["php"]        false   <-- DISAGREE
Markup #php> arrow         ["php"]        false   <-- DISAGREE
Path #php\win              ["php"]        false   <-- DISAGREE
Plain #php here            ["php"]        true
End of line #php           ["php"]        true
Punctuated #php.           ["php"]        true
Amp #php&more              ["php"]        true
```

So a post whose body reads `Learn #php/8 today` renders a link to `/tag/php`, and then:

```php
return array_values(array_filter($posts, fn($post) => body_has_tag($tag, (string) $post->body)));
```

filters that post straight back out. The tag page omits the post whose own link led there — and if it is the only post carrying the tag, `respond_tag()` sees an empty result and 404s the page entirely. `Theme\get_posts_by_tags()` drops it from related posts the same way.

`#php/8` is not a contrived body — a version- or path-shaped tag suffix is ordinary writing.

## The fix

The character class becomes a constant, `Lamb\TAG_TERMINATORS`, that `TAG_PATTERN` excludes from a tag name and `body_has_tag()` accepts after one — one statement of where a tag ends instead of two:

```php
const TAG_TERMINATORS = '\s#&.,!?;:()\[\]{}<>"\'`=\/\\\\';
const TAG_PATTERN = '/(^|[\s>])#([^' . TAG_TERMINATORS . ']+)/u';
```

The rebuilt `TAG_PATTERN` is **byte-identical** to the literal it replaces:

```
old: /(^|[\s>])#([^\s#&.,!?;:()\[\]{}<>"'`=\/\\]+)/u
new: /(^|[\s>])#([^\s#&.,!?;:()\[\]{}<>"'`=\/\\]+)/u
identical: true
```

After the change all thirteen bodies agree, and every negative case still holds:

```
body_has_tag('php', '#phpstan rules') = false     (longer tag sharing the prefix)
body_has_tag('php', 'no tag here'   ) = false
body_has_tag('php', 'email#php'     ) = false     (mid-word hash)
body_has_tag('ph' , '#php'          ) = false     (shorter prefix of a real tag)
body_has_tag('php', 'Say #PHP'      ) = true      (still case-insensitive)
body_has_tag('PHP', 'say #php'      ) = true
```

## Test

`PostTest::testBodyHasTagAgreesWithTheRendererOnWhereATagEnds`, a data-provider case per terminating character, asserting both that `get_tags()` returns `['php']` and that `body_has_tag('php', …)` is true — so the two can only pass together. The characters that already agreed are in the provider too, so a future narrowing of either pattern is caught as well. The seven existing `testBodyHasTag*` cases are untouched and still pass.

Note: this environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here. The tables above, and the provider's thirteen cases, were run against the real constants and functions extracted from `src/lamb.php` and `src/post.php`. CI will run the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_