### PR TITLE
Quote a .env value so an apostrophe cannot break the file

### DIFF
--- a/make-password.php
+++ b/make-password.php
@@ -45,9 +45,38 @@ if (($_ENV['PWD'] ?? '') === '/srv/app') {
     $site_url = 'http://localhost';
 }
 
-$data  = "SITE_URL='" . $site_url . "'" . PHP_EOL;
-$data .= "LAMB_TEST_PORT='" . $test_port . "'" . PHP_EOL;
-$data .= "LAMB_LOGIN_PASSWORD='" . $hash . "'" . PHP_EOL;
+/**
+ * One `.env` value, quoted so phpdotenv reads back exactly what was passed.
+ *
+ * Single quotes are this file's normal form and hold everything without
+ * escaping — spaces, `"`, `\`, `$`, `#`, non-ASCII — because phpdotenv treats a
+ * single-quoted value as literal. The two characters they cannot hold are a
+ * single quote itself and a real newline: both end the value early, and
+ * phpdotenv then refuses the *whole file* with InvalidFileException. Bootstrap\
+ * load_dotenv() calls safeLoad(), which only swallows a missing file, so a
+ * password containing an apostrophe left `composer serve` throwing on every
+ * request — with LAMB_LOGIN_PASSWORD unreadable even though its own line was
+ * well-formed.
+ *
+ * Those two fall back to double quotes, which phpdotenv does unescape. `$` is
+ * escaped there as well: a double-quoted value is interpolated, so `${HOME}` in
+ * a password would otherwise be substituted instead of stored.
+ */
+function env_value(string $value): string
+{
+    if (!str_contains($value, "'") && !str_contains($value, "\n") && !str_contains($value, "\r")) {
+        return "'" . $value . "'";
+    }
+
+    $escaped = str_replace(['\\', '"', '$'], ['\\\\', '\\"', '\\$'], $value);
+    $escaped = str_replace(["\r", "\n"], ['\\r', '\\n'], $escaped);
+
+    return '"' . $escaped . '"';
+}
+
+$data  = 'SITE_URL=' . env_value($site_url) . PHP_EOL;
+$data .= 'LAMB_TEST_PORT=' . env_value($test_port) . PHP_EOL;
+$data .= 'LAMB_LOGIN_PASSWORD=' . env_value($hash) . PHP_EOL;
 // The plaintext password is only useful to the acceptance suite (it logs in
 // with $_ENV['LAMB_TEST_PASSWORD']). Keep it out of .env by default so a
 // self-hoster's setup file never carries the cleartext secret; the test harness
@@ -55,7 +84,7 @@ $data .= "LAMB_LOGIN_PASSWORD='" . $hash . "'" . PHP_EOL;
 // runs this script under a variables_order that does not populate $_ENV from the
 // environment, but getenv() reads the process environment regardless.
 if (getenv('LAMB_WRITE_TEST_PASSWORD')) {
-    $data .= "LAMB_TEST_PASSWORD='" . $password . "'" . PHP_EOL;
+    $data .= 'LAMB_TEST_PASSWORD=' . env_value($password) . PHP_EOL;
 }
 $env_out = file_put_contents('.env', $data);
 if (!$env_out) {

--- a/tests/Unit/MakePasswordTest.php
+++ b/tests/Unit/MakePasswordTest.php
@@ -105,6 +105,41 @@ class MakePasswordTest extends TestCase
         $this->assertStringContainsString("LAMB_TEST_PASSWORD='hackme'", $contents);
     }
 
+    public function testPasswordWithAnApostropheProducesAParseableEnv(): void
+    {
+        // Single quotes are the file's normal form and hold everything except a
+        // single quote and a newline — both end the value early, and phpdotenv
+        // then refuses the *whole file*. load_dotenv() calls safeLoad(), which
+        // only swallows a missing file, so this left `composer serve` throwing
+        // on every request with LAMB_LOGIN_PASSWORD unreadable.
+        $contents = $this->runScript(
+            ['PWD' => $this->workspace, 'LAMB_WRITE_TEST_PASSWORD' => '1'],
+            "it's-a-secret"
+        );
+
+        // Double-quoted, so phpdotenv reads the apostrophe as part of the value.
+        $this->assertStringContainsString('LAMB_TEST_PASSWORD="it\'s-a-secret"', $contents);
+        $this->assertStringNotContainsString("LAMB_TEST_PASSWORD='it's", $contents);
+        // The line that matters most is still well-formed either way.
+        $this->assertMatchesRegularExpression("/^LAMB_LOGIN_PASSWORD='[A-Za-z0-9+\\/=]+'$/m", $contents);
+    }
+
+    public function testPasswordNeedingNoEscapeKeepsTheSingleQuotedForm(): void
+    {
+        // Spaces, double quotes, backslashes and `${...}` are all literal inside
+        // single quotes, so they must not be switched to the escaped form (where
+        // `${...}` would be interpolated).
+        $contents = $this->runScript(
+            ['PWD' => $this->workspace, 'LAMB_WRITE_TEST_PASSWORD' => '1'],
+            'a "quoted" pass\\phrase ${HOME}'
+        );
+
+        $this->assertStringContainsString(
+            'LAMB_TEST_PASSWORD=\'a "quoted" pass\\phrase ${HOME}\'',
+            $contents
+        );
+    }
+
     // Refusing to clobber an existing .env (issues #597, #598)
     //
     // The script writes .env into the current directory, and the docs tell a


### PR DESCRIPTION
## The bug

`make-password.php` wrote every value single-quoted by interpolation:

```php
$data  = "SITE_URL='" . $site_url . "'" . PHP_EOL;
$data .= "LAMB_TEST_PORT='" . $test_port . "'" . PHP_EOL;
$data .= "LAMB_LOGIN_PASSWORD='" . $hash . "'" . PHP_EOL;
…
    $data .= "LAMB_TEST_PASSWORD='" . $password . "'" . PHP_EOL;
```

Single quotes hold almost anything without escaping. Tested against phpdotenv v5.6.4 (the locked version), reading each value back through the same `RepositoryBuilder` + `safeLoad()` that `Bootstrap\load_dotenv()` uses:

```
plain         'simple'               -> 'simple'                   ok
double quote  'say "hi"'             -> 'say "hi"'                 ok
backslash     'a\b'                  -> 'a\b'                      ok
dollar brace  'pre${HOME}post'       -> 'pre${HOME}post'           ok
hash          'a#b'                  -> 'a#b'                      ok
spaces        'my pass phrase'       -> 'my pass phrase'           ok
unicode       'pässwörd-日本'         -> 'pässwörd-日本'             ok
apostrophe    'it's'                 -> THREW                      NEEDS DOUBLE QUOTES
newline       'a\nb'                 -> THREW                      NEEDS DOUBLE QUOTES
```

A single quote or a real newline ends the value early, and phpdotenv then refuses the **whole file**:

```
LAMB_TEST_PASSWORD='it's-a-secret'
→ Dotenv\Exception\InvalidFileException: Failed to parse dotenv file.
  Encountered unexpected whitespace at ['it's-a-secret'].
```

`Bootstrap\load_dotenv()` calls `->safeLoad()`, which swallows only `InvalidPathException` (a missing file) — not this. So `composer serve` throws on **every request**, and `LAMB_LOGIN_PASSWORD` goes unread even though its own line is well-formed, so there is no login either.

It is reached by the usage `AGENTS.md` documents for the acceptance suite:

```bash
LAMB_WRITE_TEST_PASSWORD=1 php make-password.php <your-password>   # for acceptance tests
```

with an apostrophe anywhere in the password.

## The fix

`env_value()` **keeps the single-quoted form** whenever it can — so the file a self-hoster reads looks exactly as it did, and every existing `MakePasswordTest` assertion (`SITE_URL='http://localhost'`, `LAMB_TEST_PASSWORD='hackme'`, …) still matches byte-for-byte. It falls back to double quotes, with `\`, `"` and `$` escaped, only for the two characters single quotes cannot carry.

`$` has to be escaped in that branch: a double-quoted value **is** interpolated by phpdotenv, so `${HOME}` in a password would be substituted rather than stored. (Under the old single-quoted writing it was literal, so this is about not *introducing* a problem, not fixing one.)

## Verification

Ran the real script end to end — `LAMB_WRITE_TEST_PASSWORD=1 php make-password.php <pw>` in a temp directory, then parsing the result with phpdotenv:

```
plain         LAMB_TEST_PASSWORD='hackme'                        parse=ok  pw_ok=true  hash=true
apostrophe    LAMB_TEST_PASSWORD="it's-a-secret"                 parse=ok  pw_ok=true  hash=true
double quote  LAMB_TEST_PASSWORD='say "hi" ok'                   parse=ok  pw_ok=true  hash=true
spaces        LAMB_TEST_PASSWORD='my long pass phrase'           parse=ok  pw_ok=true  hash=true
backslash     LAMB_TEST_PASSWORD='a\b\c'                         parse=ok  pw_ok=true  hash=true
dollar brace  LAMB_TEST_PASSWORD='pre${HOME}post'                parse=ok  pw_ok=true  hash=true
both quotes   LAMB_TEST_PASSWORD="it's \"x\""                    parse=ok  pw_ok=true  hash=true
unicode       LAMB_TEST_PASSWORD='pässwörd-日本'                  parse=ok  pw_ok=true  hash=true
```

`pw_ok` is `$repo->get('LAMB_TEST_PASSWORD') === $password` — an exact round trip, not just "parses".

## Tests

Two added to `MakePasswordTest`, which already drives the script as a subprocess:

- `testPasswordWithAnApostropheProducesAParseableEnv` — asserts the double-quoted form, asserts the broken single-quoted form is *not* present, and asserts the `LAMB_LOGIN_PASSWORD` line still matches `^LAMB_LOGIN_PASSWORD='[A-Za-z0-9+/=]+'$`
- `testPasswordNeedingNoEscapeKeepsTheSingleQuotedForm` — a password with spaces, double quotes, a backslash and `${HOME}` must stay single-quoted, so the escaped branch is not entered where it would change `${HOME}`'s meaning

Both were run against the real script before committing.

Note: this environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here. phpdotenv v5.6.4 and its dependencies were cloned at their locked versions to exercise the parser directly. CI will run the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_