### PR TITLE
Cap the RSS/Atom feed body the way the JSON feed body is capped

### DIFF
--- a/src/network/sources.php
+++ b/src/network/sources.php
@@ -8,7 +8,7 @@ use SimplePie\SimplePie;
 use function Lamb\Http\is_valid_http_url;
 use function Lamb\Http\resolve_validated_ip;
 
-// FEED_FETCH_TIMEOUT is defined in constants.php
+// FEED_FETCH_TIMEOUT and FEED_FETCH_MAX_BYTES are defined in constants.php
 
 /**
  * @return array<array-key, mixed> Configured feed URLs keyed by feed name.
@@ -66,7 +66,73 @@ class SafeFile extends SimplePieFile
             return;
         }
 
-        parent::__construct($url, $timeout, $redirects, $headers, $useragent, false, $pinned);
+        parent::__construct(
+            $url,
+            $timeout,
+            $redirects,
+            $headers,
+            $useragent,
+            false,
+            self::capBodyCurlOptions($pinned, FEED_FETCH_MAX_BYTES)
+        );
+    }
+
+    /**
+     * Merges FEED_FETCH_MAX_BYTES enforcement into a feed fetch's curl options.
+     *
+     * FEED_FETCH_MAX_BYTES exists because /_cron is unauthenticated: without a
+     * cap, a configured feed's host (or anything it redirects to) can stream an
+     * endless body into the worker's memory until it fatals. The JSON Feed
+     * crawl passes the constant to fetch_guarded(), which enforces it in a
+     * CURLOPT_WRITEFUNCTION; the RSS/Atom crawl had no cap at all, and it is
+     * the default path — every feed URL that does not end in `.json` takes it.
+     *
+     * fetch_guarded()'s approach is not available here: SimplePie reads the
+     * response out of curl_exec()'s return value (CURLOPT_RETURNTRANSFER), and
+     * installing a write callback makes curl_exec() return `true` instead, so
+     * the body would be lost. These three options cap the transfer without
+     * touching how the body is delivered:
+     *
+     * - `CURLOPT_ENCODING: identity` asks for an uncompressed body. SimplePie
+     *   requests compression (`CURLOPT_ENCODING: ''`), and curl's byte counters
+     *   report on-the-wire bytes — so a cap over a compressed transfer bounds
+     *   the *compressed* size only, while curl expands the body into the
+     *   response string as it arrives. A few megabytes of gzipped zeros expand
+     *   to gigabytes there before any cap could see them. fetch_guarded() sends
+     *   no Accept-Encoding at all for the same reason, which is what makes its
+     *   cap exact; this matches it.
+     * - `CURLOPT_MAXFILESIZE` refuses a body whose declared Content-Length is
+     *   already over the cap, before any of it is transferred.
+     * - the progress callback covers what MAXFILESIZE cannot: a chunked
+     *   response declares no length, and an endless body is precisely one that
+     *   never says how long it is. Returning non-zero aborts the transfer with
+     *   CURLE_ABORTED_BY_CALLBACK, which SimplePie surfaces as a fetch error —
+     *   so record_feed_crawl() logs it and leaves the success watermark alone,
+     *   exactly as it does for a timeout.
+     *
+     * Applied on every hop for the same reason the SSRF pin is: SimplePie
+     * follows a redirect by re-entering this constructor (see the class
+     * docblock), and it hands the recursion these same options.
+     *
+     * @param array<int, mixed> $curl_options
+     * @return array<int, mixed>
+     */
+    public static function capBodyCurlOptions(array $curl_options, int $max_bytes): array
+    {
+        $curl_options[CURLOPT_ENCODING] = 'identity';
+        $curl_options[CURLOPT_MAXFILESIZE] = $max_bytes;
+        $curl_options[CURLOPT_NOPROGRESS] = false;
+        $curl_options[CURLOPT_PROGRESSFUNCTION] = static function (
+            mixed $ch,
+            int $download_size,
+            int $downloaded,
+            int $upload_size,
+            int $uploaded
+        ) use ($max_bytes): int {
+            return ($downloaded > $max_bytes || $download_size > $max_bytes) ? 1 : 0;
+        };
+
+        return $curl_options;
     }
 
     /**

--- a/tests/Unit/SafeFileTest.php
+++ b/tests/Unit/SafeFileTest.php
@@ -114,4 +114,99 @@ class SafeFileTest extends TestCase
     {
         $this->assertFalse(SafeFile::buildPinnedCurlOptions('http://93.184.216.34/', [], true));
     }
+
+    // capBodyCurlOptions() ----------------------------------------------------
+    // /_cron is unauthenticated, so a feed body must be bounded: FEED_FETCH_MAX_BYTES
+    // was applied only on the JSON Feed crawl (via fetch_guarded()), leaving the
+    // RSS/Atom crawl — the default path for every URL that does not end in `.json`
+    // — able to read an endless body into the worker's memory. Like the pin above,
+    // this is pure option-building, tested without a request; the constructor's use
+    // of it can't be asserted here because SimplePie fetches as it is constructed.
+
+    public function testCapBodyCurlOptionsPreservesExistingCurlOptions(): void
+    {
+        $options = SafeFile::capBodyCurlOptions([CURLOPT_RESOLVE => ['h.example:80:93.184.216.34']], 1024);
+
+        $this->assertSame(['h.example:80:93.184.216.34'], $options[CURLOPT_RESOLVE]);
+    }
+
+    public function testCapBodyCurlOptionsRefusesADeclaredOversizeBody(): void
+    {
+        $options = SafeFile::capBodyCurlOptions([], 1024);
+
+        $this->assertSame(1024, $options[CURLOPT_MAXFILESIZE]);
+    }
+
+    public function testCapBodyCurlOptionsAsksForAnUncompressedBody(): void
+    {
+        // curl's byte counters report on-the-wire bytes, so a cap over a
+        // compressed transfer would bound the compressed size only while the
+        // body expands into the response string. fetch_guarded() — the JSON
+        // Feed path this now matches — sends no Accept-Encoding for the same
+        // reason, which is what makes its cap exact.
+        $options = SafeFile::capBodyCurlOptions([], 1024);
+
+        $this->assertSame('identity', $options[CURLOPT_ENCODING]);
+    }
+
+    public function testCapBodyCurlOptionsEnablesTheProgressCallback(): void
+    {
+        $options = SafeFile::capBodyCurlOptions([], 1024);
+
+        $this->assertFalse($options[CURLOPT_NOPROGRESS]);
+        $this->assertIsCallable($options[CURLOPT_PROGRESSFUNCTION]);
+    }
+
+    /**
+     * A chunked response declares no length, so CURLOPT_MAXFILESIZE never fires
+     * for it — and an endless body is precisely one that never says how long it
+     * is. The progress callback aborts on the running total instead.
+     *
+     * @return array<string, array{0: int, 1: int, 2: int}>
+     */
+    public static function progressProvider(): array
+    {
+        // [declared Content-Length, bytes downloaded so far, expected return]
+        // Non-zero aborts the transfer; 0 lets it continue.
+        return [
+            'well under the cap'          => [0, 512, 0],
+            'one byte under the cap'      => [0, 1023, 0],
+            'exactly at the cap'          => [0, 1024, 0],
+            'one byte over the cap'       => [0, 1025, 1],
+            'far over the cap'            => [0, 1 << 20, 1],
+            'declared over, none yet'     => [1025, 0, 1],
+            'declared at the cap'         => [1024, 0, 0],
+            'nothing declared or sent'    => [0, 0, 0],
+        ];
+    }
+
+    /**
+     * @dataProvider progressProvider
+     */
+    public function testCapBodyCurlOptionsProgressCallbackAbortsPastTheCap(
+        int $declared,
+        int $downloaded,
+        int $expected
+    ): void {
+        $progress = SafeFile::capBodyCurlOptions([], 1024)[CURLOPT_PROGRESSFUNCTION];
+
+        $this->assertSame($expected, $progress(null, $declared, $downloaded, 0, 0));
+    }
+
+    public function testCapBodyCurlOptionsProgressCallbackIgnoresUploadCounters(): void
+    {
+        // An upload past the cap is not a body being streamed at us; only the
+        // download counters may abort the transfer.
+        $progress = SafeFile::capBodyCurlOptions([], 1024)[CURLOPT_PROGRESSFUNCTION];
+
+        $this->assertSame(0, $progress(null, 0, 0, 4096, 4096));
+    }
+
+    public function testCapBodyCurlOptionsUsesTheCronIngestionCapByDefault(): void
+    {
+        // The constant both /_cron ingestion paths are meant to honour: the JSON
+        // Feed crawl hands it to fetch_guarded(), and SafeFile's constructor
+        // hands it to this. A positive cap is what makes either enforceable.
+        $this->assertGreaterThan(0, FEED_FETCH_MAX_BYTES);
+    }
 }


### PR DESCRIPTION
## The invariant

`FEED_FETCH_MAX_BYTES` states its own scope in `src/constants.php`:

> Largest feed body kept during **/_cron ingestion**. /_cron is unauthenticated, so an uncapped read lets a configured feed's host (or anything it redirects to) stream an endless body into the worker's memory until it fatals.

`/_cron` has two ingestion paths. The constant was applied to one of them.

## What was wrong

`crawl_feed()` dispatches by URL:

```php
if (is_json_feed_url($url)) {           // path ends in .json
    return record_json_feed_crawl($name, $url);
}
$feed = init_simplepie_feed($url);      // everything else
return record_feed_crawl($name, $url, $feed);
```

- **JSON Feed path** — `record_json_feed_crawl()` calls `fetch_guarded($url, ['timeout' => FEED_FETCH_TIMEOUT, 'max_bytes' => FEED_FETCH_MAX_BYTES])`, which enforces the cap in a `CURLOPT_WRITEFUNCTION` and discards a truncated body.
- **RSS/Atom path** — `configure_simplepie_feed()` sets a cache location, `set_cache_duration()` and `set_timeout()`. No size cap anywhere. `SafeFile` pinned the destination address but did not bound the body.

The uncapped path is the **default** one: any feed URL whose path does not end in `.json` takes it, so in practice nearly every configured feed was fetched without a cap. A feed host that streams a chunked, never-ending body holds the `/_cron` worker until it exhausts memory — the failure the constant was written to prevent, on the path most feeds use.

## The fix

`fetch_guarded()`'s technique cannot be reused here. SimplePie reads the response out of `curl_exec()`'s return value (`CURLOPT_RETURNTRANSFER`, `src/File.php:129`), and installing a write callback makes `curl_exec()` return `true` instead of the string — the body would be lost.

`SafeFile` already builds the curl options for every feed fetch, and SimplePie applies `$curl_options` **last**, after its own (`File.php:136-137`), so options set there win. It also follows a redirect by re-entering `$this->__construct(..., $curl_options)`, which is what already makes the SSRF pin apply per hop — the cap now rides along the same way.

New `SafeFile::capBodyCurlOptions()` sets three options:

| Option | Covers |
| --- | --- |
| `CURLOPT_MAXFILESIZE` | A declared `Content-Length` over the cap — refused before any of the body is transferred. |
| `CURLOPT_PROGRESSFUNCTION` (+ `NOPROGRESS: false`) | A chunked response declares no length, so `MAXFILESIZE` never fires for it — and an endless body is precisely one that never says how long it is. The callback aborts on the running total. |
| `CURLOPT_ENCODING: identity` | curl's byte counters report on-the-wire bytes, so a cap over a compressed transfer would bound the *compressed* size only while the body expands into the response string as it arrives. `fetch_guarded()` sends no `Accept-Encoding` at all for the same reason, which is what makes its cap exact; this matches it. |

Aborting returns `CURLE_ABORTED_BY_CALLBACK`, which SimplePie surfaces via `$this->error`. `record_feed_crawl()` already branches on `$feed->error()` and calls `record_crawl_failure()`, so an oversized feed is logged to the Logs tab and **does not advance the success watermark** — identical to how a timeout is handled today. No new failure handling was needed.

## Tests

`tests/Unit/SafeFileTest.php` gains coverage for the new pure option-builder, alongside the existing `buildPinnedCurlOptions()` tests:

- existing curl options (the `CURLOPT_RESOLVE` pin) survive the merge
- `CURLOPT_MAXFILESIZE` carries the cap; `CURLOPT_ENCODING` is `identity`; the progress callback is installed and enabled
- a data-provider table over the progress callback: below / one under / exactly at / one over / far over the cap, declared-oversize with nothing transferred yet, declared-at-cap, and nothing declared or sent
- upload counters never abort the transfer

As with the pin, the constructor's use of the builder is not asserted directly — SimplePie fetches as it is constructed. The test comment says so.

## Verification limitation

`composer install` cannot complete in this environment: the agent proxy refuses to authenticate against github.com for zipball downloads, so `vendor/` has no autoloader and neither Codeception nor phpstan can run locally. The new logic was verified by extracting `capBodyCurlOptions()` from the source and exercising it against the same cases the added tests cover (all pass), and `php -l` is clean on both files. SimplePie's curl behaviour was confirmed against the real `simplepie/simplepie` 1.9.0 `src/File.php` rather than assumed. CI runs the actual suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_