### PR TITLE
Stop a failed post edit from redirecting its own URL to a 404

### DIFF
--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -272,7 +272,15 @@ function redirect_edited(): void
     }
 
     $contents = trim(request_string($_POST['contents'] ?? null) ?? '');
-    $id = trim(filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT) ?: '');
+    // filter_var() over $_POST rather than filter_input(INPUT_POST, ...): the
+    // same FILTER_SANITIZE_NUMBER_INT over the same value, but read where every
+    // other input in this function is read. filter_input() reads the SAPI's
+    // request data, which does not exist under the CLI SAPI the test suite runs
+    // on — it returns null there whatever $_POST holds, so everything below this
+    // line was unreachable from a unit test (hence the existing coverage
+    // stopping at "early-return paths"). Non-numeric input still sanitises to ''
+    // and returns here, exactly as before.
+    $id = trim((string) filter_var(request_string($_POST['id'] ?? null) ?? '', FILTER_SANITIZE_NUMBER_INT));
     if (empty($contents) || empty($id)) {
         return;
     }
@@ -306,7 +314,15 @@ function redirect_edited(): void
     try {
         R::store($bean);
     } catch (SQL $e) {
+        // Return, like the reserved-slug check above: everything below this
+        // point is a consequence of the edit having been saved. Falling through
+        // on a failed write — a locked SQLite file while /_cron holds it is the
+        // realistic one — pointed the post's live URL at a slug that was never
+        // stored (a 301 to a 404), and announced the unsaved content to
+        // webmention receivers and the WebSub hub.
         $_SESSION['flash'][] = 'Failed to update status: ' . $e->getMessage();
+
+        return;
     }
 
     $new_slug = $bean->slug;

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -228,6 +228,167 @@ class ResponsePostsTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // redirect_edited — a failed save must have no side effects
+    // -------------------------------------------------------------------------
+
+    /**
+     * Seeds a post with a slug and returns its id, with the `redirect` and
+     * `webmentionoutbox` tables created so a count of them means "none were
+     * written" rather than "the table does not exist yet".
+     */
+    private function seedEditablePost(): int
+    {
+        $redirect = R::dispense('redirect');
+        $redirect->from_slug = '';
+        $redirect->to_url = '';
+        R::store($redirect);
+        R::exec('DELETE FROM redirect');
+
+        $outbox = R::dispense('webmentionoutbox');
+        $outbox->source = '';
+        $outbox->target = '';
+        $outbox->status = '';
+        R::store($outbox);
+        R::exec('DELETE FROM webmentionoutbox');
+
+        $post = R::dispense('post');
+        $post->body          = "# Original title\n\nsome text\n";
+        $post->transformed   = '<p>some text</p>';
+        $post->slug          = 'original-title';
+        $post->created       = date('Y-m-d H:i:s', time() - 3600);
+        $post->updated       = date('Y-m-d H:i:s', time() - 3600);
+        $post->version       = POST_VERSION;
+        $post->tags          = '';
+        $post->feeditem_uuid = '';
+        $post->feed_locked   = 0;
+        $post->in_reply_to   = '';
+
+        return (int) R::store($post);
+    }
+
+    /**
+     * Submits an edit that renames the post while every UPDATE on `post` fails.
+     *
+     * The trigger is how a write failure is made deterministic: SELECTs and
+     * INSERTs into other tables still succeed, which is exactly the shape of a
+     * locked SQLite file (RedBeanPHP surfaces it as RedException\SQL, the
+     * exception redirect_edited() already catches).
+     */
+    private function submitEditWithFailingWrite(int $id): void
+    {
+        $_SESSION[SESSION_LOGIN]    = true;
+        $_SESSION[HIDDEN_CSRF_NAME] = 'failtok';
+        $_POST[HIDDEN_CSRF_NAME]    = 'failtok';
+        $_POST['submit']            = SUBMIT_EDIT;
+        $_POST['id']                = (string) $id;
+        $_POST['contents']          = "# Renamed title\n\nsee [elsewhere](https://other.example/a)\n";
+
+        R::exec("CREATE TRIGGER post_block_update BEFORE UPDATE ON post BEGIN SELECT RAISE(ABORT, 'database is locked'); END");
+        try {
+            redirect_edited();
+        } finally {
+            R::exec('DROP TRIGGER IF EXISTS post_block_update');
+        }
+    }
+
+    public function testRedirectEditedFlashesAndStopsWhenTheSaveFails(): void
+    {
+        $id = $this->seedEditablePost();
+
+        $this->submitEditWithFailingWrite($id);
+
+        $this->assertNotEmpty(array_filter(
+            $_SESSION['flash'] ?? [],
+            fn ($m) => str_contains((string) $m, 'Failed to update')
+        ));
+        // Unchanged on disk — the whole point of the guard.
+        $this->assertSame('original-title', (string) R::load('post', $id)->slug);
+    }
+
+    public function testRedirectEditedDoesNotRedirectTheLiveSlugWhenTheSaveFails(): void
+    {
+        // The damaging one: the post keeps its old slug, so a redirect from that
+        // slug to the never-saved new one points the post's own live URL at a
+        // 404 and makes it unreachable.
+        $id = $this->seedEditablePost();
+
+        $this->submitEditWithFailingWrite($id);
+
+        $this->assertCount(0, R::findAll('redirect'));
+    }
+
+    public function testRedirectEditedDoesNotNotifySubscribersWhenTheSaveFails(): void
+    {
+        // Announcing an edit that was not stored: the queued mention carries a
+        // permalink built from the unsaved slug, so a receiver fetching it to
+        // verify the mention gets a 404.
+        $id = $this->seedEditablePost();
+
+        $this->submitEditWithFailingWrite($id);
+
+        $this->assertCount(0, R::findAll('webmentionoutbox'));
+    }
+
+    // -------------------------------------------------------------------------
+    // redirect_edited — the post id is read from $_POST
+    // -------------------------------------------------------------------------
+    // FILTER_SANITIZE_NUMBER_INT over $_POST, as filter_input(INPUT_POST, ...)
+    // applied to the SAPI request. These pin the sanitising semantics that read
+    // relied on, which is what the change to $_POST had to preserve.
+
+    public function testRedirectEditedReturnsEarlyWhenIdIsMissing(): void
+    {
+        $this->seedEditablePost();
+        $_SESSION[SESSION_LOGIN]    = true;
+        $_SESSION[HIDDEN_CSRF_NAME] = 'idtok1';
+        $_POST[HIDDEN_CSRF_NAME]    = 'idtok1';
+        $_POST['submit']            = SUBMIT_EDIT;
+        $_POST['contents']          = 'Updated content';
+
+        redirect_edited();
+
+        // No new post was created from id 0, and the seeded one is untouched.
+        $this->assertCount(1, R::findAll('post'));
+        $this->assertSame('original-title', (string) R::findOne('post')->slug);
+    }
+
+    public function testRedirectEditedReturnsEarlyWhenIdSanitisesToNothing(): void
+    {
+        // 'abc' has no digits, so it sanitises to '' and is refused rather than
+        // becoming post id 0 (which would create a new post instead of editing).
+        $this->seedEditablePost();
+        $_SESSION[SESSION_LOGIN]    = true;
+        $_SESSION[HIDDEN_CSRF_NAME] = 'idtok2';
+        $_POST[HIDDEN_CSRF_NAME]    = 'idtok2';
+        $_POST['submit']            = SUBMIT_EDIT;
+        $_POST['id']                = 'abc';
+        $_POST['contents']          = 'Updated content';
+
+        redirect_edited();
+
+        // No new post was created from id 0, and the seeded one is untouched.
+        $this->assertCount(1, R::findAll('post'));
+        $this->assertSame('original-title', (string) R::findOne('post')->slug);
+    }
+
+    public function testRedirectEditedReturnsEarlyWhenIdIsZero(): void
+    {
+        $this->seedEditablePost();
+        $_SESSION[SESSION_LOGIN]    = true;
+        $_SESSION[HIDDEN_CSRF_NAME] = 'idtok3';
+        $_POST[HIDDEN_CSRF_NAME]    = 'idtok3';
+        $_POST['submit']            = SUBMIT_EDIT;
+        $_POST['id']                = '0';
+        $_POST['contents']          = 'Updated content';
+
+        redirect_edited();
+
+        // No new post was created from id 0, and the seeded one is untouched.
+        $this->assertCount(1, R::findAll('post'));
+        $this->assertSame('original-title', (string) R::findOne('post')->slug);
+    }
+
+    // -------------------------------------------------------------------------
     // respond_edit
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## What was wrong

`redirect_edited()` caught a failed write and carried on:

```php
try {
    R::store($bean);
} catch (SQL $e) {
    $_SESSION['flash'][] = 'Failed to update status: ' . $e->getMessage();
}

$new_slug = $bean->slug;
if (!empty($old_slug) && $old_slug !== $new_slug) {
    store_slug_change_redirect((string) $old_slug, (string) $new_slug);
}

warn_if_manual_redirect((string) $new_slug);

notify_post_subscribers($bean);
```

Everything below the catch is a consequence of the edit having been **saved**. When it wasn't:

- **The post's own URL is redirected to a 404.** The post keeps its old slug on disk, but a redirect row is written from that slug to the new one, which nothing has. The live URL now 301s to nothing. A failed save makes the post unreachable.
- **Subscribers are notified of content that does not exist.** `notify_post_subscribers()` queues outbound webmentions and pings the WebSub hub, with a permalink built from the unsaved slug — so a receiver fetching the source to verify the mention gets a 404.

This is not a rare trigger. SQLite serialises writers, and `/_cron` holding the file while the author saves an edit is an ordinary `database is locked`, which RedBeanPHP surfaces as exactly the `RedException\SQL` already caught here.

## Verified damage

Booting all of `src/` and running the real `redirect_edited()` against SQLite, with every `UPDATE` on `post` failing:

```
--- before ---                          --- after ---
"redirects": [                          "redirects": [],
  "original-title -> /renamed-title"    "outbox": [],
],                                      "slug_on_disk": "original-title"
"outbox": [
  "http://localhost/renamed-title
     -> https://other.example/a"
],
"slug_on_disk": "original-title"
```

The post's slug on disk is still `original-title`, and there is now a redirect sending `original-title` to `/renamed-title`.

## The fix

`return` after the flash — which is what the same function already does two checks earlier for a reserved slug, leaving `respond_edit()` to re-render the edit form with the message.

## Why this was never caught, and the one enabling change

The post id was read with `filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT)`. `filter_input()` reads the **SAPI's** request data, which does not exist under the CLI SAPI the test suite runs on — it returns `null` there no matter what `$_POST` holds:

```
$ php -r '$_POST["id"] = "42"; var_dump(filter_input(INPUT_POST, "id", FILTER_SANITIZE_NUMBER_INT));'
NULL
```

So `$id` was always empty in tests and **every line after it was unreachable** — which is why this file's existing coverage is headed *"redirect_edited — early-return paths (no die())"*. The bug lived in code no unit test could reach.

`filter_var()` applies the same `FILTER_SANITIZE_NUMBER_INT` to the same value, read from `$_POST` where every other input in this function is already read (`request_string($_POST['contents'] …)`, `request_string($_POST['submit'] …)`). I checked the two expressions agree on both the `empty()` check and the `(int)` cast for every input I could think of — `null`, `''`, `'0'`, `'00'`, `'42'`, `'12abc'`, `'abc'`, `'-7'`, `' 9 '`, `'1e3'`, `'+5'`, a 19-digit number, `'-'`, `'1.5'`.

## Tests

Six added to `tests/Unit/ResponsePostsTest.php`.

Three for the fix — a deterministic write failure via a SQLite trigger, which is the right shape because `SELECT`s and inserts into *other* tables still succeed, exactly like a locked file:

- the failure is flashed and the post is unchanged on disk
- **no redirect row is created**
- **no outbound webmention is queued**

Three pinning the input semantics the change had to preserve — a missing id, an id with no digits, and `'0'` all still return early without creating a post. **These pass against the pre-change source too**, which is the point of them.

Run individually against `origin/main`'s `posts.php`, the three failed-save tests terminate the process at `redirect_uri()`'s `die()` — the fall-through this fixes. Under PHPUnit that aborts the run, so they fail in the strongest available sense.

## Considered and left alone

`redirect_created()` has the same shape, but `finalize_and_store_post()` stores once to mint the id before anything else can throw: if that first store fails `$bean->id` is falsy and both notifiers no-op already, and if the second (slug-pinning) store fails the post genuinely exists, so notifying is not wrong. Different situation, not folded in here.

## Verification limitation

`composer install` cannot complete in this environment (the agent proxy refuses to authenticate against github.com for zipball downloads), so Codeception cannot run locally. RedBeanPHP v5.7.6, Parsedown and symfony/yaml were loaded separately and all of `src/` booted, letting the real `redirect_edited()` run end to end — that is where the before/after table above comes from. `php -l` is clean on both files. CI runs the actual suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_