### PR TITLE
Read the introspection status with the shared status-line parser

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -239,8 +239,16 @@ class LambMicropubAdapter extends MicropubAdapter
             return null;
         }
 
+        // Http\parse_status_line(), not a substring test for ' 200 '. That test
+        // answered on the wrong thing in both directions: it read a status line
+        // with no reason phrase ("HTTP/1.1 200", "HTTP/2 200") as a failure, so a
+        // conforming token endpoint could take the whole Micropub endpoint down
+        // with no usable diagnosis; and it matched ' 200 ' anywhere in the line,
+        // so "HTTP/1.1 500 Error 200 x" read as a success — a fail-open answer on
+        // the request that establishes who the caller is.
         $statusLine = $result['headers'][0] ?? '';
-        if (!str_contains($statusLine, ' 200 ')) {
+        $status = \Lamb\Http\parse_status_line($statusLine);
+        if ($status !== 200) {
             mp_log('introspect', ['endpoint' => $endpoint, 'reason' => 'non_200', 'status' => trim($statusLine)]);
             return null;
         }

--- a/tests/Unit/HttpFetchTest.php
+++ b/tests/Unit/HttpFetchTest.php
@@ -81,6 +81,22 @@ class HttpFetchTest extends TestCase
         $this->assertSame(200, parse_status_line('HTTP/1.1 200'));
     }
 
+    public function testParseStatusLineReadsTheCodeNotAnyThreeDigitsInTheLine(): void
+    {
+        // Micropub's token introspection relies on this to decide whether the
+        // token endpoint answered 200. A substring test for ' 200 ' read this
+        // line as a success — a fail-open answer on the request that
+        // establishes who the caller is.
+        $this->assertSame(500, parse_status_line('HTTP/1.1 500 Error 200 x'));
+    }
+
+    public function testParseStatusLineHandlesAnHttp2StatusLine(): void
+    {
+        // curl (fetch_pinned) reports HTTP/2 responses with this shape.
+        $this->assertSame(200, parse_status_line('HTTP/2 200'));
+        $this->assertSame(404, parse_status_line('HTTP/2 404'));
+    }
+
     public function testParseStatusLineReturnsZeroForGarbage(): void
     {
         $this->assertSame(0, parse_status_line(''));


### PR DESCRIPTION
## The bug

`introspectToken()` decided whether the token endpoint answered 200 with a substring test:

```php
$statusLine = $result['headers'][0] ?? '';
if (!str_contains($statusLine, ' 200 ')) {
    mp_log('introspect', ['endpoint' => $endpoint, 'reason' => 'non_200', 'status' => trim($statusLine)]);
    return null;
}
```

That answers on the wrong thing in **both** directions. Measured against the shared parser:

```
STATUS LINE                        str_contains(" 200 ")  parse_status_line()
'HTTP/1.1 200 OK'                  true                   200
'HTTP/1.1 200 '                    true                   200
'HTTP/1.1 200'                     false                  200   <-- DISAGREE
'HTTP/2 200'                       false                  200   <-- DISAGREE
'HTTP/1.1 403 Forbidden'           false                  403
'HTTP/1.1 500 Error 200 x'         true                   500   <-- DISAGREE
```

**False reject.** A status line with no reason phrase reads as a failure, so a token endpoint that sends one takes the *whole* Micropub endpoint down — every client gets a 403, and the only clue is `"reason":"non_200"` in a diagnostic log that is off by default.

**False accept.** `' 200 '` matches anywhere in the line, so `HTTP/1.1 500 Error 200 x` reads as a success. That is a fail-open answer on the one request that establishes who the caller is: if the error body happens to be JSON carrying a `me` that matches the site, the token is accepted. Contrived to trigger deliberately, but fail-open is the wrong direction for a token check to be wrong in, and it costs one line to remove.

## The fix

`Http\parse_status_line()` already exists for exactly this, and its docblock already documents the case:

> Accepts status lines with or without a reason phrase ("HTTP/1.1 200 OK" and "HTTP/1.1 200" are both valid — the reason phrase may be empty).

`fetch()` itself uses it for the status it returns. `introspectToken()` was the one caller that didn't:

```php
$status = \Lamb\Http\parse_status_line($statusLine);
if ($status !== 200) {
```

## Tests

The existing `MicropubAdapterTest` cases go through `StubMicropubAdapter`, which overrides `introspectToken()` wholesale and returns a canned array — so the status check has no reachable seam to test without adding a fetcher injection, which would widen the change well past the bug.

What I did instead was pin the contract the fix now leans on, in `HttpFetchTest` beside the two cases already there:

- `testParseStatusLineReadsTheCodeNotAnyThreeDigitsInTheLine` — `HTTP/1.1 500 Error 200 x` → `500`, the false-accept case
- `testParseStatusLineHandlesAnHttp2StatusLine` — `HTTP/2 200` → `200` and `HTTP/2 404` → `404`, the shape curl reports through `fetch_pinned()`

Note: this environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here; the table above and the three new assertions were run against `src/http.php` directly. CI will run the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_