### PR TITLE
Upgrade util-linux in the release image to clear the scan

### DIFF
--- a/.docker/Dockerfile.release
+++ b/.docker/Dockerfile.release
@@ -20,7 +20,13 @@ RUN install-php-extensions gettext pdo_mysql gd
 # nothing needs it once the extensions are built. Dropping it also drops
 # linux-libc-dev, whose kernel CVEs blocked every release scan — the container
 # runs the host's kernel, so those headers were never the thing at risk.
-RUN apt-get purge -y --auto-remove linux-libc-dev \
+#
+# The base image's util-linux (2.41-5) trails the Debian security update
+# (2.41.5-0+deb13u1) that fixes the mount/libblkid CVEs the release scan blocks
+# on. Pull the fix in the same layer rather than suppress it.
+RUN apt-get update \
+    && apt-get install -y --only-upgrade util-linux libmount1 libblkid1 libsmartcols1 libuuid1 \
+    && apt-get purge -y --auto-remove linux-libc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,7 +92,7 @@ branch tip) and publishes the release in one step — no separate `git tag` need
 ```sh
 gh release create <version> \
   --target release \
-  --title "Lamb <version>" \
+  --title "<version>" \
   --notes-file /tmp/notes.md
 # add --prerelease for an -rcN tag
 # add --latest to mark a final release as the latest


### PR DESCRIPTION
The release image scan for 0.13.0-rc2 failed on four util-linux CVEs (CVE-2026-53612/53613/53614/53615) — mount TOCTOU/SUID bypass and a libblkid overflow — so the container image was not pushed.

`ignore-unfixed: true` means these have a published fix: the base image carries util-linux 2.41-5, and Debian security update 2.41.5-0+deb13u1 fixes them. This upgrades those packages at build time (in the same layer that already trims linux-libc-dev) instead of adding a suppression.

Also corrects the RELEASING.md release-title example to drop the `Lamb ` prefix — releases are named by version alone.

The image-scan check on this PR verifies the rebuilt image is clean.