### PR TITLE
Stop one malformed byte deleting a Micropub log entry

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1282,9 +1282,16 @@ function mp_log(string $event, array $context = []): void
         return;
     }
 
+    // JSON_INVALID_UTF8_SUBSTITUTE, as the export manifest, the JSON feed and
+    // the upload response all use: without it json_encode() returns false for
+    // the whole document over a single malformed byte, and `?: ''` then wrote a
+    // blank line — losing the event entirely. A logged value can carry one
+    // (a remote response body, a raw request body, a client-supplied filename),
+    // and a diagnostic log that drops the entry explaining a failure is worse
+    // than one that renders a byte as U+FFFD.
     $line = json_encode(
         ['ts' => \Lamb\now(), 'event' => $event] + $context,
-        JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
     ) ?: '';
     @file_put_contents(mp_log_path(), $line . PHP_EOL, FILE_APPEND | LOCK_EX);
 }
@@ -1440,7 +1447,10 @@ function respond_micropub(): void
     mp_log('response', [
         'status' => $status,
         // Only echo the body into the log on failures — it carries the error reason.
-        'body'   => $status >= 400 ? substr((string) $response->getBody(), 0, 300) : null,
+        // mb_substr(), not substr(): a response body is remote text, and cutting
+        // it mid-sequence at byte 300 produced the malformed byte above. 300
+        // characters is what "an excerpt" meant anyway.
+        'body'   => $status >= 400 ? mb_substr((string) $response->getBody(), 0, 300) : null,
     ]);
 
     http_response_code($status);
@@ -1473,7 +1483,13 @@ function micropub_error(int $status, string $error, string $description, ?string
     if ($wwwAuthenticate !== null) {
         header('WWW-Authenticate: ' . $wwwAuthenticate);
     }
-    echo json_encode(['error' => $error, 'error_description' => $description]);
+    // Same flag as mp_log() above: $description reaches here from a validation
+    // failure and can quote client input, and `echo false` would answer the
+    // error with an empty body.
+    echo json_encode(
+        ['error' => $error, 'error_description' => $description],
+        JSON_INVALID_UTF8_SUBSTITUTE
+    );
     exit;
 }
 

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -129,6 +129,56 @@ class MicropubAdapterTest extends TestCase
         );
     }
 
+    public function testMpLogKeepsTheEntryWhenAValueIsNotValidUtf8(): void
+    {
+        global $config;
+        $config['micropub_debug'] = true;
+
+        // Without JSON_INVALID_UTF8_SUBSTITUTE, json_encode() returns false for
+        // the whole document over one malformed byte and `?: ''` wrote a blank
+        // line — so the entry explaining a failure was the one that vanished.
+        \Lamb\Micropub\mp_log('response', ['status' => 400, 'body' => "oops \xC3\x28 truncated"]);
+
+        $contents = (string) @file_get_contents($GLOBALS['lamb_mp_log_path']);
+        $lines = array_values(array_filter(explode(PHP_EOL, $contents), fn ($l) => $l !== ''));
+
+        $this->assertCount(1, $lines, 'the entry must still be written');
+        $decoded = json_decode($lines[0], true);
+        $this->assertIsArray($decoded, 'the line must be valid JSON');
+        $this->assertSame(400, $decoded['status']);
+        $this->assertStringContainsString('truncated', $decoded['body']);
+    }
+
+    public function testMpLogStillWritesTheEntriesAroundABadOne(): void
+    {
+        global $config;
+        $config['micropub_debug'] = true;
+
+        \Lamb\Micropub\mp_log('first', ['body' => "bad \xC3\x28"]);
+        \Lamb\Micropub\mp_log('second', ['body' => 'clean']);
+
+        $contents = (string) @file_get_contents($GLOBALS['lamb_mp_log_path']);
+        $lines = array_values(array_filter(explode(PHP_EOL, $contents), fn ($l) => $l !== ''));
+
+        $this->assertCount(2, $lines);
+        $this->assertStringContainsString('first', $lines[0]);
+        $this->assertStringContainsString('second', $lines[1]);
+    }
+
+    public function testMpLogSubstitutesRatherThanDroppingTheBadByte(): void
+    {
+        global $config;
+        $config['micropub_debug'] = true;
+
+        \Lamb\Micropub\mp_log('response', ['body' => "a\xC3\x28b"]);
+
+        $contents = (string) @file_get_contents($GLOBALS['lamb_mp_log_path']);
+        $decoded = json_decode(trim($contents), true);
+
+        // U+FFFD in place of the malformed byte, with the surrounding text intact.
+        $this->assertSame("a\u{FFFD}(b", $decoded['body']);
+    }
+
     public function testVerifyTokenLogsMeMismatchReasonWithoutLeakingToken(): void
     {
         global $config;


### PR DESCRIPTION
## What was wrong

`mp_log()` encoded each entry with a bare `json_encode()` and fell back to `''`:

```php
$line = json_encode(
    ['ts' => \Lamb\now(), 'event' => $event] + $context,
    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
) ?: '';
@file_put_contents(mp_log_path(), $line . PHP_EOL, FILE_APPEND | LOCK_EX);
```

`json_encode()` returns `false` for the **whole document** over a single malformed UTF-8 byte, so `?: ''` wrote a blank line and the event was gone.

## The codebase already documents this hazard — three times

| site | flag | its own comment |
| --- | --- | --- |
| `export.php` manifest | ✅ `JSON_INVALID_UTF8_SUBSTITUTE` | *"one stray byte in a slug or the site title used to abort the whole export … leaving the author unable to back up at all"* |
| `themes/base/feed_json.php` | ✅ | *"json_encode() returns false for the whole …"* |
| `response/upload.php` | ✅ | *"the client's filename … need not be valid UTF-8; without substitution json_encode() throws and the upload 500s"* |
| `mp_log()` | ❌ | — |

And `mp_log()` is the one with a caller that **manufactures** the byte:

```php
'body' => $status >= 400 ? substr((string) $response->getBody(), 0, 300) : null,
```

A response body is remote text; cutting it at **byte** 300 lands mid-sequence for any non-ASCII page.

## So the entry that vanished was the one that mattered

Logging a 400 whose body is such an excerpt, followed by a clean 200, against the real `mp_log()`:

```
=== before ===                                    === after ===
non-empty log lines written: 1 (expected 2)       non-empty log lines written: 2 (expected 2)
  {"event":"response","status":200,...}             {"event":"response","status":400,"body":"aaaa…
the status-400 entry survived: NO — dropped        {"event":"response","status":200,...}
                                                   the status-400 entry survived: YES
```

The failure entry is silently deleted and the success entry kept — the exact inversion of what `micropub_debug` is turned on for.

## The fix

Three changes, one rule: **an entry must survive its own contents.**

- `mp_log()` passes `JSON_INVALID_UTF8_SUBSTITUTE`, so a malformed byte renders as `U+FFFD` and the surrounding text is kept.
- the response excerpt uses `mb_substr()`, so it stops manufacturing the byte in the first place — 300 *characters* is what "an excerpt" meant anyway.
- `micropub_error()` passes the same flag: `$description` can quote client input, and `echo false` would answer the error with an empty body.

The two remaining `json_encode()` calls in this file carry only literal strings and app-built (percent-encoded) permalinks, so they are left alone.

## Tests

Three added to `tests/Unit/MicropubAdapterTest.php`, which already has an isolated log path in `setUp()`:

- `testMpLogKeepsTheEntryWhenAValueIsNotValidUtf8` — one line written, valid JSON, status and surrounding text intact
- `testMpLogStillWritesTheEntriesAroundABadOne` — a bad entry does not cost its neighbours
- `testMpLogSubstitutesRatherThanDroppingTheBadByte` — the value is exactly `"a\u{FFFD}(b"`, so the substitution replaces the byte instead of truncating the string at it

## Verification limitation

`composer install` cannot complete in this environment (the agent proxy refuses to authenticate against github.com for zipball downloads), so Codeception cannot run locally. All of `src/` was booted from a separate scratchpad and the real `mp_log()` run against a temp log file — the before/after table above is measured, not inferred.

All eight assertions pass on this change. Against `origin/main`'s `micropub.php` the five new ones fail (the bad entry writes zero lines; the pair around it writes one instead of two) while both pre-existing behaviours — writes when debug is on, writes nothing when off — pass either way. CI runs the actual suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_