### PR TITLE
Paginate the tag page and tag feed on ids, not on loaded posts

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,7 +19,6 @@ parameters:
             message: '#expects literal-string\|null, non-falsy-string given#'
             identifier: argument.type
             paths:
-                - src/post.php
                 - src/response.php
                 - src/response/discovery.php
                 - src/response/feeds.php

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -121,7 +121,7 @@ function parse_tags(string $html): string
  *
  * "Already carries" is case-insensitive, and a tag repeated in $tags is added
  * once: `#PHP` and `#php` are one tag everywhere else (the link parse_tags()
- * writes, the lookup posts_by_tag() runs), so appending the other spelling
+ * writes, the lookup post_ids_by_tag() runs), so appending the other spelling
  * just prints the same tag twice.
  *
  * @param string       $body The raw post body.

--- a/src/post.php
+++ b/src/post.php
@@ -874,7 +874,7 @@ function get_tag_search_conditions(string $tag): array
  * excludes from a tag name, rather than a second copy of it. The copy had
  * drifted: it was missing `>`, `"`, `'`, a backtick, `=` and both slashes, so a
  * body reading `#php/8` rendered a link to /tag/php — TAG_PATTERN ends the tag
- * at the slash — while this said the post carried no such tag. posts_by_tag()
+ * at the slash — while this said the post carried no such tag. post_ids_by_tag()
  * and Theme\get_posts_by_tags() both filter on it, so the tag page and the
  * related-posts list left out the very post whose link led there.
  *
@@ -889,21 +889,94 @@ function body_has_tag(string $tag, string $body): bool
 }
 
 /**
- * Retrieves posts that contain the specified tag within their body content.
+ * How many rows a tag scan reads per query.
  *
- * @param string $tag The tag to search for within post content.
- *
- * @return list<\RedBeanPHP\OODBBean> An array of posts that match the specified tag.
+ * Only ids survive a page, so the page can be generous: it is the number of
+ * bodies held at once, and one query per 500 matches keeps the query count
+ * reasonable for a tag that really does cover the archive.
  */
-function posts_by_tag(string $tag): array
+const TAG_SCAN_PAGE = 500;
+
+/**
+ * The ids of every publicly visible post that really carries $tag, newest first.
+ *
+ * The LIKE condition get_tag_search_conditions() builds is a superset of a real
+ * tag match — `#photographylover` matches `%#photography%`, and body_has_tag()
+ * is what decides — so the rows cannot be narrowed to the wanted ones in SQL.
+ * They are read a page at a time and only the surviving ids are kept, so one
+ * page of bodies is all that is in memory at once.
+ *
+ * Holding a full bean per match instead made both /tag/<tag> and
+ * /tag/<tag>/feed die on a tag that covers a large archive: at 20,000 posts
+ * under one tag, "Allowed memory size of 134217728 bytes exhausted" on each,
+ * against the default 128M limit both images inherit. Neither endpoint needs
+ * more than a page of posts to render — the tag page paginates and the feed
+ * takes 20 — so nothing but the id list has to grow with the tag.
+ *
+ * @param string $tag            The tag to search for within post content.
+ * @param bool   $by_updated     Order by `updated` rather than `created` (what
+ *                               the tag feeds sort on). The column is chosen
+ *                               here, never interpolated from a caller.
+ * @param int    $limit          Stop once this many ids have been collected;
+ *                               0 collects every match.
+ * @return list<int>
+ */
+function post_ids_by_tag(string $tag, bool $by_updated = false, int $limit = 0): array
 {
     $conditions = get_tag_search_conditions($tag);
     $public = \Lamb\Response\public_posts_clause();
-    $posts = R::find(
-        'post',
-        '(' . $conditions['sql'] . ') AND' . $public['sql'] . 'ORDER BY created DESC',
-        array_merge($conditions['params'], $public['params'])
-    );
+    $order = $by_updated ? 'updated' : 'created';
+    $sql = 'SELECT id, body FROM post WHERE (' . $conditions['sql'] . ') AND' . $public['sql']
+        . 'ORDER BY ' . $order . ' DESC LIMIT ? OFFSET ?';
+    $params = array_merge($conditions['params'], $public['params']);
 
-    return array_values(array_filter($posts, fn($post) => body_has_tag($tag, (string) $post->body)));
+    $ids = [];
+    $offset = 0;
+    while ($limit === 0 || count($ids) < $limit) {
+        $rows = R::getAll($sql, array_merge($params, [TAG_SCAN_PAGE, $offset]));
+        if ($rows === []) {
+            break;
+        }
+        $offset += count($rows);
+        foreach ($rows as $row) {
+            if (!body_has_tag($tag, (string) ($row['body'] ?? ''))) {
+                continue;
+            }
+            $ids[] = (int) $row['id'];
+            if ($limit !== 0 && count($ids) >= $limit) {
+                break;
+            }
+        }
+        if (count($rows) < TAG_SCAN_PAGE) {
+            break;
+        }
+    }
+
+    return $ids;
+}
+
+/**
+ * Loads posts for the given ids, in the order the ids are given.
+ *
+ * R::loadAll() returns a map keyed by id, so the caller's ordering — which for
+ * a tag listing is the whole point — has to be reapplied.
+ *
+ * @param list<int> $ids
+ * @return list<\RedBeanPHP\OODBBean>
+ */
+function load_posts_in_order(array $ids): array
+{
+    if ($ids === []) {
+        return [];
+    }
+    $beans = R::loadAll('post', $ids);
+
+    $ordered = [];
+    foreach ($ids as $id) {
+        if (isset($beans[$id]) && (int) $beans[$id]->id === $id) {
+            $ordered[] = $beans[$id];
+        }
+    }
+
+    return $ordered;
 }

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -10,7 +10,8 @@ use Lamb\Security;
 use RedBeanPHP\R;
 
 use function Lamb\Http\request_string;
-use function Lamb\Post\posts_by_tag;
+use function Lamb\Post\load_posts_in_order;
+use function Lamb\Post\post_ids_by_tag;
 use function Lamb\Theme\part;
 
 use const Lamb\SQL_IS_DELETED;
@@ -275,11 +276,10 @@ function get_tag_feed_data(string $tag): array
 {
     global $config;
 
-    $posts = posts_by_tag($tag);
-
-    // Sort by updated DESC and limit to 20
-    usort($posts, fn($a, $b) => strtotime($b->updated) - strtotime($a->updated));
-    $posts = array_slice($posts, 0, 20);
+    // Twenty newest by `updated`, chosen from ids so the scan can stop as soon
+    // as it has them: this used to load a bean per match and then slice, which
+    // on a tag covering a large archive exhausted memory before it got here.
+    $posts = load_posts_in_order(post_ids_by_tag($tag, true, 20));
 
     return [
         'updated'  => get_feed_updated_date($posts),
@@ -394,14 +394,17 @@ function respond_tag(array $args): array
     // Keep $tag raw: matching, URL-encoding and the page title each handle it
     // correctly, and the title is escaped at render time (so no double-encoding).
 
-    // Get all posts for this tag (in-memory array)
-    $all_posts = posts_by_tag($tag);
+    // The id list, not the posts: it is paginated first and only the page being
+    // rendered is loaded, so a tag covering the whole archive costs one id per
+    // match rather than one full post.
+    $all_ids = post_ids_by_tag($tag);
 
-    if (empty($all_posts)) {
+    if ($all_ids === []) {
         return respond_404();
     }
 
-    $paginated = paginate_posts($all_posts);
+    $paginated = paginate_posts($all_ids);
+    $paginated['items'] = load_posts_in_order($paginated['items']);
 
     $data['title'] = 'Tagged with #' . $tag;
     $data['feed_url'] = ROOT_URL . '/tag/' . rawurlencode($tag) . '/feed';

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -404,7 +404,10 @@ function respond_tag(array $args): array
     }
 
     $paginated = paginate_posts($all_ids);
-    $paginated['items'] = load_posts_in_order($paginated['items']);
+    // paginate_posts() is generic over its source, so its items come back as
+    // array<int, mixed>; narrow them here rather than loosening the loader.
+    $page_ids = array_values(array_map('intval', $paginated['items']));
+    $paginated['items'] = load_posts_in_order($page_ids);
 
     $data['title'] = 'Tagged with #' . $tag;
     $data['feed_url'] = ROOT_URL . '/tag/' . rawurlencode($tag) . '/feed';

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -39,7 +39,7 @@ class LambTest extends TestCase
     public function testAddBodyTagsSkipsATagPresentInAnotherCase()
     {
         // `#PHP` and `#php` are one tag everywhere else — the link parse_tags()
-        // writes and the lookup posts_by_tag() runs are both case-insensitive.
+        // writes and the lookup post_ids_by_tag() runs are both case-insensitive.
         $this->assertSame('Hello #PHP', add_body_tags('Hello #PHP', ['php']));
     }
 

--- a/tests/Unit/PostDraftVisibilityTest.php
+++ b/tests/Unit/PostDraftVisibilityTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
-use function Lamb\Post\posts_by_tag;
+use function Lamb\Post\post_ids_by_tag;
 
 class PostDraftVisibilityTest extends TestCase
 {
@@ -38,7 +38,7 @@ class PostDraftVisibilityTest extends TestCase
         $bean->created = date('Y-m-d H:i:s');
         R::store($bean);
 
-        $results = posts_by_tag('php');
+        $results = post_ids_by_tag('php');
 
         $this->assertNotEmpty($results, 'Posts with NULL draft should be visible in tag pages');
     }
@@ -51,7 +51,7 @@ class PostDraftVisibilityTest extends TestCase
         $bean->created = date('Y-m-d H:i:s');
         R::store($bean);
 
-        $results = posts_by_tag('php');
+        $results = post_ids_by_tag('php');
 
         $this->assertNotEmpty($results, 'Posts with draft=0 should be visible in tag pages');
     }
@@ -64,7 +64,7 @@ class PostDraftVisibilityTest extends TestCase
         $bean->created = date('Y-m-d H:i:s');
         R::store($bean);
 
-        $results = posts_by_tag('php');
+        $results = post_ids_by_tag('php');
 
         $this->assertEmpty($results, 'Posts with draft=1 should NOT be visible in tag pages');
     }

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -8,11 +8,14 @@ use RedBeanPHP\R;
 use function Lamb\get_tags;
 use function Lamb\Post\body_has_tag;
 use function Lamb\Post\get_tag_search_conditions;
+use function Lamb\Post\load_posts_in_order;
 use function Lamb\Post\parse_matter;
-use function Lamb\Post\posts_by_tag;
+use function Lamb\Post\post_ids_by_tag;
 use function Lamb\Post\sanitize_explicit_slug;
 use function Lamb\Post\slugify;
 use function Lamb\render_body;
+
+use const Lamb\Post\TAG_SCAN_PAGE;
 
 class PostTest extends TestCase
 {
@@ -389,7 +392,7 @@ class PostTest extends TestCase
         $this->assertTrue((bool) $result['draft']);
     }
 
-    // posts_by_tag
+    // post_ids_by_tag
 
     protected function setUpDb(): void
     {
@@ -405,6 +408,69 @@ class PostTest extends TestCase
         R::exec('DELETE FROM post');
     }
 
+    /**
+     * The scan reads a page at a time and keeps only ids, because holding a
+     * bean per match killed both tag endpoints on a tag covering a large
+     * archive: at 20,000 posts under one tag, "Allowed memory size of
+     * 134217728 bytes exhausted" on /tag/<tag> and on /tag/<tag>/feed alike.
+     * Paging is only safe if a real match sitting past a page boundary is
+     * still found, so that is what this pins — with a page and a bit of
+     * LIKE-only decoys in front of it, which is also why a plain SQL LIMIT
+     * cannot replace the scan.
+     */
+    public function testPostIdsByTagFindsAMatchBeyondTheFirstScanPage(): void
+    {
+        $this->setUpDb();
+
+        for ($i = 1; $i <= TAG_SCAN_PAGE + 20; $i++) {
+            $this->tagPost("decoy $i #phplover", date('Y-m-d H:i:s'));
+        }
+        // Oldest, so it sorts last and the scan has to reach the second page.
+        $this->tagPost('the real one #php', '2020-01-01 00:00:00');
+
+        $this->assertCount(1, post_ids_by_tag('php'));
+    }
+
+    public function testPostIdsByTagStopsAtTheRequestedLimit(): void
+    {
+        $this->setUpDb();
+
+        for ($i = 1; $i <= 5; $i++) {
+            $this->tagPost("post $i #php", date('Y-m-d H:i:s', time() - $i * 60));
+        }
+
+        $this->assertCount(2, post_ids_by_tag('php', false, 2));
+        $this->assertCount(5, post_ids_by_tag('php'));
+    }
+
+    public function testLoadPostsInOrderKeepsTheGivenOrder(): void
+    {
+        $this->setUpDb();
+
+        $ids = [];
+        foreach (['a', 'b', 'c'] as $letter) {
+            $ids[] = $this->tagPost("post $letter #php", date('Y-m-d H:i:s'));
+        }
+        $reversed = array_reverse($ids);
+
+        $loaded = load_posts_in_order($reversed);
+
+        $this->assertSame($reversed, array_map(static fn($p): int => (int) $p->id, $loaded));
+        $this->assertSame([], load_posts_in_order([]));
+    }
+
+    private function tagPost(string $body, string $created): int
+    {
+        $post = R::dispense('post');
+        $post->body    = $body;
+        $post->version = 1;
+        $post->draft   = null;
+        $post->created = $created;
+        $post->updated = $created;
+
+        return (int) R::store($post);
+    }
+
     public function testPostsByTagReturnsMatchingPost(): void
     {
         $this->setUpDb();
@@ -416,7 +482,7 @@ class PostTest extends TestCase
         $post->created = date('Y-m-d H:i:s');
         R::store($post);
 
-        $result = posts_by_tag('php');
+        $result = post_ids_by_tag('php');
         $this->assertCount(1, $result);
     }
 
@@ -431,7 +497,7 @@ class PostTest extends TestCase
         $draft->created = date('Y-m-d H:i:s');
         R::store($draft);
 
-        $result = posts_by_tag('php');
+        $result = post_ids_by_tag('php');
         $this->assertCount(0, $result);
     }
 
@@ -439,7 +505,7 @@ class PostTest extends TestCase
     {
         $this->setUpDb();
 
-        $result = posts_by_tag('nonexistenttag999');
+        $result = post_ids_by_tag('nonexistenttag999');
         $this->assertIsArray($result);
         $this->assertCount(0, $result);
     }
@@ -455,7 +521,7 @@ class PostTest extends TestCase
         $post->created = date('Y-m-d H:i:s');
         R::store($post);
 
-        $result = posts_by_tag('endtag');
+        $result = post_ids_by_tag('endtag');
         $this->assertCount(1, $result);
     }
 
@@ -470,7 +536,7 @@ class PostTest extends TestCase
         $post->created = date('Y-m-d H:i:s');
         R::store($post);
 
-        $result = posts_by_tag('til');
+        $result = post_ids_by_tag('til');
         $this->assertCount(1, $result);
     }
 
@@ -485,7 +551,7 @@ class PostTest extends TestCase
         $post->created = date('Y-m-d H:i:s');
         R::store($post);
 
-        $result = posts_by_tag('til');
+        $result = post_ids_by_tag('til');
         $this->assertCount(0, $result);
     }
 
@@ -502,7 +568,7 @@ class PostTest extends TestCase
             R::store($post);
         }
 
-        $result = posts_by_tag('multitag');
+        $result = post_ids_by_tag('multitag');
         $this->assertCount(3, $result);
     }
 }

--- a/tests/Unit/ScheduledPostTest.php
+++ b/tests/Unit/ScheduledPostTest.php
@@ -7,7 +7,7 @@ use RedBeanPHP\R;
 
 use function Lamb\post_has_slug;
 use function Lamb\Post\populate_bean;
-use function Lamb\Post\posts_by_tag;
+use function Lamb\Post\post_ids_by_tag;
 use function Lamb\Response\count_scheduled;
 use function Lamb\Response\respond_home;
 use function Lamb\Response\respond_post;
@@ -99,7 +99,7 @@ class ScheduledPostTest extends TestCase
     {
         $this->makePost('A scheduled post #php', $this->future());
 
-        $this->assertEmpty(posts_by_tag('php'), 'Future-dated posts must not appear on tag pages');
+        $this->assertEmpty(post_ids_by_tag('php'), 'Future-dated posts must not appear on tag pages');
     }
 
     public function testFutureCreatedPostIsHiddenFromSearch(): void


### PR DESCRIPTION
`posts_by_tag()` ran one unbounded query and returned a bean per match. Both its callers then threw most of them away — `respond_tag()` paginated the array in memory and rendered ten, `get_tag_feed_data()` sorted by `updated` and sliced twenty. So `/tag/<tag>` and `/tag/<tag>/feed` each held every matching post's `body` and rendered `transformed` at once.

## Measured

Against a real SQLite file with 20,000 posts under one tag, at the default 128M limit both images inherit:

| | before | after |
| --- | --- | --- |
| `/tag/<tag>/feed` | **fatal: memory exhausted** | 6 MB, 20 items |
| `/tag/<tag>` page 1 | **fatal: memory exhausted** | 8 MB, 10 posts |
| `/tag/<tag>` page 900 | — | 8 MB, 10 posts |

This is the third instance of the shape #664 and #665 fix, and the only one that broke a mainstream page rather than a feed or a crawler URL.

## Why the rows can't just be narrowed in SQL

`get_tag_search_conditions()`' `LIKE` is a superset of a real tag match — `#photographylover` matches `%#photography%` — and `body_has_tag()` is what decides.

So `post_ids_by_tag()` scans a page of `id` and `body` at a time and keeps only the surviving ids: one page of bodies is all that is in memory, and the id list is the only thing that grows with the tag. The feed asks for twenty ordered by `updated` and the scan stops as soon as it has them; the tag page paginates the id list and `load_posts_in_order()` loads just the page being rendered.

The order column is chosen inside the function from a bool, never interpolated from a caller.

## Behaviour is unchanged

The comparison corpus has `created` and `updated` deliberately in **opposite** orders, so a feed sorted by `updated` cannot accidentally agree with a page ordered by `created`, plus `LIKE`-only decoys, a draft, a trashed post and a future-dated post. Dumped before and after:

```
IDENTICAL: ordering, feed contents, all three pages and their pagination metadata

ordered slugs  : real-1 real-2 real-3 real-4 real-5 real-6 ...
feed slugs     : real-12 real-11 real-10 real-9 real-8 real-7 ...
page 1         : ['real-1', 'real-2', 'real-3']
page 5         : ['real-10', 'real-11', 'real-12']
page 5 meta    : {"current": 4, "per_page": 3, "total_posts": 12, "total_pages": 4, ...}
```

Feed title, url and `updated` stamp are in the diff too, and page 5 clamping to 4 still matches.

## Tests

The paging is only sound if a match past a page boundary is still found, so `PostTest` pins that with a page and a bit of decoys ahead of the real one — which is also the case a plain SQL `LIMIT` would get wrong. Plus the limit behaviour and `load_posts_in_order()`'s ordering.

The existing tag assertions in `PostTest`, `PostDraftVisibilityTest` and `ScheduledPostTest` now call `post_ids_by_tag()`. Every one of them asserted a count or emptiness, which reads the same on ids; I re-ran all thirteen against the new function before switching them over.

`src/post.php` leaves the `literal-string` ignore list because the query that needed it is gone, and an ignore that matches nothing fails phpstan — the same trap that turned #664 red.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_