### PR TITLE
Never store a redirect from a post to itself

### DIFF
--- a/src/import.php
+++ b/src/import.php
@@ -722,8 +722,17 @@ function prepare_imported_html(string $html, string $created, callable $download
 
 /**
  * Stores an automatic redirect from an imported source URL path to a local
- * Lamb path. Importers only create redirects for old paths that do not
- * naturally match Lamb's freshly minted permalink.
+ * Lamb path, unless the source path is the post's own new permalink.
+ *
+ * A row pointing a path at itself is not a redirect. While the post is live
+ * index.php prefers the post, so the row is invisible dead weight in the
+ * author's redirect list; once the post is trashed the router falls through to
+ * the redirect instead, and the old permalink 301s to itself until the next
+ * /_cron run reaches flatten_redirects(). The comparison lives here rather than
+ * in each importer because a source path that differs from the new permalink
+ * only by encoding is the same key once decoded — and because each importer
+ * having its own copy is how one of them (Known's <guid> branch) came to be
+ * missing it.
  */
 function store_redirect(string $from, string $to): void
 {
@@ -731,6 +740,9 @@ function store_redirect(string $from, string $to): void
     // before looking a redirect up), while an imported path arrives encoded as
     // the source site wrote it.
     $from = rawurldecode($from);
+    if ($from === '' || $from === rawurldecode(ltrim($to, '/'))) {
+        return;
+    }
     $redirect = R::findOneOrDispense('redirect', ' from_slug = ? ', [$from]);
     $redirect->from_slug = $from;
     $redirect->to_url = $to;

--- a/src/known.php
+++ b/src/known.php
@@ -376,35 +376,27 @@ function import_item(array $item, callable $downloader, bool $dry_run = false, ?
 /**
  * Stores automatic redirects from an imported Known item's old URLs to its
  * new local Lamb path: the on-host `<link>` path (`2020/<slug>`, skipped for
- * offsite bookmarks and when it already equals the new path) and the `<guid>`
- * path (`view/<hash>`) — Known's own permalinks resolved either way.
+ * offsite bookmarks, whose `<link>` is the bookmarked page rather than a Known
+ * URL) and the `<guid>` path (`view/<hash>`) — Known's own permalinks resolved
+ * either way. A path that is already the post's new permalink is dropped by
+ * store_redirect() rather than here, so both branches get the same treatment.
  *
  * @param array<string, mixed> $item
  */
 function store_source_redirects(array $item, OODBBean $bean): void
 {
     $to = \Lamb\permalink_path($bean);
-    // store_redirect() keys on the decoded path; compare in the same space so a
-    // source path that merely differs by encoding is still recognised as the
-    // post's own new URL (and skipped) rather than stored as a self-redirect.
-    $to_slug = rawurldecode(ltrim($to, '/'));
 
     $bookmark_url = trim((string) ($item['bookmark_url'] ?? ''));
     if ($bookmark_url === '') {
         $link_path = parse_url((string) ($item['link'] ?? ''), PHP_URL_PATH);
         if (is_string($link_path) && $link_path !== '') {
-            $from = trim($link_path, '/');
-            if ($from !== '' && rawurldecode($from) !== $to_slug) {
-                store_redirect($from, $to);
-            }
+            store_redirect(trim($link_path, '/'), $to);
         }
     }
 
     $guid_path = parse_url((string) ($item['guid'] ?? ''), PHP_URL_PATH);
     if (is_string($guid_path) && $guid_path !== '') {
-        $from = trim($guid_path, '/');
-        if ($from !== '') {
-            store_redirect($from, $to);
-        }
+        store_redirect(trim($guid_path, '/'), $to);
     }
 }

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -278,8 +278,8 @@ function wordpress_status_path(array $item): ?string
 
 /**
  * Stores an automatic redirect from an imported WordPress URL path to the
- * local Lamb path. The importer only creates redirects for old paths that do
- * not naturally match Lamb's freshly minted permalink.
+ * local Lamb path. An old path that already matches Lamb's freshly minted
+ * permalink is dropped by store_redirect(), which every importer shares.
  *
  * @param array<string, mixed> $item
  */
@@ -290,11 +290,5 @@ function store_source_redirect(array $item, OODBBean $bean): void
         return;
     }
 
-    $to = \Lamb\permalink_path($bean);
-    // Compared in the decoded space store_redirect() keys on.
-    if (rawurldecode($from) === rawurldecode(ltrim($to, '/'))) {
-        return;
-    }
-
-    store_redirect($from, $to);
+    store_redirect($from, \Lamb\permalink_path($bean));
 }

--- a/tests/Unit/KnownImportTest.php
+++ b/tests/Unit/KnownImportTest.php
@@ -530,6 +530,36 @@ XML;
         $this->assertSame('/' . $bean->slug, (string) $guidRedirect->to_url);
     }
 
+    /**
+     * The <guid> branch used to skip the check the <link> branch applies, so an
+     * item whose Known permalink is a single segment matching its own new slug
+     * left a row pointing the post's URL at itself. index.php prefers the post
+     * while it is live, so the row was invisible until the post was trashed —
+     * at which point the permalink 301ed to itself.
+     */
+    public function testImportItemStoresNoRedirectWhenTheSourcePathIsTheNewPermalink(): void
+    {
+        $rss = str_replace(
+            '<guid>https://known.example/view/aaaa1111</guid>',
+            '<guid>https://example.test/turn-that-frown-upside-down</guid>',
+            self::SAMPLE_RSS
+        );
+        $items = extract_items(parse_rss_string($rss));
+
+        $bean = import_item($items[0], fn(): ?string => null, false);
+        $this->assertNotNull($bean);
+        $this->assertSame('turn-that-frown-upside-down', (string) $bean->slug);
+
+        $this->assertNull(
+            R::findOne('redirect', ' from_slug = ? ', ['turn-that-frown-upside-down']),
+            'a post must not be redirected to itself'
+        );
+        // The dated <link> path is a different path, so it still redirects.
+        $this->assertNotNull(
+            R::findOne('redirect', ' from_slug = ? ', ['2020/turn-that-frown-upside-down'])
+        );
+    }
+
     public function testImportItemIsIdempotentByUuid(): void
     {
         $items = $this->sampleItems();

--- a/tests/Unit/RedirectTest.php
+++ b/tests/Unit/RedirectTest.php
@@ -47,6 +47,39 @@ class RedirectTest extends TestCase
         $this->assertSame('/caf%C3%A9', find_redirect('2020/café'));
     }
 
+    /**
+     * @dataProvider selfRedirectProvider
+     */
+    public function testStoreRedirectDropsAPathThatIsAlreadyItsTarget(string $from, string $to): void
+    {
+        \Lamb\Import\store_redirect($from, $to);
+
+        $this->assertCount(0, R::findAll('redirect'), $from . ' -> ' . $to . ' is a loop, not a redirect');
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function selfRedirectProvider(): array
+    {
+        return [
+            'identical path'      => ['hello-world', '/hello-world'],
+            'target encoded'      => ['café', '/caf%C3%A9'],
+            'source encoded'      => ['caf%C3%A9', '/café'],
+            'status permalink'    => ['status/12', '/status/12'],
+            'empty source'        => ['', '/hello-world'],
+        ];
+    }
+
+    public function testStoreRedirectKeepsAPathThatOnlyEndsWithItsTarget(): void
+    {
+        // The check is equality, not containment: a dated source path ending in
+        // the new slug is exactly the redirect an import exists to create.
+        \Lamb\Import\store_redirect('2020/hello-world', '/hello-world');
+
+        $this->assertSame('/hello-world', find_redirect('2020/hello-world'));
+    }
+
     // find_redirect — config-based
 
     public function testFindRedirectReturnsAbsoluteUrlFromConfig(): void


### PR DESCRIPTION
`Known\store_source_redirects()` applies the "is this already the post's new path?" check to the `<link>` branch and not to the `<guid>` branch. The docblock describes the guard as if it covered both.

## Reproduction

One item, `<link>` and `<guid>` both `https://old.example.com/hello-world`, imported through the real pipeline:

```
post#1 slug='hello-world'
redir hello-world -> /hello-world
```

The `<link>` branch skipped it. The `<guid>` branch stored it.

## Why it matters

While the post is live, `index.php` prefers the post — `post_has_slug()` matches first and registers the post route, so the redirect is never consulted. The row is invisible except in the author's redirect list on `/settings`.

Trash the post and the router changes its mind:

```
after soft-delete (trash):
  post_has_slug('hello-world') = NULL
  find_redirect('hello-world') = '/hello-world'
```

`post_has_slug()` stops matching, the `elseif` branch runs `find_redirect()`, and the URL that should 404 301s to itself. `flatten_redirects()` does classify it as a loop and delete it — but only on the next `/_cron`, and only on an install that has cron wired up.

## The fix

The check moves into `store_redirect()`, which every importer already goes through, instead of being copied per call site. The WordPress importer had the third copy, and Known's `<guid>` branch is missing it precisely because there were copies to miss.

Both importers keep the behaviour they documented. The comparison stays in the decoded space `store_redirect()` keys on, so a source path that differs from the new permalink only by encoding is still recognised as the same path. An empty source path is dropped for the same reason — it can never match a request.

The WordPress side is a literal code motion: same expression, same inputs, same result.

## Verification

`RedirectTest` pins the guard — five self-redirect shapes (identical, either side percent-encoded, a `status/<id>` permalink, empty source) plus the dated path that merely *ends* with the slug and must still be stored, so the check can't drift to containment. `KnownImportTest` pins the `<guid>` case that was wrong, and asserts the dated `<link>` redirect still exists alongside it.

Run against the previous code, the five guard cases fail (each stored a row) and the Known case stores the self-redirect; the two "must still redirect" cases pass either way. After, all pass. The slug-collision path is unaffected — two items colliding on `same-name` still get `2019/same-name → /same-name` and `2021/same-name → /same-name-2`, each resolving to its own post.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_