### PR TITLE
Keep the YYYY/MM path shape the export and import gates match on

### DIFF
--- a/src/import.php
+++ b/src/import.php
@@ -368,7 +368,25 @@ function build_post_body(string $title, string $markdown_body, array $tags, stri
 
 /**
  * Returns the YYYY/MM subpath under src/assets/ for a post's created date.
- * Falls back to the current month when the date can't be parsed.
+ * Falls back to the current month when the date can't be used.
+ *
+ * `YYYY/MM` is not just a convention here — it is the shape both gates that
+ * read these paths match on. Restore\safe_entry_path() anchors `\d{4}/\d{2}`,
+ * and Export\referenced_assets() only picks up `/assets/\d{4}/\d{2}/…` out of a
+ * body. A year that does not render as four digits therefore produces a path
+ * the rest of the system cannot see:
+ *
+ * - `created: 0000-00-00` in front matter (what an older install, or a
+ *   MySQL-era row, hands you) parses to year -1, so a post exported to
+ *   `posts/-0001/11/<slug>.md` was refused by the importer as a "bad path" —
+ *   the post did not come back from its own backup.
+ * - Images for such a post downloaded into `src/assets/-0001/11/`, where
+ *   referenced_assets() cannot match them, so they were absent from every
+ *   export.
+ *
+ * Only the folder falls back; the date itself is untouched, and front matter
+ * and the manifest still carry it. That is the same trade this function
+ * already made for a date that does not parse at all.
  */
 function asset_dir_for_date(string $created): string
 {
@@ -376,7 +394,12 @@ function asset_dir_for_date(string $created): string
     if ($ts === false) {
         $ts = time();
     }
-    return date('Y/m', $ts);
+    $dir = date('Y/m', $ts);
+    if (preg_match('#^\d{4}/\d{2}$#D', $dir) !== 1) {
+        $dir = date('Y/m');
+    }
+
+    return $dir;
 }
 
 /**

--- a/tests/Unit/ExportTest.php
+++ b/tests/Unit/ExportTest.php
@@ -13,6 +13,7 @@ use function Lamb\Export\export_filename_stem;
 use function Lamb\Export\manifest_post_entry;
 use function Lamb\Export\post_export_path;
 use function Lamb\Export\referenced_assets;
+use function Lamb\Restore\safe_entry_path;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\split_frontmatter;
 
@@ -133,6 +134,42 @@ class ExportTest extends TestCase
 
         $this->assertSame('posts/2026/07/etc-passwd.md', $path);
         $this->assertStringNotContainsString('..', $path);
+    }
+
+    /**
+     * The layout is not decoration: Restore\safe_entry_path() anchors
+     * `posts/\d{4}/\d{2}/…`, so a path the exporter writes outside that shape is
+     * one the importer refuses — the post does not come back from its own
+     * backup. A `created` of `0000-00-00`, which an older install or a
+     * MySQL-era row hands you, parses to year -1 and used to produce
+     * `posts/-0001/11/…`.
+     *
+     * @dataProvider awkwardCreatedDateProvider
+     */
+    public function testEveryExportPathIsOneTheImporterAccepts(string $created): void
+    {
+        $taken = [];
+        $path = post_export_path($this->post(['created' => $created]), $taken);
+
+        $this->assertSame($path, safe_entry_path($path), $created . ' produced ' . $path);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function awkwardCreatedDateProvider(): array
+    {
+        return [
+            'ordinary'          => ['2026-07-14 09:30:00'],
+            'empty'             => [''],
+            'unparseable'       => ['not a date'],
+            'a zero date'       => ['0000-00-00'],
+            'a negative year'   => ['-0001-11-30 00:00:00'],
+            'year 0'            => ['0000-01-01 00:00:00'],
+            'a five-digit year' => ['10000-01-01 00:00:00'],
+            'last century'      => ['1900-01-01 00:00:00'],
+            'past 2038'         => ['2038-02-01 00:00:00'],
+        ];
     }
 
     public function testReferencedAssetsFindsRootRelativeAndAbsoluteUrls(): void

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -313,6 +313,13 @@ XML;
     {
         $this->assertSame('2024/03', asset_dir_for_date('2024-03-15 12:00:00'));
         $this->assertSame('2019/12', asset_dir_for_date('2019-12-01 00:00:00'));
+        // Both readers of these paths match on `\d{4}/\d{2}` exactly, so a year
+        // that is not four digits has to fall back to the current month the way
+        // an unparseable date already does. `0000-00-00` parses to year -1.
+        $this->assertMatchesRegularExpression('#^\d{4}/\d{2}$#', asset_dir_for_date('0000-00-00'));
+        $this->assertMatchesRegularExpression('#^\d{4}/\d{2}$#', asset_dir_for_date('-0001-11-30 00:00:00'));
+        $this->assertMatchesRegularExpression('#^\d{4}/\d{2}$#', asset_dir_for_date('not a date'));
+        $this->assertMatchesRegularExpression('#^\d{4}/\d{2}$#', asset_dir_for_date(''));
     }
 
     public function testParseWxrStringReturnsRssElement(): void


### PR DESCRIPTION
`asset_dir_for_date()` formats a post's created date with `date('Y/m')` and returns whatever comes out.

`YYYY/MM` is not just a navigability convention here — it is the shape both readers of these paths anchor on:

- `Restore\safe_entry_path()` matches `posts/\d{4}/\d{2}/…` and `assets/\d{4}/\d{2}/…`
- `Export\referenced_assets()` only picks up `/assets/\d{4}/\d{2}/…` out of a body

So a year that does not render as four digits produces a path the rest of the system cannot see.

## Reachable from ordinary front matter

`created: 0000-00-00` — what an older install, or a MySQL-era row, hands you — parses to year −1 and is stored as `-0001-11-30 00:00:00`:

```
front matter created: '0000-00-00'  ->  stored '-0001-11-30 00:00:00'
```

Running that post through the real export and the importer's gate:

```
                before                                  after
asset dir       -0001/11                                2026/08
exporter sees   NOTHING                                 2026/08/photo.webp
export path     posts/-0001/11/legacy-post.md           posts/2026/08/legacy-post.md
importer gate   REJECTED                                accepted
asset gate      REJECTED                                accepted
```

Two separate losses, both silent:

1. **The post does not come back from its own backup.** Its `.md` file is in the archive, but `safe_entry_path()` refuses the path, so the restore skips it as a `bad path`.
2. **Its images are in no backup at all.** `referenced_assets()` cannot match `/assets/-0001/11/…`, so they are never added to the archive in the first place.

## The change

Only the folder falls back; the date itself is untouched, and both the front matter and the manifest still carry it. That is exactly the trade this function already made for a date that does not parse at all — so the fix widens that existing fallback to cover a date that parses into a year the layout cannot express, rather than loosening the two gates to accept `-0001`.

One change covers both callers: the export path in `post_export_path()` and the download directory in the WordPress importer.

## Verification

`ExportTest` now pins the contract directly — every path `post_export_path()` emits has to be one `safe_entry_path()` accepts — across nine created dates: ordinary, empty, unparseable, the zero date, a negative year, year 0, a five-digit year, 1900 and 2038. Two of those fail against the previous code, along with the `asset_dir_for_date` shape assertion in `WordPressImportTest`. Real dates are asserted unchanged (`2024-03-15` → `2024/03`, `2019-12-01` → `2019/12`).

Found while sweeping `export.php` after #654 and #655.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_