### PR TITLE
Edit categories with the same tag boundaries the renderer uses

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -158,7 +158,14 @@ function add_body_tags(string $body, array $tags): string
  */
 function strip_trailing_body_tags(string $body): string
 {
-    return rtrim(preg_replace('/(\s+#[^\s#.,!?;:()\[\]{}<]+)+$/u', '', $body) ?? $body);
+    // TAG_TERMINATORS, not a third copy of the class: the copy here was missing
+    // `&`, `>`, `"`, `'`, a backtick, `=` and both slashes, so a token like
+    // `#php&more` counted as one long "hashtag" and the whole of it was
+    // stripped — taking `&more`, which is body text, with it. Ending the token
+    // where a tag actually ends means such a run is no longer trailing (there
+    // is text after the tag), so it is left alone, which is what this function
+    // says it does with an inline tag.
+    return rtrim(preg_replace('/(\s+#[^' . TAG_TERMINATORS . ']+)+$/u', '', $body) ?? $body);
 }
 
 /**
@@ -172,7 +179,26 @@ function strip_trailing_body_tags(string $body): string
 function remove_body_tags(string $body, array $tags): string
 {
     foreach ($tags as $tag) {
-        $body = preg_replace('/(\s+)#' . preg_quote($tag, '/') . '(?=\s|$)/u', '', $body) ?? $body;
+        // An empty name would leave a pattern that matches a bare `#`, deleting
+        // a literal one out of the body. add_body_tags() skips it the same way.
+        if ($tag === '') {
+            continue;
+        }
+        // Matched with the same boundaries as TAG_PATTERN, and case-insensitively
+        // like add_body_tags(), so this removes exactly the tags get_tags()
+        // reports. It used to demand whitespace on both sides, which left the
+        // tag in place for most real bodies — `Hello #php.`, `Hello #php, ok`,
+        // `#php at the start` — while Micropub's category delete-values still
+        // answered success, so the client was told the tag was gone.
+        //
+        // A callback rather than a replacement string: the leading whitespace
+        // goes with the tag (or two spaces close up where one belonged), but a
+        // `>` before it is the quote marker it was already part of and stays.
+        $body = preg_replace_callback(
+            '/(^|[\s>])#' . preg_quote($tag, '/') . '(?=[' . TAG_TERMINATORS . ']|$)/iu',
+            static fn(array $match): string => $match[1] === '>' ? '>' : '',
+            $body
+        ) ?? $body;
     }
 
     return $body;

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -82,6 +82,51 @@ class LambTest extends TestCase
         $this->assertSame('Hello #foo', remove_body_tags('Hello #foo', ['bar']));
     }
 
+    public function testRemoveBodyTagsRemovesATagFollowedByPunctuation(): void
+    {
+        // The old pattern demanded whitespace or end-of-string after the tag,
+        // which is not how a tag ends anywhere else — so for most real bodies
+        // the tag stayed while Micropub's category delete reported success.
+        $this->assertSame('Hello.', remove_body_tags('Hello #php.', ['php']));
+        $this->assertSame('Hello, ok', remove_body_tags('Hello #php, ok', ['php']));
+        $this->assertSame('Hello!', remove_body_tags('Hello #php!', ['php']));
+    }
+
+    public function testRemoveBodyTagsRemovesATagAtTheStartOfTheBody(): void
+    {
+        // TAG_PATTERN accepts the start of the string as a tag boundary; the old
+        // pattern required preceding whitespace, so this tag was never removed.
+        $this->assertSame(' hello', remove_body_tags('#php hello', ['php']));
+    }
+
+    public function testRemoveBodyTagsIgnoresCaseLikeAddBodyTags(): void
+    {
+        // add_body_tags() treats `#PHP` and `#php` as one tag, so removing one
+        // has to find the other or add/remove are not inverses.
+        $this->assertSame('Hello', remove_body_tags('Hello #PHP', ['php']));
+    }
+
+    public function testRemoveBodyTagsLeavesALongerTagAlone(): void
+    {
+        $this->assertSame('Hello #phpstan', remove_body_tags('Hello #phpstan', ['php']));
+    }
+
+    public function testRemoveBodyTagsIgnoresAnEmptyTagName(): void
+    {
+        // An empty name would leave a pattern matching a bare `#`.
+        $this->assertSame('Hello # there', remove_body_tags('Hello # there', ['']));
+    }
+
+    public function testStripTrailingBodyTagsKeepsTextAfterATag(): void
+    {
+        // `&more` and `/8` are body text, not part of the tag name — the old
+        // token class swallowed them into one long "hashtag" and stripped both.
+        // With the tag ending where TAG_PATTERN ends it, neither run is
+        // trailing any more, so the inline tag is left alone as documented.
+        $this->assertSame('Hello #php&more', strip_trailing_body_tags('Hello #php&more'));
+        $this->assertSame('Hello #php/8', strip_trailing_body_tags('Hello #php/8'));
+    }
+
     // get_tags
 
     public function testGetTagsExtractsSingleTag()


### PR DESCRIPTION
> **Stacked on #631**, which introduces the `Lamb\TAG_TERMINATORS` constant this uses. Base is `claude/coarse-bug-sweep-8utphq-tag-boundary`; retarget to `main` once #631 lands.

## The bug

The two helpers Micropub's category edits go through each carried their own copy of "where does a tag end", and both disagreed with `TAG_PATTERN`.

### `remove_body_tags()` — Micropub `delete: {category: [...]}`

```php
$body = preg_replace('/(\s+)#' . preg_quote($tag, '/') . '(?=\s|$)/u', '', $body) ?? $body;
```

It demanded whitespace *before* the tag and whitespace or end-of-string *after* it. Neither is how a tag ends anywhere else, so for most real bodies it silently did nothing — while `applyDeleteValues()` returns `true` regardless, so the client was told the category was gone:

```
'Hello #php'       carries=true  -> 'Hello'            removed=true
'Hello #php.'      carries=true  -> 'Hello #php.'      removed=false   <-- SILENT NO-OP
'Hello #php, ok'   carries=true  -> 'Hello #php, ok'   removed=false   <-- SILENT NO-OP
'Hello #php!'      carries=true  -> 'Hello #php!'      removed=false   <-- SILENT NO-OP
'Hello #php/8'     carries=true  -> 'Hello #php/8'     removed=false   <-- SILENT NO-OP
'Hello #php&x'     carries=true  -> 'Hello #php&x'     removed=false   <-- SILENT NO-OP

remove_body_tags('#php hello', ['php']) -> '#php hello'                <-- tag at start of body
```

A tag at the end of a sentence is the common case, not an edge case. It also matched **case-sensitively**, while `add_body_tags()` explicitly treats `#PHP` and `#php` as one tag — so add and remove were not inverses.

### `strip_trailing_body_tags()` — `delete: ['category']`, and the strip half of a category replace

```php
preg_replace('/(\s+#[^\s#.,!?;:()\[\]{}<]+)+$/u', '', $body)
```

The token class is missing `&`, `>`, `"`, `'`, a backtick, `=` and both slashes, so a token like `#php&more` counted as one long "hashtag" and **the whole of it was stripped — taking `&more`, which is body text, with it**:

```
'Hello #php&more'    tags=["php"]   -> 'Hello'
'Hello #php/8'       tags=["php"]   -> 'Hello'
'Hello #php"q"'      tags=["php"]   -> 'Hello'
'Hello #php=1'       tags=["php"]   -> 'Hello'
```

## The fix

Both build on `TAG_TERMINATORS`.

`remove_body_tags()` matches `(^|[\s>])#tag(?=[TAG_TERMINATORS]|$)` case-insensitively — exactly `body_has_tag()`'s rule — through a `preg_replace_callback()` so the leading whitespace still goes with the tag (two spaces close up where one belonged) while a `>` before it, the quote marker it was already part of, stays. An empty tag name is skipped, as `add_body_tags()` already skips it: the pattern would otherwise match a bare `#` and delete a literal one out of the body.

`strip_trailing_body_tags()` ends its token where a tag ends. `#php&more` is then no longer a *trailing* hashtag (there is text after the tag), so it is left alone — which is what the function's own docblock says it does with an inline tag.

Verified:

```
-- existing LambTest assertions must still hold --
ok   strip: trailing run           'Some text'
ok   strip: inline left alone      'Text #foo more text'
ok   strip: no tags                'No tags here.'
ok   remove: one of two            'Hello #bar'
ok   remove: both                  'Hello'
ok   remove: absent tag            'Hello #foo'

-- the bugs --
ok   remove: before full stop      'Hello.'
ok   remove: before comma          'Hello, ok'
ok   remove: before bang           'Hello!'
ok   remove: at start of body      ' hello'
ok   remove: differing case        'Hello'
ok   remove: longer tag alone      'Hello #phpstan'
ok   remove: empty tag name        'Hello # there'
ok   strip: keeps body text        'Hello #php&more'
ok   strip: keeps slash text       'Hello #php/8'

-- add/remove round trip --
ok   add then remove               'Hello'
ok   no tag left behind            false
```

Removing a tag at the very start of a body leaves the space that followed it (`' hello'`) — there is no preceding whitespace to absorb there. It is trimmed at render (`render_body()` calls `trim($content)`), so this is cosmetic in the stored body only; I left it rather than widen the change.

## Tests

Six added to `LambTest`: `testRemoveBodyTagsRemovesATagFollowedByPunctuation`, `…RemovesATagAtTheStartOfTheBody`, `…IgnoresCaseLikeAddBodyTags`, `…LeavesALongerTagAlone`, `…IgnoresAnEmptyTagName`, and `testStripTrailingBodyTagsKeepsTextAfterATag`. All six existing assertions for these two functions are untouched.

Note: this environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here; every table above was run against the real functions extracted from `src/lamb.php`. CI will run the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_