### PR TITLE
Record a feed crawl attempt before the fetch, not after it

### DIFF
--- a/src/network/status.php
+++ b/src/network/status.php
@@ -48,8 +48,21 @@ function feed_status_bean(string $name, string $url): OODBBean
  *
  * Every source type records an *attempt* before it fetches, so a feed that keeps
  * failing is still rate-limited by /_cron's 30-minute per-feed window (that window
- * is gated on `last_attempt`, not `last_success`). The bean is returned unsaved —
- * record_crawl_success()/record_crawl_failure() persist it with the outcome.
+ * is gated on `last_attempt`, not `last_success`).
+ *
+ * The stamp is *persisted* here rather than left for
+ * record_crawl_success()/record_crawl_failure(), because those only run when the
+ * fetch returns. A fetch that never returns — the worker OOMs on a hostile feed
+ * body, hits max_execution_time, or fatals in the parser — left `last_attempt`
+ * untouched on disk, so the feed was still due on the next run and /_cron died at
+ * the same feed every time. Everything after it in process_feeds() is downstream
+ * of that loop: the remaining feeds, the WebSub pings for newly published
+ * scheduled posts, and the entire outbound webmention queue never ran again.
+ * Writing the attempt before the fetch costs one row write per crawl and turns
+ * that into one lost run per 30-minute window.
+ *
+ * The bean is returned so record_crawl_success()/record_crawl_failure() can store
+ * the outcome on it; they overwrite this row rather than insert a second one.
  *
  * @param string $name Feed name from config.
  * @param string $url  Feed URL from config.
@@ -60,6 +73,7 @@ function begin_crawl(string $name, string $url): array
     $status = feed_status_bean($name, $url);
     $now    = (int)date('U');
     $status->last_attempt = $now;
+    R::store($status);
 
     return [$status, $now];
 }

--- a/tests/Unit/FeedStatusTest.php
+++ b/tests/Unit/FeedStatusTest.php
@@ -8,6 +8,7 @@ use SimplePie\Item as SimplePieItem;
 use SimplePie\SimplePie;
 
 use function Lamb\Network\begin_crawl;
+use function Lamb\Network\feed_fetch_due;
 use function Lamb\Network\feed_status_bean;
 use function Lamb\Network\get_feed_statuses;
 use function Lamb\Network\prune_feed_status;
@@ -193,6 +194,50 @@ class FeedStatusTest extends TestCase
         $this->assertGreaterThan(0, $now);
         $this->assertSame($now, (int)$status->last_attempt);
         $this->assertSame(1700000000, (int)$status->last_success);
+    }
+
+    public function testBeginCrawlPersistsTheAttemptBeforeTheFetchRuns(): void
+    {
+        // record_crawl_success()/record_crawl_failure() only run when the fetch
+        // returns. A fetch that never returns (the worker OOMs on a hostile feed
+        // body, hits max_execution_time, fatals in the parser) used to leave
+        // last_attempt untouched on disk, so /_cron found the same feed due on
+        // the next run and died at it again — starving every feed after it, the
+        // WebSub pings and the whole outbound webmention queue, all of which sit
+        // downstream of that loop in process_feeds().
+        [, $now] = begin_crawl('TestBlog', 'https://testblog.example.com/feed');
+
+        $reloaded = R::findOne('feedstatus', ' feedkey = ? ', [md5('TestBlog' . 'https://testblog.example.com/feed')]);
+
+        $this->assertNotNull($reloaded);
+        $this->assertSame($now, (int)$reloaded->last_attempt);
+    }
+
+    public function testBeginCrawlMakesTheFeedNotDueEvenIfTheCrawlNeverReports(): void
+    {
+        // The observable consequence: the per-feed window is gated on
+        // last_attempt, so a crawl that never reports an outcome still holds the
+        // feed off for the full window instead of being retried every run.
+        [, $now] = begin_crawl('TestBlog', 'https://testblog.example.com/feed');
+
+        $status = feed_status_bean('TestBlog', 'https://testblog.example.com/feed');
+
+        $this->assertFalse(feed_fetch_due((int)$status->last_attempt, $now));
+        $this->assertTrue(feed_fetch_due((int)$status->last_attempt, $now + FEED_FETCH_INTERVAL));
+    }
+
+    public function testBeginCrawlDoesNotInsertASecondRowForTheOutcome(): void
+    {
+        // begin_crawl() stores, then record_crawl_*() stores the same bean again.
+        // If the second store inserted instead of updating, the Logs tab would
+        // grow a duplicate row per crawl and prune_feed_status() would not clear
+        // it (the feedkey still matches a configured feed).
+        [$status, $now] = begin_crawl('TestBlog', 'https://testblog.example.com/feed');
+        record_crawl_success($status, $now, 2);
+
+        $rows = R::find('feedstatus', ' feedkey = ? ', [md5('TestBlog' . 'https://testblog.example.com/feed')]);
+
+        $this->assertCount(1, $rows);
     }
 
     public function testRecordCrawlFailurePersistsMessageAndReturnsOutcome(): void


### PR DESCRIPTION
## The invariant

`begin_crawl()`'s own docblock states it:

> Every source type records an **attempt before it fetches**, so a feed that keeps failing is still rate-limited by /_cron's 30-minute per-feed window (that window is gated on `last_attempt`, not `last_success`).

## What was wrong

It stamped `last_attempt` on the bean before fetching, but returned the row unsaved:

```php
$status = feed_status_bean($name, $url);
$now    = (int)date('U');
$status->last_attempt = $now;

return [$status, $now];   // nothing on disk yet
```

The stamp only reached disk if `record_crawl_success()` or `record_crawl_failure()` ran — and those only run **when the fetch returns**. A fetch that never returns recorded nothing at all: not a failure, not even an attempt.

Verified against the pre-change source — after `begin_crawl()` alone there is no `feedstatus` row whatsoever:

```
FAIL attempt row exists after begin_crawl alone
FAIL attempt timestamp persisted
PHP Warning: Attempt to read property "last_attempt" on null
```

## Why it matters

`process_feeds()` crawls feeds in a loop, and everything else in the cron run sits *after* that loop:

```php
foreach ($feeds as $name => $url) {
    $status = feed_status_bean($name, $url);
    if (!feed_fetch_due((int)$status->last_attempt, time())) { continue; }
    echo crawl_line($name, crawl_feed($name, $url));
}
echo count_line(\Lamb\Websub\ping_scheduled_publishes(), …);
echo webmention_line(\Lamb\Webmention\process_outbound());
set_option($cron_last_updated, (int)date('U'));
```

So if a fetch kills the worker — OOM on an oversized feed body, `max_execution_time`, a fatal in the parser — then:

1. `last_attempt` is unchanged on disk, so `feed_fetch_due()` still says that feed is due;
2. the next `/_cron` run reaches the same feed, in the same config order, and dies the same way;
3. **every remaining feed, the WebSub pings for scheduled posts that just went live, and the entire outbound webmention queue never run again**;
4. the run also dies before `set_option('last_processed_date')`, so the run-level rate limit isn't recorded and the next request retries immediately rather than being told "too often".

One bad feed permanently starves the rest of cron, silently — a crashed run prints nothing about what it never got to.

## The fix

`R::store($status)` in `begin_crawl()`. One row write per crawl, which turns permanent starvation into **one lost run per 30-minute window**: the crashing feed is skipped for the rest of its window and everything after it proceeds.

This makes the docblock's claim true rather than aspirational, and it changes nothing for a fetch that *does* return — `record_crawl_success()`/`record_crawl_failure()` already wrote the same `last_attempt` value; only the moment it is persisted moves earlier.

`record_crawl_*()` still receive the same bean and now **update** that row rather than insert the first one. A test pins the row count: a duplicate per crawl would show up on the Logs tab, and `prune_feed_status()` would not clear it, since the `feedkey` still matches a configured feed.

## Tests

`tests/Unit/FeedStatusTest.php` gains three:

- `testBeginCrawlPersistsTheAttemptBeforeTheFetchRuns` — the row exists, with the right timestamp, after `begin_crawl()` and **no** `record_crawl_*` call at all (the crashed-worker case)
- `testBeginCrawlMakesTheFeedNotDueEvenIfTheCrawlNeverReports` — the observable consequence: `feed_fetch_due()` is false now and true after `FEED_FETCH_INTERVAL`
- `testBeginCrawlDoesNotInsertASecondRowForTheOutcome` — exactly one row after `begin_crawl()` + `record_crawl_success()`

No existing test asserted the bean was unsaved, so none needed changing.

## Verification limitation

`composer install` cannot complete in this environment (the agent proxy refuses to authenticate against github.com for zipball downloads), so `vendor/` has no autoloader and Codeception cannot run locally. RedBeanPHP v5.7.6 — the version in `composer.lock` — was cloned separately and the four extracted functions exercised against an in-memory SQLite database.

Nineteen assertions pass on this change, covering the new behaviour and the pre-existing invariants it must not disturb: a failure does not advance the success watermark, the ingestion watermark only ever moves forward, the failure path still stores its message and `last_error`, and there is one row per feed after repeated crawls. The same harness run against `origin/main`'s `status.php` fails on the first assertion, as quoted above. CI runs the actual suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_