### PR TITLE
Keep CSS string literals out of the minifier's whitespace collapse

### DIFF
--- a/src/theme/assets.php
+++ b/src/theme/assets.php
@@ -84,8 +84,17 @@ function rewrite_css_urls(string $css, string $base_url): string
 /**
  * Minifies CSS for inlining: strips comments and collapses insignificant whitespace.
  *
- * Conservative by design — it only touches whitespace and comments, so it is safe
- * for the controlled, hand-written theme stylesheets Lamb ships.
+ * Conservative by design — it only touches whitespace and comments. "Insignificant"
+ * is the whole difficulty: collapsing whitespace around `{}:;,>` across the entire
+ * stylesheet also reached inside quoted strings and url() tokens, where that
+ * whitespace is content. `content: "Note: hello"` became `content:"Note:hello"`,
+ * and `[data-label="a > b"]` became `[data-label="a>b"]` — a selector that no
+ * longer matches the element, so the rule silently stopped applying.
+ *
+ * No theme Lamb ships triggers it, but the_styles() inlines whichever theme the
+ * `theme` setting names, so a hand-written or third-party stylesheet is an input
+ * this has to survive. String literals and url() tokens are therefore split out
+ * and copied through untouched, and only the CSS syntax between them is collapsed.
  *
  * @param string $css The stylesheet contents.
  * @return string Minified CSS.
@@ -93,11 +102,35 @@ function rewrite_css_urls(string $css, string $base_url): string
 function minify_css(string $css): string
 {
     $css = preg_replace('#/\*.*?\*/#s', '', $css) ?? $css;
-    $css = preg_replace('/\s+/', ' ', $css) ?? $css;
-    $css = preg_replace('/\s*([{}:;,>])\s*/', '$1', $css) ?? $css;
-    $css = str_replace(';}', '}', $css);
 
-    return trim($css);
+    // Capturing split, so the delimiters (the literals) are kept and land on the
+    // odd indices. url() is included so an unquoted data URI is protected too.
+    $parts = preg_split(
+        '/("(?:[^"\\\\]|\\\\.)*"|\'(?:[^\'\\\\]|\\\\.)*\'|url\([^)]*\))/',
+        $css,
+        -1,
+        PREG_SPLIT_DELIM_CAPTURE
+    );
+    if ($parts === false) {
+        return trim($css);
+    }
+
+    $out = '';
+    foreach ($parts as $index => $part) {
+        if ($index % 2 === 1) {
+            // A literal or url() token: content, not syntax.
+            $out .= $part;
+            continue;
+        }
+        $part = preg_replace('/\s+/', ' ', $part) ?? $part;
+        $part = preg_replace('/\s*([{}:;,>])\s*/', '$1', $part) ?? $part;
+        // A `;` that CSS syntax owns is always in the same segment as the `}`
+        // that follows it — `;"foo"}` is not valid CSS — so this is safe here
+        // and cannot reach a literal ending in `;}`.
+        $out .= str_replace(';}', '}', $part);
+    }
+
+    return trim($out);
 }
 
 /**

--- a/tests/Unit/ThemeAssetsTest.php
+++ b/tests/Unit/ThemeAssetsTest.php
@@ -96,6 +96,71 @@ class ThemeAssetsTest extends TestCase
         $this->assertSame('a{color:red}', minify_css('a { color: red; }'));
     }
 
+    /**
+     * Whitespace inside a quoted string is content, not formatting. Collapsing
+     * it around `{}:;,>` across the whole stylesheet reached into string
+     * literals: `content: "Note: hello"` lost its space, and an attribute
+     * selector like `[data-label="a > b"]` became `[data-label="a>b"]`, which
+     * no longer matches the element — the rule silently stopped applying.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function literalPreservingProvider(): array
+    {
+        return [
+            'colon in content'      => ['.a::before { content: "Note: hello"; }', '.a::before{content:"Note: hello"}'],
+            'comma in content'      => ['.a::before { content: "one, two"; }',    '.a::before{content:"one, two"}'],
+            'semicolon in content'  => ['.a::before { content: "a; b"; }',        '.a::before{content:"a; b"}'],
+            'child combinator'      => ['[data-label="a > b"] { color: red; }',   '[data-label="a > b"]{color:red}'],
+            'comma in selector'     => ['[data-label="a, b"] { color: red; }',    '[data-label="a, b"]{color:red}'],
+            'single-quoted string'  => [".a::before { content: 'x: y'; }",        ".a::before{content:'x: y'}"],
+        ];
+    }
+
+    /**
+     * @dataProvider literalPreservingProvider
+     */
+    public function testMinifyCssLeavesStringLiteralsAlone(string $css, string $expected): void
+    {
+        $this->assertSame($expected, minify_css($css));
+    }
+
+    public function testMinifyCssStillCollapsesSyntaxAroundLiterals(): void
+    {
+        // The syntax between literals must still be minified — protecting the
+        // literals must not turn the whole declaration into a no-op.
+        $this->assertSame(
+            'body{font-family:"Segoe UI","Noto Sans",sans-serif}',
+            minify_css('body { font-family: "Segoe UI" , "Noto Sans" , sans-serif; }')
+        );
+    }
+
+    public function testMinifyCssProtectsAnUnquotedUrlToken(): void
+    {
+        // An unquoted data: URI can contain spaces and `>`; collapsing them
+        // corrupts the payload.
+        $css = '.a { background: url(data:image/svg+xml;utf8,<svg a=\'1\' > </svg>); }';
+
+        $this->assertStringContainsString("<svg a='1' > </svg>", minify_css($css));
+    }
+
+    public function testMinifyCssKeepsAnEscapedQuoteInsideALiteral(): void
+    {
+        // A `\"` does not end the string, so the split must not treat it as a
+        // delimiter — otherwise the rest of the stylesheet is misclassified.
+        $out = minify_css('.a::before { content: "a\\" b: c"; }');
+
+        $this->assertStringContainsString('b: c', $out);
+    }
+
+    public function testMinifyCssReturnsUsableCssWhenGivenAnUnterminatedString(): void
+    {
+        // Malformed input must not silently disable minification altogether.
+        $out = minify_css('.a { content: "unterminated ; }');
+
+        $this->assertStringContainsString('.a{', $out);
+    }
+
     // -------------------------------------------------------------------------
     // rewrite_css_urls
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## What was wrong

`minify_css()` collapsed whitespace around `{}:;,>` across the whole stylesheet:

```php
$css = preg_replace('/\s*([{}:;,>])\s*/', '$1', $css) ?? $css;
```

Inside a quoted string that whitespace is **content**, not formatting:

| input | before |
| --- | --- |
| `content: "Note: hello"` | `content:"Note:hello"` |
| `content: "one, two"` | `content:"one,two"` |
| `[data-label="a > b"]` | `[data-label="a>b"]` |

The first changes rendered text. The second is worse: **the selector no longer matches the element**, so the rule silently stops applying — no error, no warning, the styling just goes missing. An unquoted `data:` URI carrying spaces or `>` is corrupted the same way.

## Why it reaches real input

The docblock called the function *"conservative by design … safe for the controlled, hand-written theme stylesheets Lamb ships"* — and that much is true. I checked all three shipped stylesheets and none trips it.

But `the_styles()` inlines whichever theme the `theme` setting names:

```php
$css_path = (defined('ROOT_DIR') ? ROOT_DIR : '') . '/' . THEME_URL . 'styles/styles.css';
echo styles_markup($css_path, $css_url, $base_url);
```

So a hand-written or third-party stylesheet is an input this has to survive, and for those the safety claim did not hold.

## The fix

String literals and `url()` tokens are split out with a capturing `preg_split()` and copied through untouched; only the CSS syntax between them is collapsed.

Two details worth flagging for review:

- **An escaped quote does not end a literal.** The split pattern accounts for `\"`, otherwise everything after `content: "a\" b"` is misclassified as syntax and the rest of the stylesheet is mangled — a worse failure than the one being fixed. There's a test for it.
- **The `;}` collapse moved inside the per-segment transform.** A `;` that CSS syntax owns is always in the same segment as the `}` that follows it, because `;"foo"}` is not valid CSS — so it can't reach a literal that happens to contain `;}`.

## Nothing Lamb ships changes

All three shipped stylesheets minify **byte-identically** before and after:

```
base     before=c0a54b08166299162544ab31b04a93ce  after=c0a54b08166299162544ab31b04a93ce  IDENTICAL
2024     before=b3adc284bc680ae9cda428036f51efed  after=b3adc284bc680ae9cda428036f51efed  IDENTICAL
2026     before=92ba7078f2a23fdba9f75e5d5e0ff4fc  after=92ba7078f2a23fdba9f75e5d5e0ff4fc  IDENTICAL
```

Only CSS that was previously corrupted behaves differently. Compression is unchanged too (68% / 70% / 74% of original).

## Tests

`tests/Unit/ThemeAssetsTest.php`, alongside the three existing `minify_css` tests:

- a provider over the six corrupting shapes — a colon, comma and semicolon inside `content`, `>` and `,` inside an attribute selector, and a single-quoted string
- `testMinifyCssStillCollapsesSyntaxAroundLiterals` — protecting literals must not make the surrounding declaration a no-op: `"Segoe UI" , "Noto Sans" , sans-serif` still minifies
- `testMinifyCssProtectsAnUnquotedUrlToken` — an unquoted `data:` SVG keeps its spaces and `>`
- `testMinifyCssKeepsAnEscapedQuoteInsideALiteral`
- `testMinifyCssReturnsUsableCssWhenGivenAnUnterminatedString` — malformed input must not silently disable minification altogether

That last one earned its place: my first attempt at the split pattern had a mis-escaped character class that failed to compile, so `preg_split()` returned `false` and the fallback quietly returned the stylesheet **unminified**. The test now pins that a usable result comes back regardless.

## Verification limitation

`composer install` cannot complete in this environment (the agent proxy refuses to authenticate against github.com for zipball downloads), so Codeception cannot run locally. All of `src/` was booted from a separate scratchpad and `minify_css()` run directly — the tables above are measured output.

All 13 assertions pass on this change. Against `origin/main`'s `assets.php` the 8 new ones fail with exactly the corrupted values shown, while the three pre-existing behaviours (comments removed, whitespace collapsed, final semicolon dropped) pass either way. CI runs the actual suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_