### PR TITLE
Reject a protocol-relative path in the Referer redirect guard

### DIFF
--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -125,6 +125,15 @@ function store_slug_change_redirect(string $old_slug, string $new_slug): void
  * redirect_uri()/sanitize_location() only strip control characters and do not
  * check the host, so an off-site Referer would otherwise redirect off-site.
  *
+ * The host check alone was not enough for that. A same-origin Referer of
+ * `https://site/​/evil.test/x` has host `site`, so it passed — and yielded the
+ * path `//evil.test/x`, which a browser resolves as protocol-relative and
+ * follows off-site. `/\evil.test` does the same, since browsers normalise the
+ * backslash. Referer is a request header, so its path is caller-supplied
+ * either way. local_redirect_target() already refuses both shapes for
+ * `?redirect_to=` and states why, and sanitize_explicit_slug() refuses them for
+ * a slug — so the final answer is delegated to it rather than restated here.
+ *
  * @param string|null $referer The request Referer header (may be null).
  * @return string A same-origin path (with query), or '/'.
  */
@@ -147,7 +156,8 @@ function safe_referer_path(?string $referer): string
     if (isset($parts['query']) && $parts['query'] !== '') {
         $path .= '?' . $parts['query'];
     }
-    return $path;
+
+    return local_redirect_target($path);
 }
 
 /**

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -323,6 +323,25 @@ class ResponsePostsTest extends TestCase
         $this->assertSame('/drafts', safe_referer_path('/drafts'));
     }
 
+    public function testSafeRefererPathRejectsAProtocolRelativePath(): void
+    {
+        // The host check passes — the Referer *is* same-origin — but the path it
+        // yields is `//evil.example/x`, which a browser resolves as
+        // protocol-relative and follows off-site. local_redirect_target()
+        // already refuses this shape for `?redirect_to=`, and states why.
+        $this->assertSame('/', safe_referer_path(ROOT_URL . '//evil.example/x'));
+        $this->assertSame('/', safe_referer_path('//evil.example/x'));
+    }
+
+    public function testSafeRefererPathRejectsABackslashPrefixedPath(): void
+    {
+        // Browsers normalise `\` to `/` in a URL, so `/\host` resolves the same
+        // way as `//host`. sanitize_explicit_slug() refuses it for a slug for
+        // exactly this reason.
+        $this->assertSame('/', safe_referer_path(ROOT_URL . '/\\evil.example/x'));
+        $this->assertSame('/', safe_referer_path('/\\evil.example'));
+    }
+
     // -------------------------------------------------------------------------
     // delete_return_path
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

`safe_referer_path()` describes itself as the shared open-redirect guard and promises a same-origin path:

> This is the open-redirect guard the redirect-after-action handlers share: `redirect_uri()`/`sanitize_location()` only strip control characters and do not check the host, so an off-site Referer would otherwise redirect off-site.
>
> `@return string` A same-origin path (with query), or `'/'`.

The host check alone does not deliver that. A **same-origin** Referer of `https://site//evil.test/x` has host `site`, so it passes — and yields the path `//evil.test/x`, which a browser resolves as protocol-relative and follows off-site. `/\evil.test` does the same, since browsers normalise the backslash in a URL. Referer is a request header, so the path is caller-supplied either way.

Measured side by side against the sibling guard:

```
REFERER                                  safe_referer_path      local_redirect_target(same path)
'https://victim.test/drafts'             '/drafts'              '/drafts'
'https://victim.test//evil.test/x'       '//evil.test/x'        '/'   <-- DISAGREE
'https://victim.test/\evil.test/x'       '/\evil.test/x'        '/'   <-- DISAGREE
'https://evil.test/x'                    '/'                    '/'
'//evil.test/x'                          '/'                    '/'
'/\evil.test'                            '/\evil.test'          '/'   <-- DISAGREE
```

The result feeds `redirect_uri()` → `sanitize_location()`, which strips only CR/LF/NUL, then goes straight into a `Location:` header. Two callers reach it: `redirect_edited()` (via `$_SESSION['edit-referrer']`) and `redirect_deleted()` (via `delete_return_path()`).

**Two siblings already refuse both shapes and say why.** `local_redirect_target()`, for `?redirect_to=`:

> must not begin with `"//"` or `"/\"` (which browsers treat as protocol-relative URLs pointing off-site)

and `Post\sanitize_explicit_slug()`, for a slug:

> A slug beginning with `/` (or `\`, which some browsers normalise to `/` in a URL) would make that concatenation a protocol-relative `//host/...` (or `/\host/...`) URL — an open redirect off the site.

`safe_referer_path()` is the third place that needs the same rule and the only one without it.

## Scope, honestly

**I could not construct an end-to-end exploit.** Reaching the vulnerable value needs the author to submit an edit or delete *from a page served at a `//`-prefixed URL*, and `index.php` routes `//evil.test` to the 404 page (`$action = strtok('//evil.test', '/')` → `'evil.test'` → no post, no route), which carries no edit or delete form. A cross-origin attacker page cannot supply the Referer either, because its host fails the check.

So this is a contract violation and hardening, not a demonstrated open redirect. I filed it because the guard is the entire purpose of the function, the promise in its own docblock is not met, and both siblings already cover the case.

## The fix

Delegate the final answer to `local_redirect_target()` rather than restate the check a third time. Both functions are in `Lamb\Response`, so it is a direct call.

```php
    if (isset($parts['query']) && $parts['query'] !== '') {
        $path .= '?' . $parts['query'];
    }

    return local_redirect_target($path);
```

A hostless relative Referer like `foo/bar` now also falls back to `/` instead of being emitted as a *relative* `Location` — `local_redirect_target()` requires a leading `/`.

## Verification

```
ok   same-origin // path                      '/'
ok   same-origin /\ path                      '/'
ok   bare /\ referer                          '/'
ok   bare // referer                          '/'
ok   ordinary path                            '/drafts'
ok   path with query                          '/search/x?page=2'
ok   off-site host                            '/'
ok   null referer                             '/'
ok   empty referer                            '/'
ok   root                                     '/'
ok   no path                                  '/'
ok   relative referer                         '/'
ok   status permalink                         '/status/12'
```

Every existing `ResponsePostsTest` assertion is covered there and unchanged: `/tag/lamb`, `/?page=2`, `null`, `''`, the cross-origin host, and the hostless `/drafts`. `delete_return_path()` composes unchanged — it compares `explode('?', $target)[0]` against the post's own path, and a rejected referer just becomes `/`.

Two tests added: `testSafeRefererPathRejectsAProtocolRelativePath` and `testSafeRefererPathRejectsABackslashPrefixedPath`, each covering both the same-origin-URL and bare-path spellings.

Note: this environment could not complete `composer install` (the proxy refuses `api.github.com` zipball downloads), so the Codeception suite was not executed here; the tables above were produced by running the real `safe_referer_path()` and `local_redirect_target()` extracted from source. CI will run the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_