### PR TITLE
Do not report a stored file the media endpoint failed to store

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1579,7 +1579,14 @@ function respond_micropub_media(): void
     $filename = \Lamb\Response\store_webp_copy($file['tmp_name'], $ext, $uploadDir, $seed);
     if ($filename === null) {
         $filename = $seed . ".$ext";
-        move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $filename);
+        // Checked, the way /upload checks it. Everything store_webp_copy()
+        // declines — gif, webp, avif and every video — lands here, so this is
+        // the ordinary path for a video upload, not a rare one. Answering 201
+        // with a Location for a file that was never written hands the client a
+        // URL it embeds in a published post, where it 404s forever.
+        if (!move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $filename)) {
+            micropub_error(500, 'server_error', 'Could not store the uploaded file.');
+        }
     }
 
     // The media endpoint hands this URL back to an external Micropub client, so


### PR DESCRIPTION
`respond_micropub_media()` ignores `move_uploaded_file()`'s return value and then answers `201` with a `Location` header, so a failed write is reported to the client as a successful upload:

```php
$filename = \Lamb\Response\store_webp_copy($file['tmp_name'], $ext, $uploadDir, $seed);
if ($filename === null) {
    $filename = $seed . ".$ext";
    move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $filename);   // <- result dropped
}
...
http_response_code(201);
header('Location: ' . $url);
```

`/upload` has the same store-or-fall-back-to-move structure and checks the same call, answering 500. Measured, for a `.gif` whose move fails: `/upload` returns `"Move upload error: …"` with a 500; the media endpoint returned 201.

## The fallback is the ordinary path, not a rare one

`store_webp_copy()` only converts JPEG and PNG. Across the whole upload allowlist:

| ext | `store_webp_copy()` | | ext | | | ext | |
| --- | --- | --- | --- | --- | --- | --- | --- |
| jpg | `seed.webp` | | gif | `null` | | mp4 | `null` |
| jpeg | `seed.webp` | | webp | `null` | | webm | `null` |
| png | `seed.webp` | | avif | `null` | | mov | `null` |

So every video, gif, webp and avif uploaded through the media endpoint is stored by the unchecked move. On a full disk or a read-only assets mount the client is handed a URL for a file that does not exist — and the media endpoint exists precisely so the client can put that URL into a post, where it 404s for good.

`server_error` follows OAuth 2.0 (RFC 6749 §4.1.2.1); Micropub defines no code of its own for a 500.

## Verification, and the test I did not write

There is no new test here, and that is a real gap rather than an oversight: making `move_uploaded_file()` fail requires a genuine registered upload, which cannot be arranged in-process, and the endpoint's auth path introspects the token against the configured token endpoint over HTTP.

What I measured instead: the extension table above, from `store_webp_copy()` itself; that `move_uploaded_file()` on a non-upload returns `false` and creates nothing; and the sibling endpoint's answer for the identical failure.

Once #651's batch rework lands, both call sites can share one store-the-uploaded-file helper — which would also be unit-testable — instead of repeating the pair. Kept out of this PR so the two don't conflict on the same lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_