### PR TITLE
Answer the empty upload with JSON, like every other refusal

### DIFF
--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -31,9 +31,12 @@ function respond_upload(array $_args): void
     header('Content-Type: application/json');
 
     if (empty($_FILES[IMAGE_FILES])) {
-        // invalid request http status code
+        // JSON like every other refusal on this endpoint: upload-image.js parses
+        // the body to find the message, so a bare string was thrown away and the
+        // author got the generic "Upload failed (400)" instead of the reason.
         header('HTTP/1.1 400 Bad Request');
-        die('No files uploaded!');
+        echo json_encode('No files uploaded.', JSON_THROW_ON_ERROR);
+        die();
     }
 
     $files = normalize_uploaded_files($_FILES[IMAGE_FILES]);


### PR DESCRIPTION
`/upload` sets `Content-Type: application/json` and then `die()`s a bare `No files uploaded!` on this one path. Every other refusal on the endpoint goes through `json_encode()`.

`upload-image.js` reads the body to find the message:

```js
.then(response => response.json().catch(() => null).then(body => {
    if (!response.ok) {
        throw new Error(uploadErrorMessage(body, response.status))
    }
    ...
// uploadErrorMessage:
return typeof body === 'string' && body.trim() !== '' ? body.trim() : `Upload failed (${status})`
```

An unquoted string is not JSON, so the parse fails, `body` becomes `null`, and the author is shown the generic fallback instead of the reason.

Simulating exactly that client logic against the endpoint:

```
before: body 'No files uploaded!'    -> client shows "Upload failed (400)"
after:  body '"No files uploaded."'  -> client shows "No files uploaded."
```

Status and behaviour are otherwise unchanged; the `!` becomes a `.` to match the wording of the endpoint's other messages.

Found while working on #651 and deliberately left out of it — same function, different bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_