### PR TITLE
Pass the git ref to the test step through env, quoted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,18 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
+      # GITHUB_REF is quoted, and reached through env: rather than interpolated
+      # into the script. git allows `'`, `;`, `&`, `|` and `$( )` in a ref name
+      # (check-ref-format only forbids space, `~^:?*[`, control characters and a
+      # few shapes), so an unquoted expansion here made the ref name shell
+      # syntax: `refs/heads/a$(id)` ran `id`. Reaching it needs push access —
+      # a pull_request run gets `refs/pull/N/merge` — so this is hardening
+      # rather than an open hole, but it costs one quote pair.
       - name: Run Codeception tests
+        env:
+          GIT_REF: ${{ github.ref }}
         run: |
-          LAMB_WRITE_TEST_PASSWORD=1 php make-password.php $GITHUB_REF
+          LAMB_WRITE_TEST_PASSWORD=1 php make-password.php "$GIT_REF"
           vendor/bin/codecept run --steps
 
       - name: Check code coverage


### PR DESCRIPTION
## The bug

`cut-release.yml` states the convention this repository already follows:

> All inputs are passed via env (never interpolated into the script) so release notes can contain quotes/backticks without breaking the shell.

And every other workflow does it — `dependabot-auto-merge.yml`'s `"$PR_URL"`, `release-artifacts.yml`'s `"$TAG"`, `cut-release.yml`'s `"$VERSION"` / `"$NOTES"`.

The Codeception step in `ci.yml` was the one place that expanded a ref name into the script unquoted:

```yaml
- name: Run Codeception tests
  run: |
    LAMB_WRITE_TEST_PASSWORD=1 php make-password.php $GITHUB_REF
    vendor/bin/codecept run --steps
```

git allows plenty of shell syntax in a ref name. `git check-ref-format` only forbids space, `~^:?*[`, control characters and a few shapes:

```
ALLOWED  : it's-branch
ALLOWED  : x;whoami
ALLOWED  : a$(id)
ALLOWED  : a&b
ALLOWED  : a|b
rejected : a b
rejected : a*b
rejected : a?b
```

So the ref name *was* shell syntax at this line. `refs/heads/a$(id)` runs `id` and passes its output on as the password; `refs/heads/it's-branch` fails the step outright on an unterminated quote.

**Reachability:** a `pull_request` run gets `refs/pull/N/merge` (numeric, harmless), and the `push` trigger is limited to `main` and `release`, so getting an arbitrary ref name in here needs push access. This is hardening, not an open hole — but it costs one quote pair, and it is the pattern GitHub's own hardening guidance and this repo's own comment both say to avoid.

## The fix

Adopt the convention the other four workflows document:

```yaml
- name: Run Codeception tests
  env:
    GIT_REF: ${{ github.ref }}
  run: |
    LAMB_WRITE_TEST_PASSWORD=1 php make-password.php "$GIT_REF"
    vendor/bin/codecept run --steps
```

## Verification

- `git check-ref-format` results above were run directly.
- The edited file still parses as YAML, with the same seven jobs: `changes`, `quality`, `test`, `js-test`, `image-scan`, `playwright`, `ci`.
- I audited every other `github.*` / `$GITHUB_*` expansion across all five workflows; the rest already go through `env:` and are quoted at use, and the two remaining unquoted expansions (`$GITHUB_WORKSPACE`, `$GITHUB_REPOSITORY` in `release-verify.yml` / `release-artifacts.yml`) are runner-controlled paths, not ref names.

Behaviour is otherwise unchanged — `github.ref` is the same value `GITHUB_REF` held.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_