### PR TITLE
Do not leave the login hash in a world-readable .env

### DIFF
--- a/make-password.php
+++ b/make-password.php
@@ -86,6 +86,21 @@ $data .= 'LAMB_LOGIN_PASSWORD=' . env_value($hash) . PHP_EOL;
 if (getenv('LAMB_WRITE_TEST_PASSWORD')) {
     $data .= 'LAMB_TEST_PASSWORD=' . env_value($password) . PHP_EOL;
 }
+// 0600 before the secret goes in, not the umask default: this file holds the
+// login hash, and file_put_contents() alone left it whatever the umask allowed —
+// 644 normally, 664 under 0002, and 666 under 0000, which is not unusual in
+// containers. World-readable hands a local user the bcrypt hash to crack
+// offline; world-*writable* lets them replace it and own the login outright.
+// bootstrap_db() already applies the same reasoning to the data directory
+// ("under a permissive umask 0777 would leave the database world-readable and
+// replaceable"). Creating the file first and tightening it before writing means
+// there is no moment where the hash sits in a readable one.
+if (!file_exists('.env')) {
+    touch('.env');
+}
+if (!chmod('.env', 0600)) {
+    user_error('Could not restrict permissions on .env; check it is not world-readable', E_USER_WARNING);
+}
 $env_out = file_put_contents('.env', $data);
 if (!$env_out) {
     user_error('Problem saving .env', E_USER_WARNING);

--- a/tests/Unit/MakePasswordTest.php
+++ b/tests/Unit/MakePasswordTest.php
@@ -225,6 +225,59 @@ class MakePasswordTest extends TestCase
         $this->assertStringNotContainsString('--force', $contents);
     }
 
+    /**
+     * .env holds the login hash, so its permissions matter as much as the data
+     * directory's — bootstrap_db() creates that 0750 for the same reason.
+     * file_put_contents() alone left .env at whatever the umask allowed: 644
+     * normally, and 666 under a 0000 umask, which is not unusual in containers.
+     * World-readable hands a local user the bcrypt hash; world-writable lets
+     * them replace it and own the login.
+     */
+    public function testEnvIsNotReadableByOtherUsers(): void
+    {
+        $this->runScript(['PWD' => $this->workspace], 'correct-horse-battery-staple');
+
+        $this->assertEnvMode0600();
+    }
+
+    public function testEnvPermissionsHoldUnderAPermissiveUmask(): void
+    {
+        // umask 0000 is what a container often runs with, and it is the case
+        // that produced a world-*writable* .env rather than merely readable.
+        $process = new Process(
+            ['sh', '-c', 'umask 000 && exec "$0" "$@"', 'php',
+                codecept_root_dir('make-password.php'), 'correct-horse-battery-staple'],
+            $this->workspace,
+            ['PWD' => $this->workspace]
+        );
+        $process->mustRun();
+
+        $this->assertEnvMode0600();
+    }
+
+    public function testForceTightensAnAlreadyLooseEnv(): void
+    {
+        $this->seedExistingEnv('superseded-marker');
+        chmod($this->workspace . '/.env', 0666);
+
+        $this->runScript(['PWD' => $this->workspace], 'correct-horse-battery-staple', ['--force']);
+
+        $this->assertEnvMode0600();
+    }
+
+    private function assertEnvMode0600(): void
+    {
+        $path = $this->workspace . '/.env';
+        clearstatcache(true, $path);
+        $mode = fileperms($path) & 0777;
+
+        $this->assertSame(
+            '0600',
+            sprintf('%04o', $mode),
+            '.env holds the login hash and must not be readable by other users'
+        );
+    }
+
     public function testOptInIsReadFromProcessEnvNotVariablesOrder(): void
     {
         // Mirror CI: run with the stock variables_order (which omits 'E', so


### PR DESCRIPTION
`make-password.php` writes `.env` with `file_put_contents()` and nothing else, so the file lands at whatever the umask allows.

`bootstrap_db()` already treats this exact risk as real for the data directory:

> 0750, not 0777: this directory holds lamb.db and the session files, so only the web-server user has any business reading it. **Under a permissive umask (0002/0000, not unusual in containers) 0777 would leave the database world-readable and replaceable.**

`.env` holds `LAMB_LOGIN_PASSWORD` — the login hash — and got no such treatment.

## Measured

Running the script under three umasks:

```
umask 022 -> .env mode 644  -rw-r--r--
umask 002 -> .env mode 664  -rw-rw-r--
umask 000 -> .env mode 666  -rw-rw-rw-
```

`0000` is the case that matters most, and it's the one `bootstrap_db()`'s comment already calls out as normal in containers. `644` hands any local user the bcrypt hash to crack offline; `666` lets them **replace** it and own the login outright. With `LAMB_WRITE_TEST_PASSWORD` set, the file also carries the cleartext password.

## The change

The file is created and chmodded to `0600` *before* the secret is written into it, so there is no moment where the hash sits in a readable file. A `--force` run over an existing loose `.env` tightens it too. A failing `chmod` warns rather than passing silently.

```
umask 022 -> 600   umask 002 -> 600   umask 000 -> 600
```

## Everything else is unchanged

Re-checked by hand, since this script is what a self-hoster runs once and a broken one is a bad first impression:

- the hash still goes to STDOUT and round-trips through `password_verify()`
- the refusal without `--force` still refuses, and leaves the existing file untouched
- `--force` still replaces it
- `LAMB_WRITE_TEST_PASSWORD` still opts the cleartext line in
- the weak-password warning still goes to STDERR only

All three new assertions fail against the previous code (644, 666, 666). `.env` is gitignored and untracked, so this was never a repository exposure — only a filesystem one.

Found sweeping the last files outside `src/`. For the record, the theme templates came back clean in the same pass: of every `<?= … ?>` site across the 22 templates, exactly one echoes a bare variable without escaping, and it is the intentional pre-rendered `transformed`. The only path that can write attacker-influenced HTML into that column is Micropub's `sanitizeHtml()`, and all 24 payloads I threw at it (script/iframe/object/style/svg/form/base/meta tags, `on*` handlers in both cases, `javascript:`/`vbscript:`/`data:` in href, src and background, entity- and space-obfuscated schemes, inline `style`) came back neutralised, with legitimate rich content passing through intact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_