### PR TITLE
Probe before writing in the boot-time migrations

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -78,11 +78,6 @@ function bootstrap_db(string $data_dir): void
     R::setup(sprintf("sqlite:%s/lamb.db", $data_dir));
     R::useWriterCache(true);
 
-    // One-time migration: mark pre-versioning posts as version 1.
-    // transformed is already populated for these posts (parse_bean ran at creation/edit time);
-    // we only need to stamp the version column so upgrade_posts() never writes them again.
-    R::exec('UPDATE post SET version = 1 WHERE version IS NULL');
-
     ensure_post_columns();
 }
 
@@ -109,7 +104,41 @@ function ensure_post_columns(): void
     if (!in_array('import_uuid', $columns, true)) {
         R::exec('ALTER TABLE post ADD COLUMN import_uuid TEXT');
     }
+    backfill_post_version($columns);
     backfill_imported_post_identity($columns);
+}
+
+/**
+ * One-time migration: mark pre-versioning posts as version 1.
+ *
+ * `transformed` is already populated for these posts (parse_bean() ran at
+ * creation/edit time); only the version column needs stamping so
+ * upgrade_posts() never writes them again.
+ *
+ * Probes with a SELECT before writing. SQLite takes a write lock for an UPDATE
+ * even when no row matches it, so running this unconditionally made every
+ * request — an anonymous page view included — a writer, and writers serialise:
+ * with another request or a /_cron run holding the lock, the read blocked
+ * behind it (up to PDO's 60-second busy timeout) instead of being served under
+ * a shared read lock. The probe is a read, so it does not.
+ *
+ * Also skipped when the column does not exist yet: a `post` table predating it
+ * has nothing to stamp, and naming it in an UPDATE is an error rather than a
+ * no-op. Runs from ensure_post_columns(), which has already established that
+ * the table exists and collected its columns.
+ *
+ * @param list<string> $columns Column names as they were before the ALTERs above.
+ */
+function backfill_post_version(array $columns): void
+{
+    if (!in_array('version', $columns, true)) {
+        return;
+    }
+    if (!R::getCell('SELECT 1 FROM post WHERE version IS NULL LIMIT 1')) {
+        return;
+    }
+
+    R::exec('UPDATE post SET version = 1 WHERE version IS NULL');
 }
 
 /**
@@ -124,7 +153,9 @@ function ensure_post_columns(): void
  * are not available here — the guard is the only discriminator there is.
  *
  * Rows whose uuid is already claimed by another post's import_uuid are left
- * alone rather than duplicated. Idempotent, so running it every boot is fine.
+ * alone rather than duplicated. Idempotent, so running it every boot is
+ * correct — but it probes with a SELECT first, because an UPDATE that matches
+ * nothing still takes a write lock (see backfill_post_version()).
  *
  * @param list<string> $columns Column names as they were before this call.
  */
@@ -134,11 +165,18 @@ function backfill_imported_post_identity(array $columns): void
         return;
     }
     $source_url = in_array('source_url', $columns, true) ? ' AND source_url IS NULL' : '';
-    R::exec(
-        'UPDATE post SET import_uuid = feeditem_uuid, feeditem_uuid = NULL, feed_name = NULL'
-        . " WHERE feed_name IN ('wordpress', 'known') AND feeditem_uuid IS NOT NULL" . $source_url
-        . ' AND NOT EXISTS (SELECT 1 FROM post other WHERE other.import_uuid = post.feeditem_uuid)'
-    );
+    // One predicate, used by the probe and the update, so the two cannot
+    // disagree about which rows this migration is for.
+    $where = "feed_name IN ('wordpress', 'known') AND feeditem_uuid IS NOT NULL" . $source_url
+        . ' AND NOT EXISTS (SELECT 1 FROM post other WHERE other.import_uuid = post.feeditem_uuid)';
+
+    // Probe first: see backfill_post_version() for why an unconditional UPDATE
+    // makes every request a writer even once there is nothing left to migrate.
+    if (!R::getCell('SELECT 1 FROM post WHERE ' . $where . ' LIMIT 1')) {
+        return;
+    }
+
+    R::exec('UPDATE post SET import_uuid = feeditem_uuid, feeditem_uuid = NULL, feed_name = NULL WHERE ' . $where);
 }
 
 /**

--- a/tests/Unit/ImportIdentityBackfillTest.php
+++ b/tests/Unit/ImportIdentityBackfillTest.php
@@ -49,6 +49,79 @@ class ImportIdentityBackfillTest extends TestCase
         return (int) R::getCell('SELECT last_insert_rowid()');
     }
 
+    /**
+     * The write statements a call to ensure_post_columns() issues.
+     *
+     * SQLite takes a write lock for an UPDATE even when no row matches it, and
+     * writers serialise — so a migration that runs unconditionally makes every
+     * request a writer and every read wait behind any concurrent write (up to
+     * PDO's 60-second busy timeout) instead of sharing a read lock. What
+     * matters is therefore not just the resulting rows but whether anything was
+     * written at all.
+     *
+     * @return list<string>
+     */
+    private function writesDuringEnsureColumns(): array
+    {
+        R::debug(true, \RedBeanPHP\Logger\RDefault::C_LOGGER_ARRAY);
+        try {
+            ensure_post_columns();
+            $logs = R::getDatabaseAdapter()->getDatabase()->getLogger()->getLogs();
+        } finally {
+            R::debug(false);
+        }
+
+        return array_values(array_filter(
+            $logs,
+            fn ($line) => is_string($line) && preg_match('/^\s*(UPDATE|INSERT|DELETE|ALTER)\b/i', $line) === 1
+        ));
+    }
+
+    public function testNoWriteWhenThereIsNothingToMigrate(): void
+    {
+        // Steady state: the columns exist and no row needs either migration.
+        $this->insert('', '', null);
+        ensure_post_columns();
+
+        $this->assertSame([], $this->writesDuringEnsureColumns());
+    }
+
+    public function testTheIdentityBackfillWritesOnlyWhenARowMatches(): void
+    {
+        $this->insert('wordpress', md5('wordpress-https://old.example/?p=1'), null);
+        ensure_post_columns();
+
+        // First call migrated the row; a second has nothing left to do.
+        $this->assertSame([], $this->writesDuringEnsureColumns());
+    }
+
+    public function testTheVersionStampWritesOnlyWhenAPostNeedsIt(): void
+    {
+        // Settle the schema first: the ALTERs that add deleted/draft/import_uuid
+        // are writes too, and they are not what this measures.
+        ensure_post_columns();
+        R::exec('ALTER TABLE post ADD COLUMN version INTEGER');
+        R::exec("INSERT INTO post (body, version) VALUES ('body', NULL)");
+
+        $writes = $this->writesDuringEnsureColumns();
+        $this->assertCount(1, $writes);
+        $this->assertStringContainsString('version', $writes[0]);
+        $this->assertSame(1, (int) R::getCell('SELECT version FROM post LIMIT 1'));
+
+        // Stamped: nothing left to write.
+        $this->assertSame([], $this->writesDuringEnsureColumns());
+    }
+
+    public function testTheVersionStampIsSkippedWhenTheColumnDoesNotExist(): void
+    {
+        // A post table predating the version column has nothing to stamp, and
+        // naming a missing column in an UPDATE is an error rather than a no-op.
+        $this->insert('', '', null);
+        ensure_post_columns();
+
+        $this->assertSame([], $this->writesDuringEnsureColumns());
+    }
+
     public function testBackfillMovesLegacyImportedPostsOntoImportUuid(): void
     {
         $wp = $this->insert('wordpress', md5('wordpress-https://old.example/?p=1'), null);


### PR DESCRIPTION
## What was wrong

`bootstrap_db()` runs on every request, and two of the migrations it drives were unconditional `UPDATE`s:

```php
// One-time migration: mark pre-versioning posts as version 1.
R::exec('UPDATE post SET version = 1 WHERE version IS NULL');
```

plus `backfill_imported_post_identity()`, whose docblock says:

> Idempotent, so running it every boot is fine.

Idempotent it is. Free it is not.

## SQLite takes a write lock for an UPDATE that matches nothing

Measured with two connections, one holding a write transaction:

```
SELECT COUNT(*) FROM post WHERE version IS NULL   -> succeeded: 0
UPDATE post SET version = 1 WHERE version IS NULL -> database is locked
```

PDO's default busy timeout is 60 000 ms, so in practice it does not fail — **it waits**. The same zero-row `UPDATE`, against a lock held for 2 seconds, returned after `2.03s`.

So every request — an anonymous page view included — was a **writer**, and SQLite serialises writers. A page load could block behind a concurrent save or a `/_cron` run for as long as that run held the lock, where a reader would have taken a shared read lock and been served immediately. Turning every read into a writer removes read concurrency entirely, for migrations that have had nothing to do since the upgrade that introduced them.

## The fix

Both migrations probe with a `SELECT` and write only when a row matches. Statements issued per boot, counted through RedBeanPHP's logger against real SQLite databases:

| database state | before | after |
| --- | --- | --- |
| fully migrated (steady state) | **2** | **0** |
| fresh, no `post` table | 1 | 0 |
| `post` table without a `version` column | 4 | 3 (the ALTERs) |
| one post needing a version stamp | 2 | 1 (that stamp) |
| one legacy `wordpress` post | 2 | 1 (that backfill) |

Where there is work the write still happens — and only the migration that *has* work runs.

`backfill_imported_post_identity()` builds its predicate once and hands it to both the probe and the update, so the two cannot disagree about which rows the migration is for.

## Two latent oddities the guard also removes

The version stamp ran *before* `ensure_post_columns()`'s table-exists check, so:

- a **fresh install** issued `UPDATE post …` against a table that does not exist yet;
- a **`post` table predating the version column** got an `UPDATE` naming a column it does not have.

Both were silently tolerated and neither did anything. The stamp now sits inside `ensure_post_columns()`, which has already established the table exists and collected its columns, and it checks for `version` among them.

## Tests

`tests/Unit/ImportIdentityBackfillTest.php` gains a `writesDuringEnsureColumns()` helper that captures the statements through RedBeanPHP's array logger, because what matters here is not only the resulting rows but **whether anything was written at all**:

- `testNoWriteWhenThereIsNothingToMigrate` — steady state issues no write
- `testTheIdentityBackfillWritesOnlyWhenARowMatches` — the second call after a real migration writes nothing
- `testTheVersionStampWritesOnlyWhenAPostNeedsIt` — exactly one write, the value applied, then nothing on a repeat
- `testTheVersionStampIsSkippedWhenTheColumnDoesNotExist`

## Verification limitation

`composer install` cannot complete in this environment (the agent proxy refuses to authenticate against github.com for zipball downloads), so Codeception cannot run locally. RedBeanPHP v5.7.6 was loaded separately and the statements counted against real SQLite databases seeded into each of the five states in the table above — that is where those numbers come from.

All nine assertions pass on this change. Against `origin/main`'s `bootstrap.php` the five write-count assertions fail (each showing the two unconditional writes) while the behavioural ones — legacy import migrated, a genuine feed named `wordpress` left alone, columns added, stamp value applied — pass either way. CI runs the actual suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_