### PR TITLE
Read related posts a page at a time instead of the whole archive

### DIFF
--- a/src/theme.php
+++ b/src/theme.php
@@ -254,6 +254,25 @@ function related_posts(string $body, int $exclude_id = 0): array
 }
 
 /**
+ * How many rows a related-posts lookup reads per query, and how many it will
+ * read in total for one tag before giving up.
+ *
+ * The LIKE condition is a superset of a real tag match — body_has_tag() is what
+ * decides — so the query cannot simply LIMIT to the number of posts wanted: a
+ * page of rows can be filtered away entirely. It read every matching row
+ * instead, which on a common tag meant loading the whole archive to show ten
+ * links: 58 MB for one post page at 8,000 posts sharing a tag, and at 20,000 a
+ * fatal "Allowed memory size of 134217728 bytes exhausted" against the images'
+ * default 128M limit. Reading a page at a time keeps that flat.
+ *
+ * The scan cap is the same trade OUTBOX_SCAN_LIMIT makes: far more rows than a
+ * real tag needs before it has ten survivors, so in practice it is never
+ * reached, and a pathological tag costs a bounded read instead of the archive.
+ */
+const RELATED_TAG_BATCH = 50;
+const RELATED_SCAN_LIMIT = 500;
+
+/**
  * Finds all posts that contain at least one of the given tags, ordered by created date descending.
  *
  * @param list<string> $tags List of tag strings to search for.
@@ -273,13 +292,22 @@ function get_posts_by_tags(array $tags, int $exclude_id = 0, int $limit = 10): a
             $sql .= ' AND id != ?';
             $params[] = $exclude_id;
         }
-        $sql .= ' ORDER BY created DESC';
-        $tag_posts = R::find('post', $sql, $params);
-        foreach ($tag_posts as $tag_post) {
-            if (!body_has_tag($tag, (string) $tag_post->body)) {
-                continue;
+        $sql .= ' ORDER BY created DESC LIMIT ? OFFSET ?';
+
+        $scanned = 0;
+        while (count($related_posts) < $limit && $scanned < RELATED_SCAN_LIMIT) {
+            $batch = min(RELATED_TAG_BATCH, RELATED_SCAN_LIMIT - $scanned);
+            $tag_posts = R::find('post', $sql, array_merge($params, [$batch, $scanned]));
+            if (count($tag_posts) === 0) {
+                break;
             }
-            $related_posts[$tag_post->id] = $tag_post;
+            $scanned += count($tag_posts);
+            foreach ($tag_posts as $tag_post) {
+                if (!body_has_tag($tag, (string) $tag_post->body)) {
+                    continue;
+                }
+                $related_posts[$tag_post->id] = $tag_post;
+            }
         }
         if (count($related_posts) >= $limit) {
             break;

--- a/tests/Unit/ThemeExtendedTest.php
+++ b/tests/Unit/ThemeExtendedTest.php
@@ -211,6 +211,58 @@ class ThemeExtendedTest extends TestCase
         $this->assertCount(1, $result);
     }
 
+    /**
+     * The block shows ten links; it used to read every row the LIKE matched to
+     * find them. On a common tag that is the whole archive, on the most-visited
+     * anonymous page there is: 58 MB for one post page at 8,000 posts sharing a
+     * tag, and a fatal "Allowed memory size of 134217728 bytes exhausted" at
+     * 20,000 against the images' default 128M limit.
+     */
+    public function testGetPostsByTagsReadsInBoundedPages(): void
+    {
+        // More than one page, and interleaved with rows the LIKE matches but
+        // body_has_tag() rejects — the reason a plain LIMIT will not do.
+        for ($i = 1; $i <= 120; $i++) {
+            $this->taggedPost("Post $i about #photography", $i * 2);
+            $this->taggedPost("Post $i about #photographylover", $i * 2 + 1);
+        }
+
+        R::debug(true, \RedBeanPHP\Logger\RDefault::C_LOGGER_ARRAY);
+        try {
+            $result = get_posts_by_tags(['photography']);
+            $logs = R::getDatabaseAdapter()->getDatabase()->getLogger()->getLogs();
+        } finally {
+            R::debug(false);
+        }
+
+        // The decoys must not stop it filling the block.
+        $this->assertCount(10, $result);
+
+        $selects = array_filter(
+            array_map(static fn(string $sql): string => str_replace('`', '', $sql), $logs),
+            static fn(string $sql): bool => stripos($sql, 'SELECT') !== false
+                && stripos($sql, 'FROM post') !== false
+        );
+        $this->assertNotSame([], $selects, 'the lookup should have queried the post table');
+        foreach ($selects as $sql) {
+            $this->assertStringContainsStringIgnoringCase(
+                'LIMIT',
+                $sql,
+                'a related-posts query must be bounded: ' . $sql
+            );
+        }
+    }
+
+    private function taggedPost(string $body, int $minutesOld): void
+    {
+        $bean = R::dispense('post');
+        $bean->body = $body;
+        $bean->version = 1;
+        $bean->created = date('Y-m-d H:i:s', time() - $minutesOld * 60);
+        $bean->updated = $bean->created;
+        R::store($bean);
+    }
+
     // related_posts
 
     public function testRelatedPostsReturnsEmptyPostsArrayWhenBodyHasNoTags(): void


### PR DESCRIPTION
`get_posts_by_tags()` runs one query per tag with no `LIMIT`, collects every row the `LIKE` matched, filters them with `body_has_tag()` and *then* slices to ten.

On a tag the author uses often, that is the entire archive loaded to render ten links — and this is the post page, the most-visited anonymous URL on the site, not a crawler-only endpoint like #664's sitemap.

## Measured

Against a real SQLite file, at the images' default 128M limit, rendering one post page's related block with every post sharing the tag:

| posts sharing the tag | peak |
| --- | --- |
| 8,000 | 58 MB |
| 20,000 | `PHP Fatal error: Allowed memory size of 134217728 bytes exhausted` in `OODBBean.php` |
| 20,000, after this change | **6 MB**, still returning ten posts |

## Why not just add a LIMIT

The `LIKE` condition is a superset of a real tag match — `#photographylover` matches `%#photography%` — so `body_has_tag()` is what actually decides, and a page of rows can be filtered away entirely. `LIMIT 10` could return ten decoys and an empty block.

It now reads a page at a time until ten survive, with a scan cap per tag. That is the same trade `OUTBOX_SCAN_LIMIT` already makes for the webmention queue: far more rows than a real tag needs before it has ten survivors, so in practice it is never reached, and a pathological tag costs a bounded read instead of the archive.

## Results are unchanged

Dumped before and after across seven scenarios — one common tag, no exclusion, a lower limit, a rare tag, a rare tag falling through to a common one, an unknown tag, and a limit larger than the corpus — over a corpus interleaving 40 real matches with 40 `LIKE`-only decoys, so the paging has to step past rejected rows to fill the block:

```
IDENTICAL results across all 7 scenarios
```

Drafts, deleted posts and future-scheduled posts stay excluded, dedup across tags still holds, and the excluded current post is still excluded.

## The test

It pins the bound rather than the batch size: every query the lookup issues against `post` has to carry a `LIMIT`, and the block still fills to ten with decoys interleaved. Against the previous code it fails on the first unbounded query:

```
unbounded query: SELECT post.* FROM post WHERE (body LIKE ? ESCAPE '\') AND (draft IS NULL OR …
```

## The rest of the sweep for this shape

Found by looking for the same pattern as #664. Of the other unbounded `R::find`/`R::findAll` calls: the listings and both feeds already cap (`LIMIT ?, ?` and `LIMIT 20`), and the two redirect queries are login- or cron-gated over tiny rows.

One more is genuinely unbounded and I have **not** changed it: `webmentions_for_post()` reads every verified mention for a post, on the anonymous post page. I judged it materially different rather than harmless — rows are small, they are deduplicated on `(source, target)`, and each one costs the sender a real, publicly fetchable URL that actually links to the post, so there is no way to inflate the count without either a sustained attack or genuine popularity. Worth a bound eventually (the snippet in `content` has no length cap either), but it is not the same defect as an author simply using a tag a lot, and I would rather raise it than fold it in here.