### PR TITLE
Let a changed ETag decide the 304, as RFC 9110 requires

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -407,8 +407,19 @@ function content_etag(int $contentTs, int $configTs): string
  * Decides whether the client already holds the current version of a response,
  * so a 304 Not Modified can be returned instead of a full body.
  *
- * Honours both If-None-Match (against the ETag) and If-Modified-Since (against
- * the last-modified timestamp).
+ * Honours If-None-Match (against the ETag), and If-Modified-Since (against the
+ * last-modified timestamp) only when no If-None-Match was sent — RFC 9110
+ * §13.1.3: "A recipient MUST ignore If-Modified-Since if the request contains
+ * an If-None-Match header field."
+ *
+ * That precedence is load-bearing here, not pedantry. A browser revalidating
+ * sends both, and latest_content_timestamp() is not actually monotonic: it is
+ * the newest `updated` among published posts, so trashing the newest post moves
+ * it *backwards*. Checking the date after a non-matching ETag therefore answered
+ * 304 to a client holding the pre-deletion page — the deleted post stayed in
+ * its cache until the timestamp climbed back past where it had been. The ETag
+ * had already noticed (it is what #279 added for same-second changes); it just
+ * wasn't allowed to decide.
  *
  * @param array<string, mixed> $server          Typically $_SERVER.
  * @param string $etag            The current response ETag.
@@ -418,8 +429,8 @@ function content_etag(int $contentTs, int $configTs): string
 function client_has_current_version(array $server, string $etag, int $lastModifiedTs): bool
 {
     $if_none_match = trim($server['HTTP_IF_NONE_MATCH'] ?? '');
-    if ($if_none_match !== '' && $if_none_match === $etag) {
-        return true;
+    if ($if_none_match !== '') {
+        return $if_none_match === $etag;
     }
     $if_modified_since = $server['HTTP_IF_MODIFIED_SINCE'] ?? '';
     if ($if_modified_since !== '') {

--- a/tests/Unit/ConditionalRequestTest.php
+++ b/tests/Unit/ConditionalRequestTest.php
@@ -82,4 +82,42 @@ class ConditionalRequestTest extends TestCase
         $server = ['HTTP_IF_MODIFIED_SINCE' => http_date($ts - 60)];
         $this->assertFalse(client_has_current_version($server, $etag, $ts));
     }
+
+    /**
+     * RFC 9110 §13.1.3: If-Modified-Since is ignored when If-None-Match is
+     * present. A browser revalidating sends both, and
+     * latest_content_timestamp() is the newest `updated` among published posts
+     * — so trashing the newest post moves it backwards, and the date test then
+     * passed for a client holding the pre-deletion page. Checking it after a
+     * non-matching ETag therefore answered 304 and left the deleted post in
+     * that cache.
+     */
+    public function testANonMatchingEtagWinsOverAStillCurrentDate(): void
+    {
+        $ts = 1234567890;
+        // What the client cached, then what the server holds after the newest
+        // post was trashed: an earlier timestamp, so a different ETag.
+        $cachedTs = $ts;
+        $nowTs    = $ts - 86400;
+        $server = [
+            'HTTP_IF_NONE_MATCH'     => content_etag($cachedTs, 0),
+            'HTTP_IF_MODIFIED_SINCE' => http_date($cachedTs),
+        ];
+
+        $this->assertFalse(client_has_current_version($server, content_etag($nowTs, 0), $nowTs));
+    }
+
+    public function testAMatchingEtagIsStillCurrentWhenADateIsAlsoSent(): void
+    {
+        // The other half of the precedence rule: sending both headers must not
+        // stop an unchanged response from being a 304.
+        $ts = 1234567890;
+        $etag = content_etag($ts, 0);
+        $server = [
+            'HTTP_IF_NONE_MATCH'     => $etag,
+            'HTTP_IF_MODIFIED_SINCE' => http_date($ts - 86400),
+        ];
+
+        $this->assertTrue(client_has_current_version($server, $etag, $ts));
+    }
 }


### PR DESCRIPTION
`client_has_current_version()` checked `If-None-Match` first but fell through to `If-Modified-Since` when the ETag did **not** match:

```php
if ($if_none_match !== '' && $if_none_match === $etag) {
    return true;
}
// ...falls through to the date test even though the ETag said "changed"
```

RFC 9110 §13.1.3 is explicit: *"A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field."*

## Why that precedence is load-bearing here

`latest_content_timestamp()` is not the monotonic validator its docblock describes. It is the newest `updated` among *published* posts — so trashing the newest post moves it **backwards**:

```
with both posts : Last-Modified Mon, 10 Aug 2026 10:00:00 GMT  ETag "6a79a120-0"
after trashing  : Last-Modified Sat, 01 Aug 2026 10:00:00 GMT  ETag "6a6dc3a0-0"
validator moved : BACKWARDS
```

A browser revalidating sends **both** headers, holding the pre-deletion pair. The ETag no longer matched; the date test then passed, because the server's timestamp had dropped below the cached one; the answer was a 304:

```
before: browser sends a stale ETag AND its stale date -> 304 Not Modified
after:  browser sends a stale ETag AND its stale date -> 200 with fresh content
```

So the deleted post stayed in that client's cache until ordinary content pushed the timestamp back past where it had been. The ETag had already noticed the change — it is exactly what #279 added it for — it just wasn't allowed to decide.

## Everything else is unchanged

Asserted explicitly, because the risk of a precedence change is breaking caching rather than breaking correctness:

| request | before | after |
| --- | --- | --- |
| stale ETag only | 200 | 200 |
| **stale ETag + stale date** | **304** | **200** |
| date only | 304 | 304 |
| current ETag (+ any date) | 304 | 304 |

Every pre-existing assertion in `ConditionalRequestTest` passes untouched — I re-ran all five against the change — and only the new regression test fails against the previous code.

No existing test sent both headers together, which is why the fall-through had gone unnoticed rather than being a deliberate choice.

## Not fixed here

The validator's non-monotonicity itself. A **date-only** client — some intermediary caches — can still be served a stale 304 after a trash. Making the timestamp genuinely monotonic needs a stored high-water mark rather than a `MAX()` over live rows (restoring from trash would drop it again too), which is a design choice rather than a fix. Happy to open it separately if you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_