### PR TITLE
Give every theme the p-name title it hides on a post page

### DIFF
--- a/src/themes/2024/parts/_items.php
+++ b/src/themes/2024/parts/_items.php
@@ -26,6 +26,7 @@ else :
         echo '<ul>';
     endif;
     foreach ($data['posts'] as $bean) :
+        /** @var \RedBeanPHP\OODBBean $bean */
         if ($template !== 'status' && is_menu_item($bean->slug ?? $bean->id)) :
             # Hide from timeline
             continue;

--- a/src/themes/2024/parts/_items.php
+++ b/src/themes/2024/parts/_items.php
@@ -38,11 +38,13 @@ else :
 
         <article class="h-entry" data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
             <header>
-                <?php if ($template !== 'status') : ?>
-                    <?php $title = title_link($bean); ?>
-                    <?php if (!empty(trim(strip_tags($title)))) : ?>
-                        <h2><?= $title ?></h2>
-                    <?php endif; ?>
+                <?php // On a post page the h1 already shows the title, and the
+                      // stylesheet hides this h2 — but the h-entry still needs a
+                      // p-name, so the element is emitted and hidden rather than
+                      // skipped. Same expression as the base theme.
+                ?>
+                <?php if (!empty($bean->title)) : ?>
+                    <h2><?= $template !== 'status' ? title_link($bean) : '<span class="p-name">' . escape($bean->title) . '</span>' ?></h2>
                 <?php endif; ?>
                 <div class="meta">
                     <span itemprop="author"><?= author_card() ?></span> @

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -39,12 +39,14 @@ else :
 
         <article class="h-entry" data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
             <header>
-                <?php if ($template !== 'status') :
-                    $title = title_link($bean);
-                    if (!empty(trim(strip_tags($title)))) : ?>
-                        <h2><?= $title ?></h2>
-                    <?php endif;
-                endif; ?>
+                <?php // On a post page the h1 already shows the title, and the
+                      // stylesheet hides this h2 — but the h-entry still needs a
+                      // p-name, so the element is emitted and hidden rather than
+                      // skipped. Same expression as the base theme.
+                ?>
+                <?php if (!empty($bean->title)) : ?>
+                    <h2><?= $template !== 'status' ? title_link($bean) : '<span class="p-name">' . escape($bean->title) . '</span>' ?></h2>
+                <?php endif; ?>
                 <div class="meta">
                     <span itemprop="author" class="screen-reader-text"><?= author_card() ?></span>
                     <?= date_created($bean) ?>

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -26,6 +26,7 @@ else :
         echo '<ul>';
     endif;
     foreach ($data['posts'] as $bean) :
+        /** @var \RedBeanPHP\OODBBean $bean */
         if ($template !== 'status' && is_menu_item($bean->slug ?? $bean->id)) :
             # Backstop for the owner-only views that query everything (drafts,
             # trash, scheduled); public listings exclude menu pages in SQL.

--- a/src/themes/base/styles/styles.css
+++ b/src/themes/base/styles/styles.css
@@ -227,7 +227,11 @@ mark {
 .status, .post {
     /* The h1 is the article header */
 
-    article header + h2 {
+    /* Descendant, not `header + h2`: the h2 is *inside* the header (see
+       parts/_items.php), so the sibling combinator matched nothing and the
+       title rendered twice — once as the h1, once as the h2 that exists to
+       carry the p-name. Same selector the 2024 theme already uses. */
+    article header h2 {
         display: none
     }
 }

--- a/tests/Unit/MicroformatsTest.php
+++ b/tests/Unit/MicroformatsTest.php
@@ -138,11 +138,56 @@ class MicroformatsTest extends TestCase
         $this->assertStringContainsString('h-card', $html, "$theme: author should be an h-card");
     }
 
-    public function testBaseStatusTitleCarriesPName(): void
+    /**
+     * On a post page the h1 already shows the title, so the h2 that carries the
+     * entry's p-name is hidden by CSS rather than skipped — the h-entry still
+     * needs a name for anything parsing the permalink. The 2024 and 2026
+     * templates skipped the element instead, so their stylesheets were hiding
+     * markup that was never emitted and their permalink pages published an
+     * h-entry with no p-name at all.
+     *
+     * @dataProvider themeProvider
+     */
+    public function testThemeStatusTitleCarriesPName(string $theme): void
     {
-        $html = $this->renderItems('base', 'status', ['title' => 'Hello World']);
-        $this->assertStringContainsString('p-name', $html);
-        $this->assertStringContainsString('Hello World', $html);
+        $html = $this->renderItems($theme, 'status', ['title' => 'Hello World']);
+
+        $this->assertStringContainsString('p-name', $html, "$theme: status entry should carry a p-name");
+        $this->assertStringContainsString('Hello World', $html, "$theme: status entry should name the post");
+    }
+
+    /**
+     * @dataProvider themeProvider
+     */
+    public function testThemeStatusTitleIsEscaped(string $theme): void
+    {
+        // The p-name span holds the raw title rather than title_link()'s
+        // already-escaped output, so it needs escaping of its own.
+        $html = $this->renderItems($theme, 'status', ['title' => '<img src=x onerror=alert(1)>']);
+
+        $this->assertStringNotContainsString('<img src=x', $html, "$theme: title must not reach the page as markup");
+        $this->assertStringContainsString('&lt;img', $html, "$theme: title should be escaped");
+    }
+
+    /**
+     * The element exists to be machine-readable, not visible, so each theme
+     * hides it on the post page. base used `article header + h2` — a sibling
+     * combinator — while the h2 is a *child* of the header in every theme, so
+     * the rule matched nothing and the title rendered twice.
+     *
+     * @dataProvider themeProvider
+     */
+    public function testThemeHidesTheStatusTitleItEmits(string $theme): void
+    {
+        $css = (string) file_get_contents(dirname(__DIR__, 2) . "/src/themes/$theme/styles/styles.css");
+
+        // A descendant or child relationship between `header` and `h2`; a `+`
+        // between them would not select the emitted element.
+        $this->assertMatchesRegularExpression(
+            '/article\s+(?:>\s*)?header\s+(?:>\s*)?h2/',
+            $css,
+            "$theme: stylesheet should hide the h2 the template emits inside article header"
+        );
     }
 
     public static function themeProvider(): array


### PR DESCRIPTION
## The arrangement

On a post page the `h1` already shows the title, so the `h2` inside the `h-entry` exists only to carry the entry's `p-name` and is hidden by CSS. **All three themes say so in their stylesheets:**

```css
/* base */   .status, .post { article header + h2 { display: none } }
                              /* The h1 is the article header */
/* 2024 */   .status, .post { article header h2   { display: none } }
                              /* The h1 is the article title on post pages */
/* 2026 */   .status article > header > h2,
             .post article > header > h2 { display: none; }
```

Each half of that arrangement is broken in a different theme, and the two failures are mirror images.

## base emits the element; its selector doesn't match it

`header + h2` is a **sibling** combinator, but the `h2` is a **child** of the `header` in every theme's `_items.php`. Rendering base's status template and querying the DOM:

```
base  status:  article > header > h2 = 1    header + h2 (sibling) = 0
```

It is the only `display: none` for an `h2` anywhere in base's stylesheet, so nothing hides it — **the post title renders twice on every permalink page**, once as the `h1` and once as the `h2` that was meant to be invisible.

Fixed by using the descendant selector the 2024 theme already uses.

## 2024 and 2026 hide it correctly but never emit it

Their templates wrap the entire title in `if ($template !== 'status')`, so the status branch renders no title element at all and those stylesheet rules match nothing:

```
2026  status:  article > header > h2 = 0    p-name nodes = 0
2024  status:  article > header > h2 = 0    p-name nodes = 0
```

So their permalink pages publish an `h-entry` with no `p-name` and the title nowhere inside the entry — on exactly the URL a webmention points at and an IndieWeb consumer parses, so a reply or like displayed elsewhere has no title to show.

Both now use the same expression as base: `title_link()` on a listing, an escaped `p-name` span on a post page. After the change all three agree:

| theme | listing | permalink |
| --- | --- | --- |
| base | `title-link` | `<span class="p-name">` |
| 2024 | `title-link` | `<span class="p-name">` |
| 2026 | `title-link` | `<span class="p-name">` |

## Why it survived

`themeProvider` parametrises the `h-entry` and `p-author` assertions across all three themes — but the `p-name` one was `testBaseStatusTitleCarriesPName`, **base only**. The parity harness existed; this assertion just wasn't in it.

It is now parametrised, alongside two more:

- `testThemeStatusTitleIsEscaped` — the span holds the **raw** title, unlike `title_link()`'s already-escaped output, so it needs escaping of its own. Verified with ``'&lt;img src=x onerror=alert(1)&gt;'`` as a title: no theme lets it through as markup, before or after.
- `testThemeHidesTheStatusTitleItEmits` — each stylesheet must hide the element its template emits, which is what base got wrong.

## Verification limitation

`composer install` cannot complete in this environment (the agent proxy refuses to authenticate against github.com for zipball downloads), so Codeception cannot run locally. RedBeanPHP v5.7.6, Parsedown and symfony/yaml were loaded separately and each theme's `_items.php` rendered for both templates, with the DOM relationships read through `DOMXPath` — that is where the counts above come from rather than from reading selectors by eye.

All 18 assertions pass on this change. Against `origin/main` the five new ones fail, split exactly along the two bugs — base fails the hiding assertion, 2024 and 2026 fail the `p-name` and escaping ones — and every pre-existing assertion (h-entry, e-content, p-author, h-card, and a linked title on listings) passes either way. CI runs the actual suite, including Playwright against the rendered pages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_