### PR TITLE
Refuse an upload batch before storing any of it

### DIFF
--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -38,28 +38,22 @@ function respond_upload(array $_args): void
 
     $files = normalize_uploaded_files($_FILES[IMAGE_FILES]);
 
+    // The whole batch is checked before any of it is stored. The client posts
+    // every dropped file in one request, so refusing file 2 mid-loop left
+    // file 1 already written into src/assets/ — stored, referenced by nothing,
+    // and invisible to the author, who saw only the refusal.
+    [$accepted, $refusal] = accept_upload_batch($files);
+    if ($refusal !== null) {
+        // The status is load-bearing: upload-image.js keys on response.ok to
+        // tell markdown-to-insert from error-to-report.
+        header('HTTP/1.1 400 Bad Request');
+        echo json_encode($refusal, JSON_THROW_ON_ERROR);
+        die();
+    }
+
     $out = '';
-    foreach ($files as $f) {
-        if ($f['error'] !== UPLOAD_ERR_OK) {
-            // The status is load-bearing: upload-image.js keys on response.ok to
-            // tell markdown-to-insert from error-to-report.
-            header('HTTP/1.1 400 Bad Request');
-            echo json_encode('File upload error: ' . $f['error'], JSON_THROW_ON_ERROR);
-            die();
-        }
-        // File upload successful
-        $ext = safe_upload_extension($f['name']);
-        if ($ext === null) {
-            header('HTTP/1.1 400 Bad Request');
-            echo json_encode('Unsupported file type.', JSON_THROW_ON_ERROR);
-            die();
-        }
-        $temp_fp  = $f['tmp_name'];
-        if (!upload_content_allowed(sniff_file_content_type($temp_fp), $ext)) {
-            header('HTTP/1.1 400 Bad Request');
-            echo json_encode('File contents do not match its type.', JSON_THROW_ON_ERROR);
-            die();
-        }
+    $stored = [];
+    foreach ($accepted as $f) {
         // Salt with uniqid() so two uploads with the same client-supplied
         // filename in the same month don't collide on disk — without this,
         // an attacker-controlled filename can silently overwrite an earlier,
@@ -70,16 +64,22 @@ function respond_upload(array $_args): void
 
         // Re-encode JPEG/PNG to WebP for smaller files; fall back to the original
         // bytes if conversion fails (assume success, communicate failure).
-        $new_fn = store_webp_copy($temp_fp, $ext, $dir, $seed);
+        $new_fn = store_webp_copy($f['tmp_name'], $f['ext'], $dir, $seed);
         if ($new_fn === null) {
-            $new_fn = "$seed.$ext";
+            $new_fn = $seed . '.' . $f['ext'];
             $new_fp = sprintf("%s/%s", $dir, $new_fn);
-            if (!move_uploaded_file($temp_fp, $new_fp)) {
+            if (!move_uploaded_file($f['tmp_name'], $new_fp)) {
+                // Same reasoning as the batch check: the request is failing, so
+                // the files that did land are unreachable. Take them with it.
+                foreach ($stored as $orphan) {
+                    @unlink($orphan);
+                }
                 header('HTTP/1.1 500 Internal Server Error');
-                echo json_encode('Move upload error: ' . $temp_fp, JSON_THROW_ON_ERROR);
+                echo json_encode('Move upload error: ' . $f['tmp_name'], JSON_THROW_ON_ERROR);
                 die();
             }
         }
+        $stored[] = $dir . '/' . $new_fn;
         $out .= sprintf("![%s](%s)", $f['name'], asset_url($sub_path, $new_fn));
     }
 
@@ -88,6 +88,43 @@ function respond_upload(array $_args): void
     // after the file has already been stored.
     echo json_encode($out, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
     die();
+}
+
+/**
+ * Checks every file in an upload batch, resolving each one's extension.
+ *
+ * Returns the accepted files and null, or an empty list and the message for the
+ * first file that cannot be stored. Every refusal here is a 400: the request
+ * described something Lamb will not accept, and nothing has been written yet.
+ *
+ * Separated from respond_upload() because the responder stores as it validates
+ * and dies on every exit path — which is both why the mixed order was a bug and
+ * why it could not be tested. This half is pure: it reads the batch and the
+ * files it names, and writes nothing.
+ *
+ * @param array<int, array<string, mixed>> $files From normalize_uploaded_files().
+ * @return array{0: list<array{name: string, tmp_name: string, ext: string}>, 1: string|null}
+ */
+function accept_upload_batch(array $files): array
+{
+    $accepted = [];
+    foreach ($files as $file) {
+        if (($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+            return [[], 'File upload error: ' . (int) ($file['error'] ?? UPLOAD_ERR_NO_FILE)];
+        }
+        $name = (string) ($file['name'] ?? '');
+        $ext  = safe_upload_extension($name);
+        if ($ext === null) {
+            return [[], 'Unsupported file type.'];
+        }
+        $tmp_fp = (string) ($file['tmp_name'] ?? '');
+        if (!upload_content_allowed(sniff_file_content_type($tmp_fp), $ext)) {
+            return [[], 'File contents do not match its type.'];
+        }
+        $accepted[] = ['name' => $name, 'tmp_name' => $tmp_fp, 'ext' => $ext];
+    }
+
+    return [$accepted, null];
 }
 
 /**

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+use function Lamb\Response\accept_upload_batch;
 use function Lamb\Response\asset_dimensions;
 use function Lamb\Response\asset_url;
 use function Lamb\Response\convert_to_webp;
@@ -633,6 +634,96 @@ class UploadTest extends TestCase
         imagefill($im, 0, 0, imagecolorallocate($im, 10, 120, 200));
         imagepng($im, $path);
         imagedestroy($im);
+    }
+
+    // accept_upload_batch — the whole batch is judged before anything is stored
+
+    public function testAcceptUploadBatchResolvesTheExtensionOfEveryFile(): void
+    {
+        $one = $this->makePng(8, 8);
+        $two = $this->makePng(8, 8);
+
+        [$accepted, $refusal] = accept_upload_batch([
+            $this->uploadEntry('photo.PNG', $one),
+            $this->uploadEntry('other.png', $two),
+        ]);
+
+        $this->assertNull($refusal);
+        $this->assertCount(2, $accepted);
+        $this->assertSame('png', $accepted[0]['ext'], 'the extension is lower-cased');
+        $this->assertSame('photo.PNG', $accepted[0]['name']);
+        $this->assertSame($one, $accepted[0]['tmp_name']);
+    }
+
+    /**
+     * The regression this function exists for: respond_upload() used to check
+     * and store in the same loop, so a batch refused on its second file had
+     * already written the first into src/assets/ — orphaned, referenced by
+     * nothing, and never mentioned to the author.
+     *
+     * @dataProvider refusedSecondFileProvider
+     */
+    public function testAcceptUploadBatchRefusesTheWholeBatchWhateverTheFilePosition(
+        string $name,
+        string $contents,
+        int $error,
+        string $expected
+    ): void {
+        $good = $this->makePng(8, 8);
+        $bad  = $this->tempRootDir . '/' . $name;
+        file_put_contents($bad, $contents);
+
+        [$accepted, $refusal] = accept_upload_batch([
+            $this->uploadEntry('photo.png', $good),
+            $this->uploadEntry($name, $bad, $error),
+        ]);
+
+        $this->assertSame($expected, $refusal);
+        $this->assertSame([], $accepted, 'no file may be accepted out of a refused batch');
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: int, 3: string}>
+     */
+    public static function refusedSecondFileProvider(): array
+    {
+        return [
+            'disallowed extension' => ['notes.txt', "hello\n", UPLOAD_ERR_OK, 'Unsupported file type.'],
+            'markup behind an image extension' => [
+                'evil.png',
+                '<html><body><script>alert(1)</script></body></html>',
+                UPLOAD_ERR_OK,
+                'File contents do not match its type.',
+            ],
+            'upload error code' => [
+                'big.png',
+                'x',
+                UPLOAD_ERR_INI_SIZE,
+                'File upload error: ' . UPLOAD_ERR_INI_SIZE,
+            ],
+        ];
+    }
+
+    public function testAcceptUploadBatchAcceptsAnEmptyBatch(): void
+    {
+        [$accepted, $refusal] = accept_upload_batch([]);
+
+        $this->assertNull($refusal);
+        $this->assertSame([], $accepted);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function uploadEntry(string $name, string $path, int $error = UPLOAD_ERR_OK): array
+    {
+        return [
+            'name'     => $name,
+            'type'     => 'application/octet-stream',
+            'tmp_name' => $path,
+            'error'    => $error,
+            'size'     => (int) filesize($path),
+        ];
     }
 
     private function makePng(int $w, int $h): string


### PR DESCRIPTION
`respond_upload()` validated and stored in the same loop, so a batch refused on a later file had already written the earlier ones into `src/assets/`.

This is the ordinary shape of a multi-file drop, not an edge case — `upload-image.js` appends every dropped file to one `FormData` and posts it as a single request:

```js
for (const file of files) {
    formData.append('imageFiles[]', file)
}
```

## Reproduction

A valid PNG followed by a rejected file, three ways, counting what was left on disk after the refusal:

| second file | files stored before | after |
| --- | --- | --- |
| `notes.txt` (disallowed extension) | 1 | 0 |
| `evil.png` containing HTML (content sniff mismatch) | 1 | 0 |
| `UPLOAD_ERR_INI_SIZE` (oversized) | 1 | 0 |

The happy path is unchanged — two valid files still return both `[…](…)` links and store both.

## Why it matters

The response is a 400 carrying only the refusal message, so the stored file is referenced by nothing and its URL is never shown to anyone. It sits under `src/assets/YYYY/MM/` and rides along in every export archive. Drop three photos and one `.txt` and two conversions are silently orphaned.

Swap the order — bad file first — and nothing is stored, which is what made this hard to notice.

## The change

Validation moves into `accept_upload_batch()`, which reads the batch and the files it names and writes nothing. Every refusal it can return is a 400, so `respond_upload()` keeps one exit for all three; the messages and status are unchanged.

Extracting it is also what makes the checks testable at all — the responder needs real `$_FILES` entries and `die()`s on every path, which is why none of this had coverage.

The one refusal that cannot be decided in advance is a failed `move_uploaded_file()`. It now unlinks what already landed before answering 500, for the same reason: the request is failing, so those files are unreachable either way.

## Verification

End-to-end through the real responder with a seeded `$_FILES` (the table above), plus `UploadTest` coverage of `accept_upload_batch`: extension resolution and lower-casing, an empty batch, and a data provider asserting each of the three refusals rejects the *whole* batch with `$accepted === []`, so no file can be accepted out of a refused one.

Not changed here, noticed nearby: the `empty($_FILES[IMAGE_FILES])` path `die()`s a bare `No files uploaded!` under a `Content-Type: application/json` header, so `upload-image.js` fails its `response.json()` parse and shows the generic `Upload failed (400)` instead of the message. Separate one-liner, separate PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_