### PR TITLE
Do not run the theme migration on unparseable config

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -158,6 +158,23 @@ function parse_ini_safe(string $ini_text): array
  */
 function ensure_explicit_theme(string $ini_text, string $default_theme = 'base'): string
 {
+    // Unparseable INI is not themeless INI, and parse_ini_safe() answers []
+    // for both. Prepending a `theme =` line to a file with a syntax error
+    // leaves it exactly as unparseable, so the migration below fired again on
+    // the next request — and every request after that, since get_ini_text()
+    // saves whenever the text changed. The stored config grew by a line per
+    // request, each one a write, and save_ini_text() advances the config
+    // timestamp monotonically, so latest_content_timestamp() moved every
+    // request too and no anonymous response could be served from cache.
+    //
+    // A broken file needs fixing, not migrating: leave it alone. Nothing
+    // downstream depends on the migration having run — normalize_config()
+    // drops an unusable theme and index.php falls back to the base theme,
+    // which is the same outcome this function aims at.
+    if (!validate_ini($ini_text)['valid']) {
+        return $ini_text;
+    }
+
     $parsed = parse_ini_safe($ini_text);
 
     if (!array_key_exists('theme', $parsed)) {

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -149,6 +149,63 @@ class ConfigTest extends TestCase
         $this->assertSame($once, $twice);
     }
 
+    /**
+     * INI that parse_ini_string() refuses outright. parse_ini_safe() answers []
+     * for these exactly as it does for a themeless file, which is what made the
+     * migration mistake them for one.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function unparseableIniProvider(): array
+    {
+        return [
+            'unclosed section header' => ["[unclosed\nsite_title = Example\n"],
+            'stray closing bracket'   => ["]\nsite_title = Example\n"],
+            'key with no name'        => ["=\n"],
+            'stray brace'             => ["{\n"],
+            'reserved word as key'    => ["yes = 1\n"],
+            'bare quote'              => ["\"\n"],
+        ];
+    }
+
+    /**
+     * @dataProvider unparseableIniProvider
+     */
+    public function testEnsureExplicitThemeLeavesUnparseableIniAlone(string $ini): void
+    {
+        // Prepending a theme line to a file with a syntax error leaves it just
+        // as unparseable, so the migration fired again on every request:
+        // get_ini_text() saves whenever the text changed, so the stored config
+        // grew a line per request and save_ini_text() advanced the config
+        // timestamp each time, defeating every anonymous cache validator.
+        $this->assertSame($ini, ensure_explicit_theme($ini));
+    }
+
+    /**
+     * @dataProvider unparseableIniProvider
+     */
+    public function testEnsureExplicitThemeIsIdempotentForUnparseableIni(string $ini): void
+    {
+        // The property the valid-input test above already asserts, on the input
+        // that broke it. Repeated application must reach a fixed point.
+        $once = ensure_explicit_theme($ini);
+        $twice = ensure_explicit_theme($once);
+        $thrice = ensure_explicit_theme($twice);
+
+        $this->assertSame($once, $twice);
+        $this->assertSame($twice, $thrice);
+    }
+
+    public function testEnsureExplicitThemeStillMigratesAThemelessFile(): void
+    {
+        // The guard must not cost the migration its actual job.
+        $migrated = ensure_explicit_theme("site_title = Example\n");
+        $parsed = parse_ini_string($migrated, true, INI_SCANNER_RAW);
+
+        $this->assertSame('base', $parsed['theme']);
+        $this->assertSame('Example', $parsed['site_title']);
+    }
+
     public function testEnsureExplicitThemeMigratesLegacyDefaultToBase(): void
     {
         $ini = "theme = default\nsite_title = Example\n";


### PR DESCRIPTION
## What was wrong

`ensure_explicit_theme()` decided a file was themeless from `parse_ini_safe()`, whose docblock says it returns:

> The parsed sections/keys, **or `[]` on failure**.

Those two answers are the same array. INI with a syntax error looks exactly like INI with no `theme` key, so the migration prepended a `theme =` line to it — and prepending a line to a file with a syntax error leaves it just as unparseable.

Nothing converged, because `get_ini_text()` saves whenever the migration changed the text:

```php
$ini_text = ensure_explicit_theme($option->value);
$ini_text = reset_stale_experimental_flag($ini_text);
if ($ini_text !== $option->value) {
    save_ini_text($ini_text);
}
```

So **every request prepended another line and wrote the row again.** Measured against a stored `"[unclosed\nsite_title = My Blog\n"`, six consecutive `get_ini_text()` calls:

```
request 1: stored length =   45, updated = 2026-08-21 07:56:24
request 2: stored length =   59, updated = 2026-08-21 07:56:25
request 3: stored length =   73, updated = 2026-08-21 07:56:26
request 4: stored length =   87, updated = 2026-08-21 07:56:27
request 5: stored length =  101, updated = 2026-08-21 07:56:28
request 6: stored length =  115, updated = 2026-08-21 07:56:29

final stored value:
'theme = base

theme = base

theme = base
...
[unclosed
site_title = My Blog
'
```

## The write is the smaller half

`save_ini_text()` advances the config timestamp **monotonically on purpose** (#279), so `updated` moved on every request. That timestamp is folded into `latest_content_timestamp()` — the composite validator every anonymous conditional GET is keyed on:

```php
return max($post_ts, \Lamb\Config\config_modified_timestamp());
```

So while the config is broken, no anonymous response can ever be served from cache: the ETag changes every request. Plus a DB write per request and ~14 bytes of permanent growth. All silent — nothing reports it.

## How a file gets into that state

Not through the settings form: `validate_ini()` gates that and correctly refuses. But `get_ini_text()`'s bootstrap reads `config.ini` from disk and saves it **unvalidated** —

```php
if (file_exists('config.ini')) {
    $ini_text = file_get_contents('config.ini');
}
```

— and a hand-written file is exactly where a typo like `[unclosed` lives.

## The fix

A broken file needs fixing, not migrating. `validate_ini()` is already this codebase's definition of "valid INI", so the guard reuses it rather than adding a second opinion. I checked the two agree on every realistic config — the default INI, themeless, sectioned, empty, comment-only, quoted values, a URL value, unicode, trailing whitespace, CRLF, duplicate keys, and brackets/equals signs inside values — so this does not make the migration stricter for any config that works today.

Skipping the migration costs nothing downstream: `normalize_config()` drops an unusable theme and `index.php` falls back to the base theme, which is the outcome the migration was aiming at anyway.

## Tests

`testEnsureExplicitThemeIsIdempotent` already asserted this exact property — for a *valid* input. The added tests assert it for the inputs that broke it:

- `testEnsureExplicitThemeLeavesUnparseableIniAlone` and `testEnsureExplicitThemeIsIdempotentForUnparseableIni`, over a provider of six inputs `parse_ini_string()` refuses: unclosed section header, stray `]`, a key with no name, a stray `{`, a reserved word as a key, and a bare quote
- `testEnsureExplicitThemeStillMigratesAThemelessFile` — the guard must not cost the migration its actual job

## Verification limitation

`composer install` cannot complete in this environment (the agent proxy refuses to authenticate against github.com for zipball downloads), so Codeception cannot run locally. RedBeanPHP v5.7.6, Parsedown and symfony/yaml were loaded separately and all of `src/` booted — the byte counts above come from the real `get_ini_text()` against a real SQLite database, not from reading the code.

All 17 assertions pass on this change. Against `origin/main`'s `config.php` the 12 new ones fail, with the growth visible in the failure output (`lengths 45/59/73`), while the 5 pre-existing behaviours — idempotence for valid input, an existing theme left untouched, an empty `theme =` rewritten, `theme = default` rewritten, and a themeless file migrated — pass either way. CI runs the actual suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_