### PR TITLE
Build the sitemap from three columns, not from whole posts

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,7 +21,6 @@ parameters:
             paths:
                 - src/post.php
                 - src/response.php
-                - src/response/discovery.php
                 - src/response/feeds.php
                 - src/theme.php
     bootstrapFiles:

--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -39,16 +39,32 @@ function sitemap_date(?string $datetime): ?string
  * otherwise emit the same <loc> twice — invalid for a sitemap. Entries are
  * deduplicated by URL, keeping the first (newest, since ordered by updated DESC).
  *
+ * Only the three columns a URL entry is built from are read. /sitemap.xml is
+ * anonymous and unpaginated — unlike the feeds, which cap at 20 rows — so
+ * loading whole post beans put every body and every rendered `transformed`
+ * blob in memory at once: about 14 MB at 2,000 posts, and a fatal
+ * "Allowed memory size of 134217728 bytes exhausted" at 20,000 against the
+ * images' default 128M limit, which is a blank 500 for every crawler. The rows
+ * become beans one at a time so permalink() stays the only place a post URL is
+ * built.
+ *
  * @return list<array{loc: string, lastmod: string|null}>
  */
 function sitemap_urls(): array
 {
     $visible = \Lamb\visible_clause();
-    $posts = R::find('post', $visible['sql'] . 'ORDER BY updated DESC', $visible['params']);
+    $rows = R::getAll(
+        'SELECT id, slug, updated FROM post WHERE ' . $visible['sql'] . 'ORDER BY updated DESC',
+        $visible['params']
+    );
 
     $entries = [];
     $seen = [];
-    foreach ($posts as $post) {
+    foreach ($rows as $row) {
+        $post = R::convertToBean('post', $row);
+        if ($post === null) {
+            continue;
+        }
         $loc = \Lamb\permalink($post);
         if (isset($seen[$loc])) {
             continue;

--- a/tests/Unit/SitemapTest.php
+++ b/tests/Unit/SitemapTest.php
@@ -124,6 +124,55 @@ class SitemapTest extends TestCase
         $this->assertSame(date('c', strtotime('2026-06-01 09:30:00')), $entry['lastmod']);
     }
 
+    /**
+     * /sitemap.xml is anonymous and unpaginated — the feeds cap at 20 rows, this
+     * lists every visible post — so reading whole beans put every body and every
+     * rendered `transformed` blob in memory at once. Measured: ~14 MB at 2,000
+     * posts, and at 20,000 a fatal "Allowed memory size of 134217728 bytes
+     * exhausted", which is a blank 500 for every crawler on the images' default
+     * 128M limit. The URL entries need three columns; nothing must widen that
+     * back to the whole row.
+     */
+    public function testSitemapNeverReadsAPostBody(): void
+    {
+        $this->makePost(['slug' => 'hello-world', 'body' => 'Body text']);
+        $this->makePost(['slug' => null]);
+
+        R::debug(true, \RedBeanPHP\Logger\RDefault::C_LOGGER_ARRAY);
+        try {
+            sitemap_urls();
+            $logs = R::getDatabaseAdapter()->getDatabase()->getLogger()->getLogs();
+        } finally {
+            R::debug(false);
+        }
+
+        // RedBean quotes the table name in the SQL it builds but not in SQL it is
+        // handed, so the backticks come off before matching either form.
+        $logs = array_map(static fn(string $sql): string => str_replace('`', '', $sql), $logs);
+        $selects = array_values(array_filter(
+            $logs,
+            static fn(string $sql): bool => stripos($sql, 'SELECT') !== false
+                && stripos($sql, 'FROM post') !== false
+        ));
+
+        $this->assertNotSame([], $selects, 'the sitemap should have queried the post table');
+        foreach ($selects as $sql) {
+            // The column list, not the whole statement: a wildcard here is
+            // `post`.* as much as it is *, and either one drags the bodies in.
+            $columns = (string) preg_replace('/^.*?SELECT(.*?)FROM.*$/is', '$1', $sql);
+            $this->assertStringNotContainsString(
+                '*',
+                $columns,
+                'the sitemap must name its columns rather than select them all: ' . $sql
+            );
+            $this->assertStringNotContainsStringIgnoringCase(
+                'body',
+                $columns,
+                'the sitemap must not read post bodies: ' . $sql
+            );
+        }
+    }
+
     public function testRenderSitemapWrapsUrlsInUrlset(): void
     {
         $xml = render_sitemap([


### PR DESCRIPTION
`sitemap_urls()` ran `R::find('post', …)` — which selects `` `post`.* `` — and used three fields of each bean: `id`, `slug` and `updated`. Every body and every rendered `transformed` blob came along, all of them alive at once.

`/sitemap.xml` is anonymous and unpaginated. The feeds it sits beside cap at `LIMIT 20`; this one lists every visible post, so its memory scales with the whole database on a URL anyone can request.

## Measured

Against a real SQLite file, in a clean process, at the images' default 128M limit — neither Dockerfile overrides `php.ini-production`'s `memory_limit`:

| posts | peak |
| --- | --- |
| 2,000 | 14 MB |
| 8,000 | 62 MB |
| 16,000 | 120 MB |
| 20,000 | `PHP Fatal error: Allowed memory size of 134217728 bytes exhausted` in `OODBBean.php` |

That last one is a blank 500 for every crawler that asks. The same query reading only the three columns costs ~0 MB at 2,000 posts, and 30 MB at 20,000 — where the old one could not finish at all.

## The change

Rows are turned into beans one at a time rather than having their URLs built inline, so `permalink()` stays the only place a post URL is constructed.

## Output is unchanged

Dumped before and after across ten post shapes and diffed — slugged, slugless (`/status/<id>`), two posts sharing a slug (deduplicated), a percent-encoded slug, a draft, a deleted post, a future-scheduled post, and both an unparseable and an empty `updated`:

```
IDENTICAL output across all 10 post shapes
```

## The test

It pins the invariant rather than the statement: every `SELECT` the sitemap issues against `post` must name its columns, so neither `*` nor `` `post`.* `` can creep back in. Against the previous code it fails with `selects all columns: post.*`.

(First attempt at that assertion passed on both sides — RedBean logs `` SELECT `post`.* ``, which contains neither the literal `SELECT *` nor the word `body`. The check now parses the column list out of the statement.)

## Not addressed here

sitemaps.org caps a sitemap at 50,000 URLs, and this still emits a single document however many posts there are. That needs a sitemap index, which is a feature rather than a fix — happy to open it separately if you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_