### PR TITLE
Do not count an asset the restore failed to put in place

### DIFF
--- a/src/restore.php
+++ b/src/restore.php
@@ -478,7 +478,15 @@ function restore_assets(array $manifest, string $assets_root, callable $reader, 
             $tally['skipped']++;
             continue;
         }
-        rename($staged, $dest);
+        // Checked: the tally is the only account an operator gets of a restore,
+        // and a rename that failed leaves the bytes at the .part name, where
+        // nothing serves them and nothing cleans them up. Counting that as
+        // restored reports a recovery that did not happen.
+        if (!rename($staged, $dest)) {
+            @unlink($staged);
+            $tally['skipped']++;
+            continue;
+        }
         $tally['restored']++;
     }
 

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -815,6 +815,35 @@ class LambRestoreTest extends TestCase
         $this->assertSame(['restored' => 0, 'skipped' => 1, 'rejected' => 0], $tally);
     }
 
+    /**
+     * The tally is the only account an operator gets of a restore, so it has to
+     * describe what reached disk. A failed rename left the bytes at the .part
+     * name, where nothing serves them and nothing cleans them up, and still
+     * counted as restored.
+     */
+    public function testRestoreAssetsDoesNotCountARestoreTheRenameFailed(): void
+    {
+        $root = "$this->tmp_dir/assets_dest";
+        // A directory where the asset belongs: the staged write succeeds and the
+        // rename onto it cannot.
+        mkdir("$root/2026/07/photo.png", 0777, true);
+
+        $manifest = $this->manifest(['assets' => ['assets/2026/07/photo.png']]);
+        [, $reader] = open_source($this->zip([
+            'manifest.json'             => (string) json_encode($manifest),
+            'assets/2026/07/photo.png'  => $this->pngBytes(),
+        ], 'rename-fails.zip'));
+
+        // Silenced deliberately: rename() onto a directory raises E_WARNING, and
+        // Codeception turns PHP errors into exceptions. The warning is the
+        // condition under test, not a surprise.
+        $tally = @restore_assets($manifest, $root, $reader, false);
+
+        $this->assertSame(['restored' => 0, 'skipped' => 1, 'rejected' => 0], $tally);
+        $this->assertFalse(is_file("$root/2026/07/photo.png"));
+        $this->assertFileDoesNotExist("$root/2026/07/photo.png.part");
+    }
+
     public function testRestoreAssetsWritesNothingOnADryRun(): void
     {
         [$tally, $root] = $this->restoreAssets(['assets/2026/07/photo.png' => $this->pngBytes()], true);


### PR DESCRIPTION
`restore_assets()` stages each asset beside its destination and renames it into place, then counts a restore without looking at whether the rename worked:

```php
rename($staged, $dest);
$tally['restored']++;
```

When it fails the bytes stay at the `.part` name — where nothing serves them and nothing cleans them up — and the tally still reports the asset as restored.

Measured with a directory sitting where the asset belongs, so the staged write succeeds and the rename cannot:

```
before: {"restored":1,"skipped":0,"rejected":0}   stray .part left behind
after:  {"restored":0,"skipped":1,"rejected":0}   staged file removed
```

The tally is the only account an operator gets of a restore, and they are reading it at the one moment they most need it to be true. Every other step in this loop already reports a failure it cannot fix as `skipped` — the missing archive entry, the `mkdir`, the staged write. The rename was the one that didn't.

I'll be straight about reachability: this needs the destination to be unrenameable-onto, which is an odd pre-existing state rather than an everyday one. It's the reporting invariant I'm fixing, not a common crash.

## The rest of the restore path

Swept alongside this, and it holds:

- `safe_entry_path()` refuses all 18 hostile names tried — traversal in both the `posts/` and `assets/` shapes, absolute paths, dotfiles, nested directories, `.php` and `.md.php` tails, a trailing newline (the `D` modifier earns its comment), an uppercase `.MD`, a query suffix, percent-encoded traversal — and accepts every legitimate shape.
- A rejected path is never handed to the reader at all: `manifest_items()` gates first, so the reader is called zero times and `item_skip_reason()` reports `bad path`.
- The manifest's own `import_uuid` and `body` lose to the computed ones — the `array_merge()` order is doing what its comment claims.
- `restore_uuid()` is stable per origin and distinct across both origins and ids, so two archives can't collide.
- A second restore of the same item adds no row; a dry run writes nothing and tallies exactly what a real run would; an existing file is never overwritten by a restore into a live site.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_