### PR TITLE
Stop deferred outbox rows consuming the webmention send window

### DIFF
--- a/src/webmention.php
+++ b/src/webmention.php
@@ -33,6 +33,20 @@ const WEBMENTION_FETCH_TIMEOUT = 10;
 const WEBMENTION_FETCH_MAX_BYTES = 2_000_000;
 
 /**
+ * Most pending outbox rows a single /_cron run will step over while looking
+ * for ones it can deliver.
+ *
+ * process_outbound()'s `$limit` bounds sends, and a deferred row (its source
+ * post is still scheduled) costs no network request — so a run pages past
+ * deferred rows rather than letting them consume the window. This caps that
+ * paging: stepping over a row still costs a post load, and a queue holding
+ * hundreds of scheduled rows must not make one run walk the whole backlog.
+ * Well above any plausible number of simultaneously scheduled posts, so in
+ * practice a run reaches deliverable rows long before this.
+ */
+const OUTBOX_SCAN_LIMIT = 500;
+
+/**
  * Route handler for POST /webmention.
  *
  * Accepts `source` and `target` form parameters per the Webmention spec,
@@ -586,9 +600,19 @@ function reconcile_resends_on_restore(int $post_id): int
  * draft, or missing posts are cancelled, and rows for still-scheduled posts
  * are left pending (untouched, no attempt counted) until publication. This
  * deliberately does not use is_viewable(), which trusts logged-in sessions —
- * a logged-in author hitting /_cron must not leak drafts. Deferred scheduled
- * rows still occupy part of the LIMIT window; with the default of 20 that is
- * harmless.
+ * a logged-in author hitting /_cron must not leak drafts.
+ *
+ * `$limit` bounds the rows that *attempt a send*, not the rows looked at. A
+ * deferred row stays pending, so it stays at the front of the queue: once
+ * `$limit` scheduled posts with external links are queued, they filled the
+ * whole window on every run and no webmention was ever sent again — silently,
+ * because a deferred row increments no counter and webmention_line() prints
+ * nothing when all four are zero. Deferring costs one post load and no network
+ * request, so a run steps over deferred rows (paging by how many it has seen)
+ * and spends its window on rows that can actually be delivered.
+ *
+ * OUTBOX_SCAN_LIMIT bounds that stepping, so a queue with a very large backlog
+ * of scheduled rows cannot make a single run walk it end to end.
  *
  * Both network operations are injectable for testing:
  *  - $fetcher fn(string $url): ?array{headers: string[], body: string}
@@ -606,12 +630,33 @@ function process_outbound(?callable $fetcher = null, ?callable $sender = null, i
     $sender ??= __NAMESPACE__ . '\\send_webmention';
 
     $stats = ['sent' => 0, 'failed' => 0, 'skipped' => 0, 'cancelled' => 0];
-    $rows = R::find('webmentionoutbox', ' status = ? ORDER BY created ASC LIMIT ? ', ['pending', $limit]);
+    $handled  = 0;
+    $deferred = 0;
 
-    foreach ($rows as $row) {
-        $outcome = process_outbound_row($row, $fetcher, $sender, $resolver);
-        if ($outcome !== null) {
+    while ($handled < $limit && $deferred < OUTBOX_SCAN_LIMIT) {
+        // `id` breaks ties on `created`: enqueue_for_post() writes every row for
+        // one post in the same second, so `created` alone is not a total order
+        // and SQLite may return tied rows differently between the pages below —
+        // which would let a row be seen twice, or skipped.
+        $rows = R::find(
+            'webmentionoutbox',
+            ' status = ? ORDER BY created ASC, id ASC LIMIT ? OFFSET ? ',
+            ['pending', $limit - $handled, $deferred]
+        );
+        if (count($rows) === 0) {
+            break;
+        }
+
+        foreach ($rows as $row) {
+            $outcome = process_outbound_row($row, $fetcher, $sender, $resolver);
+            if ($outcome === null) {
+                // Left pending and untouched, so it stays in this result set —
+                // the next page has to step over it.
+                $deferred++;
+                continue;
+            }
             $stats[$outcome]++;
+            $handled++;
         }
     }
 

--- a/tests/Unit/WebmentionSendTest.php
+++ b/tests/Unit/WebmentionSendTest.php
@@ -412,6 +412,119 @@ class WebmentionSendTest extends TestCase
         $this->assertSame('cancelled', R::findOne('webmentionoutbox')->status);
     }
 
+    // process_outbound (deferred rows must not starve the queue) -------------
+
+    /**
+     * A post whose `created` is in the future, so its outbox rows defer.
+     */
+    private function schedulePost(): int
+    {
+        $post = R::dispense('post');
+        $post->body = 'Later';
+        $post->transformed = '<p>Later</p>';
+        $post->created = date('Y-m-d H:i:s', time() + 3600);
+        $post->updated = date('Y-m-d H:i:s');
+        $post->version = 1;
+
+        return (int) R::store($post);
+    }
+
+    /**
+     * Queues $count rows for one post in a single enqueue_outbound() call.
+     *
+     * One call, not $count of them: enqueue_outbound() cancels pending rows for
+     * the same source whose target is absent from the HTML it is given, so
+     * calling it once per link would leave only the last row pending. A single
+     * call is also how a real post with several links enqueues — which is why
+     * every row it writes carries the same `created` second.
+     *
+     * @return string The source URL the rows share.
+     */
+    private function seedPendingBatch(int $postId, string $sourcePath, string $hostPrefix, int $count): string
+    {
+        $html = '';
+        for ($i = 0; $i < $count; $i++) {
+            $html .= '<a href="https://' . $hostPrefix . $i . '.example/a">x</a>';
+        }
+        $source = ROOT_URL . $sourcePath;
+        $this->assertSame($count, enqueue_outbound($postId, $source, $html));
+
+        return $source;
+    }
+
+    public function testProcessDoesNotLetDeferredRowsConsumeTheSendWindow(): void
+    {
+        // A deferred row stays pending, so it stays at the front of the queue.
+        // Once $limit scheduled posts' links were queued they filled the whole
+        // window on every run and nothing was ever sent again — silently, since
+        // a deferred row increments no counter and webmention_line() prints
+        // nothing when all four are zero.
+        $this->seedPendingBatch($this->schedulePost(), '/status/2', 's', 20);
+        $this->seedPending('https://live.example/a');
+
+        $fetcher = fn (string $url) => ['headers' => ['<https://live.example/wm>; rel="webmention"'], 'body' => ''];
+        $sender = fn (string $e, string $s, string $t): int => 202;
+
+        $result = process_outbound($fetcher, $sender, 20, $this->publicResolver());
+
+        $this->assertSame(1, $result['sent']);
+        $this->assertSame(
+            'sent',
+            R::findOne('webmentionoutbox', ' target = ? ', ['https://live.example/a'])->status
+        );
+        $this->assertCount(20, R::find('webmentionoutbox', ' status = ? ', ['pending']));
+    }
+
+    public function testProcessStillCapsSendsAtTheLimit(): void
+    {
+        // The window bounds sends, and that has to stay true: paging past
+        // deferred rows must not turn $limit into "everything deliverable".
+        $this->seedPendingBatch($this->postId, '/status/1', 't', 25);
+
+        $fetcher = fn (string $url) => ['headers' => ['<https://t.example/wm>; rel="webmention"'], 'body' => ''];
+        $sender = fn (string $e, string $s, string $t): int => 202;
+
+        $result = process_outbound($fetcher, $sender, 20, $this->publicResolver());
+
+        $this->assertSame(20, $result['sent']);
+        $this->assertCount(5, R::find('webmentionoutbox', ' status = ? ', ['pending']));
+    }
+
+    public function testProcessSendsEachRowOnceWhenCreatedTimestampsTie(): void
+    {
+        // Every row from one enqueue_outbound() call shares a `created` second,
+        // so `created` alone is not a total order — paging over a non-total
+        // order could send a row twice or skip one. The query breaks the tie
+        // on `id`.
+        $this->seedPendingBatch($this->schedulePost(), '/status/2', 's', 5);
+        $this->seedPendingBatch($this->postId, '/status/1', 'l', 5);
+
+        $sent = [];
+        $fetcher = fn (string $url) => ['headers' => ['<https://l.example/wm>; rel="webmention"'], 'body' => ''];
+        $sender = function (string $e, string $s, string $target) use (&$sent): int {
+            $sent[] = $target;
+            return 202;
+        };
+
+        $result = process_outbound($fetcher, $sender, 20, $this->publicResolver());
+
+        $this->assertSame(5, $result['sent']);
+        $this->assertSame($sent, array_values(array_unique($sent)));
+        $this->assertCount(5, R::find('webmentionoutbox', ' status = ? ', ['pending']));
+    }
+
+    public function testProcessTerminatesWhenEveryPendingRowIsDeferred(): void
+    {
+        // The paging loop must not spin when there is nothing it can deliver.
+        $this->seedPendingBatch($this->schedulePost(), '/status/2', 's', 25);
+
+        [$fetcher, $sender] = $this->unreachableNetwork();
+        $result = process_outbound($fetcher, $sender, 20, $this->publicResolver());
+
+        $this->assertSame(['sent' => 0, 'failed' => 0, 'skipped' => 0, 'cancelled' => 0], $result);
+        $this->assertCount(25, R::find('webmentionoutbox', ' status = ? ', ['pending']));
+    }
+
     public function testProcessSendsOnceScheduledPostBecomesPublic(): void
     {
         $post = R::load('post', $this->postId);


### PR DESCRIPTION
## The claim that fails

`process_outbound()`'s docblock saw the shape of this and judged it safe:

> Deferred scheduled rows still occupy part of the LIMIT window; **with the default of 20 that is harmless.**

It is harmless *below* the boundary, and total starvation at it.

## What was wrong

```php
$rows = R::find('webmentionoutbox', ' status = ? ORDER BY created ASC LIMIT ? ', ['pending', $limit]);
```

A deferred row — one whose source post is still scheduled — is returned to the caller as `null` and left **pending and untouched**, by design. So it stays at the front of `ORDER BY created ASC`, and the next run selects it again.

Once 20 links belonging to still-scheduled posts are queued, they fill the window on every run, `process_outbound_row()` returns `null` for all 20, and **no webmention is ever sent again — for any post, however new.** Queueing a month of scheduled posts that link out is enough.

It is also completely silent:

```php
function webmention_line(array $sent): string
{
    if (!$sent['sent'] && !$sent['failed'] && !$sent['skipped'] && !$sent['cancelled']) {
        return '';
    }
```

A deferred row increments no counter, so all four stay zero and `/_cron` prints **nothing at all** about webmentions while the queue is wedged. There is no symptom to notice.

## The fix

The limit exists to bound the network work a run does. A deferred row does none — it costs one `R::load('post')` and no HTTP request. So:

**`$limit` now bounds rows that attempt a send, not rows looked at.** A run pages past deferred rows to reach rows it can deliver. Paging by the count of deferred rows seen is exact: those are precisely the rows that remain pending, while handled rows leave the result set, so the offset always lands just past them.

**The ordering gained an `id` tiebreaker.** `enqueue_outbound()` writes every row for one post inside the same second, so `created` alone is not a total order — SQLite need not return tied rows the same way for two different `OFFSET`s, which paging over it could turn into a row sent twice or skipped. Necessary for the paging to be correct, not incidental.

**`OUTBOX_SCAN_LIMIT` (500) bounds the paging**, so a backlog of hundreds of scheduled rows cannot make a single run walk it end to end.

**Per-row semantics are untouched.** `process_outbound_row()` is not modified: rows for deleted, draft and missing posts are still cancelled, scheduled rows still defer with no attempt counted, and the SSRF check on a discovered endpoint is unchanged. The selection *predicate* is also unchanged — only pagination is added. That matters: a `NOT EXISTS`-style SQL exclusion of scheduled posts was the other option and I rejected it, because a resend row (`resend = 1`) is processed without any `is_scheduled()` check today, so excluding scheduled posts in SQL would silently stop delivering a deletion resend for a post that was scheduled *and* deleted.

## Tests

`tests/Unit/WebmentionSendTest.php` gains four, plus a `seedPendingBatch()` helper. The helper exists because `enqueue_outbound()` cancels pending rows for the same `source` whose target is absent from the HTML it is handed — so queueing N rows takes **one** call with N links, not N calls, and that is also how a real multi-link post enqueues (which is why the rows share a `created` second).

- `testProcessDoesNotLetDeferredRowsConsumeTheSendWindow` — 20 deferred rows plus one deliverable: the deliverable one is sent and the 20 stay pending
- `testProcessStillCapsSendsAtTheLimit` — 25 deliverable rows, limit 20 → 20 sent, 5 pending. Paging must not turn `$limit` into "everything deliverable"
- `testProcessSendsEachRowOnceWhenCreatedTimestampsTie` — 5 deferred + 5 deliverable sharing `created` values: each target sent exactly once
- `testProcessTerminatesWhenEveryPendingRowIsDeferred` — all-deferred queue returns all zeros and touches no network

## Verification limitation

`composer install` cannot complete in this environment (the agent proxy refuses to authenticate against github.com for zipball downloads), so `vendor/` has no autoloader and Codeception cannot run locally. RedBeanPHP v5.7.6 — the version in `composer.lock` — was cloned separately and the **real** `is_external_http_url()`, `extract_outbound_links()`, `enqueue_outbound()`, `process_outbound()` and `process_outbound_row()` run against an in-memory SQLite database, with only the network calls and the endpoint discovery stubbed.

The four scenarios above pass on this change. Run against `origin/main`'s `webmention.php`, the starvation test fails and the other three pass — so the new tests catch the bug and the guards genuinely guard rather than restate. A wider harness also confirmed the cancellation paths still fire, an empty queue is a no-op, and a 600-row deferred backlog terminates promptly under the scan cap. CI runs the actual suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_