### PR TITLE
docs(response): add module README, thin subsystem essays from docblocks

### DIFF
--- a/src/response.php
+++ b/src/response.php
@@ -62,10 +62,9 @@ function latest_content_timestamp(): int
  *
  * No-ops when there is no content timestamp. Callers must only use this for
  * cacheable (anonymous, non-error) GET/HEAD responses, before any output.
- *
- * Last-Modified is the second-resolution max() of the two timestamps (the only
- * resolution HTTP-date supports), while the ETag keeps them distinct so a config
- * edit in the same second as the latest post still invalidates caches (#279).
+ * Validator model (why the ETag and Last-Modified diverge, #279): see
+ * response/README.md ("Conditional GET, ETag, and 304 caching") and
+ * AGENTS.md's Security section.
  *
  * @param int $contentTs Unix timestamp of the most recent content change.
  * @param int $configTs  Unix timestamp of the last config edit.

--- a/src/response/README.md
+++ b/src/response/README.md
@@ -1,0 +1,217 @@
+# Routing and responses (`Lamb\Response`)
+
+Developer notes for how a request becomes a response. This is the *why* behind
+the code in this directory; the per-function docblocks carry the contract
+(params, returns, invariants) and point here for the design. For routing,
+pagination, conditional-GET/caching and the security invariants this module
+must not break, see [AGENTS.md](../../AGENTS.md) — this README does not
+restate that material, only extends it with the parts specific to this
+directory.
+
+## Files
+
+All files declare the `Lamb\Response` namespace (a split, not separate
+namespaces — callers don't care which file a function lives in):
+
+| File | Responsibility |
+|------|----------------|
+| `../response.php` | Namespace entry: cookie options, pagination core, conditional-GET/304, 404/redirect helpers, `upgrade_posts()` |
+| `auth.php` | `/login`, `/logout`, `/settings`: the sessionless login page, its CSRF model, and the brute-force throttle |
+| `discovery.php` | `/sitemap.xml`, `/robots.txt`, and the noindex marker they share with the theme |
+| `export.php` | `/export` download (login required) |
+| `feeds.php` | Home, drafts/trash/scheduled listings, search, tag pages, the Atom and JSON feeds |
+| `posts.php` | Status/slug pages, create/edit/delete/restore, the checkbox-toggle endpoint |
+| `upload.php` | Image upload, content-type checks, and WebP conversion |
+
+Routes are registered centrally in `Lamb\Route\register_app_routes()`
+(`src/routes.php`); this module supplies the callbacks.
+
+## Two responder shapes
+
+A `respond_*` function returns a view-data array for the theme to render; a
+`redirect_*` function sends a `Location` header and terminates
+(`redirect_uri()`/`#[NoReturn]`) — it never returns to the router. A few
+functions do both depending on the request: `respond_edit()` and
+`respond_home()` check `$_POST` first and dispatch to a `redirect_*` sibling
+(`redirect_edited()`, `redirect_created()`) before falling through to their
+own `respond_*` behaviour. Keeping the naming consistent lets a reader tell,
+from the route table alone, whether a handler renders or terminates.
+
+## Pagination
+
+`paginate_posts()` (`response.php`) is the one entry point both listing paths
+go through: an in-memory array (tag pages, already loaded) or a bean type
+string (everything else, a DB query). Both branches share
+`pagination_window()`, the single place that clamps a requested page against
+the available range and derives the row offset — `build_pagination_meta()`
+then reads the same total back out for `prev_page`/`next_page`. Splitting the
+clamp from the offset-into-a-query step is what let the DB path and the
+array path stay in lock-step without either one reimplementing the other's
+arithmetic.
+
+`$per_page` and `$page` are optional parameters that fall back to config
+(`posts_per_page`) and `$_GET['page']` respectively, rather than reading the
+global/superglobal directly — callers that already know the values (tests,
+the tag-feed 20-item cap) pass them explicitly, and `paginate_posts()` itself
+never has to care which source they came from.
+
+## Conditional GET, ETag, and 304 caching
+
+`latest_content_timestamp()` folds the newest published post's `updated`
+together with the last config edit (`Config\config_modified_timestamp()`),
+so a settings change invalidates cached anonymous pages exactly like a post
+edit does. `send_304_if_current()` emits the validators and short-circuits
+with `304 Not Modified` when the client already holds them; `feeds.php`'s
+`feed_cache()` is the feed-specific wrapper (longer `max-age`, no-op for
+logged-in responses). The full validator model — why the `ETag` keeps the
+content and config timestamps as distinct components while `Last-Modified`
+collapses them — is recorded in [AGENTS.md](../../AGENTS.md)'s "Conditional
+GET" note under Security; this module only wires the two call sites into it.
+
+## Login: a sessionless page with its own CSRF model
+
+`/login` is the one route an anonymous visitor can always reach, which used
+to make it a disk-exhaustion vector: every hit started (and persisted) a
+session, so a burst of anonymous requests could mint a week-lived session
+file each (issue #462). `redirect_login()` now starts no session for an
+anonymous visitor at all — a server-side session is only established *after*
+the password verifies.
+
+That leaves the form's CSRF protection unable to ride in the session, so it
+uses a signed double-submit cookie instead (`issue_login_csrf()` /
+`valid_login_csrf()`): a token is both set as a cookie and embedded in a
+hidden field, and a submission is accepted only when the two match
+byte-for-byte *and* carry a valid signature. The signing key
+(`login_csrf_secret()`) is deliberately derived from, but distinct from, the
+raw login hash that signs an authenticated `lamb_logged_in` marker
+(`set_login_marker()`) — sharing one key would make a CSRF token harvested
+from a plain `GET /login` also work as a login marker, reopening the same
+DoS by another route. A wrong password re-renders the login page in place
+with the error (`login_page_data()`), rather than a session flash, for the
+same sessionless reason (#460).
+
+Failed attempts are throttled per client address *before* `password_verify()`
+runs (`login_throttle_retry_after()`, issue #443), so a blocked client costs
+no bcrypt. The counter lives in the `option` table keyed by an HMAC of the
+address (`login_throttle_key()`) rather than the plaintext address, is pruned
+lazily on the write path, and a refused attempt is not itself counted — so
+retrying cannot extend a block. `client_ip()` reads `REMOTE_ADDR` only; see
+[AGENTS.md](../../AGENTS.md)'s Security section for why `X-Forwarded-For` is
+not trusted here.
+
+Post-login, `local_redirect_target()` constrains `?redirect_to=` to a local
+path so the parameter can't be turned into an open redirect — the same
+protocol-relative-path check reappears in `posts.php` (see below), because a
+raw path from any source can carry the same trick.
+
+## Referer-based redirect targets
+
+Deleting or editing a post redirects back to where the action was invoked
+rather than always to the home page, using the request `Referer` header
+(`safe_referer_path()` in `posts.php`). A same-origin host check on its own
+is not enough: a `Referer` of `https://site/​/evil.test/x` has host `site` and
+still yields the path `//evil.test/x`, which a browser resolves as
+protocol-relative and follows off-site (`/\evil.test` the same way, since
+browsers normalise the backslash). `safe_referer_path()` therefore delegates
+the final path shape to `local_redirect_target()` (auth.php), which already
+refuses both forms — one guard for the pattern instead of one per caller.
+`delete_return_path()` adds one more rule for deletes specifically: falling
+back to the home page when the computed target is the just-deleted post's
+own permalink, which would otherwise 404 straight back at the visitor.
+
+## Feed-sourced posts and the edit lock
+
+`lock_if_feed_sourced()` sets `feed_locked` the first time an author edits a
+feed-ingested post through the edit form, so a later crawl stops re-syncing
+over their changes. This is the response-side half of an invariant that
+lives mostly in feed ingestion — see
+[`../network/README.md`](../network/README.md) ("The watermark model") for
+why `feed_locked` exists and how the crawl side reads it.
+
+## Checkbox toggle: AJAX without CSRF
+
+`respond_checkbox()` is a login-only, no-CSRF AJAX endpoint (`posts.php`) —
+its protection is the same `SameSite=Strict` session-cookie invariant
+`respond_upload()` relies on, documented once in
+[AGENTS.md](../../AGENTS.md)'s Security section rather than repeated here.
+The toggle itself is guarded against a narrower problem: the box the request
+names is identified by a *rendered* index (`data-checkbox-index`), so
+`apply_checkbox_toggle()` re-renders before and after the edit
+(`rendered_checkbox_states()`) and refuses the write unless exactly the
+requested box changed state. Without that check, a source scan that reads a
+checkbox's position differently from the renderer could tick a different
+task than the one the author clicked.
+
+## Uploads: validate the whole batch, then store, then convert
+
+`respond_upload()` (`upload.php`) checks every file in a dropped batch
+(`accept_upload_batch()`) before writing any of it. The client posts the
+whole batch in one request, so refusing file 2 midway through a naive loop
+would leave file 1 already written under `src/assets/` — stored, unreferenced,
+and invisible to the author. `accept_upload_batch()` is a pure function
+(reads the batch, resolves each file's extension, sniffs its content) so this
+ordering is unit-testable independently of the responder that stores and
+dies on every exit path.
+
+An extension allowlist (`safe_upload_extension()`) is the primary defence —
+uploads land inside the web root, so anything else could be requested back
+as PHP. A content-type sniff (`upload_content_allowed()`) is the second line,
+catching an HTML/SVG payload stored under an image extension so a
+sniffing browser can't render it as markup from this origin; it fails open
+when `fileinfo` is unavailable, since the extension check still stands.
+
+JPEG/PNG uploads are re-encoded to WebP and downscaled to at most 1600px on
+the longest edge (`convert_to_webp()`/`scaled_dimensions()`), falling back to
+the original bytes on any failure. `max_upload_pixels()` guards the decode
+itself: GD allocates a decoded image's full pixel buffer outside PHP's memory
+manager as soon as it reads the header, so a small file that declares an
+enormous width × height can force a multi-gigabyte allocation regardless of
+`memory_limit`. The declared dimensions are checked before decoding in both
+the file-path and in-memory paths; `LAMB_MAX_UPLOAD_PIXELS` lets a
+memory-constrained host lower the cap without a code change.
+
+The same WebP pipeline serves three callers with three different starting
+points — the web upload form (`store_webp_copy()`, a file on disk), and the
+WordPress importer and Micropub inline photos (`persist_image_bytes()`, bytes
+already in memory) — so the convert-or-fall-back decision and the destination
+naming (`$seed.$ext` vs `$seed.webp`) are made once and shared rather than
+reimplemented per caller.
+
+`asset_url()`/`asset_dimensions()` are inverses of each other: the former
+builds the root-relative URL a post body links to, the latter resolves that
+URL back to a file under `src/assets/` (so the renderer can emit intrinsic
+`width`/`height`). Because post bodies are hand-written Markdown,
+`asset_dimensions()` treats anything that isn't provably inside `src/assets/`
+— a scheme/host, a `../` escape, a symlink out of the tree — as
+unresolvable rather than guessing.
+
+## Discovery: sitemap, robots.txt, and noindex
+
+`/sitemap.xml` (`discovery.php`) lists the home page and every publicly
+visible post through the same `visible_clause()` the listings use, deduping
+by URL since two posts can share a slug. `/robots.txt` derives its
+`Disallow` list from `Lamb\Route\register_private_route()` — the same
+registry the router itself is built from — plus one hand-added wildcard
+pattern for preview links (`?preview=`, which are ordinary permalinks and
+so can't be disallowed by path). A static `robots.txt` dropped in the web
+root still wins over the generated one, so an operator can override it.
+
+`should_noindex()`/`mark_noindex()` mark a response noindex for any private
+route or any request carrying a `preview` parameter (valid or not); this
+runs per request rather than inside the preview-token check, since some
+handlers (feeds, the export download) terminate before a theme ever gets to
+render `Theme\the_robots()`'s matching `<meta>` tag. See
+[DECISIONS.md](../../DECISIONS.md) ("2026-08-03") for why both the header and
+the meta tag exist side by side.
+
+## Export download
+
+`respond_export()` (`export.php`) streams the zip `Export\build_export_archive()`
+builds to a temp file, then hands it to the browser as an attachment
+(`stream_export_download()`), deleting the temp file afterwards. Output
+buffering is unwound before `readfile()` so a large archive isn't held in
+memory twice over, and `Content-Length` is sent so the browser can show real
+download progress. The archive format itself — front-matter Markdown plus a
+JSON manifest — is documented in `docs/export.md` and
+[DECISIONS.md](../../DECISIONS.md) ("2026-07-26"); this file only owns the
+HTTP delivery of it.

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -14,13 +14,9 @@ use RedBeanPHP\R;
 /**
  * Handles the /login route without starting a session for anonymous visitors.
  *
- * /login is the one anonymous-reachable route, so starting a session here let an
- * attacker mint a week-lived session file per request — a disk-exhaustion DoS
- * through the single endpoint that couldn't refuse a session (issue #462). The
- * form's CSRF protection therefore rides in a signed double-submit cookie + a
- * matching hidden field (issue_login_csrf()/valid_login_csrf()) instead of the
- * session, and a server-side session is only established *after* the password
- * verifies — so anonymous traffic never writes a session file.
+ * Sessionless-login model (why, and the CSRF/throttle scheme that replaces the
+ * session-backed CSRF token): see response/README.md ("Login: a sessionless
+ * page with its own CSRF model").
  *
  * - Already logged in (a valid marker let bootstrap start a session): the marker
  *   is reissued and the visitor is bounced to the root URL.
@@ -120,9 +116,8 @@ function login_page_data(?string $error = null): array
  * Derives the HMAC key used to sign the anonymous /login CSRF token.
  *
  * Deliberately distinct from the raw login hash (the key used for lamb_logged_in
- * markers): if the two shared a key, a CSRF token harvested from GET /login would
- * itself be a valid login marker, and replaying it as lamb_logged_in would start
- * a session per request — reopening the very DoS this endpoint avoids (#462).
+ * markers) — see response/README.md ("Login: a sessionless page with its own
+ * CSRF model") for why sharing a key would reopen the DoS this endpoint avoids.
  *
  * @param string $loginHash The per-install login hash (LAMB_LOGIN_PASSWORD).
  * @return string A derived HMAC key, distinct from $loginHash.

--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -133,10 +133,10 @@ const PREVIEW_DISALLOW = '/*?preview=';
  *
  * Preview links (src/lamb.php: preview_token_valid()) deliberately serve an
  * unpublished post to anyone holding the token, with no login — which is
- * exactly what makes them indexable if one is pasted into a page a crawler
- * already follows. Any `preview` parameter counts, even an empty or wrong one:
- * the token doesn't have to be valid for the URL to be a duplicate of the
- * canonical permalink that should not be indexed on its own.
+ * exactly what makes them indexable if pasted into a page a crawler already
+ * follows. Any `preview` parameter counts, even an empty or wrong one; see
+ * response/README.md ("Discovery: sitemap, robots.txt, and noindex") and
+ * DECISIONS.md ("2026-08-03") for the full model.
  *
  * @param bool|string          $action The current request action (first path segment).
  * @param array<string, mixed> $query  The request query parameters (i.e. $_GET).

--- a/src/response/export.php
+++ b/src/response/export.php
@@ -16,11 +16,11 @@ use const ROOT_URL;
 /**
  * Streams a full site export as a zip download.
  *
- * The archive is Lamb's own format (see docs/export.md): every post as the
- * front-matter Markdown it is stored as, the assets those posts reference, and
- * a manifest.json carrying the row state front matter cannot express. Drafts
- * and trashed posts are included and flagged in the manifest — this is a
- * backup, so leaving them out would make it a partial one.
+ * The archive is Lamb's own format, documented in docs/export.md and
+ * DECISIONS.md ("2026-07-26"); this function only owns the HTTP delivery —
+ * see response/README.md ("Export download"). Drafts and trashed posts are
+ * included and flagged in the manifest — this is a backup, so leaving them
+ * out would make it a partial one.
  *
  * @param array<int, string> $_args
  * @return void

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -182,6 +182,7 @@ function get_feed_data(): array
  * Feeds are polled by readers rather than browsed, so they get a longer max-age
  * than regular pages, plus a conditional-GET 304 short-circuit keyed on the
  * feed's freshest item. No-op for logged-in users (their responses are private).
+ * See response/README.md ("Conditional GET, ETag, and 304 caching").
  *
  * @param string $updated The feed's latest-updated datetime string.
  * @return void

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -123,16 +123,10 @@ function store_slug_change_redirect(string $old_slug, string $new_slug): void
  *
  * This is the open-redirect guard the redirect-after-action handlers share:
  * redirect_uri()/sanitize_location() only strip control characters and do not
- * check the host, so an off-site Referer would otherwise redirect off-site.
- *
- * The host check alone was not enough for that. A same-origin Referer of
- * `https://site/​/evil.test/x` has host `site`, so it passed — and yielded the
- * path `//evil.test/x`, which a browser resolves as protocol-relative and
- * follows off-site. `/\evil.test` does the same, since browsers normalise the
- * backslash. Referer is a request header, so its path is caller-supplied
- * either way. local_redirect_target() already refuses both shapes for
- * `?redirect_to=` and states why, and sanitize_explicit_slug() refuses them for
- * a slug — so the final answer is delegated to it rather than restated here.
+ * check the host, so an off-site Referer would otherwise redirect off-site. The
+ * host check alone is not enough for that (a protocol-relative path trick
+ * survives it) — see response/README.md ("Referer-based redirect targets") for
+ * the shape and why the final answer is delegated to local_redirect_target().
  *
  * @param string|null $referer The request Referer header (may be null).
  * @return string A same-origin path (with query), or '/'.
@@ -352,11 +346,10 @@ function redirect_edited(): void
 /**
  * Marks a feed-sourced post as author-owned so feed re-ingestion leaves it alone.
  *
- * Feed crawls dedupe on `feeditem_uuid` and re-sync source updates onto matching
- * posts. Once the author edits such a post through the edit form, that auto-sync
- * would clobber their changes, so set `feed_locked` to opt the post out of future
- * updates. Posts that did not originate from a feed (`feeditem_uuid` empty) are
- * left untouched.
+ * Posts that did not originate from a feed (`feeditem_uuid` empty) are left
+ * untouched. This is the response-side half of the `feed_locked` invariant; see
+ * ../network/README.md ("The watermark model") for why it exists and how the
+ * crawl side reads it.
  *
  * @param OODBBean $bean The post being saved.
  * @return void
@@ -371,13 +364,11 @@ function lock_if_feed_sourced(OODBBean $bean): void
 /**
  * Toggles a GitHub-style task-list checkbox and persists it as a post edit.
  *
- * AJAX endpoint for the logged-in author: flips the Nth `[ ]`/`[x]` marker in
- * the post body (the index supplied by the rendered checkbox's
- * `data-checkbox-index`), re-parses so `transformed` reflects the new state,
- * and bumps `updated`. Login-only, no CSRF — matching respond_upload() and the
- * SameSite=Strict session, which already blocks cross-site POSTs. Webmention
- * and WebSub are intentionally skipped: ticking a box is a minor edit and must
- * not re-notify subscribers.
+ * AJAX endpoint for the logged-in author. Login-only, no CSRF — see
+ * AGENTS.md's Security section for the SameSite=Strict invariant this and
+ * respond_upload() both rely on instead. Webmention and WebSub are
+ * intentionally skipped: ticking a box is a minor edit and must not re-notify
+ * subscribers.
  *
  * @param array<int, string> $_args Unused route arguments.
  * @return void

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -99,11 +99,8 @@ function respond_upload(array $_args): void
  * Returns the accepted files and null, or an empty list and the message for the
  * first file that cannot be stored. Every refusal here is a 400: the request
  * described something Lamb will not accept, and nothing has been written yet.
- *
- * Separated from respond_upload() because the responder stores as it validates
- * and dies on every exit path — which is both why the mixed order was a bug and
- * why it could not be tested. This half is pure: it reads the batch and the
- * files it names, and writes nothing.
+ * Why this validate-before-store split exists: see response/README.md
+ * ("Uploads: validate the whole batch, then store, then convert").
  *
  * @param array<int, array<string, mixed>> $files From normalize_uploaded_files().
  * @return array{0: list<array{name: string, tmp_name: string, ext: string}>, 1: string|null}
@@ -286,7 +283,9 @@ function should_convert_to_webp(?string $ext, ?bool $gd_available = null): bool
  *
  * Owns the full "land bytes in src/assets/" pipeline for callers that already
  * have the image content in memory (WordPress import downloader, Micropub
- * inline photos). The temp file lives under $dest_dir rather than
+ * inline photos) — see response/README.md ("Uploads: validate the whole
+ * batch, then store, then convert") for why this and store_webp_copy() share
+ * one conversion decision. The temp file lives under $dest_dir rather than
  * sys_get_temp_dir() so the final rename never crosses filesystems — a real
  * failure mode in containers where /tmp is tmpfs and the project root is a
  * bind-mount. respond_upload() keeps its own path because it must use
@@ -369,17 +368,11 @@ function store_webp_copy(string $src_path, string $ext, string $dest_dir, string
 
 /**
  * Upper bound on a source image's declared width*height before WebP conversion
- * decodes it. GD allocates the full pixel buffer as soon as it decodes an
- * image's header, before any of this app's own downscaling runs — a small
- * file can declare an enormous width/height ("decompression bomb") and force
- * a multi-gigabyte allocation. 40 megapixels comfortably covers any real
- * photo (including high-resolution phone modes) while capping the worst case.
- *
- * GD's pixel buffers are allocated outside PHP's memory manager, so they
- * neither count against memory_limit nor are limited by it — the real
- * ceiling is the host's actual free RAM. LAMB_MAX_UPLOAD_PIXELS lets a
- * self-hoster on a memory-constrained box lower the cap if conversions are
- * getting OOM-killed, without a code change.
+ * decodes it, guarding against a "decompression bomb" — see response/README.md
+ * ("Uploads: validate the whole batch, then store, then convert") for why GD's
+ * pixel buffers bypass memory_limit and why this must be checked before decode.
+ * 40 megapixels comfortably covers any real photo; LAMB_MAX_UPLOAD_PIXELS lets
+ * a memory-constrained host lower the cap without a code change.
  *
  * @return int The pixel cap: LAMB_MAX_UPLOAD_PIXELS if set to a positive
  *             integer, otherwise the 40-megapixel default.


### PR DESCRIPTION
## Summary

Applies the module-README documentation pattern (introduced for `Lamb\Network` in #658) to `Lamb\Response`.

- Adds `src/response/README.md`: the subsystem narrative for routing/responses — the `respond_*`/`redirect_*` handler split, pagination (`paginate_posts()`/`pagination_window()`), conditional-GET/ETag/304 caching, the sessionless `/login` page and its double-submit CSRF + throttle model, referer-based redirect targets (delete/edit), the `feed_locked` edit-lock invariant shared with feed ingestion, the checkbox-toggle CSRF exemption, the upload validate-then-store/WebP-conversion pipeline, and `/sitemap.xml`/`/robots.txt`/noindex.
- Trims the docblocks that restated this multi-function rationale down to their contract (`@param`/`@return`/`@throws`, unchanged) plus a one-line pointer to the new README, or to `AGENTS.md`/`DECISIONS.md`/`src/network/README.md` where the narrative already lives there (e.g. the checkbox-CSRF exemption points at AGENTS.md's Security section rather than duplicating it).
- Local "why this line" comments are untouched — only subsystem-spanning essays moved.
- Also covers `src/response/discovery.php` (sitemap/robots/noindex): it lives in the same namespace and directory as the files named in the original brief but wasn't listed there, so I included it for completeness.

No behaviour change — comments and documentation only.

## Verification

- `composer lint` — clean
- `composer analyse` (PHPStan) — `[OK] No errors`
- `vendor/bin/codecept run Unit` — `Tests: 1935, Assertions: 3519, Skipped: 2` (pre-existing skips, unrelated to this change)

## Test plan

- [x] `composer lint`
- [x] `composer analyse`
- [x] `vendor/bin/codecept run Unit`
- [x] Diff-reviewed: no code/behaviour changes, only docblocks and the new README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxAh4xZw6cU6bh5tcwaN2p