### PR TITLE
docs(theme): add module README, thin subsystem essays from docblocks

### DIFF
--- a/src/theme.php
+++ b/src/theme.php
@@ -326,11 +326,8 @@ function link_source(OODBBean $bean): string
 
     $url = $bean->source_url ?? $feeds[$bean->feed_name] ?? '';
 
-    // escape() only encodes HTML metacharacters, not URL schemes: a
-    // `javascript:`-scheme URL passes through untouched into the href
-    // attribute. source_url is attacker-influenced (any subscribed feed's
-    // item permalink), so require a genuine http(s) URL before linking it,
-    // matching the scheme allowlist Parsedown's safe mode applies elsewhere.
+    // escape() doesn't cover URL schemes and source_url is feed-supplied. See
+    // theme/README.md ("Escaping is per-context, not per-file").
     if (!is_valid_http_url($url)) {
         return sprintf('Via %s', escape($bean->feed_name));
     }
@@ -354,11 +351,9 @@ function syndication_links(OODBBean $bean): string
     $targets = $config['syndicate_to'] ?? [];
     $links = [];
     foreach (preg_split('/\s+/', trim($raw)) ?: [] as $uid) {
-        // Same reasoning as link_source() above: escape() encodes HTML
-        // metacharacters, not URL schemes, so a `javascript:` target passed
-        // straight into the href. syndicated_to is not author-only — a Micropub
-        // client holding just `create` scope sets it via mp-syndicate-to — so
-        // require a real http(s) URL before linking it.
+        // Same reasoning as link_source() above: escape() doesn't cover URL
+        // schemes, and syndicated_to can be set by a Micropub client holding
+        // just `create` scope. See theme/README.md ("Escaping is per-context").
         if ($uid === '' || !is_valid_http_url($uid)) {
             continue;
         }

--- a/src/theme/README.md
+++ b/src/theme/README.md
@@ -1,0 +1,146 @@
+# Theme rendering (`Lamb\Theme`)
+
+Developer notes for the theme-rendering subsystem. This is the *why* behind
+the code in this directory; the per-function docblocks carry the contract
+(params, returns, invariants) and point here for the design. For the
+project-wide architecture, the full `$data`/`$config` reference, and the
+theme-authoring checklist see [AGENTS.md](../../AGENTS.md#theme-system--complete-reference).
+
+## Files
+
+All files declare the `Lamb\Theme` namespace (a split, not separate
+namespaces — a part calling `Theme\escape()` doesn't care which file it lives
+in):
+
+| File | Responsibility |
+|------|----------------|
+| `../theme.php` | Core rendering: part resolution, post/nav helpers, CSRF, admin toolbar |
+| `assets.php` | CSS/JS loading: inlining, minification, cache-busting |
+| `formatting.php` | Escaping, heading re-levelling, relative-time formatting |
+| `meta.php` | OpenGraph/Twitter/robots/preconnect `<meta>` tags |
+
+## Escaping is per-context, not per-file
+
+There are three escapers, and using the wrong one is the whole risk surface
+here:
+
+- `escape()` — `htmlspecialchars()` for HTML5 body/attribute output. Used on
+  every user-supplied value rendered into markup.
+- `og_escape()` — `htmlspecialchars_decode()` first, then re-encode. OpenGraph
+  and Twitter Card content is pulled from fields (`description`, `title`)
+  that may already carry entities from an earlier render pass; encoding
+  without decoding first double-escapes them (`&amp;amp;`).
+- The URL-scheme gap: `escape()` (and `og_escape()`) only encode HTML
+  metacharacters — neither touches a URL's *scheme*. `link_source()`,
+  `syndication_links()`, and `the_reply_context()` (`theme.php`,
+  `formatting.php`) each link a value that is not author-only —
+  `source_url` comes from a subscribed feed, `syndicated_to` and
+  `in_reply_to` can be set by a Micropub client holding only `create`
+  scope — so each calls `Http\is_valid_http_url()` before emitting an
+  `<a href>`, and falls back to plain escaped text for anything that isn't a
+  genuine `http(s)` URL. A `javascript:`-scheme value would otherwise reach
+  the page verbatim.
+
+## Part resolution is theme-optional by design
+
+`part()` lets a theme override only the files that differ from `base`: it
+tries `THEME_DIR . $dir . '/' . $name . '.php'` first and falls back to
+`src/themes/base/$dir/$name.php`. Every part in the render flow
+(`html.php` → `parts/<template>.php` → `parts/_items.php`) goes through this,
+so a minimal theme can ship nothing but a stylesheet — see AGENTS.md's
+["Minimal new theme
+checklist"](../../AGENTS.md#minimal-new-theme-checklist). `$name`/`$dir` are
+sanitised to `[a-zA-Z0-9-_]` (`sanitize_filename()`) before touching the
+filesystem, since `$name` reaches here as the raw `$template` value derived
+from the request URL.
+
+## Asset loading (`assets.php`)
+
+### Why CSS gets minified and inlined, but JS never does
+
+`the_styles()` inlines the active theme's stylesheet as a `<style>` tag when
+it's small enough — the render-blocking round-trip a `<link>` costs is the
+single biggest mobile PageSpeed hit for a one-file theme. `the_scripts()`
+never does this: scripts load `defer`, so they don't block first paint the
+way a render-blocking stylesheet does, and there's no equivalent win to buy.
+
+`minify_css()` is deliberately conservative — only whitespace and comments,
+nothing that touches CSS semantics. "Insignificant whitespace" is the whole
+difficulty: collapsing it blindly around `{}:;,>` also reaches inside quoted
+strings and `url()` tokens, where that whitespace is content
+(`content: "Note: hello"` → `content:"Note:hello"`, and worse, a selector
+like `[data-label="a > b"]` silently stops matching). String literals and
+`url()` tokens are split out with a capturing regex and copied through
+untouched; only the syntax between them is collapsed. No theme Lamb ships
+triggers this, but `the_styles()` inlines whichever theme the `theme` setting
+names, so a hand-written or third-party stylesheet is an input this has to
+survive.
+
+`rewrite_css_urls()` exists because inlining changes the CSS's frame of
+reference: a relative `url('fonts/x.woff2')` resolves against the
+*stylesheet's* directory when the CSS lives in an external file, but against
+the *page* URL once it's pasted into the HTML. Absolute, `data:`, and
+fragment URLs are left alone; only bare relative paths are rewritten against
+`$base_url`.
+
+### Cache-busting is content-addressed
+
+`asset_version()` hashes the file's *contents* (`md5_file`), not its URL or a
+build timestamp. A deploy that doesn't touch a given CSS/JS file leaves its
+`?ver=` hash unchanged, so returning visitors keep that file cached across
+deploys — only files that actually changed get invalidated. It falls back to
+hashing the URL for assets it can't read locally (e.g. a remote asset).
+
+### `asset_loader()`'s three-way key
+
+The `$assets` array passed to `asset_loader()` (see `the_scripts()`) is keyed
+by when a group should load: `''` always, `SESSION_LOGIN` only when the
+viewer is authenticated, and any other string only when it matches the
+current `$template`. This is how admin-only JS (`growing-input.js`,
+`confirm-delete.js`, …) stays off anonymous pages and how a page can carry
+JS scoped to just its own template (e.g. `search-highlight.js` on `search`)
+without a per-template loader function.
+
+## Heading re-levelling (`anchor_headings()`)
+
+Post bodies are stored at the author's literal Markdown heading levels —
+storage is theme-neutral, so the same body has to fit into whatever outline
+each theme wraps it in. A theme that renders the post title as `<h2>` passes
+`$top = 3`: the body's highest heading becomes `<h3>`, sitting directly under
+the title, and everything else shifts by the same signed amount (a body
+written deeper than `$top` is pulled up; one written shallower is pushed
+down). No level is skipped at the top of the body, which keeps the document
+outline in the order screen readers expect (WCAG heading order). Results
+clamp at `h6`; a body with no headings is returned unchanged.
+
+## OpenGraph image selection (`meta.php`)
+
+`og_image()` picks a social-card image in order of specificity: the first
+image embedded in the post body (so sharing a photo post previews that
+photo, and the Twitter card upgrades to `summary_large_image`), then a
+site-supplied `og-image.<ext>` dropped in the web root (the same
+user-replaceable convention as `favicon.png`/`logo.png`), then the shipped
+Lamb card as the final fallback. Width/height/type are only emitted when the
+image maps to a real, readable local file — an embedded or site image that
+doesn't resolve locally still gets a URL, just without the dimension hints,
+since a wrong guess is worse than no hint ("assume success, communicate
+failure").
+
+`og_local_path()` is the guard behind that resolution: an embedded image's
+`src` is whatever the post body's Markdown said, and the body is not always
+the author's — a subscribed feed's item description reaches here just as
+readily as a Micropub `create`-scope client's post, and both importers.
+`![](/../../etc/whatever.png)` would otherwise build a path straight out of
+the web root, so `og_local_path()` resolves against `ROOT_DIR` with
+`realpath()` containment (covering symlinks too) before `image_dimensions()`
+is allowed to `getimagesize()` it and publish the result into `og:image`
+meta tags for anyone to read. The containment root is `ROOT_DIR` rather than
+the narrower uploads tree, because the site-default and shipped fallback
+images legitimately live outside it.
+
+## Security notes that live in AGENTS.md, not here
+
+CSRF handling, session cookie hardening, and the login throttle are
+documented once in AGENTS.md's ["Security"](../../AGENTS.md#security)
+section — `csrf_token()` here is just the token accessor. Don't duplicate
+that material when touching this module; link to it instead.

--- a/src/theme/assets.php
+++ b/src/theme/assets.php
@@ -24,14 +24,10 @@ function the_styles(): void
 }
 
 /**
- * Builds the markup that loads the active theme's stylesheet.
- *
- * Small stylesheets are inlined as a <style> tag to remove the render-blocking
- * round-trip on first paint (the single biggest mobile PageSpeed win for a
- * one-file theme). Relative url() references are rewritten to absolute so they
- * still resolve once the CSS lives in the HTML rather than at styles/styles.css.
- * Anything larger than $max_bytes, or an unreadable file, falls back to an
- * external <link> with a content-hash cache-buster.
+ * Builds the markup that loads the active theme's stylesheet: inlined as a
+ * <style> tag when small enough, otherwise an external <link> with a
+ * content-hash cache-buster. See theme/README.md ("Why CSS gets minified and
+ * inlined, but JS never does").
  *
  * @param string $css_path  Absolute filesystem path to the stylesheet.
  * @param string $css_url   Public URL of the stylesheet (fallback <link> href).
@@ -57,10 +53,9 @@ function styles_markup(string $css_path, string $css_url, string $base_url, int 
 
 /**
  * Rewrites relative url() references in CSS to absolute URLs against $base_url.
- *
- * Needed when CSS is inlined into the HTML document: a relative url('fonts/x.woff2')
- * would otherwise resolve against the page URL instead of the stylesheet's directory.
  * Absolute (http(s):, //, /), data: and fragment (#) URLs are left untouched.
+ * See theme/README.md ("Why CSS gets minified and inlined, but JS never
+ * does") for why this matters once the CSS is inlined into the HTML document.
  *
  * @param string $css      The stylesheet contents.
  * @param string $base_url Absolute URL of the stylesheet's directory (trailing slash).
@@ -82,19 +77,12 @@ function rewrite_css_urls(string $css, string $base_url): string
 }
 
 /**
- * Minifies CSS for inlining: strips comments and collapses insignificant whitespace.
- *
- * Conservative by design — it only touches whitespace and comments. "Insignificant"
- * is the whole difficulty: collapsing whitespace around `{}:;,>` across the entire
- * stylesheet also reached inside quoted strings and url() tokens, where that
- * whitespace is content. `content: "Note: hello"` became `content:"Note:hello"`,
- * and `[data-label="a > b"]` became `[data-label="a>b"]` — a selector that no
- * longer matches the element, so the rule silently stopped applying.
- *
- * No theme Lamb ships triggers it, but the_styles() inlines whichever theme the
- * `theme` setting names, so a hand-written or third-party stylesheet is an input
- * this has to survive. String literals and url() tokens are therefore split out
- * and copied through untouched, and only the CSS syntax between them is collapsed.
+ * Minifies CSS for inlining: strips comments and collapses insignificant
+ * whitespace. Deliberately conservative — string literals and url() tokens
+ * are split out and copied through untouched, since whitespace inside them
+ * is content rather than syntax. See theme/README.md ("Why CSS gets
+ * minified and inlined, but JS never does") for the concrete cases this
+ * protects.
  *
  * @param string $css The stylesheet contents.
  * @return string Minified CSS.
@@ -152,12 +140,10 @@ function the_scripts(): void
 }
 
 /**
- * Computes a content-addressed cache-busting version for an asset.
- *
- * Hashing the file contents (not the URL) means the version only changes when the
- * file actually changes, so a deploy invalidates stale browser/CDN copies while
- * returning visitors keep their cache across deploys that leave the file untouched.
- * Falls back to hashing the URL when the file cannot be read (e.g. a remote asset).
+ * Computes a content-addressed cache-busting version for an asset: hashes the
+ * file contents, falling back to hashing the URL when the file can't be read
+ * (e.g. a remote asset). See theme/README.md ("Cache-busting is
+ * content-addressed").
  *
  * @param string $local_path Absolute filesystem path to the asset.
  * @param string $href       The public URL of the asset (used as a fallback).
@@ -178,6 +164,9 @@ function asset_version(string $local_path, string $href): string
  * - ''          always loaded
  * - 'logged_in' loaded only when the user is authenticated
  * - any other string is matched against the current $template
+ *
+ * See theme/README.md ("asset_loader()'s three-way key") for why the loaders
+ * are split this way.
  *
  * @param array<string, list<string>> $assets Associative array: key = subdirectory condition, value = array of filenames.
  * @param string $asset_dir Base directory for the assets.

--- a/src/theme/formatting.php
+++ b/src/theme/formatting.php
@@ -17,18 +17,10 @@ function escape(string $html): string
 
 /**
  * Re-levels a post body's headings so its highest heading sits at $top, keeping
- * the levels relative to each other.
- *
- * Post bodies are stored at the author's literal heading levels (theme-neutral),
- * so each theme fits them into its own outline at render time. A theme that
- * renders the post title at h2 passes $top = 3, so the body's highest heading
- * becomes h3 (directly under the title) and the rest shift by the same amount —
- * the level the author actually typed is immaterial, and no level is skipped at
- * the top of the body, which keeps the document outline in order for screen
- * readers (WCAG heading-order). The shift is signed: a body written deeper than
- * $top is pulled up just as one written shallower is pushed down. Results clamp
- * at h6. Open and close tags shift identically, attributes are preserved, and a
- * body with no headings is returned unchanged.
+ * the levels relative to each other. Open and close tags shift identically,
+ * attributes are preserved, and a body with no headings is returned unchanged.
+ * See theme/README.md ("Heading re-levelling") for why the shift is signed and
+ * why no level is skipped at the top of the body.
  *
  * @param string $html The post body HTML, at the author's literal levels.
  * @param int    $top  The level the body's highest heading should occupy.
@@ -59,21 +51,16 @@ function anchor_headings(string $html, int $top): string
 
 
 /**
- * Render the reply-context line for a post that is a reply to another URL.
+ * Renders the reply-context line for a post that is a reply to another URL,
+ * or '' when the post has no `in_reply_to` target. The link carries the
+ * `u-in-reply-to` microformats2 class so Webmention receivers categorise the
+ * mention as a reply.
  *
- * Returns an empty string when the post has no `in_reply_to` target. The link
- * carries the `u-in-reply-to` microformats2 class so Webmention receivers
- * categorise the mention as a reply.
- *
- * The same guard link_source() and syndication_links() already apply: escape()
- * encodes HTML metacharacters, not URL schemes, so a `javascript:` target went
- * into the href untouched. `in_reply_to` is not author-only — a Micropub client
- * holding just `create` scope sets it, and replyTargetUrl() only unwraps the
- * value, it does not validate it — and this markup is served on every page
- * listing the post *and* inside the Atom and JSON feeds' content_html. A target
- * that is not a real http(s) URL is shown as text instead of being linked: it
- * cannot be a webmention target either (enqueue_outbound() filters on the same
- * predicate), so there is nothing for the anchor to mean.
+ * `in_reply_to` is not author-only (a Micropub client holding just `create`
+ * scope can set it) and this markup is also served inside the Atom/JSON
+ * feeds' content_html, so a target that isn't a genuine http(s) URL is shown
+ * as text rather than linked. See theme/README.md ("Escaping is per-context,
+ * not per-file").
  *
  * @param \RedBeanPHP\OODBBean $bean
  * @return string

--- a/src/theme/meta.php
+++ b/src/theme/meta.php
@@ -67,16 +67,9 @@ function the_opengraph(): void
 }
 
 /**
- * Resolves the OpenGraph/Twitter card image for a status post.
- *
- * Selection order, most specific first:
- *   1. the first image embedded in the post body — so sharing a photo/screenshot post
- *      previews that image (twitter:card upgrades to summary_large_image);
- *   2. a site default dropped in the web root as og-image.<ext>, user-replaceable in the
- *      same spirit as the favicon.png / logo.png feed convention;
- *   3. the shipped Lamb card.
- *
- * Width/height/type are emitted only when the image maps to a readable local file.
+ * Resolves the OpenGraph/Twitter card image for a status post. See
+ * theme/README.md ("OpenGraph image selection") for the fallback order and
+ * why dimensions are only emitted for a locally-resolvable image.
  *
  * @param \RedBeanPHP\OODBBean $bean
  * @return array{url:string, card:string, width?:string, height?:string, type?:string}
@@ -154,21 +147,12 @@ function image_dimensions(string $url): array
  * remote URL (which can't be measured locally) and for anything that resolves
  * outside the web root.
  *
- * The URL is the `src` of the first `<img>` in a post's rendered body, so it is
- * whatever the Markdown said — and the body is not always the author's: a
- * subscribed feed's item description reaches here (strip_tags() removes HTML
- * tags but leaves Markdown `![](…)` for Parsedown to render), as does a
- * Micropub client holding only `create` scope, and both importers. `![](/../..
- * /etc/whatever.png)` therefore built a path straight out of the web root, and
- * image_dimensions() published whether it exists — plus its pixel size and MIME
- * type — into the page's og:image meta tags for anyone to read.
- *
- * Response\asset_dimensions() already resolves the same class of body-supplied
- * `src` and documents why: "Post bodies are hand-written Markdown, so
- * /assets/../../etc/passwd … is reachable input; realpath() containment rejects
- * it, and covers symlinks out of the tree too." The containment here is against
- * ROOT_DIR rather than src/assets/, because the site default (og-image.png) and
- * the shipped card both legitimately live outside the uploads tree.
+ * The URL is body-supplied (post Markdown, including feed items and
+ * `create`-scope Micropub posts), so `realpath()` containment against
+ * ROOT_DIR — the same defence `Response\asset_dimensions()` applies — guards
+ * against a path built straight out of the web root. See theme/README.md
+ * ("OpenGraph image selection") for why the containment root is ROOT_DIR
+ * rather than the narrower uploads tree.
  *
  * @param string $url Image URL.
  * @return string|null The resolved path inside ROOT_DIR, or null.


### PR DESCRIPTION
## Summary
- Applies the module-README documentation pattern shipped for `network` (#658) to the `theme` module: adds `src/theme/README.md` capturing the subsystem narrative (escaping-per-context model, part resolution, CSS inlining/minification/cache-busting rationale, heading re-levelling, OpenGraph image selection), cross-linking `AGENTS.md` instead of duplicating it.
- Trims the corresponding per-function docblocks/comments in `src/theme.php`, `src/theme/assets.php`, `src/theme/formatting.php`, and `src/theme/meta.php`: multi-paragraph subsystem rationale moves to the README behind a one-line pointer; `@param`/`@return`/`@throws` contracts and function-local "why" notes (e.g. the microformats2 purpose in `the_reply_context()`, the security-boundary note in `og_local_path()`) are kept in place.
- No behaviour change — comments and docs only.

## Verification
- `composer lint` — clean, no violations
- `composer analyse` (PHPStan) — `[OK] No errors`
- `vendor/bin/codecept run Unit` — 1935 tests, 3519 assertions, 2 skipped (pre-existing, unrelated)

## Judgment calls
- `asset_loader()`'s existing enumeration of its three key conditions (`''`, `'logged_in'`, template-matched) stayed in the docblock rather than moving wholesale to the README, since it's part of the parameter contract needed to call the function correctly — the README section adds the "why" (admin-JS gating, per-template scripts) alongside a pointer back.
- `og_local_path()` and the escaping-related comments (`link_source()`, `syndication_links()`, `the_reply_context()`) are security-relevant, so I kept a short local restatement of the invariant at the call site (matching how the network module's `SafeFile` docblocks were trimmed but not stripped bare) rather than reducing them to a bare pointer.
- `image_dimensions()`'s docblock was already short and contract-sized; left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)