### PR TITLE
Trim a related-post title on characters, not bytes

### DIFF
--- a/src/themes/base/parts/_related.php
+++ b/src/themes/base/parts/_related.php
@@ -28,7 +28,15 @@ if (!empty($related_posts['posts'])) :
                     ?>
                     <li>
                         <?php if (!empty($bean->title)) : ?>
-                            <span><?= escape(substr(strip_tags($bean->title), 0, 42)) ?>&hellip;</span>
+                            <?php // mb_strimwidth(), as the 2026 theme's own _related.php uses:
+                                  // substr() cuts on bytes, so any title in a script whose
+                                  // characters are multi-byte was truncated mid-sequence and
+                                  // rendered a U+FFFD, and only got half as many characters as
+                                  // a Latin one. It also appends the ellipsis only when it
+                                  // actually trims — the literal &hellip; was emitted even for
+                                  // a title that fit.
+                            ?>
+                            <span><?= escape(mb_strimwidth(strip_tags($bean->title), 0, 42, '…')) ?></span>
                         <?php endif; ?>
                         <p><?= date_created($bean) ?>
                         <?php if (!empty($bean->transformed)) : ?>

--- a/tests/Unit/ThemeExtendedTest.php
+++ b/tests/Unit/ThemeExtendedTest.php
@@ -255,6 +255,96 @@ class ThemeExtendedTest extends TestCase
         $this->assertCount(0, $result['posts']);
     }
 
+    // _related.php title truncation ------------------------------------------
+
+    /**
+     * Renders the base theme's related-posts partial for one seeded post.
+     *
+     * The 2024 theme has no _related.php of its own and falls back to this one,
+     * so it renders identically; the 2026 theme overrides it.
+     */
+    private function renderRelated(string $relatedTitle): string
+    {
+        $related = R::dispense('post');
+        $related->title = $relatedTitle;
+        $related->body = 'Related post about #lamb end';
+        $related->transformed = '<p>Related post about #lamb end</p>';
+        $related->version = 1;
+        $related->created = date('Y-m-d H:i:s');
+        R::store($related);
+
+        $current = R::dispense('post');
+        $current->body = 'Current post about #lamb end';
+        $current->transformed = '<p>Current post about #lamb end</p>';
+        $current->version = 1;
+        $current->created = date('Y-m-d H:i:s');
+        R::store($current);
+
+        global $data, $template;
+        $data = ['posts' => [$current]];
+        $template = 'status';
+
+        ob_start();
+        include dirname(__DIR__, 2) . '/src/themes/base/parts/_related.php';
+        return (string) ob_get_clean();
+    }
+
+    public function testRelatedTitleIsNotCutMidCharacter(): void
+    {
+        // substr() cuts on bytes, so a title in any script whose characters are
+        // multi-byte was truncated mid-sequence; escape()'s ENT_SUBSTITUTE then
+        // rendered the broken byte as U+FFFD.
+        $html = $this->renderRelated('Заголовок статьи на русском языке для проверки длины');
+
+        $this->assertStringNotContainsString("\u{FFFD}", $html, 'title must not be cut mid-character');
+        $this->assertTrue(mb_check_encoding($html, 'UTF-8'), 'rendered markup must be valid UTF-8');
+    }
+
+    public function testRelatedTitleKeepsTheSameLengthAcrossScripts(): void
+    {
+        // Byte truncation gave a Cyrillic title half as many characters as a
+        // Latin one from the same limit.
+        $latin = $this->renderRelated(str_repeat('a', 80));
+        $cyrillic = $this->renderRelated(str_repeat('б', 80));
+
+        $this->assertSame(
+            mb_strlen((string) $this->relatedSpan($latin)),
+            mb_strlen((string) $this->relatedSpan($cyrillic)),
+            'the limit should count characters, not bytes'
+        );
+    }
+
+    public function testRelatedTitleThatFitsGetsNoEllipsis(): void
+    {
+        // The literal &hellip; sat outside the trim, so every related title got
+        // an ellipsis whether it had been shortened or not.
+        $html = $this->renderRelated('Short title');
+
+        $this->assertStringContainsString('Short title', $html);
+        $this->assertStringNotContainsString('…', $this->relatedSpan($html) ?? '');
+        $this->assertStringNotContainsString('&hellip;', $html);
+    }
+
+    public function testRelatedTitleThatIsTooLongIsTrimmedWithAnEllipsis(): void
+    {
+        $html = $this->renderRelated(str_repeat('a', 200));
+        $span = (string) $this->relatedSpan($html);
+
+        $this->assertStringContainsString('…', $span);
+        $this->assertLessThanOrEqual(42, mb_strwidth($span));
+    }
+
+    /**
+     * The text of the related item's title span, or null when none was rendered.
+     */
+    private function relatedSpan(string $html): ?string
+    {
+        if (preg_match('#<span>(.*?)</span>#s', $html, $m) !== 1) {
+            return null;
+        }
+        return html_entity_decode($m[1], ENT_QUOTES | ENT_HTML5);
+    }
+
     public function testGetPostsByTagsExcludesGivenId(): void
     {
         $bean = R::dispense('post');


### PR DESCRIPTION
## What was wrong

The base theme's related-posts partial truncated the title with `substr()`:

```php
<span><?= escape(substr(strip_tags($bean->title), 0, 42)) ?>&hellip;</span>
```

`substr()` cuts on **bytes**. Three consequences, all measured by rendering the partial against a real database:

**1. A broken character.** Any title in a script whose characters are multi-byte gets cut mid-sequence. `escape()` uses `ENT_SUBSTITUTE`, so the broken byte renders as `U+FFFD` instead of blanking the string — an ordinary Cyrillic title came out as:

```
Заголовок статьи на ру�…
```

**2. A language-dependent limit.** From the same 42-byte budget:

| title | characters kept |
| --- | --- |
| `aaaa…` (Latin) | **43** |
| `бббб…` (Cyrillic) | **22** |

So exactly the titles that need the room get half of it. CJK fares worse still.

**3. A false ellipsis.** The `&hellip;` sat *outside* the trim, so it was emitted whether the title had been shortened or not — `Short title` rendered as `Short title…`.

## The fix

`mb_strimwidth(strip_tags($bean->title), 0, 42, '…')` fixes all three: it counts display width, and it appends the marker **only when it actually trims**.

It is also what the 2026 theme's own `_related.php` already uses for its excerpt — so this is the sibling's answer rather than a new one:

```php
/* 2026 */ <?= escape(mb_strimwidth($excerpt, 0, 140, '…')) ?>
```

The 2024 theme has no `_related.php` of its own and falls back to this one (as `tests/Acceptance/RelatedPostsTagLinksCest.php` notes), so it is fixed by the same change.

**No new extension surface:** mbstring is already a hard requirement of this codebase — `normalize_utf8()` calls `mb_check_encoding()` on every save, and `mb_strimwidth()` already appears four times in the 2026 theme.

## Tests

Four added to `tests/Unit/ThemeExtendedTest.php`, which already exercises `related_posts()` against a seeded database. A `renderRelated()` helper includes the partial and a `relatedSpan()` helper reads back the rendered title:

- `testRelatedTitleIsNotCutMidCharacter` — no `U+FFFD`, and the whole markup is valid UTF-8
- `testRelatedTitleKeepsTheSameLengthAcrossScripts` — a Latin and a Cyrillic title of equal length yield spans of equal length
- `testRelatedTitleThatFitsGetsNoEllipsis` — no `…` and no `&hellip;`
- `testRelatedTitleThatIsTooLongIsTrimmedWithAnEllipsis` — the `…` is present and the span's width stays within the budget

## Verification limitation

`composer install` cannot complete in this environment (the agent proxy refuses to authenticate against github.com for zipball downloads), so Codeception cannot run locally. All of `src/` was booted from a separate scratchpad and the partial rendered against a real SQLite database — the strings and counts above are measured output.

All four assertions pass on this change. Against `origin/main`'s `_related.php` **all four fail**, reporting exactly the values quoted above (`'Заголовок статьи на ру�…'`, `latin=43 cyrillic=22`, `'Short title…'`, `width=43`). CI runs the actual suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_