### PR TITLE
Do not let a manifest date break the comparisons it feeds

### DIFF
--- a/src/restore.php
+++ b/src/restore.php
@@ -373,16 +373,27 @@ function import_post(array $item, callable $_downloader, bool $dry_run = false, 
  * crawl overwriting the author's own edits. Restoring one without the other
  * hands the post back to the feed.
  *
+ * Total does not mean unquestioning: the three date columns drive visibility
+ * and the trash purge, so a value the manifest cannot justify is dropped rather
+ * than written into a comparison it would break.
+ *
  * @param array<string, mixed> $item
  */
 function apply_manifest_state(OODBBean $bean, array $item): void
 {
-    $created = (string) ($item['created'] ?? '');
-    $updated = (string) ($item['updated'] ?? '');
-    if ($created !== '') {
+    // normalize_datetime() rather than the raw manifest value, the same way
+    // Micropub's createCallback() reads an untrusted `published`. Stored
+    // verbatim, a value that is not a date sorts above every real one, so
+    // visible_clause() reads the restored post as scheduled and it never
+    // appears in a listing; a non-string value was worse still, the (string)
+    // cast warning and storing the literal "Array". Both now fall back to what
+    // populate_bean() settled, exactly as an absent date already did.
+    $created = \Lamb\normalize_datetime($item['created'] ?? null);
+    $updated = \Lamb\normalize_datetime($item['updated'] ?? null);
+    if ($created !== null) {
         $bean->created = $created;
     }
-    $bean->updated = $updated !== '' ? $updated : $bean->created;
+    $bean->updated = $updated ?? $bean->created;
 
     $slug = Post\sanitize_explicit_slug((string) ($item['slug'] ?? ''));
     if ($slug !== '') {
@@ -397,7 +408,17 @@ function apply_manifest_state(OODBBean $bean, array $item): void
     // reads as 0 — the value such an install would have had for any post whose
     // author never took it over.
     $bean->feed_locked = empty($item['feed_locked']) ? 0 : 1;
-    $bean->deleted_at = $item['deleted_at'] ?? null;
+    // deleted_at drives purge_deleted_posts(), which hard-deletes a trashed post
+    // 30 days after this stamp. A value sorting below that cutoff — '0000-00-00'
+    // from an older install, or anything that is not a date at all — purged the
+    // post on the very next /_cron, destroying during a restore the data the
+    // restore exists to recover. Nothing earlier than the post's own created
+    // date can be a real deletion time either, so both fall back to NULL, which
+    // the purge already backfills for rows trashed before it tracked this.
+    $deleted_at = \Lamb\normalize_datetime($item['deleted_at'] ?? null);
+    $bean->deleted_at = ($deleted_at !== null && $deleted_at >= (string) $bean->created)
+        ? $deleted_at
+        : null;
     $bean->feed_name = $item['feed_name'] ?? null;
     $bean->feeditem_uuid = $item['feeditem_uuid'] ?? null;
     $bean->source_url = $item['source_url'] ?? null;

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -904,4 +904,102 @@ class LambRestoreTest extends TestCase
 
         $this->assertSame('archive-2024', $bean->slug);
     }
+
+    /**
+     * A manifest date is untrusted like the rest of the archive. Stored
+     * verbatim, one that is not a date sorted above every real date, so
+     * visible_clause() read the restored post as scheduled and it never
+     * appeared in a listing.
+     *
+     * @dataProvider unusableManifestDateProvider
+     */
+    public function testApplyManifestStateFallsBackWhenTheManifestDateIsNotADate(mixed $created): void
+    {
+        $bean = R::dispense('post');
+        $bean->created = '2024-01-01 00:00:00';
+
+        apply_manifest_state($bean, ['created' => $created, 'updated' => $created]);
+
+        $this->assertSame('2024-01-01 00:00:00', $bean->created, 'the settled date must survive');
+        $this->assertSame('2024-01-01 00:00:00', $bean->updated);
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unusableManifestDateProvider(): array
+    {
+        return [
+            'unparseable text' => ['not a date'],
+            'letters only'     => ['zzzz'],
+            'trailing markup'  => ['2019-04-05T10:11:12+00:00 <script>'],
+            'an array'         => [['2019-04-05']],
+            'a boolean'        => [true],
+            'empty string'     => [''],
+        ];
+    }
+
+    public function testApplyManifestStateKeepsAUsableManifestDate(): void
+    {
+        $bean = R::dispense('post');
+        $bean->created = '2024-01-01 00:00:00';
+
+        apply_manifest_state($bean, [
+            'created' => '2019-04-05 10:11:12',
+            'updated' => '2020-01-02 03:04:05',
+        ]);
+
+        $this->assertSame('2019-04-05 10:11:12', $bean->created);
+        $this->assertSame('2020-01-02 03:04:05', $bean->updated);
+    }
+
+    /**
+     * purge_deleted_posts() hard-deletes a trashed post 30 days after its
+     * deleted_at stamp, so a manifest value sorting below that cutoff purged
+     * the post on the very next /_cron — destroying, during a restore, the data
+     * the restore exists to recover. NULL is the safe answer: the purge already
+     * backfills it for rows trashed before it tracked this.
+     *
+     * @dataProvider unusableDeletedAtProvider
+     */
+    public function testApplyManifestStateDropsADeletedAtItCannotJustify(mixed $deletedAt): void
+    {
+        $bean = R::dispense('post');
+
+        apply_manifest_state($bean, [
+            'created'    => '2026-08-20 09:00:00',
+            'deleted'    => true,
+            'deleted_at' => $deletedAt,
+        ]);
+
+        $this->assertNull($bean->deleted_at);
+        $this->assertSame(1, $bean->deleted, 'the post is still trashed, only its stamp is dropped');
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unusableDeletedAtProvider(): array
+    {
+        return [
+            'unparseable text'    => ['not a date'],
+            'sorts below any date' => ['!'],
+            'a zero date'         => ['0000-00-00'],
+            'before the post existed' => ['2019-01-01 00:00:00'],
+            'an array'            => [['2026-08-20']],
+        ];
+    }
+
+    public function testApplyManifestStateKeepsARealDeletedAt(): void
+    {
+        $bean = R::dispense('post');
+
+        apply_manifest_state($bean, [
+            'created'    => '2026-08-01 09:00:00',
+            'deleted'    => true,
+            'deleted_at' => '2026-08-19 12:00:00',
+        ]);
+
+        $this->assertSame('2026-08-19 12:00:00', $bean->deleted_at);
+    }
 }


### PR DESCRIPTION
`apply_manifest_state()` wrote the manifest's `created`, `updated` and `deleted_at` straight into columns that drive visibility and the trash purge. `restore_assets()` names the archive as untrusted in its own docblock — *"a file the author was handed, possibly by someone else"* — and gates every asset on an extension allowlist and a content sniff. The date columns had no gate at all.

## Three failures, measured through the real restore path

**1. An unparseable `created` hides the post.** Stored verbatim, it sorts above every real date, so `visible_clause()` reads the restored post as scheduled:

```
manifest created     stored created            in public listing
well-formed          '2019-04-05 10:11:12'     yes
unparseable text     'not a date'              NO
letters only         'zzzz'                    NO
```

The restore reports success and the post appears in no listing.

**2. A non-string `created` stores the word "Array".**

```
PHP Warning:  Array to string conversion in src/restore.php on line 380
  stored created = 'Array'   in listing: NO
```

**3. A `deleted_at` below the cutoff destroys the post.** `purge_deleted_posts()` hard-deletes a trashed post 30 days after its stamp:

| manifest `deleted_at` | hard-deleted by the next `/_cron`? |
| --- | --- |
| `2026-08-20 09:00:00` (real) | no |
| `not a date` | no (sorts high — never purged instead) |
| `!` | **YES — permanently deleted** |
| `0000-00-00` | **YES — permanently deleted** |

`0000-00-00` is not a contrived value: it is what an older install or a MySQL-era row hands you. A restore destroying the data it exists to recover is the worst of the three.

## The change

Dates go through `normalize_datetime()` — the same helper `Micropub\createCallback()` uses on an untrusted `published`, for the reason its comment already gives: *"it accepts the same shapes front matter does and returns null instead of false, so a non-string `published` no longer TypeErrors and an unparseable one no longer silently backdates the post to 1970."*

An unusable `created`/`updated` falls back to what `populate_bean()` settled, exactly as an absent one already did.

`deleted_at` needs one more condition, because `strtotime('0000-00-00')` *succeeds* (yielding year −1) and would still sort below the cutoff: it must also be no earlier than the post's own `created`, since nothing before the post existed can be a real deletion time. Otherwise it becomes `NULL`, which `purge_deleted_posts()` already backfills for rows trashed before it tracked this — giving a fresh 30-day window from the restore. Every fallback errs toward keeping data.

## Verification

Both directions: 10 of the 14 new assertions fail against the previous code (including the two `Array to string conversion` warnings), all pass now.

A real export → restore round trip over published, draft, trashed (with a genuine `deleted_at`) and **future-dated scheduled** posts is byte-identical through the change:

```
preserved created '2019-04-05 10:11:12'->'2019-04-05 10:11:12'  deleted_at NULL->NULL
preserved created '2023-06-06 06:06:06'->'2023-06-06 06:06:06'  deleted_at '2026-08-19 12:00:00'->'2026-08-19 12:00:00'
preserved created '2024-12-31 23:59:59'->'2024-12-31 23:59:59'  deleted_at NULL->NULL
preserved created '2030-01-01 00:00:00'->'2030-01-01 00:00:00'  deleted_at NULL->NULL
ROUND TRIP CLEAN
```

The scheduled post is the case a careless date guard would break, so it is in there deliberately — no date the exporter actually writes is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_