### PR TITLE
Ask the renderer which checkbox a toggle means

### DIFF
--- a/src/post.php
+++ b/src/post.php
@@ -664,9 +664,12 @@ function finalize_and_store_post(OODBBean $bean): void
 }
 
 /**
- * Matches a task-list marker the renderer turns into a checkbox: optional
- * blockquote markers, an optional bullet or ordered list marker, then
- * `[ ]`/`[x]`/`[X]` followed by whitespace and a non-empty label.
+ * Matches a line that could carry a task-list marker: optional blockquote
+ * markers, an optional bullet or ordered list marker, then `[ ]`/`[x]`/`[X]`
+ * followed by whitespace and a non-empty label.
+ *
+ * Whether such a marker actually renders as a checkbox depends on the block it
+ * lands in, which only the renderer knows — see toggle_rendered_checkbox().
  *
  * Capture 2 is the state character, so its byte offset locates the single
  * character a toggle rewrites.
@@ -674,127 +677,30 @@ function finalize_and_store_post(OODBBean $bean): void
 const TASK_MARKER_PATTERN = '/^([ \t]*(?:>[ \t]?)*[ \t]*(?:(?:[-*+]|\d{1,9}[.)])[ \t]+)?\[)([ xX])(\][ \t]+\S)/';
 
 /**
- * Matches any list item line (task or not), used to track whether the scanner
- * is inside a list — where an indented line is nested content rather than an
- * indented code block.
- */
-const LIST_ITEM_PATTERN = '/^[ \t]*(?:>[ \t]?)*[ \t]*(?:[-*+]|\d{1,9}[.)])[ \t]+/';
-
-/**
- * Matches the opening line of a fenced code block, capturing the fence itself
- * so a closing fence can be required to use the same character and be at least
- * as long — the rule Parsedown applies, so a longer fence can quote a shorter
- * one inside it.
- */
-const CODE_FENCE_PATTERN = '/^[ \t]*(?:>[ \t]?)*[ \t]*(`{3,}|~{3,})/';
-
-/**
- * The width of a line's leading indentation, with tabs expanded to the next
- * multiple of four (the tab stop Markdown's four-space code indent assumes).
+ * Every byte offset in $body that could be the state character of a rendered
+ * checkbox — a deliberately permissive superset.
  *
- * @param string $line A single source line.
- * @return int The indentation width in columns.
- */
-function indent_width(string $line): int
-{
-    $width = 0;
-    for ($i = 0, $len = strlen($line); $i < $len; $i++) {
-        if ($line[$i] === ' ') {
-            $width++;
-        } elseif ($line[$i] === "\t") {
-            $width += 4 - ($width % 4);
-        } else {
-            break;
-        }
-    }
-
-    return $width;
-}
-
-/**
- * The byte offsets, within $body, of the state character of every task marker
- * the renderer turns into a checkbox — in the order the checkboxes appear.
- *
- * The toggle endpoint addresses a checkbox by its rendered position
- * (`data-checkbox-index`, numbered in document order by LambDown::text()), so
- * this has to recognise a marker exactly where the renderer does, or a click
- * flips somebody else's box. That means mirroring LambDown/Parsedown, not just
- * matching `- [ ] ` lines:
- *
- * - a marker needs no list bullet at all (`[ ] task` is a checkbox block on its
- *   own, which is why LambDown registers one), and an ordered bullet
- *   (`1. [ ] task`) counts as much as `-`/`*`/`+`;
- * - blockquoted markers render too, which every feed-ingested post is made of
- *   (Network\attributed_content() quotes the source with `> `);
- * - a marker inside a fenced or indented code block renders as code, not a
- *   checkbox, so it must not be counted;
- * - a marker with no label after it (`- [ ] `) is not a checkbox either;
- * - front matter is not rendered at all, so markers there are invisible.
+ * This is only a candidate list, not an answer: which markers actually become
+ * checkboxes is decided by Parsedown's block structure, and that is not
+ * something a line scanner can be trusted to reproduce. So this scan skips
+ * front matter (never rendered) and otherwise matches every task marker it
+ * sees, leaving toggle_rendered_checkbox() to identify the real one by asking
+ * the renderer.
  *
  * @param string $body The raw post body (front matter included).
- * @return list<int> Byte offsets of each rendered marker's state character.
+ * @return list<int> Byte offsets of each candidate marker's state character.
  */
-function checkbox_marker_offsets(string $body): array
+function candidate_marker_offsets(string $body): array
 {
     [, $content] = split_frontmatter($body);
     $position = strlen($body) - strlen($content);
 
     $offsets = [];
-    /** @var string|null $fence The opening fence (e.g. '```') while inside a code block. */
-    $fence   = null;
-    $in_list = false;
-    $blank   = true;
-
     foreach (preg_split('/(\R)/', $content, -1, PREG_SPLIT_DELIM_CAPTURE) ?: [] as $index => $piece) {
-        // Odd indices are the captured line endings.
-        if ($index % 2 === 1) {
-            $position += strlen($piece);
-            continue;
-        }
-
-        $line = $piece;
-        $advance = strlen($line);
-
-        if ($fence !== null) {
-            $closing = '/^[ \t]*(?:>[ \t]?)*[ \t]*' . $fence[0] . '{' . strlen($fence) . ',}[ \t]*$/';
-            if (preg_match($closing, $line) === 1) {
-                $fence = null;
-            }
-            $position += $advance;
-            continue;
-        }
-        if (trim($line) === '') {
-            $blank = true;
-            $position += $advance;
-            continue;
-        }
-        // An indented code block, but only outside a list: inside one the same
-        // indentation marks nested list content, which does render checkboxes.
-        if (indent_width($line) >= 4 && !$in_list) {
-            $blank = false;
-            $position += $advance;
-            continue;
-        }
-        if (preg_match(CODE_FENCE_PATTERN, $line, $m) === 1) {
-            $fence = $m[1];
-            $blank = false;
-            $position += $advance;
-            continue;
-        }
-
-        if (preg_match(LIST_ITEM_PATTERN, $line) === 1) {
-            $in_list = true;
-        } elseif ($blank && indent_width($line) === 0) {
-            // A fresh, unindented block after a blank line closes the list.
-            $in_list = false;
-        }
-        $blank = false;
-
-        if (preg_match(TASK_MARKER_PATTERN, $line, $m, PREG_OFFSET_CAPTURE) === 1) {
+        if ($index % 2 === 0 && preg_match(TASK_MARKER_PATTERN, $piece, $m, PREG_OFFSET_CAPTURE) === 1) {
             $offsets[] = $position + (int) $m[2][1];
         }
-
-        $position += $advance;
+        $position += strlen($piece);
     }
 
     return $offsets;
@@ -805,8 +711,7 @@ function checkbox_marker_offsets(string $body): array
  * the order the toggle endpoint's `data-checkbox-index` counts them.
  *
  * The renderer is the authority on which markers become checkboxes, so this is
- * what checkbox_marker_offsets()'s reading of the source is checked against
- * before a toggle is stored (see Response\apply_checkbox_toggle).
+ * what toggle_rendered_checkbox() resolves a `data-checkbox-index` against.
  *
  * @param string $body The raw post body (front matter included).
  * @return list<bool> True for each checked box, in document order.
@@ -822,27 +727,56 @@ function rendered_checkbox_states(string $body): array
 }
 
 /**
- * Toggles the checked state of the Nth GitHub-style task-list marker in a body.
+ * Rewrites the source marker behind the Nth *rendered* checkbox.
  *
- * Markers are counted exactly as the renderer numbers the checkboxes it emits
- * (see checkbox_marker_offsets()), so the Nth rendered checkbox maps to the Nth
- * source marker. Only the target marker's state character is rewritten; every
- * other marker and all surrounding text is preserved verbatim. An index past
- * the last marker returns the body unchanged.
+ * The toggle endpoint addresses a checkbox by its rendered position
+ * (`data-checkbox-index`, numbered in document order by LambDown::text()), so
+ * the marker to rewrite is the one whose flip moves that box and no other. That
+ * is a property of the renderer, not of the source text: `    - [ ] x` on the
+ * first line is a checkbox (render_body() trims the body, so the indent is
+ * gone), the same line inside a list item is a code block, and a scanner that
+ * guesses either way flips somebody else's box — or, when the requested state
+ * already holds, silently rewrites a `[ ]` inside a code block.
  *
- * @param string $body    The raw post body.
- * @param int    $index   Zero-based index of the marker to toggle.
- * @param bool   $checked True to check the marker, false to uncheck it.
- * @return string The body with the target marker toggled.
+ * So the renderer decides. Each candidate marker is rewritten in turn and the
+ * result re-rendered; the marker that produces exactly the requested change,
+ * with every other box untouched, is the right one. At most one candidate can
+ * satisfy that, because only the marker behind box $index can move it.
+ *
+ * @param string $body    The raw post body (front matter included).
+ * @param int    $index   Zero-based index of the rendered checkbox to toggle.
+ * @param bool   $checked True to check the box, false to uncheck it.
+ * @return string|null The body with that box toggled, or null when $index names
+ *                     no rendered checkbox or no marker accounts for it.
  */
-function toggle_checkbox(string $body, int $index, bool $checked): string
+function toggle_rendered_checkbox(string $body, int $index, bool $checked): ?string
 {
-    $offsets = checkbox_marker_offsets($body);
-    if ($index < 0 || !isset($offsets[$index])) {
+    if ($index < 0) {
+        return null;
+    }
+
+    $before = rendered_checkbox_states($body);
+    if (!isset($before[$index])) {
+        return null;
+    }
+    // Already in the requested state: nothing to rewrite. Skipping the search
+    // matters, because with no state change to look for every candidate would
+    // satisfy the check — including one inside a code block.
+    if ($before[$index] === $checked) {
         return $body;
     }
 
-    return substr_replace($body, $checked ? 'x' : ' ', $offsets[$index], 1);
+    $expected = $before;
+    $expected[$index] = $checked;
+
+    foreach (candidate_marker_offsets($body) as $offset) {
+        $candidate = substr_replace($body, $checked ? 'x' : ' ', $offset, 1);
+        if (rendered_checkbox_states($candidate) === $expected) {
+            return $candidate;
+        }
+    }
+
+    return null;
 }
 
 /**

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -18,9 +18,8 @@ use function Lamb\parse_bean;
 use function Lamb\Post\finalize_and_store_post;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\populate_bean;
-use function Lamb\Post\rendered_checkbox_states;
 use function Lamb\Post\sanitize_explicit_slug;
-use function Lamb\Post\toggle_checkbox;
+use function Lamb\Post\toggle_rendered_checkbox;
 use function Lamb\Route\is_reserved_route;
 
 /**
@@ -407,42 +406,30 @@ function respond_checkbox(array $_args): void
 /**
  * Toggles a task-list checkbox in a post and persists it as an edit.
  *
- * Loads the post, flips the Nth `[ ]`/`[x]` marker in its body, re-parses so
- * `transformed`/`description` reflect the new state, and bumps `updated`. The
+ * Loads the post, flips the marker behind its Nth rendered checkbox, re-parses
+ * so `transformed`/`description` reflect the new state, and bumps `updated`. The
  * testable core of respond_checkbox() (which adds auth and the JSON response).
  *
  * @param int  $id      The post id.
- * @param int  $index   Zero-based checkbox index.
+ * @param int  $index   Zero-based rendered checkbox index.
  * @param bool $checked The desired checked state.
- * @return bool True on success, false when the post is missing or the index invalid.
+ * @return bool True on success, false when the post is missing or the index
+ *              names no checkbox the renderer emits.
  */
 function apply_checkbox_toggle(int $id, int $index, bool $checked): bool
 {
-    if ($index < 0) {
-        return false;
-    }
-
     $bean = R::load('post', $id);
     if (!$bean->id) {
         return false;
     }
 
-    // The index names a *rendered* checkbox, so the rewrite is checked against
-    // the renderer rather than trusted: no such checkbox, or a rewrite that
-    // moves any other box, is refused. The client then reverts the tick instead
-    // of the author silently finding a different task crossed off — which is
-    // what a document the source scan reads differently from the renderer
-    // (see Post\checkbox_marker_offsets) used to do.
-    $body   = (string) $bean->body;
-    $before = rendered_checkbox_states($body);
-    if (!isset($before[$index])) {
-        return false;
-    }
-
-    $toggled  = toggle_checkbox($body, $index, $checked);
-    $expected = $before;
-    $expected[$index] = $checked;
-    if (rendered_checkbox_states($toggled) !== $expected) {
+    // The index names a *rendered* checkbox, and which source marker that is is
+    // the renderer's answer to give (see Post\toggle_rendered_checkbox): null
+    // means no such checkbox, or none whose flip leaves every other box alone.
+    // The client then reverts the tick instead of the author silently finding a
+    // different task crossed off.
+    $toggled = toggle_rendered_checkbox((string) $bean->body, $index, $checked);
+    if ($toggled === null) {
         return false;
     }
 

--- a/tests/Unit/CheckboxRenderParityTest.php
+++ b/tests/Unit/CheckboxRenderParityTest.php
@@ -5,16 +5,16 @@ namespace Tests\Unit;
 use Lamb\LambDown;
 use PHPUnit\Framework\TestCase;
 
-use function Lamb\Post\checkbox_marker_offsets;
+use function Lamb\Post\candidate_marker_offsets;
 use function Lamb\Post\split_frontmatter;
-use function Lamb\Post\toggle_checkbox;
+use function Lamb\Post\toggle_rendered_checkbox;
 
 /**
  * The toggle endpoint addresses a checkbox by its *rendered* position
- * (`data-checkbox-index`), so the markers checkbox_marker_offsets() counts in
- * the source have to be exactly the checkboxes LambDown renders — same count,
- * same order, same states. Where the two disagreed, clicking one box silently
- * rewrote a different one.
+ * (`data-checkbox-index`), so toggling index N has to flip the Nth rendered
+ * checkbox and leave every other one exactly as it was. Which source marker
+ * that is depends on Parsedown's block structure, so the tests below check the
+ * result against the rendered HTML rather than against a source scan.
  */
 class CheckboxRenderParityTest extends TestCase
 {
@@ -33,19 +33,6 @@ class CheckboxRenderParityTest extends TestCase
         preg_match_all('/<input type="checkbox" data-checkbox-index="\d+"( checked)?/', $html, $matches);
 
         return array_map(static fn(string $checked): bool => $checked !== '', $matches[1]);
-    }
-
-    /**
-     * The `checked` state of every marker the toggle scanner finds, in order.
-     *
-     * @return list<bool>
-     */
-    private function scannedStates(string $body): array
-    {
-        return array_map(
-            static fn(int $offset): bool => strtolower($body[$offset]) === 'x',
-            checkbox_marker_offsets($body)
-        );
     }
 
     /**
@@ -74,76 +61,132 @@ class CheckboxRenderParityTest extends TestCase
             'tab after bullet'         => ["-\t[x] tabbed\n"],
             'paragraph closes list'    => ["- [x] a\n\ntext\n\n    [ ] indented\n"],
             'mixed shapes'             => ["1. [ ] one\n\n> [x] quoted\n\n```\n[ ] code\n```\n\n[x] bare\n"],
+            // Indentation on the first line is stripped before rendering
+            // (render_body() trims the body), so this is a plain list of two
+            // checkboxes — not an indented code block followed by one.
+            'leading indent'           => ["    - [ ] indented\n\n- [ ] real\n"],
+            'leading tab'              => ["\t- [x] tabbed\n\n- [ ] real\n"],
+            // A blank line then a deep indent inside a list item is code, even
+            // though a shallower indent there would be a nested checkbox.
+            'indented code in a list'  => ["- [ ] parent\n\n      - [ ] nested\n"],
+            'indented code then task'  => ["- [ ] parent\n\n      - [ ] nested\n\n- [ ] sibling\n"],
         ];
     }
 
     /**
      * @dataProvider bodyProvider
      */
-    public function testScannerMatchesRenderer(string $body): void
-    {
-        $this->assertSame($this->renderedStates($body), $this->scannedStates($body));
-    }
-
-    /**
-     * @dataProvider bodyProvider
-     */
-    public function testTogglingEveryIndexFlipsThatCheckbox(string $body): void
+    public function testTogglingEveryIndexFlipsThatCheckboxAndNoOther(string $body): void
     {
         $states = $this->renderedStates($body);
+        $this->assertNotSame([], $states, 'the fixture should render at least one checkbox');
 
         foreach ($states as $index => $state) {
             $expected = $states;
             $expected[$index] = !$state;
 
-            $toggled = toggle_checkbox($body, $index, !$state);
+            $toggled = toggle_rendered_checkbox($body, $index, !$state);
 
+            $this->assertNotNull($toggled, "index $index should be toggleable");
             $this->assertSame($expected, $this->renderedStates($toggled), "index $index");
             $this->assertSame(strlen($body), strlen($toggled), 'only the state character changes');
         }
+    }
+
+    /**
+     * @dataProvider bodyProvider
+     */
+    public function testNoIndexBeyondTheRenderedBoxesIsAccepted(string $body): void
+    {
+        $this->assertNull(toggle_rendered_checkbox($body, count($this->renderedStates($body)), true));
+    }
+
+    /**
+     * @dataProvider bodyProvider
+     */
+    public function testCandidateOffsetsAreASupersetOfTheRenderedBoxes(string $body): void
+    {
+        // The search can only find a marker it was offered, so the permissive
+        // scan has to cover every marker the renderer might turn into a box.
+        $this->assertGreaterThanOrEqual(
+            count($this->renderedStates($body)),
+            count(candidate_marker_offsets($body))
+        );
     }
 
     public function testBareMarkerIsCountedBeforeListMarkers(): void
     {
         $body = "[ ] alpha\n\n- [ ] beta\n";
 
-        $this->assertSame("[x] alpha\n\n- [ ] beta\n", toggle_checkbox($body, 0, true));
-        $this->assertSame("[ ] alpha\n\n- [x] beta\n", toggle_checkbox($body, 1, true));
+        $this->assertSame("[x] alpha\n\n- [ ] beta\n", toggle_rendered_checkbox($body, 0, true));
+        $this->assertSame("[ ] alpha\n\n- [x] beta\n", toggle_rendered_checkbox($body, 1, true));
     }
 
     public function testMarkerInFencedCodeIsNotCounted(): void
     {
         $body = "```\n- [ ] code\n```\n\n- [ ] real\n";
 
-        $this->assertSame("```\n- [ ] code\n```\n\n- [x] real\n", toggle_checkbox($body, 0, true));
+        $this->assertSame("```\n- [ ] code\n```\n\n- [x] real\n", toggle_rendered_checkbox($body, 0, true));
     }
 
     public function testLabellessMarkerIsNotCounted(): void
     {
         $body = "- [ ] \n- [ ] real\n";
 
-        $this->assertSame("- [ ] \n- [x] real\n", toggle_checkbox($body, 0, true));
+        $this->assertSame("- [ ] \n- [x] real\n", toggle_rendered_checkbox($body, 0, true));
     }
 
     public function testFrontMatterMarkerIsNotCounted(): void
     {
         $body = "---\ntags:\n  - [ ] odd\n---\n\n- [ ] real\n";
 
-        $this->assertSame("---\ntags:\n  - [ ] odd\n---\n\n- [x] real\n", toggle_checkbox($body, 0, true));
+        $this->assertSame(
+            "---\ntags:\n  - [ ] odd\n---\n\n- [x] real\n",
+            toggle_rendered_checkbox($body, 0, true)
+        );
     }
 
     public function testOrderedAndBlockquotedMarkersAreCounted(): void
     {
         $body = "1. [ ] one\n\n> - [ ] two\n";
 
-        $this->assertSame("1. [x] one\n\n> - [ ] two\n", toggle_checkbox($body, 0, true));
-        $this->assertSame("1. [ ] one\n\n> - [x] two\n", toggle_checkbox($body, 1, true));
+        $this->assertSame("1. [x] one\n\n> - [ ] two\n", toggle_rendered_checkbox($body, 0, true));
+        $this->assertSame("1. [ ] one\n\n> - [x] two\n", toggle_rendered_checkbox($body, 1, true));
     }
 
-    public function testNegativeIndexIsNoOp(): void
+    public function testNegativeIndexIsRefused(): void
     {
-        $body = "- [ ] one\n";
+        $this->assertNull(toggle_rendered_checkbox("- [ ] one\n", -1, true));
+    }
 
-        $this->assertSame($body, toggle_checkbox($body, -1, true));
+    public function testAMarkerHiddenInIndentedCodeIsNeverRewritten(): void
+    {
+        // The box is already checked, so there is no state change to search for
+        // and every candidate — including the one inside the code block — would
+        // satisfy a naive check. The body has to come back untouched.
+        $body = "- [x] parent\n\n      - [ ] nested\n";
+
+        $this->assertSame($body, toggle_rendered_checkbox($body, 0, true));
+    }
+
+    public function testLeadingIndentDoesNotHideTheWholeList(): void
+    {
+        // render_body() trims the body, so the four spaces are gone by the time
+        // Parsedown sees the line: both markers are checkboxes.
+        $body = "    - [ ] indented\n\n- [ ] real\n";
+
+        $this->assertSame("    - [x] indented\n\n- [ ] real\n", toggle_rendered_checkbox($body, 0, true));
+        $this->assertSame("    - [ ] indented\n\n- [x] real\n", toggle_rendered_checkbox($body, 1, true));
+    }
+
+    public function testDeepIndentInsideAListIsCodeNotANestedCheckbox(): void
+    {
+        $body = "- [ ] parent\n\n      - [ ] nested\n\n- [ ] sibling\n";
+
+        $this->assertSame(
+            "- [ ] parent\n\n      - [ ] nested\n\n- [x] sibling\n",
+            toggle_rendered_checkbox($body, 1, true)
+        );
+        $this->assertNull(toggle_rendered_checkbox($body, 2, true));
     }
 }

--- a/tests/Unit/CheckboxTest.php
+++ b/tests/Unit/CheckboxTest.php
@@ -4,56 +4,62 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
-use function Lamb\Post\toggle_checkbox;
+use function Lamb\Post\toggle_rendered_checkbox;
 
 class CheckboxTest extends TestCase
 {
     public function testCheckFirstMarker(): void
     {
         $body = "- [ ] one\n- [ ] two\n";
-        $this->assertSame("- [x] one\n- [ ] two\n", toggle_checkbox($body, 0, true));
+        $this->assertSame("- [x] one\n- [ ] two\n", toggle_rendered_checkbox($body, 0, true));
     }
 
     public function testCheckSecondMarker(): void
     {
         $body = "- [ ] one\n- [ ] two\n";
-        $this->assertSame("- [ ] one\n- [x] two\n", toggle_checkbox($body, 1, true));
+        $this->assertSame("- [ ] one\n- [x] two\n", toggle_rendered_checkbox($body, 1, true));
     }
 
     public function testUncheckMarker(): void
     {
         $body = "- [x] one\n- [x] two\n";
-        $this->assertSame("- [x] one\n- [ ] two\n", toggle_checkbox($body, 1, false));
+        $this->assertSame("- [x] one\n- [ ] two\n", toggle_rendered_checkbox($body, 1, false));
     }
 
-    public function testOutOfRangeIndexIsNoOp(): void
+    public function testOutOfRangeIndexIsRefused(): void
     {
         $body = "- [ ] one\n";
-        $this->assertSame($body, toggle_checkbox($body, 5, true));
+        $this->assertNull(toggle_rendered_checkbox($body, 5, true));
+    }
+
+    public function testTogglingToTheStateAlreadyHeldLeavesTheBodyAlone(): void
+    {
+        $body = "- [x] one\n";
+        $this->assertSame($body, toggle_rendered_checkbox($body, 0, true));
     }
 
     public function testOnlyTargetLineChanges(): void
     {
         $body = "intro text\n\n- [ ] one\n- [ ] two\n- [ ] three\n\noutro";
-        $out = toggle_checkbox($body, 1, true);
+        $out = toggle_rendered_checkbox($body, 1, true);
         $this->assertSame("intro text\n\n- [ ] one\n- [x] two\n- [ ] three\n\noutro", $out);
     }
 
     public function testMixedMarkerCharacters(): void
     {
         $body = "* [ ] star\n+ [ ] plus\n- [ ] dash\n";
-        $this->assertSame("* [ ] star\n+ [x] plus\n- [ ] dash\n", toggle_checkbox($body, 1, true));
+        $this->assertSame("* [ ] star\n+ [x] plus\n- [ ] dash\n", toggle_rendered_checkbox($body, 1, true));
     }
 
     public function testUppercaseXCounted(): void
     {
         $body = "- [X] one\n- [ ] two\n";
-        $this->assertSame("- [X] one\n- [x] two\n", toggle_checkbox($body, 1, true));
+        $this->assertSame("- [X] one\n- [x] two\n", toggle_rendered_checkbox($body, 1, true));
     }
 
     public function testIndentedTaskMarker(): void
     {
         $body = "- [ ] one\n  - [ ] nested\n";
-        $this->assertSame("- [ ] one\n  - [x] nested\n", toggle_checkbox($body, 1, true));
+        $this->assertSame("- [ ] one\n  - [x] nested\n", toggle_rendered_checkbox($body, 1, true));
     }
 }

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -633,19 +633,49 @@ class ResponsePostsTest extends TestCase
         $this->assertSame("- [ ] one\n", R::load('post', $post->id)->body);
     }
 
-    public function testApplyCheckboxToggleRefusesWhenRewriteWouldMoveAnotherBox(): void
+    public function testApplyCheckboxToggleHandlesABodyASourceScanReadsDifferently(): void
     {
-        // A body whose markers the source scan and the renderer read
-        // differently: the fence is swallowed by the preceding list item, so
-        // the renderer shows three checkboxes where the scan sees two.
+        // The unclosed fence is swallowed by the preceding list item, so the
+        // renderer shows three checkboxes where a line-by-line scan of the
+        // source sees two — and the third box used to be untickable.
         $post          = R::dispense('post');
         $post->body    = "- [ ] one\n+ [ ] two\n```\n- [ ] three\n";
         $post->version = 1;
         $post->created = date('Y-m-d H:i:s');
         R::store($post);
 
-        $this->assertFalse(apply_checkbox_toggle($post->id, 2, true));
-        $this->assertSame("- [ ] one\n+ [ ] two\n```\n- [ ] three\n", R::load('post', $post->id)->body);
+        $this->assertTrue(apply_checkbox_toggle($post->id, 2, true));
+        $this->assertSame("- [ ] one\n+ [ ] two\n```\n- [x] three\n", R::load('post', $post->id)->body);
+    }
+
+    public function testApplyCheckboxToggleTicksABoxUnderALeadingIndent(): void
+    {
+        // parse_bean() renders the trimmed body, so the leading four spaces are
+        // gone by the time Parsedown sees the line: both markers are checkboxes.
+        $post          = R::dispense('post');
+        $post->body    = "    - [ ] indented\n\n- [ ] real\n";
+        $post->version = 1;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $this->assertTrue(apply_checkbox_toggle($post->id, 0, true));
+        $this->assertSame("    - [x] indented\n\n- [ ] real\n", R::load('post', $post->id)->body);
+    }
+
+    public function testApplyCheckboxToggleLeavesAMarkerInIndentedCodeAlone(): void
+    {
+        // A blank line then a deep indent inside a list item is a code block, so
+        // the nested marker is not a checkbox and must never be rewritten — not
+        // even by a toggle whose requested state already holds.
+        $post          = R::dispense('post');
+        $post->body    = "- [x] parent\n\n      - [ ] nested\n";
+        $post->version = 1;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $this->assertFalse(apply_checkbox_toggle($post->id, 1, true));
+        $this->assertTrue(apply_checkbox_toggle($post->id, 0, true));
+        $this->assertSame("- [x] parent\n\n      - [ ] nested\n", R::load('post', $post->id)->body);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
A click on a task-list checkbox sends its **rendered** position (`data-checkbox-index`), and the toggle has to turn that back into a byte offset in the source. `checkbox_marker_offsets()` did that with a line scanner that reimplemented Parsedown's block structure — fences, indented code, list nesting — and its own docblock names the stake: *"this has to recognise a marker exactly where the renderer does, or a click flips somebody else's box."*

It doesn't. Measured against `rendered_checkbox_states()` (which parses the same trimmed body the display render does):

| body | renderer | scanner | effect |
| --- | --- | --- | --- |
| `    - [ ] indented\n\n- [ ] real\n` | 2 boxes | 1 | **neither box can be ticked** |
| `- [ ] parent\n\n      - [ ] nested\n` | 1 box | 2 | phantom marker counted |
| `- [ ] one\n+ [ ] two\n```\n- [ ] three\n` | 3 boxes | 2 | **third box can't be ticked** |

The first is the ordinary one. `render_body()` renders `trim($content)`, so leading indentation on the first line is gone before Parsedown sees it — the line is a list item and both markers are checkboxes. The scanner reads four spaces as an indented code block and skips it, and every later index shifts by one. `apply_checkbox_toggle()`'s guard catches the mismatch and refuses, so nothing is corrupted, but the author's tick silently reverts with no explanation and no way to tick anything on that post. The third row was already covered by a test — which asserted the refusal rather than the fix.

There is also a narrower hole the guard cannot catch. It works by comparing rendered states before and after, so when the requested state already holds there is no change to look for: `before === expected`, and a rewrite landing on a marker inside a code block passes. A duplicate or replayed `checked=1` on an already-ticked box would silently edit the post's code sample.

## The fix

Teaching the scanner more of Parsedown is a losing game — Parsedown's list continuation re-parses each item's body at a marker-relative indent, and any line-based emulation will diverge again. So delete the scanner and let the renderer answer:

- `candidate_marker_offsets()` returns a deliberately permissive superset — every task marker outside front matter, no block-structure guessing.
- `toggle_rendered_checkbox()` rewrites each candidate in turn and re-renders, returning the one that flips the requested box and leaves every other box alone; `null` when no candidate does.

At most one candidate can satisfy that test, because only the marker behind box *N* can move box *N* — so the answer is unambiguous, and it is correct by construction for any body the renderer can render. A toggle whose requested state already holds returns the body untouched instead of searching, which closes the code-block hole above.

That collapses the scanner, its guard in `apply_checkbox_toggle()`, and ~60 lines of block-structure emulation (`indent_width()`, `LIST_ITEM_PATTERN`, `CODE_FENCE_PATTERN` and the fence/indent/list state machine) into one function whose correctness is defined by the renderer it has to agree with. Net zero lines, one implementation of Markdown block structure instead of two.

Cost is one Parsedown pass per candidate on an author click, bounded by the number of `[ ]` lines in the post and short-circuited at the first match — the common case is the same single render the guard already did.

## Tests

`CheckboxRenderParityTest` drops its source-scan comparison for the invariant that actually matters, checked against the rendered HTML: **toggling index N flips box N and no other**, for every index of every fixture, plus the candidate list being a superset and no out-of-range index being accepted. The three divergent bodies join the provider, along with the already-checked case that must leave indented code alone. `ResponsePostsTest` gains the same cases at the endpoint level.

Verified locally against the real `LambDown`: all 24 parity fixtures pass every index, the 25-body property fuzz that surfaced this (three properties: only the target box moves, toggling back restores the rendered states, an out-of-range index is refused) is clean where it previously reported violations, and the endpoint cases pass against a real SQLite-backed bean including the re-parse and `updated` bump.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1wxQhWHyyqqypMgL8x1Qc)_