### PR TITLE
docs(network): module README + thin subsystem essays from docblocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -525,10 +525,20 @@ comment is noise:
 header('HTTP/1.1 400 Bad Request');
 ```
 
-Docblocks are the exception and are deliberately expansive in this codebase —
-they carry a function's "why" as a whole, and account for most of the ~44% of
-`src/` lines that are comments. Inline `//` rationale is the part to keep scarce:
-it runs at roughly **8% of non-docblock lines**, which is the level to aim for.
+Docblocks carry a function's **contract** — `@param`, `@return` and `@throws`
+are required (they feed PHPStan and IDE hover) — plus the *local* why: an
+invariant, a coupling, a ceiling the next editor will try to remove. Keep that
+on the symbol, where it is read at the point of change.
+
+A rationale that runs to a paragraph and explains a *subsystem* rather than a
+single function is documentation. Put it in the module's README
+(`src/<module>/README.md`) and leave a one-line pointer on the symbol
+(`// SSRF model: see network/README.md`), so a design essay lives in one place
+instead of being restated across every function it touches. `src/network/` is
+the first module to follow this; see its `README.md` and the `2026-08-21`
+decision log entry.
+
+Inline `//` rationale stays scarce — around **8% of non-docblock lines**.
 
 ## Testing
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -68,6 +68,18 @@ The `preview` parameter counts even when empty or wrong. A bad token never grant
 
 ---
 
+## 2026-08-21 — Module-level developer docs live in `src/<module>/README.md`
+
+**Status:** Accepted
+
+**Context:** Between the whole-project guide (`AGENTS.md`) and per-function docblocks there was no place for a *subsystem's* story. Core files run near 50% comment lines, and the same rationale — the feed-ingestion watermark model is the clearest case — was restated across several docblocks, so the copies drift. The `2026-05-29` decision put contributor docs in root-level files but enumerated a fixed set and did not anticipate a per-module tier. The house authoring rule ("a paragraph-long comment is documentation — put it in a README and leave a one-line pointer") already pointed the way; this records where that README goes.
+
+**Decision:** A subsystem's narrative — how its parts fit, the invariants that span more than one function, the non-obvious design — lives in `src/<module>/README.md`, next to the code it explains. Docblocks keep the **contract** (`@param`/`@return`/`@throws`, still required) plus the *local* why (an invariant or coupling read at the point of change); a paragraph that explains the module rather than the function moves to the README with a one-line pointer left on the symbol. Root-level files (`README.md`, `CONTRIBUTING`, `DECISIONS.md`, `DESIGN.md`, `PRODUCT.md`) keep project-wide and cross-cutting material; `docs/` stays end-user only. First applied to `src/network/` (feed ingestion).
+
+**Consequences:** `AGENTS.md` §Comments is updated to match, so the next contributor does not read "docblocks are deliberately expansive" and re-inflate what was moved out. A design essay lives in one place instead of N drifting copies. The trade-off is deliberate: a module README sits one directory from the code — farther than a docblock — so it is for subsystem-spanning rationale, not per-line why, which stays on the symbol. New modules adopt the pattern as they are touched, not in a big-bang sweep.
+
+---
+
 ## 2026-05-29 — `docs/` is end-user documentation only
 
 **Status:** Accepted

--- a/src/network.php
+++ b/src/network.php
@@ -103,16 +103,10 @@ function webmention_line(array $sent): string
 {
     header('Content-Type: text/plain');
 
-    // /_cron is unauthenticated and meant to be hit by an external cron job
-    // (see docs/cron-scheduled-tasks.md), but nothing stops anyone from
-    // flooding it with concurrent requests. The rate-limit watermark below is
-    // only written after all work below completes, so without a lock, every
-    // request in such a burst reads the same stale watermark, passes the
-    // "too often" check, and proceeds in parallel — multiplying outbound
-    // feed/webmention HTTP calls and risking duplicate feed-item ingestion
-    // (no unique constraint on `feeditem_uuid`) and duplicate outbound
-    // webmention sends (no atomic claim on a queued row). Acquiring a
-    // non-blocking exclusive lock first serializes overlapping runs instead.
+    // Serialise overlapping runs before anything else: /_cron is unauthenticated
+    // and the rate-limit watermark is only written after all work finishes, so a
+    // concurrent burst without this lock would run in parallel on the same stale
+    // watermark. See network/README.md ("The run") for what that duplicates.
     $lock = acquire_cron_lock();
     if ($lock === false) {
         http_response_code(500);
@@ -165,19 +159,16 @@ function cron_lock_path(): string
 }
 
 /**
- * Acquires an exclusive, non-blocking lock serializing /_cron runs.
+ * Acquires an exclusive, non-blocking lock serialising /_cron runs.
  *
- * The returned handle must be kept referenced for the remainder of the
- * request: the lock releases automatically once it (and the underlying file
- * descriptor) is closed or the request ends, so an explicit unlock isn't
- * needed as long as the caller never returns normally before then (every
- * process_feeds() exit path terminates the request via die()/exit()).
+ * The handle must stay referenced until the request ends: the lock releases
+ * when it closes, so no explicit unlock is needed as long as every
+ * process_feeds() exit path terminates via die()/exit().
  *
- * The two ways this can fail are kept apart. A lock file that cannot be opened
- * at all is not another run in progress — it is a broken install, and reporting
- * it as contention is what let a mislocated lock file silently stop every cron
- * run (feeds, the webmention queue, the purge) while the endpoint kept
- * answering "Already running, try again later."
+ * The two failure modes are kept apart deliberately — a lock file that cannot
+ * be *opened* is a broken install (false), not another run in progress (null);
+ * collapsing them once silently stopped every cron run. See network/README.md
+ * ("The run").
  *
  * @param string|null $path Lock file path; defaults to cron_lock_path().
  * @return resource|false|null The open lock-file handle; null when another run

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -1,0 +1,159 @@
+# Feed ingestion (`Lamb\Network`)
+
+Developer notes for the feed-ingestion subsystem. This is the *why* behind the
+code in this directory; the per-function docblocks carry the contract (params,
+returns, invariants) and point here for the design. For the project-wide
+architecture see [AGENTS.md](../../AGENTS.md); for the end-user cron setup see
+[docs/cron-scheduled-tasks.md](../../docs/cron-scheduled-tasks.md).
+
+## Files
+
+All files declare the `Lamb\Network` namespace (a split, not separate
+namespaces — callers don't care which file a function lives in):
+
+| File | Responsibility |
+|------|----------------|
+| `../network.php` | `/_cron` orchestrator: lock, rate-limit, maintenance steps, per-feed dispatch, output lines |
+| `sources.php` | Feed config, SimplePie setup, the SSRF/body-cap-hardened `SafeFile` fetch class |
+| `json_feed.php` | JSON Feed (jsonfeed.org) detection, parsing, and the `JsonFeedItem` adapter |
+| `ingest.php` | Turning a feed item into a post: dedup, watermark decisions, slug, citation |
+| `status.php` | The per-feed `feedstatus` health bean (read by the Logs tab) |
+
+The `/_cron` route is registered centrally in `Lamb\Route\register_app_routes()`.
+
+## The run — trigger, lock, rate-limit
+
+`GET /_cron` (`process_feeds()`) is **unauthenticated** — it's meant to be hit by
+an external scheduler — so it defends itself three ways:
+
+1. **A non-blocking exclusive lock** (`acquire_cron_lock()`, a `flock` on
+   `<data_dir>/cron.lock`). Nothing stops a burst of concurrent requests, and
+   the rate-limit watermark below is only written *after* all work completes —
+   so without the lock every request in a burst reads the same stale watermark,
+   passes the "too often" check, and runs in parallel, multiplying outbound HTTP
+   and risking duplicate ingestion (no unique constraint on `feeditem_uuid`) and
+   duplicate webmention sends (no atomic claim on a queued row). The lock
+   releases when the request ends, so every exit path must `die()`/`exit()`
+   rather than return. Failure to *open* the lock file is kept distinct from
+   contention: a broken/mislocated lock file is a 500, not "already running" —
+   reporting it as contention once silently stopped every cron run while the
+   endpoint kept answering "try again later".
+2. **A whole-run gate** of one run per minute (`cron_run_due()`).
+3. **A per-feed gate** of one fetch per 30 minutes (`feed_fetch_due()`), keyed on
+   the last **attempt**, not the last success — so a failing feed is retried on
+   schedule instead of locked out, and a healthy one isn't re-fetched early.
+
+## The watermark model (the crux)
+
+Three timestamps on the `feedstatus` bean do three different jobs. Conflating
+them is what caused both the "dropped items" and "recreated draft" bugs, so keep
+them distinct:
+
+| Field | Question it answers | Used by |
+|-------|--------------------|---------|
+| `last_attempt` | When did we last *try* to reach the host? | the per-feed rate-limit gate |
+| `last_success` | When did we last *reach* the host? | crawl health only (Logs tab) |
+| `last_item_date` | How new is the newest entry we've *seen*? | the create/skip decision |
+
+Two rules follow, and both matter:
+
+- **`last_attempt` is stamped *before* the fetch** (`begin_crawl()`), persisted
+  immediately. If it were left to the success/failure recorders, a fetch that
+  never returns (OOM on a hostile body, `max_execution_time`, a parser fatal)
+  would leave `last_attempt` untouched, the feed would still be due next run,
+  and `/_cron` would die at the same feed every time — taking down everything
+  downstream of the feed loop with it (remaining feeds, WebSub pings, the entire
+  outbound webmention queue). One row-write per crawl turns "cron wedged
+  forever" into "one lost run per 30-minute window".
+
+- **Every date comparison is against something the *feed* said, never the
+  clock** (`ingest_item()`):
+  - A **new** item (no post with its `feeditem_uuid`) is created only when its
+    publish date is newer than `last_item_date`. That mark exists solely to stop
+    an entry still sitting in the feed window from resurrecting a post the author
+    trashed. It used to be the *crawl* timestamp, which silently dropped items:
+    any crawl that succeeded without seeing the entry (CDN-stale feed, lagging
+    publisher) stamped `last_success = now`, and the entry's own date was by then
+    older than that stamp, so it was never created.
+  - An **existing** post is re-synced only when the item's modified date is newer
+    than the post's `updated` column (the copy we last took from the feed) **and**
+    `feed_locked` is false. `feed_locked` means the author took the post over via
+    the edit form, so a published, re-slugged post is left intact.
+
+- **`last_item_date` only ever moves forward** (`record_crawl_success()` takes a
+  `max`). A feed whose newest entry has scrolled out of its window, or that
+  briefly serves a truncated copy, must not lower it — or every older entry still
+  listed becomes eligible again. A run that **lost an entry to a failed write**
+  also reports no new watermark at all: `ingest_item()` returns `null` for a
+  create that should have happened but didn't, and `ingest_items()` then withholds
+  the date. Stepping the watermark over an entry the run failed to create would
+  drop it below the create line for good — the same drop-forever bug by another
+  route. Holding the watermark for one run re-creates nothing that did land, since
+  every entry is deduped on `feeditem_uuid`.
+
+Dedup key throughout: `feeditem_uuid = md5(feed_name . item_id)`.
+
+## Two source types, one spine
+
+`crawl_feed()` dispatches by URL: a `.json` path goes to the JSON Feed parser,
+everything else to SimplePie (the default path — most feeds are RSS/Atom).
+
+The two paths deliberately **share** `begin_crawl()`, `record_crawl_success()`,
+`record_crawl_failure()`, and `ingest_items()`, so they can't drift on which
+watermark they read or how they record health — the exact divergence this shape
+is prone to. `JsonFeedItem` (in `json_feed.php`) adapts a JSON Feed item to the
+subset of SimplePie's `snake_case` `Item` API that the ingest pipeline uses, so a
+JSON item flows through `ingest_item()` / `create_item()` / `populate_bean()`
+unchanged. Dateless items return `null` (as SimplePie does) and are not ingested —
+we match RSS/Atom rather than invent a date.
+
+## Fetch hardening
+
+Feed URLs are admin-configured (trusted at add-time), but nothing pins their
+*eventual* destination — a compromised host or a redirect could point the
+unauthenticated cron worker at internal/loopback addresses or an endless body.
+Both fetch paths defend against this on **every redirect hop**:
+
+- **SSRF pinning.** `SafeFile` (SimplePie's fetch class, subclassed) refuses a
+  request whose host doesn't resolve to a public address, and pins curl to the
+  exact validated address via `CURLOPT_RESOLVE` (keeping the original hostname
+  for `Host:`, SNI, and cert verification). Validating the URL and then letting
+  curl do its own DNS lookup is a DNS-rebinding TOCTOU; the pin closes it. That
+  only works through curl, so a forced-`fsockopen` request (no `CURLOPT_RESOLVE`
+  equivalent) is refused rather than left unpinned. SimplePie follows redirects
+  by recursively re-entering the constructor, so the check runs per hop. The
+  JSON path uses `Http\fetch_guarded()`, which re-checks each hop the same way.
+- **Body cap** (`FEED_FETCH_MAX_BYTES`, `SafeFile::capBodyCurlOptions()`). Without
+  a cap a feed can stream an endless body into the worker until it fatals.
+  SimplePie reads the body out of `curl_exec()`'s return value, so a
+  `WRITEFUNCTION` (what `fetch_guarded()` uses) would lose it; instead the cap is
+  enforced with `CURLOPT_ENCODING: identity` (an uncompressed body, so the cap
+  bounds real bytes and not a gzip bomb's compressed size), `CURLOPT_MAXFILESIZE`
+  (rejects an over-cap declared `Content-Length` up front), and a progress
+  callback (catches chunked/undeclared-length bodies; aborting surfaces as a
+  fetch error, so the success watermark is left alone exactly as for a timeout).
+- **Timeout** (`FEED_FETCH_TIMEOUT`) so a slow or hostile feed can't stall the run.
+
+`FEED_FETCH_TIMEOUT` / `FEED_FETCH_MAX_BYTES` / `FEED_FETCH_INTERVAL` are defined
+in `constants.php`.
+
+## Untrusted content → front matter
+
+A feed item's title is remote and untrusted, and it ends up inside a post's YAML
+front matter (delimited by `---`). `sanitize_feed_title()` collapses whitespace,
+shortens `---` runs, and length-caps it so a title can't inject extra keys or
+close the block early; `get_structured_content()` then renders the block with
+`Yaml::dump()` (via `Post\build_matter()`) rather than string interpolation.
+Interpolation let the feed choose the YAML *type* of its own title — `[a, b]`
+arrived as a list, `2024-01-02` as a date object — and the run died on the first
+such item. Dumping always quotes the scalar back to text.
+
+## `feedstatus` bean
+
+Config is the source of truth for *which* feeds exist; `feedstatus` records only
+crawl *health*, keyed by `md5(name . url)`. Beans are created lazily
+(`feed_status_bean()`), seed their success watermark from any legacy
+`last_processed_date_<key>` option so upgraded installs don't re-ingest
+everything on the first run, and are pruned when their feed leaves config
+(`prune_feed_status()`). `get_feed_statuses()` returns a zeroed row for
+never-crawled feeds so the Logs tab lists them too.

--- a/src/network/ingest.php
+++ b/src/network/ingest.php
@@ -14,28 +14,12 @@ use function Lamb\Post\populate_bean;
 
 /**
  * Decides whether a single feed item is created, updated, or skipped, keyed on
- * its `feeditem_uuid` rather than dates alone.
- *
- * Deduplication lives here: an item that already has a post is never recreated
- * (the source of the recreated-draft bug when a feed re-stamps an item's
- * publication date past the watermark).
- *
- * Both remaining date comparisons are against something the *feed* said, never
- * against the clock:
- *
- * - A brand-new item is created when its publication date is newer than the
- *   newest entry this feed has ever offered us (`feedstatus.last_item_date`).
- *   That mark exists only to stop an entry still sitting in the feed window
- *   from resurrecting a post the author trashed and /_cron later purged. It
- *   used to be the *crawl* timestamp, which quietly dropped items for good: any
- *   crawl that succeeded without seeing the entry — a cached or CDN-stale copy
- *   of the feed, a feed that publishes with a lag — still stamped
- *   `last_success = now`, and the entry's own publication date was by then
- *   older than that stamp, so it was never created and never would be.
- * - An already-ingested post is re-synced only when the item was modified after
- *   the copy we stored (its `updated` column, which update_item() stamps from
- *   the item) AND the author has not taken the post over via the edit form
- *   (`feed_locked`) — so a published, re-slugged post is left intact.
+ * its `feeditem_uuid` so an item that already has a post is never recreated.
+ * Every date comparison is against something the feed said, never the clock:
+ * a new item is created only when it is newer than the ingestion watermark, an
+ * existing post re-synced only when the feed's copy is newer than ours and the
+ * author has not taken it over (`feed_locked`). See network/README.md
+ * ("The watermark model").
  *
  * @param SimplePieItem|JsonFeedItem $item      The feed item.
  * @param string        $name      Feed name from config.
@@ -76,20 +60,10 @@ function ingest_item(SimplePieItem|JsonFeedItem $item, string $name, int $waterm
 
 /**
  * Runs a crawled feed's entries through ingest_item() against that feed's
- * ingestion watermark, and reports what the run should record.
- *
- * Shared by the SimplePie and JSON Feed crawls so the two cannot drift on which
- * watermark they read — the divergence this pattern is prone to, and the reason
- * the pair already share begin_crawl()/record_crawl_*().
- *
- * A run that failed to create an entry reports no new watermark at all.
- * record_crawl_success() only ever raises the watermark, and an entry at or
- * below it is never created — so advancing past an entry the run lost would put
- * it permanently under the line that decides whether to create it, dropping it
- * for good. That is the same failure the watermark was introduced to prevent,
- * arriving by a different route. Holding the watermark for one run costs
- * nothing: every entry is deduped on feeditem_uuid, so the ones that did land
- * are not created a second time.
+ * ingestion watermark, and reports what the run should record. Shared by both
+ * crawl paths so they cannot drift on which watermark they read. A run that lost
+ * an entry to a failed write reports no new watermark, so the watermark is never
+ * stepped over a lost entry. See network/README.md ("The watermark model").
  *
  * @param array<array-key, SimplePieItem|JsonFeedItem> $items  The feed's entries.
  * @param string   $name   Feed name from config.
@@ -186,29 +160,20 @@ function get_structured_content(SimplePieItem|JsonFeedItem $item, string $name):
     $contents = attributed_content($item, $name);
     $title = sanitize_feed_title($item->get_title() ?? '');
     if (!empty($title)) {
-        // build_matter() (i.e. Yaml::dump) rather than interpolating the title
-        // into a heredoc. Interpolation let the remote feed choose the YAML
-        // *type* of its own title: `[a, b]` arrived as a list and `2024-01-02`
-        // as a date object, neither of which is a string, and the ingest run
-        // died on the first such item. Dumping quotes the scalar so a title is
-        // always read back as the text the feed sent.
+        // Dump via build_matter() (Yaml::dump), never string interpolation: a
+        // feed could otherwise choose its title's YAML type and crash the run.
+        // See network/README.md ("Untrusted content → front matter").
         $contents = build_matter(['title' => $title], "\n" . $contents);
     }
     return $contents;
 }
 
 /**
- * Sanitises a remote feed title before it is embedded in a post's YAML front matter.
- *
- * Front matter is delimited by `---` and parsed as YAML, so an untrusted title
- * containing newlines could inject extra keys (e.g. `slug`, `created`) and a `---`
- * sequence could close the block early. Whitespace is collapsed to single spaces,
- * any run of three or more hyphens is shortened, and the result is length-capped.
- *
- * Quoting and escaping are no longer done here: get_structured_content() now
- * renders the block with Yaml::dump(), which quotes the scalar correctly for
- * whatever it contains. The previous addslashes() left a literal backslash in
- * front of every apostrophe in the stored title.
+ * Sanitises a remote feed title before it is embedded in a post's YAML front
+ * matter: collapses whitespace, shortens `---` runs, and length-caps it so an
+ * untrusted title cannot inject keys or close the block early. Quoting is left to
+ * Yaml::dump() in get_structured_content(). See network/README.md
+ * ("Untrusted content → front matter").
  *
  * @param string $title The raw feed item title.
  * @return string A single-line, length-capped title safe for front matter.

--- a/src/network/json_feed.php
+++ b/src/network/json_feed.php
@@ -69,13 +69,10 @@ function parse_json_feed(string $json): ?array
 }
 
 /**
- * Fetches and ingests a JSON Feed source, recording the outcome on its
- * feedstatus bean — the JSON Feed counterpart of record_feed_crawl().
- *
- * Mirrors the SimplePie path: a failed fetch or a body that is not a JSON Feed
- * stamps the error without advancing the success watermark; on success, entries
- * newer than the newest one this feed has offered before are created/updated and
- * that ingestion watermark is raised.
+ * Fetches and ingests a JSON Feed source, recording the outcome on its feedstatus
+ * bean — the JSON Feed counterpart of record_feed_crawl(), sharing the same
+ * begin_crawl()/record_crawl_*() spine so the two paths cannot drift. See
+ * network/README.md ("Two source types, one spine").
  *
  * @param string $name Feed name from config.
  * @param string $url  Feed URL from config.
@@ -85,9 +82,8 @@ function record_json_feed_crawl(string $name, string $url): array
 {
     [$status, $now] = begin_crawl($name, $url);
 
-    // A configured feed URL is admin-trusted, but nothing pins where it (or a
-    // redirect from it) actually points — fetch_guarded() re-checks the
-    // destination is a public, non-internal address on every hop.
+    // fetch_guarded() re-checks the destination is public on every hop: a
+    // configured URL is trusted, a redirect from it is not. See README.
     $response = fetch_guarded($url, [
         'timeout' => FEED_FETCH_TIMEOUT,
         'max_bytes' => FEED_FETCH_MAX_BYTES,

--- a/src/network/sources.php
+++ b/src/network/sources.php
@@ -23,27 +23,13 @@ function get_feeds(): array
 }
 
 /**
- * SimplePie's remote-fetch class, hardened against SSRF: refuses to make a
- * request when the destination doesn't resolve to a public address, and pins
- * the curl connection to the exact address that was validated.
+ * SimplePie's remote-fetch class, subclassed to harden feed fetches against
+ * SSRF and oversized bodies. SimplePie follows a redirect by recursively
+ * re-entering this constructor (PHP dispatches `$this->__construct()`
+ * virtually), so the guards below run on every hop, not just the initial URL.
  *
- * A feed URL is admin-configured (trusted at add-time), but nothing pins its
- * *eventual* destination — if the feed host is later compromised, or simply
- * issues a redirect, the cron job would otherwise fetch wherever it points,
- * including internal/loopback addresses. SimplePie\File follows redirects by
- * recursively calling `$this->__construct()` on each hop (see its
- * constructor), which — since PHP dispatches `$this->__construct()`
- * virtually — re-enters *this* subclass's override on every hop, so each
- * redirect target is checked, not just the initial URL.
- *
- * Checking the URL and then letting curl make its own, independent DNS
- * lookup is itself a DNS-rebinding TOCTOU — the address curl connects to
- * could differ from the one just validated. `CURLOPT_RESOLVE` closes that:
- * it pins curl to a chosen address for a given host:port while still using
- * the original hostname for the `Host:` header, SNI, and certificate
- * verification. That only works through curl, so a request forced through
- * `fsockopen` (which has no equivalent) is refused rather than left
- * unpinned.
+ * See network/README.md ("Fetch hardening") for the SSRF-pinning and body-cap
+ * model this implements.
  */
 class SafeFile extends SimplePieFile
 {
@@ -78,41 +64,20 @@ class SafeFile extends SimplePieFile
     }
 
     /**
-     * Merges FEED_FETCH_MAX_BYTES enforcement into a feed fetch's curl options.
+     * Caps a feed fetch at $max_bytes without changing how SimplePie receives
+     * the body. SimplePie reads the response from curl_exec()'s return value, so
+     * a CURLOPT_WRITEFUNCTION cap (the fetch_guarded() approach) would lose it;
+     * these three options bound the transfer instead. Each guards its own line:
      *
-     * FEED_FETCH_MAX_BYTES exists because /_cron is unauthenticated: without a
-     * cap, a configured feed's host (or anything it redirects to) can stream an
-     * endless body into the worker's memory until it fatals. The JSON Feed
-     * crawl passes the constant to fetch_guarded(), which enforces it in a
-     * CURLOPT_WRITEFUNCTION; the RSS/Atom crawl had no cap at all, and it is
-     * the default path — every feed URL that does not end in `.json` takes it.
+     * - `CURLOPT_ENCODING: identity` forces an uncompressed body, so the cap
+     *   bounds real bytes — over a compressed transfer it would bound only the
+     *   *compressed* size and a gzip bomb would expand past it unseen.
+     * - `CURLOPT_MAXFILESIZE` refuses an over-cap declared Content-Length up front.
+     * - the progress callback catches a chunked/undeclared-length body; aborting
+     *   surfaces as a fetch error, so the success watermark is left alone.
      *
-     * fetch_guarded()'s approach is not available here: SimplePie reads the
-     * response out of curl_exec()'s return value (CURLOPT_RETURNTRANSFER), and
-     * installing a write callback makes curl_exec() return `true` instead, so
-     * the body would be lost. These three options cap the transfer without
-     * touching how the body is delivered:
-     *
-     * - `CURLOPT_ENCODING: identity` asks for an uncompressed body. SimplePie
-     *   requests compression (`CURLOPT_ENCODING: ''`), and curl's byte counters
-     *   report on-the-wire bytes — so a cap over a compressed transfer bounds
-     *   the *compressed* size only, while curl expands the body into the
-     *   response string as it arrives. A few megabytes of gzipped zeros expand
-     *   to gigabytes there before any cap could see them. fetch_guarded() sends
-     *   no Accept-Encoding at all for the same reason, which is what makes its
-     *   cap exact; this matches it.
-     * - `CURLOPT_MAXFILESIZE` refuses a body whose declared Content-Length is
-     *   already over the cap, before any of it is transferred.
-     * - the progress callback covers what MAXFILESIZE cannot: a chunked
-     *   response declares no length, and an endless body is precisely one that
-     *   never says how long it is. Returning non-zero aborts the transfer with
-     *   CURLE_ABORTED_BY_CALLBACK, which SimplePie surfaces as a fetch error —
-     *   so record_feed_crawl() logs it and leaves the success watermark alone,
-     *   exactly as it does for a timeout.
-     *
-     * Applied on every hop for the same reason the SSRF pin is: SimplePie
-     * follows a redirect by re-entering this constructor (see the class
-     * docblock), and it hands the recursion these same options.
+     * See network/README.md ("Fetch hardening"). Applied on every redirect hop
+     * (see the class docblock).
      *
      * @param array<int, mixed> $curl_options
      * @return array<int, mixed>
@@ -240,13 +205,10 @@ function init_simplepie_feed(string $url): SimplePie
 }
 
 /**
- * Crawls a single initialised feed and records the outcome on its feedstatus bean.
- *
- * A failed fetch (`!$feed->data` or a non-empty `$feed->error()`) does NOT advance the
- * success watermark — it only stamps `last_attempt` and records the error so the
- * Logs tab can surface it. On success, entries newer than the newest one this feed
- * has offered before are created or updated, that ingestion watermark is raised, the
- * item count is recorded and any prior error is cleared.
+ * Crawls a single initialised feed and records the outcome on its feedstatus bean:
+ * a failed fetch (`!$feed->data` or a non-empty `$feed->error()`) records the error
+ * without advancing the success watermark; a success ingests and raises it. See
+ * network/README.md ("The watermark model").
  *
  * @param string    $name Feed name from config.
  * @param string    $url  Feed URL from config.

--- a/src/network/status.php
+++ b/src/network/status.php
@@ -6,18 +6,12 @@ use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
 
 /**
- * Returns (creating if needed) the per-feed status bean keyed by md5(name . url) —
- * the same key the legacy `last_processed_date_*` option used.
- *
- * The bean records crawl *health*; config remains the source of truth for which
- * feeds exist. A freshly dispensed bean seeds its success watermark from any legacy
- * `last_processed_date_<key>` option so existing installs do not re-ingest (and
- * duplicate) every item on the first run after upgrade.
- *
- * `last_item_date` is the ingestion watermark (see ingest_item()); `last_success`
- * is only crawl health. They are separate because the first answers "how new is
- * the newest entry we have seen?" and the second "when did we last reach the
- * host?" — conflating them is what silently dropped items.
+ * Returns (creating if needed) the per-feed status bean, keyed by md5(name . url).
+ * Records crawl *health* only — config stays the source of truth for which feeds
+ * exist. A fresh bean seeds its success watermark from any legacy
+ * `last_processed_date_<key>` option so an upgraded install does not re-ingest
+ * everything on the first run. See network/README.md ("The watermark model",
+ * "feedstatus bean") for why the three timestamps are kept apart.
  *
  * @param string $name Feed name from config.
  * @param string $url  Feed URL from config.
@@ -44,25 +38,13 @@ function feed_status_bean(string $name, string $url): OODBBean
 }
 
 /**
- * Opens a crawl: loads the feed's status bean and stamps the attempt timestamp.
- *
- * Every source type records an *attempt* before it fetches, so a feed that keeps
- * failing is still rate-limited by /_cron's 30-minute per-feed window (that window
- * is gated on `last_attempt`, not `last_success`).
- *
- * The stamp is *persisted* here rather than left for
- * record_crawl_success()/record_crawl_failure(), because those only run when the
- * fetch returns. A fetch that never returns — the worker OOMs on a hostile feed
- * body, hits max_execution_time, or fatals in the parser — left `last_attempt`
- * untouched on disk, so the feed was still due on the next run and /_cron died at
- * the same feed every time. Everything after it in process_feeds() is downstream
- * of that loop: the remaining feeds, the WebSub pings for newly published
- * scheduled posts, and the entire outbound webmention queue never ran again.
- * Writing the attempt before the fetch costs one row write per crawl and turns
- * that into one lost run per 30-minute window.
- *
- * The bean is returned so record_crawl_success()/record_crawl_failure() can store
- * the outcome on it; they overwrite this row rather than insert a second one.
+ * Opens a crawl: loads the feed's status bean and *persists* the attempt
+ * timestamp before the fetch. Stamping it here, not in the outcome recorders
+ * (which only run if the fetch returns), is what stops a fetch that never
+ * returns — OOM on a hostile body, max_execution_time, a parser fatal — from
+ * leaving the feed permanently due and wedging every later step of the run. The
+ * bean is returned for the recorders to overwrite. See network/README.md
+ * ("The run").
  *
  * @param string $name Feed name from config.
  * @param string $url  Feed URL from config.
@@ -100,11 +82,8 @@ function record_crawl_failure(OODBBean $status, int $now, string $message): arra
 
 /**
  * Records a successful crawl: stamps crawl health, counts items, clears any error,
- * and raises the ingestion watermark to the newest entry the feed offered.
- *
- * The watermark only ever moves forward. A feed whose newest entry has scrolled
- * out of its window (or that briefly serves a truncated copy) must not lower it,
- * or every older entry still listed becomes eligible for ingestion again.
+ * and raises the ingestion watermark (via `max`, so it only moves forward) to the
+ * newest entry the feed offered. See network/README.md ("The watermark model").
  *
  * @param OODBBean $status      The status bean from begin_crawl().
  * @param int      $now         The attempt timestamp from begin_crawl().


### PR DESCRIPTION
Prototype of the module-level developer-doc pattern discussed for Lamb: a per-subsystem `README.md` next to the code, with the subsystem narrative lifted out of per-function docblocks (which keep their contract + local *why* and point to it). First module: feed ingestion (`Lamb\Network`).

## What changed
- **New `src/network/README.md`** — the *why* for feed ingestion in one place: the `/_cron` lock + rate-limit model, the three-timestamp watermark model (incl. #656's lost-entry rule), the two-sources-one-spine design, SSRF/body-cap fetch hardening, and front-matter safety.
- **Thinned docblocks** across `network.php`, `network/{sources,ingest,json_feed,status}.php` — subsystem essays replaced by a one-line pointer to the README; `@param`/`@return`/`@throws` and the load-bearing local *why* stay on the symbol.
- **Steering reconciled** so it matches (and doesn't contradict) the change:
  - `AGENTS.md` §Comments — was "docblocks are deliberately expansive"; now describes the paragraph→README+pointer split.
  - `DECISIONS.md` — new `2026-08-21` entry recording the `src/<module>/README.md` tier as an extension of the `2026-05-29` root-level-docs decision.

## Notes
- **No behaviour change.** Net −184 lines of docblock prose, +159 README.
- Rebased onto current `main` (post-#656 watermark change and #657 JSON-shape check); the README's watermark section reflects #656.
- Verified locally: `composer lint` clean, `composer analyse` (PHPStan) no errors, unit suite green (1929).
- Scoped deliberately to one module to judge the pattern before rolling it wider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)