### PR TITLE
Do not step the feed watermark over an entry the crawl lost

### DIFF
--- a/src/network/ingest.php
+++ b/src/network/ingest.php
@@ -40,17 +40,21 @@ use function Lamb\Post\populate_bean;
  * @param SimplePieItem|JsonFeedItem $item      The feed item.
  * @param string        $name      Feed name from config.
  * @param int           $watermark Newest entry publication timestamp seen so far.
- * @return bool True when a post was created or updated (counts toward the run total).
+ * @return bool|null True when a post was created or updated (counts toward the
+ *                   run total), false when there was nothing to do, and null
+ *                   when an entry that should now exist does not because the
+ *                   write failed — which the watermark has to know about.
  */
-function ingest_item(SimplePieItem|JsonFeedItem $item, string $name, int $watermark): bool
+function ingest_item(SimplePieItem|JsonFeedItem $item, string $name, int $watermark): ?bool
 {
     $uuid     = md5($name . $item->get_id());
     $existing = R::findOne('post', ' feeditem_uuid = ? ', [$uuid]);
 
     if (!$existing) {
         if ((int) $item->get_date('U') > $watermark) {
-            create_item($item, $name);
-            return true;
+            // null, not true, when the store failed: creation is the only
+            // decision the watermark gates, so a lost entry has to hold it back.
+            return create_item($item, $name) ? true : null;
         }
         return false;
     }
@@ -61,8 +65,10 @@ function ingest_item(SimplePieItem|JsonFeedItem $item, string $name, int $waterm
     // to run, and stops a re-synced item from being re-synced on every crawl.
     $synced_at = (int) strtotime((string) $existing->updated);
     if (!$existing->feed_locked && (int) $item->get_updated_date('U') > $synced_at) {
-        update_item($item, $name);
-        return true;
+        // A failed re-sync needs no special handling: `updated` was not stamped,
+        // so the next crawl compares against the same value and tries again. It
+        // just must not be counted as an entry this run took in.
+        return update_item($item, $name);
     }
 
     return false;
@@ -76,20 +82,36 @@ function ingest_item(SimplePieItem|JsonFeedItem $item, string $name, int $waterm
  * watermark they read — the divergence this pattern is prone to, and the reason
  * the pair already share begin_crawl()/record_crawl_*().
  *
+ * A run that failed to create an entry reports no new watermark at all.
+ * record_crawl_success() only ever raises the watermark, and an entry at or
+ * below it is never created — so advancing past an entry the run lost would put
+ * it permanently under the line that decides whether to create it, dropping it
+ * for good. That is the same failure the watermark was introduced to prevent,
+ * arriving by a different route. Holding the watermark for one run costs
+ * nothing: every entry is deduped on feeditem_uuid, so the ones that did land
+ * are not created a second time.
+ *
  * @param array<array-key, SimplePieItem|JsonFeedItem> $items  The feed's entries.
  * @param string   $name   Feed name from config.
  * @param OODBBean $status The feed's status bean from begin_crawl().
  * @return array{0: int, 1: int|null} Entries created or updated, and the newest
- *                                    entry date seen (null when none is dated).
+ *                                    entry date seen (null when none is dated,
+ *                                    or when an entry was lost to a failed write).
  */
 function ingest_items(array $items, string $name, OODBBean $status): array
 {
     $watermark = (int) $status->last_item_date;
     $ingested  = 0;
     $newest    = null;
+    $lost      = false;
 
     foreach ($items as $item) {
-        if (ingest_item($item, $name, $watermark)) {
+        $outcome = ingest_item($item, $name, $watermark);
+        if ($outcome === null) {
+            $lost = true;
+            continue;
+        }
+        if ($outcome) {
             $ingested++;
         }
         $date = (int) $item->get_date('U');
@@ -98,16 +120,20 @@ function ingest_items(array $items, string $name, OODBBean $status): array
         }
     }
 
-    return [$ingested, $newest];
+    return [$ingested, $lost ? null : $newest];
 }
 
-function update_item(SimplePieItem|JsonFeedItem $item, string $name): void
+/**
+ * Re-syncs an already-ingested entry. Returns false when the row is gone or the
+ * write failed, so the caller does not count a re-sync that did not happen.
+ */
+function update_item(SimplePieItem|JsonFeedItem $item, string $name): bool
 {
     $uuid = md5($name . $item->get_id());
     $bean = R::findOne('post', ' feeditem_uuid = ?', [$uuid]);
     if (!$bean) {
         // Record not found
-        return;
+        return false;
     }
     $bean = prepare_item($item, $name, $bean);
     $bean->updated = $item->get_updated_date("Y-m-d H:i:s");
@@ -116,8 +142,10 @@ function update_item(SimplePieItem|JsonFeedItem $item, string $name): void
     try {
         R::store($bean);
     } catch (SQL) {
-        // continue
+        return false;
     }
+
+    return true;
 }
 
 function prepare_item(SimplePieItem|JsonFeedItem $item, string $name, ?OODBBean $bean = null): OODBBean
@@ -127,7 +155,11 @@ function prepare_item(SimplePieItem|JsonFeedItem $item, string $name, ?OODBBean 
     return populate_bean($contents, $item, $name, $bean);
 }
 
-function create_item(SimplePieItem|JsonFeedItem $item, string $name): void
+/**
+ * Creates a post for a feed entry. Returns false when the write failed, so the
+ * caller can hold the watermark back instead of stepping over a lost entry.
+ */
+function create_item(SimplePieItem|JsonFeedItem $item, string $name): bool
 {
     $contents = get_structured_content($item, $name);
     $bean = populate_bean($contents, $item, $name);
@@ -138,8 +170,10 @@ function create_item(SimplePieItem|JsonFeedItem $item, string $name): void
         // body's front matter so cron updates re-derive it unchanged.
         finalize_and_store_post($bean);
     } catch (SQL) {
-        // continue
+        return false;
     }
+
+    return true;
 }
 
 /**

--- a/tests/Unit/FeedWatermarkTest.php
+++ b/tests/Unit/FeedWatermarkTest.php
@@ -9,6 +9,7 @@ use SimplePie\SimplePie;
 
 use function Lamb\Network\feed_status_bean;
 use function Lamb\Network\ingest_item;
+use function Lamb\Network\ingest_items;
 use function Lamb\Network\record_feed_crawl;
 
 /**
@@ -166,5 +167,89 @@ class FeedWatermarkTest extends TestCase
 
         $reloaded = R::load('post', $bean->id);
         $this->assertSame('Original body', $reloaded->body);
+    }
+
+    /**
+     * The watermark only ever rises, and an item at or below it is never
+     * created — so a run that stepped over an item it had failed to write put
+     * that item permanently under the line, which is the same "dropped for
+     * good" failure this whole mechanism exists to prevent.
+     */
+    public function testAFailedCreateDoesNotAdvanceTheWatermark(): void
+    {
+        $status = feed_status_bean(self::NAME, self::URL);
+        $status->last_item_date = 0;
+        R::store($status);
+
+        $item = $this->makeItem('0.12.0', time() - 60);
+
+        [$ingested, $newest] = $this->ingestWithFailingInsert([$item], $status);
+
+        $this->assertSame(0, $ingested, 'an item that was not written is not an item taken in');
+        $this->assertNull($newest, 'the watermark must not step over the lost item');
+        $this->assertSame(0, R::count('post'));
+    }
+
+    public function testAnItemLostToAFailedCreateIsStillCreatedOnTheNextCrawl(): void
+    {
+        $status = feed_status_bean(self::NAME, self::URL);
+        $status->last_item_date = 0;
+        R::store($status);
+
+        $item = $this->makeItem('0.12.0', time() - 60);
+        [, $newest] = $this->ingestWithFailingInsert([$item], $status);
+
+        // Exactly what record_crawl_success() would store for that run.
+        if ($newest !== null) {
+            $status->last_item_date = max((int) $status->last_item_date, $newest);
+            R::store($status);
+        }
+
+        [$ingested] = ingest_items([$item], self::NAME, $status);
+
+        $this->assertSame(1, $ingested);
+        $this->assertSame(1, R::count('post'));
+    }
+
+    public function testOneLostItemDoesNotStopTheOthersInTheRun(): void
+    {
+        $status = feed_status_bean(self::NAME, self::URL);
+        $status->last_item_date = 0;
+        R::store($status);
+
+        // Both fail here (the trigger blocks every insert); the point is that
+        // the run reports the loss rather than a count it cannot back up.
+        [$ingested, $newest] = $this->ingestWithFailingInsert([
+            $this->makeItem('0.11.0', time() - 86400),
+            $this->makeItem('0.12.0', time() - 60),
+        ], $status);
+
+        $this->assertSame(0, $ingested);
+        $this->assertNull($newest);
+    }
+
+    /**
+     * Runs a batch with every INSERT on `post` refused, the way a SQLite file
+     * locked by a concurrent /_cron refuses one.
+     *
+     * @param list<SimplePieItem> $items
+     * @return array{0: int, 1: int|null}
+     */
+    private function ingestWithFailingInsert(array $items, \RedBeanPHP\OODBBean $status): array
+    {
+        // Settle the schema first: RedBean's fluid mode would otherwise ALTER
+        // the table during the run, and the trigger has to already exist.
+        $warm = R::dispense('post');
+        $warm->body = 'warm';
+        R::store($warm);
+        R::exec('DELETE FROM post');
+
+        R::exec("CREATE TRIGGER lamb_block_insert BEFORE INSERT ON post"
+            . " BEGIN SELECT RAISE(ABORT, 'database is locked'); END");
+        try {
+            return ingest_items($items, self::NAME, $status);
+        } finally {
+            R::exec('DROP TRIGGER IF EXISTS lamb_block_insert');
+        }
     }
 }


### PR DESCRIPTION
`create_item()` swallows a failed store, `ingest_item()` returned `true` either way, and `ingest_items()` dated the run from every entry it looked at. So a write that failed was counted as an entry taken in, **and the watermark advanced past it**. Since `record_crawl_success()` only ever raises the watermark and an entry at or below it is never created, that entry was gone for good.

```php
create_item($item, $name);   // catch (SQL) { /* continue */ }
return true;                 // <- unconditional
```

## Reproduction

Every `INSERT` on `post` refused, the way a SQLite file locked by a concurrent `/_cron` refuses one, then the crawl replayed with writes working again:

```
before:
  run reported ingested = 1
  posts actually created = 0
  newest date reported for the watermark = 2026-08-20 12:00:00
  next crawl (writes working again): ingested = 0, posts = 0
  => the entry is lost for good

after:
  run reported ingested = 0
  posts actually created = 0
  newest date reported for the watermark = NULL
  next crawl (writes working again): ingested = 1, posts = 1
  => the entry was recovered
```

This is the failure the watermark exists to prevent, arriving by a different route. The docblock at the top of this file already describes the same *"quietly dropped items for good"* outcome from the older crawl-clock design.

## The change

`ingest_item()` answers `null` when an entry that should now exist does not because the write failed, and a run carrying any such loss reports no new watermark. Holding it for one run costs nothing: every entry is deduped on `feeditem_uuid`, so the ones that did land are not created twice.

A failed **re-sync** stays `false` rather than `null`. `update_item()` never stamped `updated`, so the next crawl compares against the same value and retries on its own — it only had to stop being counted as an entry taken in. Creation is the one decision the watermark gates, so it is the only one that needs the watermark held.

## Verification

Every healthy path measured identical before and after:

| | before | after |
| --- | --- | --- |
| two fresh entries create both, newest date reported | ok | ok |
| entry at/below the watermark skipped, run still dated | ok | ok |
| re-crawl of the same entries adds nothing | ok | ok |
| `feed_locked` post still not re-synced | ok | ok |
| **one lost entry withholds the watermark** | **fail** | ok |

The three new `FeedWatermarkTest` assertions all fail against the previous code; the middle one is the decisive one, since it replays the next crawl and shows the entry going from never-created to created. Existing `assertTrue`/`assertFalse` assertions on `ingest_item()` are untouched — those paths still return `true`/`false`, and `null` only appears for a failed create.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_