### PR TITLE
Plan: converge the duplicate mechanisms behind the recurring bugs

### DIFF
--- a/MODULARITY.md
+++ b/MODULARITY.md
@@ -1,29 +1,15 @@
-# Modularity investigation — duplicate mechanisms and plugin seams
+# Duplicate mechanisms in Lamb
 
-**Status:** findings, nothing implemented. Written in response to "the project is
-sprawled, we keep finding bugs — find where there are multiple ways to do
-something and how we can split them off into plugins."
+Where the codebase does one job two or three different ways, with file:line evidence
+for each. This is the findings document behind [PLAN.md](PLAN.md), which sequences the
+work; it records what is duplicated, not what to do about it.
 
-**The sequenced plan derived from these findings is [PLAN.md](PLAN.md).** This
-document is the evidence base — what the plan cites — and is not itself a plan.
-
-**§1 and §2 stand. §3, §4 and §5 are superseded: the module system they propose was
-rejected.** The reason is in PLAN.md §Decision and is a product one, not a technical
-one — Lamb promises a plug-and-play install, and a `src/modules/` tree puts a disable
-switch ten lines away, which is the step toward plug-many-things-and-configure. The
-duplication findings in §2 are unaffected and are what the plan acts on; three items
-§3–4 justified as module plumbing survived as standalone bug-class fixes (the `/_cron`
-ordering, the importer registry, feeds moving out of themes). Read §3–5 as the
-rejected option, kept for the record.
-
-The finding in one line: **the sprawl and the bugs are two different problems, and
-only one of them is fixed by plugins.** The bugs come from ~10 places where the
-same job is done two or three different ways inside the core. The sprawl comes from
-~44% of `src/` being optional features fused into that core. Extracting a plugin
-does not fix a duplicate mechanism — it copies it into a module boundary and makes
-it harder to see. So the order matters: **converge first, extract second.**
-
----
+The through-line: **the bugs and the sprawl are separate problems.** The bugs come
+from the ten hotspots in §2, where the same job has more than one implementation and
+the copies have drifted. The sprawl is §1 — 44% of `src/` being optional features in a
+flat namespace. Fixing the duplication does not require touching the sprawl, and the
+reverse is not true: consolidating behind a boundary before the implementations agree
+just hides the divergence somewhere harder to see.
 
 ## 1. What "sprawled" measures
 
@@ -40,16 +26,18 @@ it harder to see. So the order matters: **converge first, extract second.**
 | Syntax highlighting | 91 | post render | `phiki/phiki` |
 
 Optional features are **7,184 lines — 44% of the PHP in `src/`** — and **4 of the 8
-runtime composer dependencies exist only to serve them.** Given how much of
-`AGENTS.md` is dedicated to dependency and advisory management, a minimal install
-carrying CVE surface for a Micropub endpoint it never exposes is a real cost, not a
-theoretical one.
+runtime composer dependencies exist only to serve them.**
 
-There is currently **no extension mechanism at all**: no hooks, no filters, no
-module registry. The only existing seams are `Theme\part()`'s base-theme fallback
-and the `?callable $fetcher` / `$sender` / `$downloader` / `$resolver` injection
-parameters used for testing. That injection idiom is the right seed — the proposal
-below builds on it rather than importing a hook system.
+That ratio is worth knowing but is not, on its own, a defect: every one of those areas
+is a headline feature in `README.md`, so for most installs this is the product rather
+than dead weight. It matters here for a narrower reason — those 7,184 lines share a
+flat namespace with the core and with each other, which is the condition under which
+§2's duplication keeps appearing. Two features that never reference each other can
+still grow two copies of the same helper.
+
+The only existing seams in the codebase are `Theme\part()`'s base-theme fallback and
+the `?callable $fetcher` / `$sender` / `$downloader` / `$resolver` injection parameters
+used for testing. The latter idiom is worth reusing where §2's fixes need a seam.
 
 ---
 
@@ -202,143 +190,3 @@ scripts. `constants.php` also mixes core constants with feature constants
 (`FEED_FETCH_*`, `IMAGE_UPLOAD_EXTENSIONS`, `VIDEO_UPLOAD_EXTENSIONS`).
 
 ---
-
-## 3. What is plugin-shaped, and what must stay one way
-
-This is the distinction that decides whether this work reduces bugs or multiplies
-them.
-
-**Extract to a module** — optional, feature-complete, owns its own routes/tables/deps:
-
-| Module | Absorbs | Provides | Drops dep |
-|---|---|---|---|
-| `indieweb` | `micropub.php`, `webmention.php`, `websub.php`, `parts/_webmentions.php`, `index.php`'s 4 `Link:` headers | 3 routes, 1 cron job, 1 theme part, `webmention`/`webmentionoutbox` tables | `taproot/micropub-adapter` |
-| `feeds` | `network.php`, `network/` | `/_cron` ingest job, `feedstatus` table, `FEED_FETCH_*` | `simplepie/simplepie` |
-| `import` | `import.php`, `wordpress.php`, `known.php`, `restore.php`, 3 CLIs | 3 registered import sources, 1 CLI driver | `league/html-to-markdown` |
-| `export` | `export.php`, `response/export.php` | `/export`, needs `ext-zip` | — |
-| `highlight` | `highlight.php` | a render filter, `POST_VERSION` participant | `phiki/phiki` |
-
-**Consolidate, never make pluggable** — these need *one* implementation, and offering
-a choice is precisely what caused D1-D6:
-
-routing · config · `Lamb\Post` (front matter, slug, render) · visibility · HTTP
-egress guarding · HTML escaping and sanitizing · the upload security checks
-(`safe_upload_extension`, `upload_content_allowed`, `max_upload_pixels`) · session
-and CSRF.
-
-The project's own philosophy — *"opinionated defaults over settings"*, *"prefer the
-minimal implementation"* — argues for exactly this split: modules are an **internal
-seam for optional features**, not a third-party plugin market. No hook priorities,
-no filter chains, no plugin API to support.
-
----
-
-## 4. The minimal mechanism
-
-Four seams. Three of them already half-exist.
-
-**1. Route registration — already done.** `Route\register_route()` /
-`register_private_route()` is a registry, and `register_private_route()` already
-derives `robots.txt` and the `noindex` header from one source of truth. A module
-just calls it. Zero new machinery; this is why routes are the cheapest thing to move.
-
-**2. A post lifecycle funnel — the prerequisite for everything else.** One
-`Post\save(OODBBean $bean, array $context): void` that all nine D1 sites call,
-emitting `post.created`, `post.updated`, `post.published`, `post.deleted`,
-`post.restored`. Subscribers: outbound webmentions, WebSub pings, slug-change
-redirects, feed-lock. `$context` carries the flags each site currently expresses by
-*omitting a call* (`notify: false` for imports, `finalize_slug: false` for edits) —
-so the convention becomes a parameter that can be tested instead of a comment in
-eight files. This is the fix for D1 **and** the seam that makes `indieweb`
-extractable, because webmention/websub stop being called by name from the write paths.
-
-**3. A cron registry.** `Network\process_feeds()` `network.php:142-146` hardcodes
-`Websub\ping_scheduled_publishes()` and `Webmention\process_outbound()` inside the
-feed-ingestion loop. That single coupling means **outbound webmentions stop being
-delivered if you remove the feed reader.** Replace with `Cron\register(name,
-callable)` and a `/_cron` driver that runs whatever registered.
-
-**4. An importer registry.** `Import\register_source(['name' =>, 'parse' =>,
-'extract' =>, 'skip_reason' =>, 'uuid' =>, 'import' =>])` plus one
-`bin/lamb import <source> <path> [--dry-run] [--replace]` driver. `run_import()` is
-already the shared loop and already takes exactly these callables — this is
-mechanical, and it collapses D9 to zero while making a fourth importer a drop-in.
-
-A module is then a directory with a manifest, loaded from config:
-
-```php
-// src/modules/indieweb/module.php
-return [
-    'name'     => 'indieweb',
-    'requires' => [],                        // ext-*/composer checks, cf. Export\zip_available()
-    'register' => function (): void {
-        Route\register_route('micropub', 'Lamb\Micropub\respond_micropub');
-        Route\register_route('webmention', 'Lamb\Webmention\respond_webmention');
-        Post\on('post.published', 'Lamb\Webmention\enqueue_for_post');
-        Post\on('post.published', 'Lamb\Websub\ping_for_post');
-        Cron\register('webmention-outbox', 'Lamb\Webmention\process_outbound');
-        Http\link_header('micropub', ROOT_URL . '/micropub');
-    },
-];
-```
-
-Modules ship **enabled by default** — this is a code-organisation seam, not a new
-settings page. `experimental_features` + `EXPERIMENTAL_GATE_VERSION`
-(`config.php:436-479`) already establishes the precedent for gating a feature set
-and forcing re-opt-in when that set changes.
-
----
-
-## 5. Sequencing
-
-**Phase 0 — pure convergence, no architecture change.** Each item is independently
-shippable and removes a class of divergence. Do this first; it is where the bug
-reduction actually is.
-
-1. Delete `Http\post_form()` (D2) — dead, and its existence invites use of the
-   unguarded transport.
-2. One escaper (D3): namespaced, XML variant as an explicit argument; delete the
-   global `escape()` in `themes/base/feed.php`.
-3. One front-matter engine (D4): keep `set_frontmatter_key()`'s split/rebuild
-   semantics, re-express `set_matter()` and the four assemblers on top of it.
-4. One upload store (D5): one `store_upload()` taking either a path or bytes.
-5. Dedupe the theme parts (D8): `2024` and `2026` differ by two lines — promote the
-   shared version, keep only genuine overrides.
-6. One `Bootstrap\data_dir()` for the CLIs (D10).
-
-**Phase 1 — the post lifecycle funnel.** Convert all nine D1 write sites. This is
-the highest-value single change in the document and the gate for everything after it.
-
-**Phase 2 — cron registry.** Unhook webmention/websub from `process_feeds()`.
-
-**Phase 3 — first module: `import`.** Lowest risk by a wide margin: CLI-only, no
-web routes, no theme surface, and *already gated behind `experimental_features`* —
-a kill switch that exists today. Proves the manifest end to end.
-
-**Phase 4 — `indieweb`, `export`, `highlight`.** Move Atom and JSON Feed out of
-`themes/` into a serializer registry (D7) so themes stop owning syndication.
-
-**Phase 5 — optional dependencies.** Move the four feature-only composer packages to
-`suggest` with runtime capability checks, following `Export\zip_available()`.
-
----
-
-## 6. Risks worth stating up front
-
-- **Philosophy.** A plugin *framework* would contradict "simple over complex". The
-  answer is that this adds no user-facing configuration and no third-party API: one
-  manifest array, four registries, modules on by default.
-- **Global state is the real coupling.** `global $routes, $config, $data, $template`
-  is what any module system inherits. Not worth fixing now, but it caps how isolated
-  a module can ever be, and it should be named rather than discovered later.
-- **RedBean fluid mode and module-owned tables.** `webmention`, `webmentionoutbox`,
-  `feedstatus` are created lazily on first write. Disabling a module leaves orphan
-  tables. Acceptable, but it means "disabled" is not "uninstalled".
-- **Test suite pinning.** 100 unit tests and 22 acceptance Cests, several of which
-  (`MicropubDiscoveryCest`, `MicropubMediaCest`, `WebmentionCest`, `UploadCest`,
-  `TagFeedCest`) exercise routes that would become module-provided. CI must pin the
-  enabled module set or coverage silently drops when a default changes.
-- **Do not extract before converging.** Extracting `indieweb` while Micropub still
-  carries its own front-matter assembler, its own HTML sanitizer, and its own upload
-  pipeline just relocates D3, D4, and D5 behind a module boundary where they are
-  harder to see and easier to justify.

--- a/MODULARITY.md
+++ b/MODULARITY.md
@@ -6,7 +6,15 @@ something and how we can split them off into plugins."
 
 **The sequenced plan derived from these findings is [PLAN.md](PLAN.md).** This
 document is the evidence base — what the plan cites — and is not itself a plan.
-§5 below is the outline PLAN.md supersedes with per-PR detail.
+
+**§1 and §2 stand. §3, §4 and §5 are superseded: the module system they propose was
+rejected.** The reason is in PLAN.md §Decision and is a product one, not a technical
+one — Lamb promises a plug-and-play install, and a `src/modules/` tree puts a disable
+switch ten lines away, which is the step toward plug-many-things-and-configure. The
+duplication findings in §2 are unaffected and are what the plan acts on; three items
+§3–4 justified as module plumbing survived as standalone bug-class fixes (the `/_cron`
+ordering, the importer registry, feeds moving out of themes). Read §3–5 as the
+rejected option, kept for the record.
 
 The finding in one line: **the sprawl and the bugs are two different problems, and
 only one of them is fixed by plugins.** The bugs come from ~10 places where the

--- a/MODULARITY.md
+++ b/MODULARITY.md
@@ -1,8 +1,12 @@
 # Modularity investigation — duplicate mechanisms and plugin seams
 
-**Status:** proposal, nothing implemented. Written in response to "the project is
+**Status:** findings, nothing implemented. Written in response to "the project is
 sprawled, we keep finding bugs — find where there are multiple ways to do
 something and how we can split them off into plugins."
+
+**The sequenced plan derived from these findings is [PLAN.md](PLAN.md).** This
+document is the evidence base — what the plan cites — and is not itself a plan.
+§5 below is the outline PLAN.md supersedes with per-PR detail.
 
 The finding in one line: **the sprawl and the bugs are two different problems, and
 only one of them is fixed by plugins.** The bugs come from ~10 places where the

--- a/MODULARITY.md
+++ b/MODULARITY.md
@@ -1,0 +1,332 @@
+# Modularity investigation — duplicate mechanisms and plugin seams
+
+**Status:** proposal, nothing implemented. Written in response to "the project is
+sprawled, we keep finding bugs — find where there are multiple ways to do
+something and how we can split them off into plugins."
+
+The finding in one line: **the sprawl and the bugs are two different problems, and
+only one of them is fixed by plugins.** The bugs come from ~10 places where the
+same job is done two or three different ways inside the core. The sprawl comes from
+~44% of `src/` being optional features fused into that core. Extracting a plugin
+does not fix a duplicate mechanism — it copies it into a module boundary and makes
+it harder to see. So the order matters: **converge first, extract second.**
+
+---
+
+## 1. What "sprawled" measures
+
+`src/` is 16,179 lines of PHP. Grouped by whether an install actually needs it:
+
+| Area | LOC | Reachable via | Runtime dep it alone pulls in |
+|---|---:|---|---|
+| Core (routing, config, post, theme, http, security, response) | 8,079 | everything | redbean, parsedown, symfony/yaml |
+| IndieWeb (`micropub`, `webmention`, `websub`) | 2,558 | `/micropub`, `/micropub-media`, `/webmention`, `Link:` headers, `/_cron` | `taproot/micropub-adapter` |
+| Importers (`import`, `wordpress`, `known`, `restore` + 3 CLIs) | 2,391 | CLI only | `league/html-to-markdown` |
+| Feed reader (`network/`) | 1,042 | `/_cron` | `simplepie/simplepie` |
+| Uploads + WebP | 663 | `/upload`, micropub media | `ext-gd` |
+| Export | 439 | `/export` | `ext-zip` |
+| Syntax highlighting | 91 | post render | `phiki/phiki` |
+
+Optional features are **7,184 lines — 44% of the PHP in `src/`** — and **4 of the 8
+runtime composer dependencies exist only to serve them.** Given how much of
+`AGENTS.md` is dedicated to dependency and advisory management, a minimal install
+carrying CVE surface for a Micropub endpoint it never exposes is a real cost, not a
+theoretical one.
+
+There is currently **no extension mechanism at all**: no hooks, no filters, no
+module registry. The only existing seams are `Theme\part()`'s base-theme fallback
+and the `?callable $fetcher` / `$sender` / `$downloader` / `$resolver` injection
+parameters used for testing. That injection idiom is the right seed — the proposal
+below builds on it rather than importing a hook system.
+
+---
+
+## 2. Where there are multiple ways to do one thing
+
+Ranked by how likely each is to be the source of the bugs being found. Every one of
+these is evidenced by the code's own comments, which document the divergence rather
+than prevent it.
+
+### D1. Saving a post — 9 entry points, 3 tiers of completeness ⚠️ **highest risk**
+
+| Call site | Renders | Finalizes slug | Notifies subscribers |
+|---|---|---|---|
+| `Response\redirect_created()` `response/posts.php:45` | ✅ | ✅ | ✅ |
+| `Response\redirect_edited()` `response/posts.php:296` | ✅ | — | ✅ |
+| `Micropub::createCallback()` `micropub.php:360` | ✅ | ✅ | ✅ |
+| `Micropub::updateCallback()` `micropub.php:545` | ✅ | — | ✅ |
+| `Network\create_item()` `network/ingest.php:139` | ✅ | ✅ | ❌ |
+| `WordPress\import_item()` `wordpress.php:236` | ✅ | ✅ | ❌ |
+| `Known\import_item()` `known.php:358` | ✅ | ✅ | ❌ |
+| `Restore\import_post()` `restore.php:355` | ✅ | ✅ | ❌ |
+| `Response\apply_checkbox_toggle()` `response/posts.php:428` | ✅ | — | ❌ |
+| `Response\upgrade_posts()` `response.php:274` (read path!) | ✅ | — | ❌ |
+
+Each site independently decides whether to re-render, finalize the slug, notify
+subscribers, write a slug-change redirect, and feed-lock. `wordpress.php:203` and
+`known.php:307` both carry the comment *"finalize_and_store_post(), which never
+invokes notify_post_subscribers()"* — the asymmetry is a documented convention held
+by hand across eight files.
+
+The deeper consequence: **"published" is not an event.** Nothing emits it, so each
+interested subsystem re-derives it. `Webmention\process_outbound()` checks
+`is_publicly_visible()` at send time; `Websub\ping_scheduled_publishes()`
+(`websub.php:142`) infers it from a `created > updated` heuristic over a watermark
+window. Two different definitions of the same moment, in two files, for the same
+posts. Both are currently correct — but nothing structural keeps them agreeing, and
+a third subscriber would need a third derivation.
+
+### D2. Making an outbound HTTP request — 5 transports, 1 of them guarded, 1 dead
+
+- `Http\fetch()` `http.php:578` — streams, unguarded
+- `Http\fetch_pinned()` `http.php:482` — curl, pinned to a validated IP
+- `Http\fetch_guarded()` `http.php:683` — the SSRF-safe path, re-validates every hop
+- `Http\post_form()` `http.php:443` — **zero callers.** The only two places that
+  would use it (`websub.php:105`, `webmention.php:778`) carry comments explaining
+  they deliberately don't. Dead code that still reads as an available option.
+- `Network\SafeFile` `network/sources.php:34` — a SimplePie `File` subclass with its
+  own hardening, because SimplePie can't be handed `fetch_guarded()`
+
+Which one you get depends on which file you are editing, not on what the call needs.
+
+### D3. Sanitizing and escaping HTML — 4 sanitizers, 5 escapers
+
+Sanitizers, each with its own tag allowlist:
+`LambDown` (Parsedown safe mode, post bodies) · `Import\sanitize_html_in_dom()`
+`import.php:95` · `Micropub::sanitizeHtml()` + `sanitizeAttributes()`
+`micropub.php:1102` · `Webmention\extract_meta()` `webmention.php:224` (regex +
+`strip_tags`).
+
+Escapers, each with different flags:
+
+| Location | Flags |
+|---|---|
+| `Theme\escape()` `theme/formatting.php:15` | `ENT_HTML5\|ENT_QUOTES\|ENT_SUBSTITUTE` |
+| `Theme\og_escape()` `theme/formatting.php:94` | decode-then-`ENT_COMPAT\|ENT_HTML5` |
+| `Theme\preload_text()` `theme/formatting.php:104` | `ENT_QUOTES` only |
+| `themes/base/feed.php:9` | `ENT_XML1\|ENT_QUOTES\|ENT_SUBSTITUTE` |
+| `response/discovery.php:106` | `ENT_XML1\|ENT_QUOTES\|ENT_SUBSTITUTE` |
+
+The feed one is the worst of these: it declares a **global** function named `escape()`
+from inside a template, behind a `function_exists()` guard, shadowing the namespaced
+helper every other template uses.
+
+### D4. Writing YAML front matter — 2 engines, 4 assemblers
+
+Two engines with different semantics: `Post\set_matter()` `post.php:459` rewrites a
+value in place with a regex; `Post\set_frontmatter_key()` `post.php:526` splits,
+rebuilds through the YAML writer, and can also remove a key. Four assemblers:
+`Post\build_matter()` `post.php:416`, `Import\build_post_body()` `import.php:344`,
+`Micropub::assembleFrontMatter()` `micropub.php:886`, and
+`Micropub::rebuildBody()` `micropub.php:861` doing its own fence handling. Then
+`persist_slug`, `set_reply_to`, `inject_title_matter`, `persist_resolved_created`
+are thin wrappers, split across *both* engines.
+
+Front matter is the post format. Six ways to write it is the single most
+bug-productive duplication in the codebase after D1.
+
+### D5. Storing an uploaded image — 3 pipelines, 3 move semantics
+
+`respond_upload()` (`move_uploaded_file()` then `store_webp_copy()`) ·
+`respond_micropub_media()` `micropub.php:1502` (same two, opposite order) ·
+`persist_image_bytes()` `response/upload.php:300` (`tempnam` + `rename` + explicit
+`chmod`, used by micropub inline photos and the import downloader). Two WebP
+encoders for one decision (`convert_to_webp` / `convert_to_webp_from_bytes`).
+
+`response/upload.php:328-333` documents the consequence in full: the `tempnam`
+path landed assets at `0600` while every other path landed at `0666 & ~umask`, so
+a static file server or backup user couldn't read images the site was serving.
+Fixed — in one of the three paths.
+
+### D6. Deciding a post is visible — 5 expressions
+
+`Lamb\visible_clause()` `lamb.php:715` (documented as *"the single allow-list
+definition"*) · `Response\public_posts_clause()` `response.php:118` (adds menu
+exclusion) · `is_publicly_visible()` / `is_viewable()` / `is_scheduled()`
+`lamb.php:773-817` (in-memory) · `websub.php:157` re-assembles `SQL_PUBLISHED` with
+its own conditions inline · plus an `is_menu_item()` backstop **inside each theme's
+`_items.php`**.
+
+The docblocks record two bugs already shipped from this: *"which is how scheduled
+posts leaked into related posts"* and *"both used to assemble the two clauses
+inline, in opposite orders."*
+
+### D7. Serializing a post for output — 5 writers, 2 owned by the theme layer
+
+Atom (`themes/base/feed.php`), JSON Feed (`themes/base/feed_json.php`), sitemap
+(`Response\render_sitemap()` `response/discovery.php:94`), export manifest
+(`Export\manifest_post_entry()` `export.php:212`), mf2
+(`Micropub::beanToMf2Properties()` `micropub.php:104`).
+
+Two of the five are **theme parts**, which means a custom theme owns the syndication
+contract. `themes/2026/html.php:85-89` shows exactly this class of failure already
+happening for a different part: *"A theme that omits the call hides them from the
+author entirely — this one did, and it is the default theme."*
+
+### D8. Rendering the post list — 3 copies
+
+`themes/2024/parts/_items.php` and `themes/2026/parts/_items.php` differ by **two
+lines, one of which is a comment**, and both have diverged from
+`themes/base/parts/_items.php` in the same direction (schema.org attributes, `<ul>`
+wrapping, meta block, logged-in footer). `themes/base/parts/_related.php:31`
+carries the giveaway: *"mb_strimwidth(), as the 2026 theme's own _related.php
+uses"* — a truncation fix hand-ported between copies after it was found in one.
+
+### D9. Running an importer — 3 near-identical CLI scripts
+
+`import-wordpress.php`, `import-known.php`, `import-lamb.php` are ~60-70 lines each
+of the same sequence: SAPI check, `define('ROOT_DIR')`, `parse_import_args()`,
+readability check, `getenv('LAMB_DATA_DIR')`, `bootstrap_db()`, `Config\load()`,
+`apply_timezone()`, experimental gate, parse, extract, `run_import()`. The
+*conversion* logic already converged on `Lamb\Import`; only the wiring is triplicated.
+
+### D10. Configuring the install — 6 sources
+
+`.env` via phpdotenv/`getenv()` · a `config.ini` file (`config.php:511`) · the
+`option.site_config_ini` DB row · `Config\get_default_ini_text()` built-in defaults ·
+`constants.php` · and `define()` at runtime in `index.php` and `response.php:22`.
+`LAMB_DATA_DIR` is read independently in `bootstrap.php:58` and all three CLI
+scripts. `constants.php` also mixes core constants with feature constants
+(`FEED_FETCH_*`, `IMAGE_UPLOAD_EXTENSIONS`, `VIDEO_UPLOAD_EXTENSIONS`).
+
+---
+
+## 3. What is plugin-shaped, and what must stay one way
+
+This is the distinction that decides whether this work reduces bugs or multiplies
+them.
+
+**Extract to a module** — optional, feature-complete, owns its own routes/tables/deps:
+
+| Module | Absorbs | Provides | Drops dep |
+|---|---|---|---|
+| `indieweb` | `micropub.php`, `webmention.php`, `websub.php`, `parts/_webmentions.php`, `index.php`'s 4 `Link:` headers | 3 routes, 1 cron job, 1 theme part, `webmention`/`webmentionoutbox` tables | `taproot/micropub-adapter` |
+| `feeds` | `network.php`, `network/` | `/_cron` ingest job, `feedstatus` table, `FEED_FETCH_*` | `simplepie/simplepie` |
+| `import` | `import.php`, `wordpress.php`, `known.php`, `restore.php`, 3 CLIs | 3 registered import sources, 1 CLI driver | `league/html-to-markdown` |
+| `export` | `export.php`, `response/export.php` | `/export`, needs `ext-zip` | — |
+| `highlight` | `highlight.php` | a render filter, `POST_VERSION` participant | `phiki/phiki` |
+
+**Consolidate, never make pluggable** — these need *one* implementation, and offering
+a choice is precisely what caused D1-D6:
+
+routing · config · `Lamb\Post` (front matter, slug, render) · visibility · HTTP
+egress guarding · HTML escaping and sanitizing · the upload security checks
+(`safe_upload_extension`, `upload_content_allowed`, `max_upload_pixels`) · session
+and CSRF.
+
+The project's own philosophy — *"opinionated defaults over settings"*, *"prefer the
+minimal implementation"* — argues for exactly this split: modules are an **internal
+seam for optional features**, not a third-party plugin market. No hook priorities,
+no filter chains, no plugin API to support.
+
+---
+
+## 4. The minimal mechanism
+
+Four seams. Three of them already half-exist.
+
+**1. Route registration — already done.** `Route\register_route()` /
+`register_private_route()` is a registry, and `register_private_route()` already
+derives `robots.txt` and the `noindex` header from one source of truth. A module
+just calls it. Zero new machinery; this is why routes are the cheapest thing to move.
+
+**2. A post lifecycle funnel — the prerequisite for everything else.** One
+`Post\save(OODBBean $bean, array $context): void` that all nine D1 sites call,
+emitting `post.created`, `post.updated`, `post.published`, `post.deleted`,
+`post.restored`. Subscribers: outbound webmentions, WebSub pings, slug-change
+redirects, feed-lock. `$context` carries the flags each site currently expresses by
+*omitting a call* (`notify: false` for imports, `finalize_slug: false` for edits) —
+so the convention becomes a parameter that can be tested instead of a comment in
+eight files. This is the fix for D1 **and** the seam that makes `indieweb`
+extractable, because webmention/websub stop being called by name from the write paths.
+
+**3. A cron registry.** `Network\process_feeds()` `network.php:142-146` hardcodes
+`Websub\ping_scheduled_publishes()` and `Webmention\process_outbound()` inside the
+feed-ingestion loop. That single coupling means **outbound webmentions stop being
+delivered if you remove the feed reader.** Replace with `Cron\register(name,
+callable)` and a `/_cron` driver that runs whatever registered.
+
+**4. An importer registry.** `Import\register_source(['name' =>, 'parse' =>,
+'extract' =>, 'skip_reason' =>, 'uuid' =>, 'import' =>])` plus one
+`bin/lamb import <source> <path> [--dry-run] [--replace]` driver. `run_import()` is
+already the shared loop and already takes exactly these callables — this is
+mechanical, and it collapses D9 to zero while making a fourth importer a drop-in.
+
+A module is then a directory with a manifest, loaded from config:
+
+```php
+// src/modules/indieweb/module.php
+return [
+    'name'     => 'indieweb',
+    'requires' => [],                        // ext-*/composer checks, cf. Export\zip_available()
+    'register' => function (): void {
+        Route\register_route('micropub', 'Lamb\Micropub\respond_micropub');
+        Route\register_route('webmention', 'Lamb\Webmention\respond_webmention');
+        Post\on('post.published', 'Lamb\Webmention\enqueue_for_post');
+        Post\on('post.published', 'Lamb\Websub\ping_for_post');
+        Cron\register('webmention-outbox', 'Lamb\Webmention\process_outbound');
+        Http\link_header('micropub', ROOT_URL . '/micropub');
+    },
+];
+```
+
+Modules ship **enabled by default** — this is a code-organisation seam, not a new
+settings page. `experimental_features` + `EXPERIMENTAL_GATE_VERSION`
+(`config.php:436-479`) already establishes the precedent for gating a feature set
+and forcing re-opt-in when that set changes.
+
+---
+
+## 5. Sequencing
+
+**Phase 0 — pure convergence, no architecture change.** Each item is independently
+shippable and removes a class of divergence. Do this first; it is where the bug
+reduction actually is.
+
+1. Delete `Http\post_form()` (D2) — dead, and its existence invites use of the
+   unguarded transport.
+2. One escaper (D3): namespaced, XML variant as an explicit argument; delete the
+   global `escape()` in `themes/base/feed.php`.
+3. One front-matter engine (D4): keep `set_frontmatter_key()`'s split/rebuild
+   semantics, re-express `set_matter()` and the four assemblers on top of it.
+4. One upload store (D5): one `store_upload()` taking either a path or bytes.
+5. Dedupe the theme parts (D8): `2024` and `2026` differ by two lines — promote the
+   shared version, keep only genuine overrides.
+6. One `Bootstrap\data_dir()` for the CLIs (D10).
+
+**Phase 1 — the post lifecycle funnel.** Convert all nine D1 write sites. This is
+the highest-value single change in the document and the gate for everything after it.
+
+**Phase 2 — cron registry.** Unhook webmention/websub from `process_feeds()`.
+
+**Phase 3 — first module: `import`.** Lowest risk by a wide margin: CLI-only, no
+web routes, no theme surface, and *already gated behind `experimental_features`* —
+a kill switch that exists today. Proves the manifest end to end.
+
+**Phase 4 — `indieweb`, `export`, `highlight`.** Move Atom and JSON Feed out of
+`themes/` into a serializer registry (D7) so themes stop owning syndication.
+
+**Phase 5 — optional dependencies.** Move the four feature-only composer packages to
+`suggest` with runtime capability checks, following `Export\zip_available()`.
+
+---
+
+## 6. Risks worth stating up front
+
+- **Philosophy.** A plugin *framework* would contradict "simple over complex". The
+  answer is that this adds no user-facing configuration and no third-party API: one
+  manifest array, four registries, modules on by default.
+- **Global state is the real coupling.** `global $routes, $config, $data, $template`
+  is what any module system inherits. Not worth fixing now, but it caps how isolated
+  a module can ever be, and it should be named rather than discovered later.
+- **RedBean fluid mode and module-owned tables.** `webmention`, `webmentionoutbox`,
+  `feedstatus` are created lazily on first write. Disabling a module leaves orphan
+  tables. Acceptable, but it means "disabled" is not "uninstalled".
+- **Test suite pinning.** 100 unit tests and 22 acceptance Cests, several of which
+  (`MicropubDiscoveryCest`, `MicropubMediaCest`, `WebmentionCest`, `UploadCest`,
+  `TagFeedCest`) exercise routes that would become module-provided. CI must pin the
+  enabled module set or coverage silently drops when a default changes.
+- **Do not extract before converging.** Extracting `indieweb` while Micropub still
+  carries its own front-matter assembler, its own HTML sanitizer, and its own upload
+  pipeline just relocates D3, D4, and D5 behind a module boundary where they are
+  harder to see and easier to justify.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,478 @@
+# Plan: converge, then modularise
+
+Deliverable plan for the sprawl/duplicate-mechanism work. The evidence behind every
+claim here — file:line for all ten duplication findings, D1–D10 — is in
+[MODULARITY.md](MODULARITY.md); this document does not restate it, it sequences the
+work.
+
+**Thesis:** the bugs and the sprawl are separate problems. The bugs come from ~10
+places where the core does one job two or three ways; the sprawl comes from 44% of
+`src/` being optional features fused into that core. A module boundary drawn around a
+duplicate mechanism relocates the bug instead of removing it. So: **converge first,
+extract second.** Every stage below is ordered by that constraint, not by appeal.
+
+**Shape:** 15 PRs across 6 stages. Stages 0–1 (7 PRs) are independent of each other
+and of everything after — they can land in any order, in parallel, and each one is
+worth landing even if the rest of this plan is dropped. Stage 2 is the keystone.
+Stages 3–5 are only unlocked by it.
+
+---
+
+## Objectives
+
+1. Remove the divergence that is producing the bugs (Stages 0–2).
+2. Make "published" a single event instead of a convention re-derived per subsystem (Stage 2).
+3. Let an install not ship — and not carry the dependency surface of — features it doesn't use (Stages 3–6).
+
+## Non-goals
+
+- **No plugin framework.** No hook priorities, no filter chains, no third-party
+  plugin API, no plugin admin UI. Four registries and a manifest array.
+- **No new user-facing configuration.** Modules ship enabled by default. This is an
+  internal code-organisation seam.
+- **No pluggability for the core.** Routing, config, `Lamb\Post`, visibility, HTTP
+  egress guarding, escaping, upload security, session/CSRF each get *one*
+  implementation. Offering a choice there is what caused D1–D6.
+- **Not a global-state cleanup.** `global $routes, $config, $data, $template` stays.
+  It caps how isolated a module can be; that is accepted and stated, not fixed here.
+
+## Ground rules (house process, per AGENTS.md)
+
+- Branch from `main`. **Open an issue per PR first** and get maintainer agreement —
+  AGENTS.md requires it for feature work, and Stage 2 onward is feature work.
+- **Red-green TDD is mandatory.** Every step below names its failing test. No
+  implementation before the test fails.
+- Gates that must stay green, per PR: `composer lint`, `composer analyse`
+  (**PHPStan level 8, empty baseline — keep it empty**), `vendor/bin/codecept run`,
+  `composer coverage` (**≥70%**), `pnpm test`, `composer audit`.
+- A refactor PR that touches no behaviour still needs its characterisation test
+  written first, so the "no behaviour change" claim is enforced rather than asserted.
+- Per the 2026-08-21 decision, each new module directory gets a
+  `src/modules/<name>/README.md`. Per the 2026-05-29 decision, `docs/` stays
+  end-user only — none of this work adds pages there except where a module changes
+  documented behaviour.
+- `DECISIONS.md` entries at three points only: the funnel (Stage 2), the module
+  manifest (Stage 4), and optional dependencies (Stage 6). The convergence PRs are
+  not decisions, they are cleanups.
+
+---
+
+## Stage 0 — The bug that proves the thesis
+
+**PR 1 · Fix the notify-after-failed-write twin on the create path**
+
+`Response\redirect_edited()` (`src/response/posts.php:317-329`) carries this comment
+on its catch block:
+
+> *"Falling through on a failed write … announced the unsaved content to webmention
+> receivers and the WebSub hub."*
+
+That bug was found and fixed — **on one of the two save paths.**
+`Response\redirect_created()` (`src/response/posts.php:48-58`) still calls
+`notify_post_subscribers($bean)` *outside* its try/catch. It is narrower than the
+edit-path version but live: `finalize_and_store_post()` stores twice
+(`src/post.php:658`), and if the *second* store throws — SQLite locked by a
+concurrent `/_cron` run, which is the realistic case the edit-path comment names —
+the bean already has an id, so neither `enqueue_for_post()` nor `ping_for_post()`
+early-returns. Outbound webmentions are queued against a permalink built from an
+unstored slug, and the hub is pinged for content that was not persisted.
+
+- **Test first:** `tests/Unit/` — create path, second `R::store()` throws, assert no
+  `webmentionoutbox` row and no hub ping (both already take injectable senders).
+- **Fix:** move the notify inside the success path, matching the edit path.
+- **Sweep** (AGENTS.md "After a bugfix"): the same class across all nine D1 write
+  sites. That sweep is what produces the Stage 2 design, and its output is the PR
+  description for Stage 2's issue.
+- **Size:** small. **Risk:** none. **Rollback:** revert.
+
+This PR is the argument for the rest of the plan: a fix applied to one of two twins,
+because nothing structural made them one path.
+
+---
+
+## Stage 1 — Convergence
+
+Six independent PRs. No ordering between them, no dependency on anything later.
+Each removes one class of divergence outright.
+
+**PR 2 · Delete `Http\post_form()`** (D2)
+
+Zero callers. The only two call sites that would use it (`src/websub.php:105`,
+`src/webmention.php:778`) carry comments explaining why they deliberately don't. Its
+existence advertises the unguarded transport as an option.
+- Test: none needed (deletion); confirm `grep -rn post_form src/ tests/` is empty.
+- Size: trivial. Risk: none.
+
+**PR 3 · One escaper** (D3)
+
+Keep `Theme\escape()` (91 call sites, unchanged). Add `Theme\escape_xml()` for the
+`ENT_XML1` variant. Delete the **global** `escape()` declared inside
+`src/themes/base/feed.php:6-11` behind a `function_exists()` guard — it shadows the
+namespaced helper every other template uses — and point `feed.php` and
+`src/response/discovery.php:106` at `escape_xml()`. Leave `og_escape()` and
+`preload_text()` alone or fold them in only if the flag difference is provably
+incidental; do not "unify" a deliberate flag choice.
+- Test first: `tests/Unit/` for `escape_xml()` over `&`, `<`, a stray `'`, and an
+  invalid UTF-8 byte; acceptance already covers feed well-formedness (`TagFeedCest`).
+- Size: small (≈5 sites). Risk: low — a wrong flag here breaks feed XML, which
+  `TagFeedCest` catches.
+
+**PR 4 · One front-matter engine** (D4)
+
+Two engines with different semantics (`Post\set_matter()` regex-in-place,
+`Post\set_frontmatter_key()` split/rebuild-via-YAML) behind four assemblers
+(`Post\build_matter()`, `Import\build_post_body()`,
+`Micropub::assembleFrontMatter()`, `Micropub::rebuildBody()`) and four thin wrappers.
+14 call sites across 8 files.
+
+Keep `set_frontmatter_key()`'s split/rebuild semantics as the single engine — it
+round-trips through the YAML writer, so it cannot leave a stale list under a key or
+inject a newline. Re-express `set_matter()`, `persist_slug()`, `set_reply_to()`,
+`inject_title_matter()`, `persist_resolved_created()` and the four assemblers on top
+of it.
+- Test first: characterisation tests pinning current output for each of the 14 call
+  sites' inputs — CRLF bodies from the edit form, no-front-matter bodies, a body
+  whose block holds an unrecognised key, both hyphen and underscore key spellings.
+  `set_matter()`'s no-churn contract (`src/post.php:467-471`) must be pinned before
+  it moves: it exists because CRLF made every save rewrite the line.
+- Size: **large — the biggest PR in Stage 1.** Consider splitting: (4a) tests +
+  engine, (4b) migrate `Lamb\Post` wrappers, (4c) migrate Micropub and the importers.
+- Risk: medium-high. Front matter *is* the post format; a regression corrupts stored
+  bodies. Mitigation: characterisation tests first, and `--dry-run` on a real import
+  archive before and after (`import-lamb.php` supports it).
+
+**PR 5 · One upload store** (D5)
+
+Three pipelines, three move semantics, two WebP encoders, 5 call sites
+(`src/response/upload.php:70-74`, `src/micropub.php:932`, `:1579-1582`,
+`src/import.php:699`). `src/response/upload.php:320-333` documents the fallout: the
+`tempnam` path landed assets `0600` while the others landed `0666 & ~umask`, so a
+static-file server or backup user couldn't read images the site was serving. Fixed
+in one of three paths.
+
+Single `Response\store_upload()` accepting either a temp path (uses
+`move_uploaded_file()` for PHP's managed check) or bytes, owning the WebP decision
+and the final mode for both.
+- Test first: mode assertion (`0666 & ~umask`) and WebP-vs-fallback for every input
+  shape; the existing `UploadCest` and `MicropubMediaCest` cover the routes.
+- Size: medium. Risk: medium — the `move_uploaded_file()` safety check must not be
+  lost on the path that has it. Keep the two entry shapes; unify only what follows.
+
+**PR 6 · Dedupe the theme parts** (D8)
+
+`themes/2024/parts/_items.php` and `themes/2026/parts/_items.php` differ by **two
+lines, one a comment**, and both diverged from base in the same direction.
+`themes/base/parts/_related.php:31` carries the giveaway — *"mb_strimwidth(), as the
+2026 theme's own _related.php uses"* — a truncation fix hand-ported between copies.
+
+Promote the shared markup into `base`, keep only genuine per-theme overrides. Where
+base and the two themes genuinely disagree (base's `<footer>` vs the themes'
+logged-in-only `<small>`), decide once and record it — do not preserve all three.
+- Test first: `tests/Unit/Theme*PartTest.php` is an established pattern (9 such
+  files exist); add render assertions per theme before moving markup.
+- Verify: `pnpm run screenshot` before/after per theme at all three widths, plus the
+  `playwright` CI job.
+- Size: medium. Risk: low functionally, **visible** cosmetically — screenshot diffs
+  are the gate, and `PRODUCT.md` is the arbiter for the 2026 theme.
+
+**PR 7 · One `data_dir()`** (D10)
+
+`getenv('LAMB_DATA_DIR')` is read independently in `src/bootstrap.php:58` and all
+three CLI scripts. Route the CLIs through `Bootstrap\data_dir()`. Move the
+feature-only constants out of `src/constants.php` (`FEED_FETCH_*`,
+`IMAGE_UPLOAD_EXTENSIONS`, `VIDEO_UPLOAD_EXTENSIONS`) — parking them next to their
+owners now saves moving them twice in Stages 4–5.
+- Test first: `UpgradeScriptTest`/`LambRestoreTest` already spawn CLI subprocesses
+  with a seeded data dir — extend to assert the resolved path.
+- Size: small. Risk: low. Note the default differs by design (`../data` for web,
+  `__DIR__/data` for CLI) — preserve that, don't "fix" it.
+
+**Stage 1 exit criteria:** `grep` finds one escaper for XML, one front-matter engine,
+one upload store, one `data_dir()`, no `post_form()`, and no duplicated `_items.php`.
+Coverage ≥70% and the PHPStan baseline still empty.
+
+---
+
+## Stage 2 — The post lifecycle funnel (keystone)
+
+**PR 8 · `Post\save()` and the lifecycle events**
+
+The one change that both fixes D1 and unlocks Stages 3–5. Nine write sites each
+independently decide whether to re-render, finalize the slug, notify subscribers,
+write a slug-change redirect and feed-lock (table in MODULARITY.md §D1). The
+asymmetry is currently held by a comment repeated across `src/wordpress.php:203` and
+`src/known.php:307`.
+
+```php
+Post\save(OODBBean $bean, array $context = []): void
+// $context: ['finalize_slug' => bool, 'notify' => bool, 'lock_if_feed_sourced' => bool,
+//            'redirect_on_slug_change' => bool]
+// emits: post.created | post.updated | post.published | post.deleted | post.restored
+Post\on(string $event, callable $subscriber): void
+```
+
+The flags each site currently expresses **by omitting a call** become parameters
+that can be asserted in a test. Notification moves inside the funnel's success path,
+so PR 1's fix becomes structural rather than a convention.
+
+Subscribers registered at the seam: `Webmention\enqueue_for_post`,
+`Websub\ping_for_post`, `Response\store_slug_change_redirect`,
+`Response\lock_if_feed_sourced`.
+
+The second, subtler win: **`post.published` becomes the single definition of
+publication.** Today `Webmention\process_outbound()` checks `is_publicly_visible()`
+at send time while `Websub\ping_scheduled_publishes()` (`src/websub.php:142`) infers
+it from a `created > updated` heuristic over a watermark window. Both are currently
+correct; nothing structural keeps them agreeing, and a third subscriber would need a
+third derivation.
+
+- **Test first:** one test per write site asserting which events fire with which
+  context — 9 sites × the flag matrix. This is the bulk of the PR and it is the
+  point: the convention becomes executable.
+- **Conversion order** (each independently revertable): create → edit → checkbox
+  toggle → `upgrade_posts()` → micropub create → micropub update → feed ingest →
+  the three importers.
+- **Do not** make the scheduled-publish sweep an event subscriber in this PR. It
+  needs the cron registry (Stage 3) and conflating them makes both hard to review.
+- **Size:** large. **Risk:** high — every write path in the application. Mitigation:
+  land the funnel with a single call site converted, then convert the rest one PR-sized
+  commit at a time behind the same green suite.
+- **DECISIONS.md entry:** "Post writes go through one funnel; publication is an event."
+
+**Stage 2 exit criteria:** `grep -rn 'notify_post_subscribers\|finalize_and_store_post' src/`
+returns hits only inside `src/post.php`. No write path outside the funnel.
+
+---
+
+## Stage 3 — Cron registry
+
+**PR 9 · `Cron\register()` and a `/_cron` driver**
+
+`Network\process_feeds()` (`src/network.php:142-146`) hardcodes
+`Websub\ping_scheduled_publishes()` and `Webmention\process_outbound()` *inside the
+feed-ingestion loop*. Consequence: **removing the feed reader silently stops
+outbound webmention delivery.** This single coupling is why `indieweb` and `feeds`
+cannot be separated today.
+
+Replace with `Cron\register(string $name, callable $job)` and a `/_cron` driver that
+runs whatever registered, keeping the existing lock (`Network\acquire_cron_lock()`),
+the per-job output lines, and `purge_deleted_posts()`. Feed ingestion becomes one
+registered job among several.
+
+- Test first: registry ordering, one job throwing does not abort the rest, output
+  shape unchanged (the existing `count_line`/`crawl_line`/`webmention_line` helpers
+  are already unit-testable).
+- Size: medium. Risk: medium — `/_cron` is the only scheduled entry point; a
+  swallowed exception must still surface in the output. Verify against a real run.
+
+**Exit criteria:** `src/network.php` contains no reference to `Lamb\Webmention` or
+`Lamb\Websub`.
+
+---
+
+## Stage 4 — Module loader, and the first module
+
+**PR 10 · The manifest and loader**
+
+```php
+// src/modules/<name>/module.php
+return [
+    'name'     => 'import',
+    'requires' => [],          // ext-*/composer probes, cf. Export\zip_available()
+    'register' => function (): void { /* route/cron/event/import registrations */ },
+];
+```
+
+`index.php` loads enabled modules and calls `register()` before
+`Route\call_route()`. Enabled-by-default; the enabled set is resolved in one place so
+CI can pin it. `Route\is_reserved_route()` rebuilds the registry on demand for CLI
+callers (`src/routes.php:170`) — module registration must participate in that
+rebuild or an importer will stop seeing module routes as reserved, which is exactly
+the `/login`-shadowing bug that function was added to fix.
+
+- Test first: a fixture module registering a route and a cron job; assert both
+  reachable, and assert a module whose `requires` probe fails is skipped without
+  fataling.
+- Size: medium. Risk: medium. **DECISIONS.md entry:** "Optional features live in
+  `src/modules/<name>/` behind a manifest."
+
+**PR 11 · Extract the `import` module**
+
+Lowest-risk extraction by a wide margin: CLI-only, no web routes, no theme surface,
+and **already gated behind `experimental_features`** (`src/config.php:436`) — a kill
+switch that exists today, with `EXPERIMENTAL_GATE_VERSION` machinery for forcing
+re-opt-in when the gated set changes.
+
+Moves `import.php`, `wordpress.php`, `known.php`, `restore.php` into
+`src/modules/import/`. Adds the **importer registry** that collapses D9:
+
+```php
+Import\register_source(['name','parse','extract','skip_reason','uuid','import']);
+```
+
+`Import\run_import()` already takes exactly these callables, so this is mechanical.
+Replace the three ~65-line CLI scripts — identical but for their parse/extract calls
+— with one `bin/lamb import <source> <path> [--dry-run] [--replace]` driver. Keep
+thin `import-*.php` shims at the root for one release, deprecation-warning to STDERR,
+since they are documented entry points.
+
+- Test first: `LambRestoreTest` already spawns the CLI as a subprocess with a seeded
+  data dir — extend it to the new driver and to a registered-source lookup, plus a
+  `--dry-run` byte-comparison of the summary output against the old scripts.
+- Size: medium-large (mostly file moves). Risk: low-medium. Verify with a real
+  archive `--dry-run` diff before/after.
+- Drops `league/html-to-markdown` from the core's required set.
+
+**Exit criteria:** one CLI driver, three registered sources, `composer.json`
+`autoload.files` no longer lists the four importer files individually.
+
+---
+
+## Stage 5 — The remaining modules
+
+**PR 12 · Serializer registry; move Atom and JSON Feed out of `themes/`** (D7)
+
+Two of five post→wire serializers are **theme parts**
+(`themes/base/feed.php`, `feed_json.php`), so a custom theme owns the syndication
+contract. `themes/2026/html.php:85-89` records this class of failure already
+happening for a different part: *"A theme that omits the call hides them from the
+author entirely — this one did, and it is the default theme."*
+
+Move Atom and JSON Feed to a serializer registry owned by code, not themes. Themes
+keep presentation; formats stop being overridable by omission.
+- Test first: `tests/Unit/` feed-shape assertions; `TagFeedCest` and the feed
+  conditional-GET Cests already guard the routes.
+- Risk: medium — this is a **breaking change for any third-party theme** that
+  overrides a feed part. Announce it; it is the one user-visible change in the plan.
+
+**PR 13 · Extract `indieweb`** (2,558 LOC)
+
+`micropub.php`, `webmention.php`, `websub.php`, `parts/_webmentions.php`, and
+`index.php`'s four hardcoded `Link:` headers. Owns the `webmention` and
+`webmentionoutbox` tables, its `post.published` subscriptions (Stage 2) and its cron
+jobs (Stage 3). Drops `taproot/micropub-adapter`.
+- **Only viable after Stages 2–4.** Extracting it while Micropub still carries its
+  own front-matter assembler (PR 4), its own upload pipeline (PR 5), and its own HTML
+  sanitizer just relocates D3/D4/D5 behind a boundary where they are harder to see.
+- Micropub's `sanitizeHtml()`/`sanitizeAttributes()` (`src/micropub.php:1102`) is the
+  one sanitizer that legitimately stays module-local — it filters *inbound* client
+  HTML, a different job from rendering trusted author Markdown. Say so in the module
+  README rather than leaving it looking like a stray fourth copy.
+- Test first: acceptance coverage already exists (`MicropubDiscoveryCest`,
+  `MicropubMediaCest`, `WebmentionCest`) — add a module-disabled case asserting the
+  routes 404 and the `Link:` headers are absent.
+- Size: large (mostly moves). Risk: medium-high — it is the largest module and owns
+  security-sensitive endpoints.
+
+**PR 14 · Extract `feeds`, `export`, `highlight`**
+
+- `feeds` (1,042 LOC, `network.php` + `network/`): the ingest cron job. Drops
+  `simplepie/simplepie`. `src/network/README.md` already exists — move it along.
+- `export` (439 LOC): `/export`, `ext-zip`. `Export\zip_available()` is already the
+  `requires`-probe pattern the loader borrows.
+- `highlight` (91 LOC): a render filter, and a `POST_VERSION` participant — disabling
+  it changes rendered output, so the module must be part of the version stamp or
+  every post re-parses on read. Call that out in its README.
+- Size: medium each. Risk: low-medium.
+
+---
+
+## Stage 6 — Optional dependencies
+
+**PR 15 · Move feature-only deps to `suggest`**
+
+`taproot/micropub-adapter`, `simplepie/simplepie`, `league/html-to-markdown`,
+`phiki/phiki` — **4 of 8 runtime deps** — exist only for modules. Move to `suggest`
+with runtime capability probes in each module's `requires`.
+
+This is the payoff for the whole plan given how much of AGENTS.md is dependency and
+advisory management: a minimal install stops carrying CVE surface for a Micropub
+endpoint it never exposes.
+
+- Risk: **this is where the plan can bite users.** An existing install that runs
+  `composer install --no-dev` after upgrading loses packages its enabled modules
+  need. Needs a boot-time probe with an actionable message, `RELEASING.md` coverage,
+  and a docs note — do not ship it as a silent `composer.json` edit.
+- **DECISIONS.md entry:** "Feature-only dependencies are suggested, not required."
+
+---
+
+## Dependency graph
+
+```
+PR 1  (create-path notify fix) ─── independent, do first (it is the argument)
+
+PR 2  post_form deletion       ─┐
+PR 3  one escaper               │
+PR 4  one front-matter engine   ├─ Stage 1: parallel, no inter-dependencies,
+PR 5  one upload store          │  each valuable standalone
+PR 6  theme part dedupe         │
+PR 7  one data_dir             ─┘
+
+PR 8  Post\save() + events  ◄─── needs PR 4, 5 (or Micropub/importers get
+  │                               converted twice)
+  ├──► PR 9  cron registry
+  │      │
+  │      └──► PR 13 indieweb ◄── also needs PR 10
+  │           PR 14 feeds
+  └──► PR 10 module loader
+           └──► PR 11 import module
+                PR 12 serializer registry
+                PR 14 export, highlight
+                     └──► PR 15 optional deps  (last: needs every module extracted)
+```
+
+**Stop-anywhere property.** Stages 0–1 pay for themselves with no architectural
+commitment. Stage 2 is worth landing even if Stages 3–6 never happen — it is the
+D1 fix. Stages 3–6 are the only part that requires believing in the module idea, and
+they are last on purpose.
+
+---
+
+## Definition of done
+
+Per PR: issue agreed → failing test → minimum implementation → green → all six gates
+→ PHPStan baseline still empty → coverage ≥70% → `AGENTS.md` updated where structure
+moved (its Project Structure and Namespaces tables both go stale from Stage 4 on).
+
+Overall, measured against MODULARITY.md's numbers:
+
+| Metric | Now | Target |
+|---|---:|---:|
+| Post write entry points | 9 | 1 |
+| Definitions of "published" | 2 | 1 |
+| HTTP transports | 5 (1 dead) | 4 |
+| XML escapers | 2 + 1 global | 1 |
+| Front-matter engines / assemblers | 2 / 4 | 1 / 1 |
+| Upload store pipelines | 3 | 1 |
+| Copies of the post-list template | 3 | 1 |
+| Importer CLI scripts | 3 | 1 driver |
+| Runtime deps required by a minimal install | 8 | 4 |
+| Optional-feature LOC inside the core | 7,184 (44%) | ~0 |
+
+---
+
+## Risks, and where this plan is most likely to go wrong
+
+1. **PR 4 (front matter) is the most dangerous PR here.** Front matter is the post
+   format; a regression corrupts stored bodies rather than breaking a page. Split it,
+   characterise before touching, and diff a real `--dry-run` import both sides.
+2. **PR 8 touches every write path.** Land the funnel with one site converted, then
+   convert the rest incrementally. Do not convert nine sites in one commit.
+3. **PR 12 breaks third-party themes** that override a feed part. It is the only
+   user-visible break in the plan; announce rather than absorb it.
+4. **PR 15 can break existing installs' `composer install`.** Boot-time probe with an
+   actionable message, or don't ship it.
+5. **RedBean fluid mode means "disabled" is not "uninstalled."** `webmention`,
+   `webmentionoutbox` and `feedstatus` are created lazily on first write; disabling a
+   module leaves orphan tables. Acceptable — but say it in the module READMEs so it
+   isn't discovered as a bug.
+6. **CI must pin the enabled module set from PR 10 onward.** Five acceptance Cests
+   (`MicropubDiscoveryCest`, `MicropubMediaCest`, `WebmentionCest`, `UploadCest`,
+   `TagFeedCest`) exercise routes that become module-provided; coverage drops
+   silently otherwise.
+7. **Philosophy drift is the real long-term risk.** "Simple over complex",
+   "opinionated defaults over settings". The moment this grows hook priorities, a
+   filter chain, or a plugin settings page, it has stopped being this plan. The
+   non-goals above are the guardrail; revisit them at Stage 4, which is where the
+   temptation arrives.

--- a/PLAN.md
+++ b/PLAN.md
@@ -11,7 +11,7 @@ places where the core does one job two or three ways; the sprawl comes from 44% 
 duplicate mechanism relocates the bug instead of removing it. So: **converge first,
 extract second.** Every stage below is ordered by that constraint, not by appeal.
 
-**Shape:** 16 PRs across 6 stages. Stages 0–1 (7 PRs) are independent of each other
+**Shape:** 14 PRs across 5 stages. Stages 0–1 (7 PRs) are independent of each other
 and of everything after — they can land in any order, in parallel, and each one is
 worth landing even if the rest of this plan is dropped. Stage 2 is the keystone.
 Stages 3–5 are only unlocked by it.
@@ -22,46 +22,60 @@ Stages 3–5 are only unlocked by it.
 
 1. Remove the divergence that is producing the bugs (Stages 0–2).
 2. Make "published" a single event instead of a convention re-derived per subsystem (Stage 2).
-3. Let an install not ship — and not carry the dependency surface of — features it doesn't use (Stages 3–6).
+3. Give each optional feature one owner, one directory and one registered seam, so a
+   change to it cannot reach the rest of the codebase by accident (Stages 3–5).
 
-**The premise for objective 3 is a real installed base.** Lamb has other installs,
-so "don't ship what you don't use" is a benefit that lands on actual users rather
-than a hypothetical one. That premise also imposes the constraint below: with real
-installs, every module extraction needs an upgrade path, and shipping a regression
-costs more than the sprawl does. Convergence-before-extraction gets *stronger* under
-that premise, not weaker — a duplicate mechanism relocated behind a module boundary
-is now a bug shipped to other people's blogs.
+**Objective 3 is maintainability, not a shippable subset.** An earlier draft of this
+plan justified modules by "let an install not ship what it doesn't use". That is
+struck: Lamb's promise is a **plug-and-play install**, and the moment an operator has
+to decide which modules to enable, that promise is gone — replaced by a
+plug-many-things-and-configure install, which is what people choose Lamb to avoid.
+The README sells "no plugin needed" as a feature and `PRODUCT.md` says "opinionated
+defaults over settings"; a module set an operator picks contradicts both.
 
-The clearest single win is `import`: 2,391 lines and `league/html-to-markdown` that
-every install carries forever to serve a migration each install runs at most once.
+So modules are **internal organisation only. Every module always loads.** There is no
+disable switch, no per-install module set, and nothing about them in the operator's
+config. An operator upgrading through Stages 3–5 sees no change whatsoever: same
+routes, same features, same `composer install`.
+
+What the seam buys is bounded and worth having on its own: the cron coupling fixed
+(Stage 3), a fourth importer becoming a drop-in instead of a fourth CLI (PR 11),
+syndication formats stopping being a theme's responsibility (PR 12), and each
+feature's blast radius being one directory instead of the whole of `src/`.
+
+**A real installed base is what makes this split the right one.** It raises the value
+of clear ownership — a regression now reaches other people's blogs — and raises the
+cost of anything operator-visible, because that needs an upgrade path, a docs page
+and a deprecation cycle. Convergence-before-extraction gets *stronger* for the same
+reason: a duplicate mechanism relocated behind a module boundary is a bug shipped to
+someone else's site.
 
 ## Non-goals
 
 - **No plugin framework.** No hook priorities, no filter chains, no third-party
   plugin API, no plugin admin UI. Four registries and a manifest array.
-- **No new user-facing configuration.** Modules ship enabled by default. This is an
-  internal code-organisation seam.
+- **No new user-facing configuration, and no disable switch.** Modules always load.
+  There is no enabled/disabled set, in config or anywhere else. If a PR in Stages 3–5
+  adds an operator-visible knob, it has left this plan.
 - **No pluggability for the core.** Routing, config, `Lamb\Post`, visibility, HTTP
   egress guarding, escaping, upload security, session/CSRF each get *one*
   implementation. Offering a choice there is what caused D1–D6.
 - **Not a global-state cleanup.** `global $routes, $config, $data, $template` stays.
   It caps how isolated a module can be; that is accepted and stated, not fixed here.
 - **Not a third-party plugin ecosystem — even though other installs exist.** An
-  installed base justifies *modules* (an install can drop what it doesn't run); it
+  installed base justifies *internal* modules (one owner per feature); it
   does not justify a public extension API, which is a support commitment and a
   compatibility surface forever. The README sells "no plugin needed" as a feature.
   Modules stay an internal seam that happens to be toggleable.
 
 ## Ground rules (house process, per AGENTS.md)
 
-- **Every extraction ships an upgrade path.** Other installs are upgrading through
-  this work, so no module may default to off for an install that is already using
-  the feature: derive the enabled set from existing config (a populated `[feeds]`
-  means `feeds` is on) rather than from a new default. The precedents are
-  `Config\ensure_explicit_theme()` and `Bootstrap\backfill_imported_post_identity()`
-  — boot-time, idempotent, safe to run on every request. A moved route, config key
-  or CLI entry point keeps a deprecated shim for one release, warning rather than
-  breaking.
+- **Every extraction is invisible to an operator.** Other installs are upgrading
+  through this work and must see no change: same routes, same features, same
+  `composer install`, nothing new to configure. Modules always load, so there is no
+  enabled set to migrate. What does need care is anything an operator or theme author
+  *addresses by name* — a moved route, config key, CLI entry point or theme part keeps
+  a deprecated shim for one release, warning rather than breaking.
 - Branch from `main`. **Open an issue per PR first** and get maintainer agreement —
   AGENTS.md requires it for feature work, and Stage 2 onward is feature work.
 - **Red-green TDD is mandatory.** Every step below names its failing test. No
@@ -302,21 +316,22 @@ registered job among several.
 // src/modules/<name>/module.php
 return [
     'name'     => 'import',
-    'requires' => [],          // ext-*/composer probes, cf. Export\zip_available()
+    // No 'enabled' key and no 'requires' probe: every module loads, always.
+    // A module needing an extension states it in composer.json like any core code.
     'register' => function (): void { /* route/cron/event/import registrations */ },
 ];
 ```
 
-`index.php` loads enabled modules and calls `register()` before
-`Route\call_route()`. Enabled-by-default; the enabled set is resolved in one place so
-CI can pin it. `Route\is_reserved_route()` rebuilds the registry on demand for CLI
+`index.php` loads every module and calls `register()` before `Route\call_route()` —
+a fixed list discovered from `src/modules/`, with no configuration consulted. The
+manifest is a wiring convention, not a feature flag. `Route\is_reserved_route()` rebuilds the registry on demand for CLI
 callers (`src/routes.php:170`) — module registration must participate in that
 rebuild or an importer will stop seeing module routes as reserved, which is exactly
 the `/login`-shadowing bug that function was added to fix.
 
 - Test first: a fixture module registering a route and a cron job; assert both
-  reachable, and assert a module whose `requires` probe fails is skipped without
-  fataling.
+  reachable, and assert a module whose `register()` throws fails loudly at boot
+  rather than silently dropping its routes.
 - Size: medium. Risk: medium. **DECISIONS.md entry:** "Optional features live in
   `src/modules/<name>/` behind a manifest."
 
@@ -397,8 +412,8 @@ jobs (Stage 3). Drops `taproot/micropub-adapter`.
   HTML, a different job from rendering trusted author Markdown. Say so in the module
   README rather than leaving it looking like a stray fourth copy.
 - Test first: acceptance coverage already exists (`MicropubDiscoveryCest`,
-  `MicropubMediaCest`, `WebmentionCest`) — add a module-disabled case asserting the
-  routes 404 and the `Link:` headers are absent.
+  `MicropubMediaCest`, `WebmentionCest`) — they must pass unchanged, which is the
+  whole acceptance criterion: the extraction is invisible from outside.
 - Size: large (mostly moves). Risk: medium-high — it is the largest module and owns
   security-sensitive endpoints.
 
@@ -406,46 +421,39 @@ jobs (Stage 3). Drops `taproot/micropub-adapter`.
 
 - `feeds` (1,042 LOC, `network.php` + `network/`): the ingest cron job. Drops
   `simplepie/simplepie`. `src/network/README.md` already exists — move it along.
-- `export` (439 LOC): `/export`, `ext-zip`. `Export\zip_available()` is already the
-  `requires`-probe pattern the loader borrows.
-- `highlight` (91 LOC): a render filter, and a `POST_VERSION` participant — disabling
-  it changes rendered output, so the module must be part of the version stamp or
-  every post re-parses on read. Call that out in its README.
+- `export` (439 LOC): `/export`. Keeps its own `Export\zip_available()` runtime check
+  for `ext-zip`, exactly as today — that is a capability probe, not a feature flag.
+- `highlight` (91 LOC): a render filter and a `POST_VERSION` participant. Because it
+  always loads, the version stamp keeps its current meaning and no post re-parses;
+  note in its README that this is *why* it is not switchable.
 - Size: medium each. Risk: low-medium.
 
 ---
 
-## Stage 6 — Optional dependencies
+## Stage 6 — Struck
 
-**PR 15 · Move feature-only deps to `suggest`**
+**Cut: "move feature-only deps to `suggest`" and "document modules for operators".**
 
-`taproot/micropub-adapter`, `simplepie/simplepie`, `league/html-to-markdown`,
-`phiki/phiki` — **4 of 8 runtime deps** — exist only for modules. Move to `suggest`
-with runtime capability probes in each module's `requires`.
+Both were the operator-visible half of the plan, and both are gone with the
+disable switch. If every module always loads, every module's dependencies are always
+needed, so `taproot/micropub-adapter`, `simplepie/simplepie` and `phiki/phiki` stay
+in `require` where they belong — and there is nothing for an operator to read about,
+because there is nothing for them to decide.
 
-This is the payoff for the whole plan given how much of AGENTS.md is dependency and
-advisory management: a minimal install stops carrying CVE surface for a Micropub
-endpoint it never exposes.
+This is a deliberate trade. It gives up the dependency-surface reduction that
+objective 3 originally claimed, and that reduction was real: a stripped install would
+have dropped from 8 runtime deps to 4. It is given up because collecting it requires
+asking the operator which features they run, and that question is the thing Lamb
+exists not to ask.
 
-- Risk: **this is where the plan can bite users, and with a real installed base it
-  will.** An existing install that runs `composer install --no-dev` after upgrading
-  loses packages its enabled modules still need, and finds out when a route 500s.
-  Requirements, not suggestions: a boot-time `requires` probe that names the missing
-  package and the module needing it; the enabled-module set derived from existing
-  config per the upgrade rule above; a `RELEASING.md` checklist item; an upgrade
-  note in `docs/`. Land it at a **release boundary**, never mid-release, so
-  `release` never carries a half-applied dependency change.
-- **DECISIONS.md entry:** "Feature-only dependencies are suggested, not required."
-
-**PR 16 · Document modules for operators**
-
-Added because there is an installed base: from PR 10 on, "which features does this
-install run" becomes something an operator has to be able to answer. `docs/` is
-end-user-only (2026-05-29 decision), so this is one page — what a module is, the
-enabled set, how upgrades derive it, and what disabling one does and does not remove
-(orphan tables stay; see risk 5). The `src/modules/<name>/README.md` files stay
-contributor-facing per the 2026-08-21 decision; this is the operator-facing half.
-- Size: small. Risk: none. Do not start it before PR 10 settles the vocabulary.
+**The one case worth revisiting later** is `import`: CLI-only, already gated behind
+`experimental_features`, run at most once per install, and carrying
+`league/html-to-markdown` in perpetuity for that one run. Moving *that* dependency to
+`suggest` degrades a CLI script into a clear error message rather than degrading the
+website, so it does not put the site's behaviour in the operator's hands. Even so:
+not now. It is a separate decision on its own merits once PR 11 has landed and the
+module seam has proven itself, and it needs `composer install --no-dev` on a real
+install to behave correctly first.
 
 ---
 
@@ -471,14 +479,13 @@ PR 8  Post\save() + events  ◄─── needs PR 4, 5 (or Micropub/importers ge
            └──► PR 11 import module
                 PR 12 serializer registry
                 PR 14 export, highlight
-                     └──► PR 15 optional deps  (last: needs every module extracted,
-                          │                       and lands at a release boundary)
-                          └──► PR 16 operator docs (needs PR 10's vocabulary settled)
+                          (PR 15 optional deps, PR 16 operator docs: struck — see
+                           Stage 6. They were the operator-visible half.)
 ```
 
 **Stop-anywhere property.** Stages 0–1 pay for themselves with no architectural
-commitment. Stage 2 is worth landing even if Stages 3–6 never happen — it is the
-D1 fix. Stages 3–6 are the only part that requires believing in the module idea, and
+commitment. Stage 2 is worth landing even if Stages 3–5 never happen — it is the
+D1 fix. Stages 3–5 are the only part that requires believing in the module idea, and
 they are last on purpose.
 
 ---
@@ -501,16 +508,13 @@ Overall, measured against MODULARITY.md's numbers:
 | Upload store pipelines | 3 | 1 |
 | Copies of the post-list template | 3 | 1 |
 | Importer CLI scripts | 3 | 1 driver |
-| Runtime deps required by a minimal install | 8 | 4 |
-| Deps required by a *typical* install (keeps IndieWeb + feeds) | 8 | 6 |
-| Optional-feature LOC inside the core | 7,184 (44%) | ~0 |
+| Optional-feature LOC in a flat `src/` | 7,184 (44%) | 0 (owned by a module dir) |
+| Runtime deps required | 8 | 8 — unchanged, by choice |
 
-The two dependency rows are the honest pair. Most installs run the IndieWeb and feed
-features — that is why they chose Lamb — so their surface drops by two
-(`league/html-to-markdown` once `import` is extracted, `phiki` if they forgo
-highlighting), not four. The full drop to four is real but applies to the stripped
-install, not the median one. `import` supplies most of the typical win, because it is
-the one module nobody keeps using.
+The dependency row is deliberately flat. An earlier draft targeted 8 → 4; that
+required an operator-selectable module set, which is struck (see Stage 6). The 44%
+still *ships* — it just stops being spread through a flat namespace with no owner.
+That is a smaller claim than the earlier draft made, and it is the honest one.
 
 ---
 
@@ -525,24 +529,32 @@ the one module nobody keeps using.
    a real installed base, means someone's live blog loses its feed. Hence the
    two-step deprecation rather than a clean cut. Do not collapse it back into one PR
    because the fallback looks like dead weight.
-4. **PR 15 can break existing installs' `composer install`.** Boot-time probe with an
-   actionable message, at a release boundary, or don't ship it.
-5. **The upgrade path is the part most likely to be skipped, and the most expensive
-   to get wrong.** Defaulting a module to off for an install already using the
-   feature silently removes it — webmentions stop being delivered and nothing errors.
-   Every extraction PR needs a boot-time derivation test against a config that
-   predates it, not just a fresh-install test. This risk did not exist when the plan
-   assumed one install; it is now the top operational risk in Stages 4–6.
+4. **The dependency reduction is struck, and should stay struck.** It is the most
+   tempting thing to reinstate, because 8 → 4 deps reads well against AGENTS.md's
+   advisory burden. Reinstating it means asking the operator which features they run.
+   See Stage 6 for the one narrow exception worth a separate decision later.
+5. **The upgrade path.** Largely dissolved by always-loading modules: with no
+   enabled set there is nothing to derive, and an operator upgrading sees no change.
+   What remains is narrow and still needs testing — a moved route or CLI entry point
+   must keep its deprecated shim for a release (PR 11's `import-*.php`, PR 12's theme
+   feed parts). Test each against a config and a theme that predate the move, not
+   just a fresh install.
 6. **RedBean fluid mode means "disabled" is not "uninstalled."** `webmention`,
    `webmentionoutbox` and `feedstatus` are created lazily on first write; disabling a
    module leaves orphan tables. Acceptable — but say it in the module READMEs so it
    isn't discovered as a bug.
-7. **CI must pin the enabled module set from PR 10 onward.** Five acceptance Cests
-   (`MicropubDiscoveryCest`, `MicropubMediaCest`, `WebmentionCest`, `UploadCest`,
-   `TagFeedCest`) exercise routes that become module-provided; coverage drops
-   silently otherwise.
-8. **Philosophy drift is the real long-term risk.** "Simple over complex",
-   "opinionated defaults over settings". The moment this grows hook priorities, a
+7. **CI needs no module pinning — and that is the test that the seam stayed
+   internal.** Five acceptance Cests (`MicropubDiscoveryCest`, `MicropubMediaCest`,
+   `WebmentionCest`, `UploadCest`, `TagFeedCest`) exercise routes that become
+   module-provided. They must keep passing untouched, with no module configuration in
+   the suite. The day CI needs to know which modules are on, this plan has drifted.
+8. **Philosophy drift is the real long-term risk, and it has a specific shape here.**
+   Not hook priorities first — a *disable switch*. Once `src/modules/` exists, adding
+   one is a ten-line change and will look obviously useful. That is the change that
+   turns a plug-and-play install into a plug-many-things-and-configure install, and
+   it should be refused on those grounds rather than debated on its merits.
+   "Simple over complex", "opinionated defaults over settings". The moment this grows
+   hook priorities, a
    filter chain, or a plugin settings page, it has stopped being this plan. The
    non-goals above are the guardrail; revisit them at Stage 4, which is where the
    temptation arrives.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,74 +1,41 @@
-# Plan: converge the duplicate mechanisms. No module system.
+# Plan: converge the duplicate mechanisms
 
-Deliverable plan for the sprawl/duplicate-mechanism work. The evidence behind every
-claim here — file:line for all ten duplication findings, D1–D10 — is in
-[MODULARITY.md](MODULARITY.md); this document does not restate it, it sequences the
-work.
-
-## Decision
-
-**The module system is rejected. The convergence work proceeds.**
-
-The investigation was asked where the project does one job several ways and how those
-could be split into plugins. It found the first (ten hotspots) and proposed the second
-(five modules behind a manifest). The second half is now declined, for a product
-reason rather than a technical one: Lamb's promise is a **plug-and-play install**, and
-a module set is a step toward a plug-many-things-and-configure install. The README
-sells "no plugin needed" as a feature and `PRODUCT.md` says "opinionated defaults over
-settings". A `src/modules/` tree makes a disable switch a ten-line change away, and
-that switch is what erodes the promise. Not building the tree is the cheapest way to
-never have that argument.
-
-What is *not* declined is everything the module proposal was carrying. Three of its
-parts turned out to be de-duplication fixes wearing a module costume, and they stand
-on their own with no module boundary anywhere:
-
-| Was justified as | Is actually | Kept as |
-|---|---|---|
-| "unhook webmentions so `feeds` can be removed" | a live availability bug in `/_cron` | Stage 3 |
-| "an importer registry so a module can register sources" | the D9 fix — 3 CLIs → 1 | Stage 4 |
-| "move feeds out of themes so a module owns formats" | the D7 fix — themes silently drop syndication | Stage 5 |
+Lamb keeps producing the same kinds of bug because ten jobs in the codebase have two
+or three implementations each, and the copies drift. This plan collapses each of them
+to one. The evidence — file:line for all ten, D1–D10 — is in
+[MODULARITY.md](MODULARITY.md); this document sequences the work.
 
 **Shape:** 11 PRs across 5 stages. Stages 0–1 (7 PRs) are independent of each other
 and of everything after — any order, in parallel, each worth landing alone. Stage 2 is
-the keystone. Stages 3–5 are three unrelated bug-class fixes that happen to be the
-salvage from the rejected half.
+the largest change and the one with the most reach. Stages 3–5 are three unrelated
+bug-class fixes.
+
+Only one real dependency edge exists in the whole plan: PR 8 after PRs 4–5. Nothing
+here is a prerequisite for a larger architectural change, and nothing requires
+committing to one.
 
 ## Objectives
 
-1. Remove the divergence that is producing the bugs (Stages 0–2, 4, 5).
+1. Give each duplicated job one implementation (Stages 0–1, 4, 5).
 2. Make "published" a single event instead of a convention re-derived per subsystem (Stage 2).
 3. Stop `/_cron` from being able to lose webmention delivery (Stage 3).
 
-## Non-goals
+## Scope boundaries
 
-- **No module system, no plugin framework, no extension API.** No `src/modules/`, no
-  manifest, no registries-for-registries' sake, no hook priorities, no filter chains.
-  `src/` stays flat and greppable. A PR that creates a module directory has left this
-  plan.
-- **Nothing operator-visible.** No new configuration, no feature toggles, no docs page
-  explaining which features are on. An install upgrading through all 11 PRs sees the
-  same routes, the same features and the same `composer install`. The only intended
-  operator-visible change in the whole plan is a *bug stopping happening*.
-- **No dependency reduction.** All 8 runtime deps stay in `require`. The earlier draft
-  targeted 8 → 4; collecting that requires asking operators which features they run.
-- **No pluggability for the core.** Routing, config, `Lamb\Post`, visibility, HTTP
-  egress guarding, escaping, upload security, session/CSRF each get *one*
-  implementation. Offering a choice there is what caused D1–D6 in the first place.
+- **`src/` stays flat.** Optional features are not moved into a module tree and there
+  is no manifest, loader, hook system or extension API. The sprawl in MODULARITY.md §1
+  is out of scope: 44% of `src/` is optional features and stays that way. Lamb promises
+  a plug-and-play install, so anything that would make a feature set something an
+  operator selects is out of scope by design, not by omission.
+- **Nothing operator-visible.** No new configuration, no feature toggles, no
+  dependency changes — all 8 runtime deps stay in `require`. An install upgrading
+  through all 11 PRs sees the same routes, the same features and the same
+  `composer install`. The only intended operator-visible effect is a bug stopping
+  happening.
+- **The core stays single-implementation.** Routing, config, `Lamb\Post`, visibility,
+  HTTP egress guarding, escaping, upload security, session/CSRF each get exactly one
+  way to do the job. Offering a choice is what produced D1–D6.
 - **Not a global-state cleanup.** `global $routes, $config, $data, $template` stays.
-
-## What this gives up, stated plainly
-
-7,184 lines — 44% of the PHP in `src/` — are optional features, and they all still
-ship to every install, in a flat namespace, with no enforced ownership. That is the
-cost of this decision and it is accepted, not solved. Two mitigations already exist
-and should be used rather than replaced: the `src/<module>/README.md` convention
-(2026-08-21 decision) gives a subsystem a place to describe itself without a code
-boundary, and `experimental_features` already gates the importers.
-
-Revisit only if a concrete need appears — a real operator asking to run Lamb without
-the IndieWeb stack, or a feature whose dependency becomes a recurring advisory
-burden. "The codebase would be tidier" is not that need.
 
 ## Ground rules (house process, per AGENTS.md)
 
@@ -80,17 +47,15 @@ burden. "The codebase would be tidier" is not that need.
   `composer coverage` (**≥70%**), `pnpm test`, `composer audit`.
 - A refactor PR that touches no behaviour still needs its characterisation test
   written first, so "no behaviour change" is enforced rather than asserted.
-- **Every change is invisible to an operator** except where it stops a bug. Other
-  installs are upgrading through this work. Anything addressed *by name* — a route, a
-  config key, a CLI entry point, a theme part — keeps a deprecated shim for one
-  release, warning rather than breaking.
-- `DECISIONS.md` entries at two points: the funnel (Stage 2), and this rejection —
-  "Lamb stays a flat codebase; optional features are not modules", recording the
-  plug-and-play reasoning so the question does not get re-opened from scratch.
+- **Other installs are upgrading through this work.** Anything addressed *by name* —
+  a route, a config key, a CLI entry point, a theme part — keeps a deprecated shim for
+  one release, warning rather than breaking.
+- `DECISIONS.md` entry at one point: the post lifecycle funnel (Stage 2), which
+  changes an invariant every write path depends on.
 
 ---
 
-## Stage 0 — The bug that proves the thesis
+## Stage 0 — The bug that makes the case
 
 **PR 1 · Fix the notify-after-failed-write twin on the create path**
 
@@ -215,7 +180,7 @@ three CLI scripts. Route the CLIs through `Bootstrap\data_dir()`. Optionally mov
 feature-only constants out of `src/constants.php` (`FEED_FETCH_*`,
 `IMAGE_UPLOAD_EXTENSIONS`, `VIDEO_UPLOAD_EXTENSIONS`) next to their owners — the
 file's own docblock says it holds "application-wide" constants, and these are not.
-Skip it if it reads worse; with no module extraction coming, nothing forces it.
+Skip it if it reads worse; nothing downstream depends on it.
 - Test first: `UpgradeScriptTest`/`LambRestoreTest` already spawn CLI subprocesses
   with a seeded data dir — extend to assert the resolved path.
 - Size: small. Risk: low. Note the default differs by design (`../data` for web,
@@ -227,7 +192,7 @@ Coverage ≥70% and the PHPStan baseline still empty.
 
 ---
 
-## Stage 2 — The post lifecycle funnel (keystone)
+## Stage 2 — The post lifecycle funnel
 
 **PR 8 · `Post\save()` and the lifecycle events**
 
@@ -282,7 +247,7 @@ returns hits only inside `src/post.php`. No write path outside the funnel.
 
 **PR 9 · Isolate and order the cron jobs**
 
-Kept from the rejected half, but not for its original reason. `Network\process_feeds()`
+`Network\process_feeds()`
 (`src/network.php:102-149`) is one straight-line function running five unrelated jobs,
 with the two notification drains **last**:
 
@@ -318,8 +283,7 @@ Fix, smallest first — the ordering change alone removes the reported failure:
    immediate re-run that repeats the same failure.
 4. Optional, only if 1–3 leave the function unwieldy: a small `Cron\register(name,
    callable)` list so `/_cron` iterates jobs instead of naming them. This is the piece
-   the module plan wanted; it is now a readability nicety, not a requirement. Skip it
-   if the guarded version reads fine.
+   a readability nicety, not a requirement. Skip it if the guarded version reads fine.
 
 - **Test first:** a feed whose crawl throws, asserting `process_outbound()` still ran
   and the watermark advanced; then a second run asserting it is rate-limited rather
@@ -339,7 +303,7 @@ with the outbound queue undrained and the watermark unwritten.
 
 **PR 10 · Importer registry and a single CLI driver**
 
-The D9 fix, with no module directory. `import-wordpress.php`, `import-known.php` and
+The D9 fix. `import-wordpress.php`, `import-known.php` and
 `import-lamb.php` are ~65 lines each of the same sequence — SAPI check,
 `define('ROOT_DIR')`, `parse_import_args()`, readability check, `data_dir()`,
 `bootstrap_db()`, `Config\load()`, `apply_timezone()`, experimental gate, parse,
@@ -374,7 +338,7 @@ unmoved. A fourth importer becomes a registration instead of a fourth script.
 
 **PR 11 · Feed output moves from theme parts into code**
 
-The D7 fix, with no serializer registry abstraction beyond what this needs. Atom and
+The D7 fix. Atom and
 JSON Feed live as **theme parts** (`themes/base/feed.php`, `feed_json.php`), so a
 theme owns the syndication contract, and a theme that simply *omits* the part loses
 the site's feed. That exact class of failure is already recorded in
@@ -425,12 +389,11 @@ PR 10 importer registry      ─── independent (PR 7 first if both touch the
 PR 11 feeds out of themes    ─── independent (after PR 3, which touches feed.php)
 ```
 
-Only one real edge in the whole plan (PR 8 after PR 4/5). Stages 3–5 are three
-unrelated fixes and can go in any order, before or after the funnel.
+Stages 3–5 are three unrelated fixes and can go in any order, before or after Stage 2.
 
-**Stop-anywhere property.** Stages 0–1 pay for themselves with no architectural
-commitment. Stage 2 is the D1 fix and stands alone. Stages 3–5 are each a single
-bug-class fix. Nothing in this plan requires believing in anything.
+**Stop-anywhere property.** Stages 0–1 pay for themselves immediately. Stage 2 is the
+D1 fix and stands alone. Stages 3–5 are each a single bug-class fix. Any subset of
+this plan is coherent on its own.
 
 ---
 
@@ -454,11 +417,10 @@ Measured against MODULARITY.md's numbers:
 | Copies of the post-list template | 3 | 1 |
 | Importer CLI scripts | 3 | 1 driver |
 | Feed formats a theme can silently drop | 2 | 0 |
-| Runtime deps required | 8 | 8 — unchanged, by choice |
-| Optional-feature LOC in a flat `src/` | 7,184 (44%) | 7,184 — unchanged, by choice |
+| Runtime deps required | 8 | 8 |
+| Optional-feature LOC in a flat `src/` | 7,184 (44%) | 7,184 (44%) |
 
-The last two rows are the shape of the decision: the duplication goes, the sprawl
-stays.
+The last two rows are the shape of the plan: the duplication goes, the sprawl stays.
 
 ---
 
@@ -473,14 +435,9 @@ stays.
    someone's live blog losing its feed, hence the two-step deprecation. Do not
    collapse it into one PR because the fallback looks like dead weight.
 4. **PR 9 is easy to under-fix.** Reordering the drains removes the reported symptom
-   but leaves an unguarded loop and an all-or-nothing watermark. Do all of 1–3 in that
-   PR, or the next slow feed produces a different version of the same outage.
-5. **RedBean fluid mode.** Unchanged by this plan, but worth stating since the module
-   proposal raised it: `webmention`, `webmentionoutbox` and `feedstatus` are created
-   lazily on first write. With no modules there is nothing to disable, so no orphan
-   tables — one fewer thing to reason about.
-6. **The module idea will come back.** It is a genuinely appealing refactor and each of
-   these PRs makes the seams cleaner, which makes it *more* appealing. The rejection
-   is on plug-and-play grounds, not code-health grounds, so a code-health argument for
-   reinstating it does not answer the objection. Put the `DECISIONS.md` entry in early
-   (Stage 2 at the latest) so the reasoning outlives this conversation.
+   but leaves an unguarded loop and an all-or-nothing watermark. Do all four parts in
+   that PR, or the next slow feed produces a different version of the same outage.
+5. **Every one of these PRs makes the seams cleaner, which makes a larger refactor
+   look more tractable.** That is a good outcome to notice and a bad one to act on
+   mid-plan. Each PR's value is the duplication it removes; finish the list before
+   re-opening the question of how `src/` is organised.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,97 +1,92 @@
-# Plan: converge, then modularise
+# Plan: converge the duplicate mechanisms. No module system.
 
 Deliverable plan for the sprawl/duplicate-mechanism work. The evidence behind every
 claim here — file:line for all ten duplication findings, D1–D10 — is in
 [MODULARITY.md](MODULARITY.md); this document does not restate it, it sequences the
 work.
 
-**Thesis:** the bugs and the sprawl are separate problems. The bugs come from ~10
-places where the core does one job two or three ways; the sprawl comes from 44% of
-`src/` being optional features fused into that core. A module boundary drawn around a
-duplicate mechanism relocates the bug instead of removing it. So: **converge first,
-extract second.** Every stage below is ordered by that constraint, not by appeal.
+## Decision
 
-**Shape:** 14 PRs across 5 stages. Stages 0–1 (7 PRs) are independent of each other
-and of everything after — they can land in any order, in parallel, and each one is
-worth landing even if the rest of this plan is dropped. Stage 2 is the keystone.
-Stages 3–5 are only unlocked by it.
+**The module system is rejected. The convergence work proceeds.**
 
----
+The investigation was asked where the project does one job several ways and how those
+could be split into plugins. It found the first (ten hotspots) and proposed the second
+(five modules behind a manifest). The second half is now declined, for a product
+reason rather than a technical one: Lamb's promise is a **plug-and-play install**, and
+a module set is a step toward a plug-many-things-and-configure install. The README
+sells "no plugin needed" as a feature and `PRODUCT.md` says "opinionated defaults over
+settings". A `src/modules/` tree makes a disable switch a ten-line change away, and
+that switch is what erodes the promise. Not building the tree is the cheapest way to
+never have that argument.
+
+What is *not* declined is everything the module proposal was carrying. Three of its
+parts turned out to be de-duplication fixes wearing a module costume, and they stand
+on their own with no module boundary anywhere:
+
+| Was justified as | Is actually | Kept as |
+|---|---|---|
+| "unhook webmentions so `feeds` can be removed" | a live availability bug in `/_cron` | Stage 3 |
+| "an importer registry so a module can register sources" | the D9 fix — 3 CLIs → 1 | Stage 4 |
+| "move feeds out of themes so a module owns formats" | the D7 fix — themes silently drop syndication | Stage 5 |
+
+**Shape:** 11 PRs across 5 stages. Stages 0–1 (7 PRs) are independent of each other
+and of everything after — any order, in parallel, each worth landing alone. Stage 2 is
+the keystone. Stages 3–5 are three unrelated bug-class fixes that happen to be the
+salvage from the rejected half.
 
 ## Objectives
 
-1. Remove the divergence that is producing the bugs (Stages 0–2).
+1. Remove the divergence that is producing the bugs (Stages 0–2, 4, 5).
 2. Make "published" a single event instead of a convention re-derived per subsystem (Stage 2).
-3. Give each optional feature one owner, one directory and one registered seam, so a
-   change to it cannot reach the rest of the codebase by accident (Stages 3–5).
-
-**Objective 3 is maintainability, not a shippable subset.** An earlier draft of this
-plan justified modules by "let an install not ship what it doesn't use". That is
-struck: Lamb's promise is a **plug-and-play install**, and the moment an operator has
-to decide which modules to enable, that promise is gone — replaced by a
-plug-many-things-and-configure install, which is what people choose Lamb to avoid.
-The README sells "no plugin needed" as a feature and `PRODUCT.md` says "opinionated
-defaults over settings"; a module set an operator picks contradicts both.
-
-So modules are **internal organisation only. Every module always loads.** There is no
-disable switch, no per-install module set, and nothing about them in the operator's
-config. An operator upgrading through Stages 3–5 sees no change whatsoever: same
-routes, same features, same `composer install`.
-
-What the seam buys is bounded and worth having on its own: the cron coupling fixed
-(Stage 3), a fourth importer becoming a drop-in instead of a fourth CLI (PR 11),
-syndication formats stopping being a theme's responsibility (PR 12), and each
-feature's blast radius being one directory instead of the whole of `src/`.
-
-**A real installed base is what makes this split the right one.** It raises the value
-of clear ownership — a regression now reaches other people's blogs — and raises the
-cost of anything operator-visible, because that needs an upgrade path, a docs page
-and a deprecation cycle. Convergence-before-extraction gets *stronger* for the same
-reason: a duplicate mechanism relocated behind a module boundary is a bug shipped to
-someone else's site.
+3. Stop `/_cron` from being able to lose webmention delivery (Stage 3).
 
 ## Non-goals
 
-- **No plugin framework.** No hook priorities, no filter chains, no third-party
-  plugin API, no plugin admin UI. Four registries and a manifest array.
-- **No new user-facing configuration, and no disable switch.** Modules always load.
-  There is no enabled/disabled set, in config or anywhere else. If a PR in Stages 3–5
-  adds an operator-visible knob, it has left this plan.
+- **No module system, no plugin framework, no extension API.** No `src/modules/`, no
+  manifest, no registries-for-registries' sake, no hook priorities, no filter chains.
+  `src/` stays flat and greppable. A PR that creates a module directory has left this
+  plan.
+- **Nothing operator-visible.** No new configuration, no feature toggles, no docs page
+  explaining which features are on. An install upgrading through all 11 PRs sees the
+  same routes, the same features and the same `composer install`. The only intended
+  operator-visible change in the whole plan is a *bug stopping happening*.
+- **No dependency reduction.** All 8 runtime deps stay in `require`. The earlier draft
+  targeted 8 → 4; collecting that requires asking operators which features they run.
 - **No pluggability for the core.** Routing, config, `Lamb\Post`, visibility, HTTP
   egress guarding, escaping, upload security, session/CSRF each get *one*
-  implementation. Offering a choice there is what caused D1–D6.
+  implementation. Offering a choice there is what caused D1–D6 in the first place.
 - **Not a global-state cleanup.** `global $routes, $config, $data, $template` stays.
-  It caps how isolated a module can be; that is accepted and stated, not fixed here.
-- **Not a third-party plugin ecosystem — even though other installs exist.** An
-  installed base justifies *internal* modules (one owner per feature); it
-  does not justify a public extension API, which is a support commitment and a
-  compatibility surface forever. The README sells "no plugin needed" as a feature.
-  Modules stay an internal seam that happens to be toggleable.
+
+## What this gives up, stated plainly
+
+7,184 lines — 44% of the PHP in `src/` — are optional features, and they all still
+ship to every install, in a flat namespace, with no enforced ownership. That is the
+cost of this decision and it is accepted, not solved. Two mitigations already exist
+and should be used rather than replaced: the `src/<module>/README.md` convention
+(2026-08-21 decision) gives a subsystem a place to describe itself without a code
+boundary, and `experimental_features` already gates the importers.
+
+Revisit only if a concrete need appears — a real operator asking to run Lamb without
+the IndieWeb stack, or a feature whose dependency becomes a recurring advisory
+burden. "The codebase would be tidier" is not that need.
 
 ## Ground rules (house process, per AGENTS.md)
 
-- **Every extraction is invisible to an operator.** Other installs are upgrading
-  through this work and must see no change: same routes, same features, same
-  `composer install`, nothing new to configure. Modules always load, so there is no
-  enabled set to migrate. What does need care is anything an operator or theme author
-  *addresses by name* — a moved route, config key, CLI entry point or theme part keeps
-  a deprecated shim for one release, warning rather than breaking.
-- Branch from `main`. **Open an issue per PR first** and get maintainer agreement —
-  AGENTS.md requires it for feature work, and Stage 2 onward is feature work.
+- Branch from `main`. **Open an issue per PR first** and get maintainer agreement.
 - **Red-green TDD is mandatory.** Every step below names its failing test. No
   implementation before the test fails.
 - Gates that must stay green, per PR: `composer lint`, `composer analyse`
   (**PHPStan level 8, empty baseline — keep it empty**), `vendor/bin/codecept run`,
   `composer coverage` (**≥70%**), `pnpm test`, `composer audit`.
 - A refactor PR that touches no behaviour still needs its characterisation test
-  written first, so the "no behaviour change" claim is enforced rather than asserted.
-- Per the 2026-08-21 decision, each new module directory gets a
-  `src/modules/<name>/README.md`. Per the 2026-05-29 decision, `docs/` stays
-  end-user only — none of this work adds pages there except where a module changes
-  documented behaviour.
-- `DECISIONS.md` entries at three points only: the funnel (Stage 2), the module
-  manifest (Stage 4), and optional dependencies (Stage 6). The convergence PRs are
-  not decisions, they are cleanups.
+  written first, so "no behaviour change" is enforced rather than asserted.
+- **Every change is invisible to an operator** except where it stops a bug. Other
+  installs are upgrading through this work. Anything addressed *by name* — a route, a
+  config key, a CLI entry point, a theme part — keeps a deprecated shim for one
+  release, warning rather than breaking.
+- `DECISIONS.md` entries at two points: the funnel (Stage 2), and this rejection —
+  "Lamb stays a flat codebase; optional features are not modules", recording the
+  plug-and-play reasoning so the question does not get re-opened from scratch.
 
 ---
 
@@ -216,10 +211,11 @@ logged-in-only `<small>`), decide once and record it — do not preserve all thr
 **PR 7 · One `data_dir()`** (D10)
 
 `getenv('LAMB_DATA_DIR')` is read independently in `src/bootstrap.php:58` and all
-three CLI scripts. Route the CLIs through `Bootstrap\data_dir()`. Move the
+three CLI scripts. Route the CLIs through `Bootstrap\data_dir()`. Optionally move the
 feature-only constants out of `src/constants.php` (`FEED_FETCH_*`,
-`IMAGE_UPLOAD_EXTENSIONS`, `VIDEO_UPLOAD_EXTENSIONS`) — parking them next to their
-owners now saves moving them twice in Stages 4–5.
+`IMAGE_UPLOAD_EXTENSIONS`, `VIDEO_UPLOAD_EXTENSIONS`) next to their owners — the
+file's own docblock says it holds "application-wide" constants, and these are not.
+Skip it if it reads worse; with no module extraction coming, nothing forces it.
 - Test first: `UpgradeScriptTest`/`LambRestoreTest` already spawn CLI subprocesses
   with a seeded data dir — extend to assert the resolved path.
 - Size: small. Risk: low. Note the default differs by design (`../data` for web,
@@ -235,7 +231,7 @@ Coverage ≥70% and the PHPStan baseline still empty.
 
 **PR 8 · `Post\save()` and the lifecycle events**
 
-The one change that both fixes D1 and unlocks Stages 3–5. Nine write sites each
+The D1 fix, and the largest single change in the plan. Nine write sites each
 independently decide whether to re-render, finalize the slug, notify subscribers,
 write a slug-change redirect and feed-lock (table in MODULARITY.md §D1). The
 asymmetry is currently held by a comment repeated across `src/wordpress.php:203` and
@@ -282,178 +278,130 @@ returns hits only inside `src/post.php`. No write path outside the funnel.
 
 ---
 
-## Stage 3 — Cron registry
+## Stage 3 — Make `/_cron` unable to lose webmention delivery
 
-**PR 9 · `Cron\register()` and a `/_cron` driver**
+**PR 9 · Isolate and order the cron jobs**
 
-`Network\process_feeds()` (`src/network.php:142-146`) hardcodes
-`Websub\ping_scheduled_publishes()` and `Webmention\process_outbound()` *inside the
-feed-ingestion loop*. Consequence: **removing the feed reader silently stops
-outbound webmention delivery.** This single coupling is why `indieweb` and `feeds`
-cannot be separated today.
+Kept from the rejected half, but not for its original reason. `Network\process_feeds()`
+(`src/network.php:102-149`) is one straight-line function running five unrelated jobs,
+with the two notification drains **last**:
 
-Replace with `Cron\register(string $name, callable $job)` and a `/_cron` driver that
-runs whatever registered, keeping the existing lock (`Network\acquire_cron_lock()`),
-the per-job output lines, and `purge_deleted_posts()`. Feed ingestion becomes one
-registered job among several.
+```
+lock → rate-limit check → purge → prune → flatten
+     → feed crawl loop (N feeds × up to FEED_FETCH_TIMEOUT each)
+     → Websub\ping_scheduled_publishes()
+     → Webmention\process_outbound()
+     → write the run watermark
+```
 
-- Test first: registry ordering, one job throwing does not abort the rest, output
-  shape unchanged (the existing `count_line`/`crawl_line`/`webmention_line` helpers
-  are already unit-testable).
-- Size: medium. Risk: medium — `/_cron` is the only scheduled entry point; a
-  swallowed exception must still surface in the output. Verify against a real run.
+Anything that ends the request inside the crawl loop skips both drains *and* the
+watermark write. No exception is required: nothing in the repo calls
+`set_time_limit()`, so `/_cron` inherits the host's PHP limit — typically 30s under
+the FPM/Caddy/nginx setups the repo ships — while a single feed fetch may take up to
+`FEED_FETCH_TIMEOUT` (15s, `src/constants.php`). Two slow feeds exhaust the budget.
+And because the watermark is written only at the end, the next run is immediately due
+and walks into the same wall, so **one persistently slow feed can stop outbound
+webmention delivery indefinitely, silently.** The only symptom is replies never
+arriving at their targets.
 
-**Exit criteria:** `src/network.php` contains no reference to `Lamb\Webmention` or
-`Lamb\Websub`.
+`crawl_feed()` is also unguarded: `ingest.php` catches `SQL` around individual stores
+(`network/ingest.php:116,141`), but nothing wraps the per-feed crawl, so a throw from
+the JSON or SimplePie path has the same effect as the timeout.
+
+Fix, smallest first — the ordering change alone removes the reported failure:
+
+1. **Run the drains before the crawl loop**, or guard the loop with `try/finally`, so
+   the notification work cannot be starved by feed fetching. Prefer both.
+2. **Wrap each feed's crawl** so one bad feed reports and the run continues, rather
+   than aborting the request. `crawl_line()` already has an error shape to render into.
+3. **Advance the watermark in a `finally`**, so a partial run cannot cause an
+   immediate re-run that repeats the same failure.
+4. Optional, only if 1–3 leave the function unwieldy: a small `Cron\register(name,
+   callable)` list so `/_cron` iterates jobs instead of naming them. This is the piece
+   the module plan wanted; it is now a readability nicety, not a requirement. Skip it
+   if the guarded version reads fine.
+
+- **Test first:** a feed whose crawl throws, asserting `process_outbound()` still ran
+  and the watermark advanced; then a second run asserting it is rate-limited rather
+  than repeating. `count_line`/`crawl_line`/`webmention_line` are already unit-testable.
+- **Also add** a `set_time_limit(0)` (or a documented explicit budget) at the top of
+  `process_feeds()`, since the whole class of failure comes from a long job running
+  under a web request's limit. Note it in `src/network/README.md`.
+- Size: small-medium. Risk: low — the change is ordering and guards, not new logic.
+  Verify against a real `/_cron` run with a deliberately slow feed.
+
+**Exit criteria:** no path through `process_feeds()` reaches the end of the request
+with the outbound queue undrained and the watermark unwritten.
 
 ---
 
-## Stage 4 — Module loader, and the first module
+## Stage 4 — One importer entry point (D9)
 
-**PR 10 · The manifest and loader**
+**PR 10 · Importer registry and a single CLI driver**
 
-```php
-// src/modules/<name>/module.php
-return [
-    'name'     => 'import',
-    // No 'enabled' key and no 'requires' probe: every module loads, always.
-    // A module needing an extension states it in composer.json like any core code.
-    'register' => function (): void { /* route/cron/event/import registrations */ },
-];
-```
+The D9 fix, with no module directory. `import-wordpress.php`, `import-known.php` and
+`import-lamb.php` are ~65 lines each of the same sequence — SAPI check,
+`define('ROOT_DIR')`, `parse_import_args()`, readability check, `data_dir()`,
+`bootstrap_db()`, `Config\load()`, `apply_timezone()`, experimental gate, parse,
+extract, `run_import()` — differing only in which parse/extract/uuid/import callables
+they pass.
 
-`index.php` loads every module and calls `register()` before `Route\call_route()` —
-a fixed list discovered from `src/modules/`, with no configuration consulted. The
-manifest is a wiring convention, not a feature flag. `Route\is_reserved_route()` rebuilds the registry on demand for CLI
-callers (`src/routes.php:170`) — module registration must participate in that
-rebuild or an importer will stop seeing module routes as reserved, which is exactly
-the `/login`-shadowing bug that function was added to fix.
-
-- Test first: a fixture module registering a route and a cron job; assert both
-  reachable, and assert a module whose `register()` throws fails loudly at boot
-  rather than silently dropping its routes.
-- Size: medium. Risk: medium. **DECISIONS.md entry:** "Optional features live in
-  `src/modules/<name>/` behind a manifest."
-
-**PR 11 · Extract the `import` module**
-
-Lowest-risk extraction by a wide margin: CLI-only, no web routes, no theme surface,
-and **already gated behind `experimental_features`** (`src/config.php:436`) — a kill
-switch that exists today, with `EXPERIMENTAL_GATE_VERSION` machinery for forcing
-re-opt-in when the gated set changes.
-
-It is also the **highest-value** extraction, not just the safest: an importer is
-run once per install, at migration time, and never again. Today every install
-carries 2,391 lines and a `league/html-to-markdown` dependency in perpetuity to
-serve that one-off. No other module has that profile — the rest are features people
-actually keep using.
-
-Moves `import.php`, `wordpress.php`, `known.php`, `restore.php` into
-`src/modules/import/`. Adds the **importer registry** that collapses D9:
+`Import\run_import()` already takes exactly those callables (`src/import.php:834`), so
+this is mechanical:
 
 ```php
 Import\register_source(['name','parse','extract','skip_reason','uuid','import']);
 ```
 
-`Import\run_import()` already takes exactly these callables, so this is mechanical.
-Replace the three ~65-line CLI scripts — identical but for their parse/extract calls
-— with one `bin/lamb import <source> <path> [--dry-run] [--replace]` driver. Keep
-thin `import-*.php` shims at the root for one release, deprecation-warning to STDERR,
-since they are documented entry points.
+plus one `bin/lamb import <source> <path> [--dry-run] [--replace]` driver. Files stay
+where they are — `import.php`, `wordpress.php`, `known.php`, `restore.php` in `src/`,
+unmoved. A fourth importer becomes a registration instead of a fourth script.
 
-- Test first: `LambRestoreTest` already spawns the CLI as a subprocess with a seeded
-  data dir — extend it to the new driver and to a registered-source lookup, plus a
-  `--dry-run` byte-comparison of the summary output against the old scripts.
-- Size: medium-large (mostly file moves). Risk: low-medium. Verify with a real
-  archive `--dry-run` diff before/after.
-- Drops `league/html-to-markdown` from the core's required set.
+- **Test first:** `LambRestoreTest` already spawns the CLI as a subprocess against a
+  seeded data dir — extend it to the new driver and to a registered-source lookup,
+  plus a `--dry-run` byte-comparison of the summary output against the old scripts
+  (`run_import()` was written to keep that output identical, so this is a real check).
+- Keep the three `import-*.php` shims for one release, delegating to the driver and
+  warning to STDERR. They are documented entry points in `README.md` and `docs/`.
+- Size: medium. Risk: low — CLI-only, no web surface, and already behind
+  `experimental_features` (`src/config.php:436`).
 
-**Exit criteria:** one CLI driver, three registered sources, `composer.json`
-`autoload.files` no longer lists the four importer files individually.
-
----
-
-## Stage 5 — The remaining modules
-
-**PR 12 · Serializer registry; move Atom and JSON Feed out of `themes/`** (D7)
-
-Two of five post→wire serializers are **theme parts**
-(`themes/base/feed.php`, `feed_json.php`), so a custom theme owns the syndication
-contract. `themes/2026/html.php:85-89` records this class of failure already
-happening for a different part: *"A theme that omits the call hides them from the
-author entirely — this one did, and it is the default theme."*
-
-Move Atom and JSON Feed to a serializer registry owned by code, not themes. Themes
-keep presentation; formats stop being overridable by omission.
-
-**Because third-party themes are real, this cannot be a hard break.** Ship it in two
-steps: the registry resolves a theme-supplied `feed.php`/`feed_json.php` first and
-emits a deprecation notice when it finds one, so existing themes keep working; the
-fallback is removed a release later. That inverts the current footgun — a theme that
-*omits* the part silently loses syndication today, whereas after this a theme that
-omits it inherits a correct feed and only an override is deprecated.
-- Test first: `tests/Unit/` feed-shape assertions, plus a fixture theme overriding a
-  feed part to pin the deprecated path while it exists. `TagFeedCest` and the feed
-  conditional-GET Cests already guard the routes.
-- Risk: medium — the only user-visible change in the plan. The two-step lands it
-  without breaking a theme mid-release; `docs/` needs a theme-author note.
-
-**PR 13 · Extract `indieweb`** (2,558 LOC)
-
-`micropub.php`, `webmention.php`, `websub.php`, `parts/_webmentions.php`, and
-`index.php`'s four hardcoded `Link:` headers. Owns the `webmention` and
-`webmentionoutbox` tables, its `post.published` subscriptions (Stage 2) and its cron
-jobs (Stage 3). Drops `taproot/micropub-adapter`.
-- **Only viable after Stages 2–4.** Extracting it while Micropub still carries its
-  own front-matter assembler (PR 4), its own upload pipeline (PR 5), and its own HTML
-  sanitizer just relocates D3/D4/D5 behind a boundary where they are harder to see.
-- Micropub's `sanitizeHtml()`/`sanitizeAttributes()` (`src/micropub.php:1102`) is the
-  one sanitizer that legitimately stays module-local — it filters *inbound* client
-  HTML, a different job from rendering trusted author Markdown. Say so in the module
-  README rather than leaving it looking like a stray fourth copy.
-- Test first: acceptance coverage already exists (`MicropubDiscoveryCest`,
-  `MicropubMediaCest`, `WebmentionCest`) — they must pass unchanged, which is the
-  whole acceptance criterion: the extraction is invisible from outside.
-- Size: large (mostly moves). Risk: medium-high — it is the largest module and owns
-  security-sensitive endpoints.
-
-**PR 14 · Extract `feeds`, `export`, `highlight`**
-
-- `feeds` (1,042 LOC, `network.php` + `network/`): the ingest cron job. Drops
-  `simplepie/simplepie`. `src/network/README.md` already exists — move it along.
-- `export` (439 LOC): `/export`. Keeps its own `Export\zip_available()` runtime check
-  for `ext-zip`, exactly as today — that is a capability probe, not a feature flag.
-- `highlight` (91 LOC): a render filter and a `POST_VERSION` participant. Because it
-  always loads, the version stamp keeps its current meaning and no post re-parses;
-  note in its README that this is *why* it is not switchable.
-- Size: medium each. Risk: low-medium.
+**Exit criteria:** one driver, three registered sources, three shims warning.
 
 ---
 
-## Stage 6 — Struck
+## Stage 5 — Themes stop owning syndication (D7)
 
-**Cut: "move feature-only deps to `suggest`" and "document modules for operators".**
+**PR 11 · Feed output moves from theme parts into code**
 
-Both were the operator-visible half of the plan, and both are gone with the
-disable switch. If every module always loads, every module's dependencies are always
-needed, so `taproot/micropub-adapter`, `simplepie/simplepie` and `phiki/phiki` stay
-in `require` where they belong — and there is nothing for an operator to read about,
-because there is nothing for them to decide.
+The D7 fix, with no serializer registry abstraction beyond what this needs. Atom and
+JSON Feed live as **theme parts** (`themes/base/feed.php`, `feed_json.php`), so a
+theme owns the syndication contract, and a theme that simply *omits* the part loses
+the site's feed. That exact class of failure is already recorded in
+`themes/2026/html.php:85-89` for a different part:
 
-This is a deliberate trade. It gives up the dependency-surface reduction that
-objective 3 originally claimed, and that reduction was real: a stripped install would
-have dropped from 8 runtime deps to 4. It is given up because collecting it requires
-asking the operator which features they run, and that question is the thing Lamb
-exists not to ask.
+> *"A theme that omits the call hides them from the author entirely — this one did,
+> and it is the default theme."*
 
-**The one case worth revisiting later** is `import`: CLI-only, already gated behind
-`experimental_features`, run at most once per install, and carrying
-`league/html-to-markdown` in perpetuity for that one run. Moving *that* dependency to
-`suggest` degrades a CLI script into a clear error message rather than degrading the
-website, so it does not put the site's behaviour in the operator's hands. Even so:
-not now. It is a separate decision on its own merits once PR 11 has landed and the
-module seam has proven itself, and it needs `composer install --no-dev` on a real
-install to behave correctly first.
+Move both into `Lamb\Response` alongside the sitemap, which is already code
+(`Response\render_sitemap()`, `src/response/discovery.php:94`). Themes keep
+presentation; feeds stop being overridable by omission.
+
+**Third-party themes are real, so this is two steps, not a cut.** The feed responder
+resolves a theme-supplied `feed.php`/`feed_json.php` first and emits a deprecation
+notice when it finds one; existing themes keep working. The fallback is removed a
+release later. This inverts today's footgun: after the change, a theme that omits the
+part inherits a correct feed, and only an override is deprecated.
+
+- **Test first:** `tests/Unit/` feed-shape assertions, plus a fixture theme overriding
+  a feed part to pin the deprecated path while it exists. `TagFeedCest` and the feed
+  conditional-GET Cests already guard the routes and must pass untouched.
+- This is the one developer-visible change in the plan; it needs a theme-author note
+  in `docs/` and a mention in the release notes.
+- Size: medium. Risk: medium — feeds are cacheable and validator-sensitive, so verify
+  `ETag`/`Last-Modified` behaviour is unchanged (`Response\feed_cache()`).
+
+**Exit criteria:** `themes/*/feed*.php` are optional overrides, not the only source.
 
 ---
 
@@ -470,91 +418,69 @@ PR 6  theme part dedupe         │
 PR 7  one data_dir             ─┘
 
 PR 8  Post\save() + events  ◄─── needs PR 4, 5 (or Micropub/importers get
-  │                               converted twice)
-  ├──► PR 9  cron registry
-  │      │
-  │      └──► PR 13 indieweb ◄── also needs PR 10
-  │           PR 14 feeds
-  └──► PR 10 module loader
-           └──► PR 11 import module
-                PR 12 serializer registry
-                PR 14 export, highlight
-                          (PR 15 optional deps, PR 16 operator docs: struck — see
-                           Stage 6. They were the operator-visible half.)
+                                  converted twice)
+
+PR 9  cron ordering + guards ─── independent of everything; it is a bug fix
+PR 10 importer registry      ─── independent (PR 7 first if both touch the CLIs)
+PR 11 feeds out of themes    ─── independent (after PR 3, which touches feed.php)
 ```
 
+Only one real edge in the whole plan (PR 8 after PR 4/5). Stages 3–5 are three
+unrelated fixes and can go in any order, before or after the funnel.
+
 **Stop-anywhere property.** Stages 0–1 pay for themselves with no architectural
-commitment. Stage 2 is worth landing even if Stages 3–5 never happen — it is the
-D1 fix. Stages 3–5 are the only part that requires believing in the module idea, and
-they are last on purpose.
+commitment. Stage 2 is the D1 fix and stands alone. Stages 3–5 are each a single
+bug-class fix. Nothing in this plan requires believing in anything.
 
 ---
 
 ## Definition of done
 
 Per PR: issue agreed → failing test → minimum implementation → green → all six gates
-→ PHPStan baseline still empty → coverage ≥70% → `AGENTS.md` updated where structure
-moved (its Project Structure and Namespaces tables both go stale from Stage 4 on).
+→ PHPStan baseline still empty → coverage ≥70% → `AGENTS.md` updated where behaviour
+or structure moved.
 
-Overall, measured against MODULARITY.md's numbers:
+Measured against MODULARITY.md's numbers:
 
 | Metric | Now | Target |
 |---|---:|---:|
 | Post write entry points | 9 | 1 |
 | Definitions of "published" | 2 | 1 |
+| Cron paths that can silently skip webmention delivery | ≥1 | 0 |
 | HTTP transports | 5 (1 dead) | 4 |
 | XML escapers | 2 + 1 global | 1 |
 | Front-matter engines / assemblers | 2 / 4 | 1 / 1 |
 | Upload store pipelines | 3 | 1 |
 | Copies of the post-list template | 3 | 1 |
 | Importer CLI scripts | 3 | 1 driver |
-| Optional-feature LOC in a flat `src/` | 7,184 (44%) | 0 (owned by a module dir) |
+| Feed formats a theme can silently drop | 2 | 0 |
 | Runtime deps required | 8 | 8 — unchanged, by choice |
+| Optional-feature LOC in a flat `src/` | 7,184 (44%) | 7,184 — unchanged, by choice |
 
-The dependency row is deliberately flat. An earlier draft targeted 8 → 4; that
-required an operator-selectable module set, which is struck (see Stage 6). The 44%
-still *ships* — it just stops being spread through a flat namespace with no owner.
-That is a smaller claim than the earlier draft made, and it is the honest one.
+The last two rows are the shape of the decision: the duplication goes, the sprawl
+stays.
 
 ---
 
-## Risks, and where this plan is most likely to go wrong
+## Risks
 
 1. **PR 4 (front matter) is the most dangerous PR here.** Front matter is the post
    format; a regression corrupts stored bodies rather than breaking a page. Split it,
    characterise before touching, and diff a real `--dry-run` import both sides.
 2. **PR 8 touches every write path.** Land the funnel with one site converted, then
    convert the rest incrementally. Do not convert nine sites in one commit.
-3. **PR 12 would break third-party themes** that override a feed part — which, with
-   a real installed base, means someone's live blog loses its feed. Hence the
-   two-step deprecation rather than a clean cut. Do not collapse it back into one PR
-   because the fallback looks like dead weight.
-4. **The dependency reduction is struck, and should stay struck.** It is the most
-   tempting thing to reinstate, because 8 → 4 deps reads well against AGENTS.md's
-   advisory burden. Reinstating it means asking the operator which features they run.
-   See Stage 6 for the one narrow exception worth a separate decision later.
-5. **The upgrade path.** Largely dissolved by always-loading modules: with no
-   enabled set there is nothing to derive, and an operator upgrading sees no change.
-   What remains is narrow and still needs testing — a moved route or CLI entry point
-   must keep its deprecated shim for a release (PR 11's `import-*.php`, PR 12's theme
-   feed parts). Test each against a config and a theme that predate the move, not
-   just a fresh install.
-6. **RedBean fluid mode means "disabled" is not "uninstalled."** `webmention`,
-   `webmentionoutbox` and `feedstatus` are created lazily on first write; disabling a
-   module leaves orphan tables. Acceptable — but say it in the module READMEs so it
-   isn't discovered as a bug.
-7. **CI needs no module pinning — and that is the test that the seam stayed
-   internal.** Five acceptance Cests (`MicropubDiscoveryCest`, `MicropubMediaCest`,
-   `WebmentionCest`, `UploadCest`, `TagFeedCest`) exercise routes that become
-   module-provided. They must keep passing untouched, with no module configuration in
-   the suite. The day CI needs to know which modules are on, this plan has drifted.
-8. **Philosophy drift is the real long-term risk, and it has a specific shape here.**
-   Not hook priorities first — a *disable switch*. Once `src/modules/` exists, adding
-   one is a ten-line change and will look obviously useful. That is the change that
-   turns a plug-and-play install into a plug-many-things-and-configure install, and
-   it should be refused on those grounds rather than debated on its merits.
-   "Simple over complex", "opinionated defaults over settings". The moment this grows
-   hook priorities, a
-   filter chain, or a plugin settings page, it has stopped being this plan. The
-   non-goals above are the guardrail; revisit them at Stage 4, which is where the
-   temptation arrives.
+3. **PR 11 is the only developer-visible break.** A theme overriding a feed part is
+   someone's live blog losing its feed, hence the two-step deprecation. Do not
+   collapse it into one PR because the fallback looks like dead weight.
+4. **PR 9 is easy to under-fix.** Reordering the drains removes the reported symptom
+   but leaves an unguarded loop and an all-or-nothing watermark. Do all of 1–3 in that
+   PR, or the next slow feed produces a different version of the same outage.
+5. **RedBean fluid mode.** Unchanged by this plan, but worth stating since the module
+   proposal raised it: `webmention`, `webmentionoutbox` and `feedstatus` are created
+   lazily on first write. With no modules there is nothing to disable, so no orphan
+   tables — one fewer thing to reason about.
+6. **The module idea will come back.** It is a genuinely appealing refactor and each of
+   these PRs makes the seams cleaner, which makes it *more* appealing. The rejection
+   is on plug-and-play grounds, not code-health grounds, so a code-health argument for
+   reinstating it does not answer the objection. Put the `DECISIONS.md` entry in early
+   (Stage 2 at the latest) so the reasoning outlives this conversation.

--- a/PLAN.md
+++ b/PLAN.md
@@ -11,7 +11,7 @@ places where the core does one job two or three ways; the sprawl comes from 44% 
 duplicate mechanism relocates the bug instead of removing it. So: **converge first,
 extract second.** Every stage below is ordered by that constraint, not by appeal.
 
-**Shape:** 15 PRs across 6 stages. Stages 0–1 (7 PRs) are independent of each other
+**Shape:** 16 PRs across 6 stages. Stages 0–1 (7 PRs) are independent of each other
 and of everything after — they can land in any order, in parallel, and each one is
 worth landing even if the rest of this plan is dropped. Stage 2 is the keystone.
 Stages 3–5 are only unlocked by it.
@@ -24,6 +24,17 @@ Stages 3–5 are only unlocked by it.
 2. Make "published" a single event instead of a convention re-derived per subsystem (Stage 2).
 3. Let an install not ship — and not carry the dependency surface of — features it doesn't use (Stages 3–6).
 
+**The premise for objective 3 is a real installed base.** Lamb has other installs,
+so "don't ship what you don't use" is a benefit that lands on actual users rather
+than a hypothetical one. That premise also imposes the constraint below: with real
+installs, every module extraction needs an upgrade path, and shipping a regression
+costs more than the sprawl does. Convergence-before-extraction gets *stronger* under
+that premise, not weaker — a duplicate mechanism relocated behind a module boundary
+is now a bug shipped to other people's blogs.
+
+The clearest single win is `import`: 2,391 lines and `league/html-to-markdown` that
+every install carries forever to serve a migration each install runs at most once.
+
 ## Non-goals
 
 - **No plugin framework.** No hook priorities, no filter chains, no third-party
@@ -35,9 +46,22 @@ Stages 3–5 are only unlocked by it.
   implementation. Offering a choice there is what caused D1–D6.
 - **Not a global-state cleanup.** `global $routes, $config, $data, $template` stays.
   It caps how isolated a module can be; that is accepted and stated, not fixed here.
+- **Not a third-party plugin ecosystem — even though other installs exist.** An
+  installed base justifies *modules* (an install can drop what it doesn't run); it
+  does not justify a public extension API, which is a support commitment and a
+  compatibility surface forever. The README sells "no plugin needed" as a feature.
+  Modules stay an internal seam that happens to be toggleable.
 
 ## Ground rules (house process, per AGENTS.md)
 
+- **Every extraction ships an upgrade path.** Other installs are upgrading through
+  this work, so no module may default to off for an install that is already using
+  the feature: derive the enabled set from existing config (a populated `[feeds]`
+  means `feeds` is on) rather than from a new default. The precedents are
+  `Config\ensure_explicit_theme()` and `Bootstrap\backfill_imported_post_identity()`
+  — boot-time, idempotent, safe to run on every request. A moved route, config key
+  or CLI entry point keeps a deprecated shim for one release, warning rather than
+  breaking.
 - Branch from `main`. **Open an issue per PR first** and get maintainer agreement —
   AGENTS.md requires it for feature work, and Stage 2 onward is feature work.
 - **Red-green TDD is mandatory.** Every step below names its failing test. No
@@ -303,6 +327,12 @@ and **already gated behind `experimental_features`** (`src/config.php:436`) — 
 switch that exists today, with `EXPERIMENTAL_GATE_VERSION` machinery for forcing
 re-opt-in when the gated set changes.
 
+It is also the **highest-value** extraction, not just the safest: an importer is
+run once per install, at migration time, and never again. Today every install
+carries 2,391 lines and a `league/html-to-markdown` dependency in perpetuity to
+serve that one-off. No other module has that profile — the rest are features people
+actually keep using.
+
 Moves `import.php`, `wordpress.php`, `known.php`, `restore.php` into
 `src/modules/import/`. Adds the **importer registry** that collapses D9:
 
@@ -340,10 +370,18 @@ author entirely — this one did, and it is the default theme."*
 
 Move Atom and JSON Feed to a serializer registry owned by code, not themes. Themes
 keep presentation; formats stop being overridable by omission.
-- Test first: `tests/Unit/` feed-shape assertions; `TagFeedCest` and the feed
+
+**Because third-party themes are real, this cannot be a hard break.** Ship it in two
+steps: the registry resolves a theme-supplied `feed.php`/`feed_json.php` first and
+emits a deprecation notice when it finds one, so existing themes keep working; the
+fallback is removed a release later. That inverts the current footgun — a theme that
+*omits* the part silently loses syndication today, whereas after this a theme that
+omits it inherits a correct feed and only an override is deprecated.
+- Test first: `tests/Unit/` feed-shape assertions, plus a fixture theme overriding a
+  feed part to pin the deprecated path while it exists. `TagFeedCest` and the feed
   conditional-GET Cests already guard the routes.
-- Risk: medium — this is a **breaking change for any third-party theme** that
-  overrides a feed part. Announce it; it is the one user-visible change in the plan.
+- Risk: medium — the only user-visible change in the plan. The two-step lands it
+  without breaking a theme mid-release; `docs/` needs a theme-author note.
 
 **PR 13 · Extract `indieweb`** (2,558 LOC)
 
@@ -389,11 +427,25 @@ This is the payoff for the whole plan given how much of AGENTS.md is dependency 
 advisory management: a minimal install stops carrying CVE surface for a Micropub
 endpoint it never exposes.
 
-- Risk: **this is where the plan can bite users.** An existing install that runs
-  `composer install --no-dev` after upgrading loses packages its enabled modules
-  need. Needs a boot-time probe with an actionable message, `RELEASING.md` coverage,
-  and a docs note — do not ship it as a silent `composer.json` edit.
+- Risk: **this is where the plan can bite users, and with a real installed base it
+  will.** An existing install that runs `composer install --no-dev` after upgrading
+  loses packages its enabled modules still need, and finds out when a route 500s.
+  Requirements, not suggestions: a boot-time `requires` probe that names the missing
+  package and the module needing it; the enabled-module set derived from existing
+  config per the upgrade rule above; a `RELEASING.md` checklist item; an upgrade
+  note in `docs/`. Land it at a **release boundary**, never mid-release, so
+  `release` never carries a half-applied dependency change.
 - **DECISIONS.md entry:** "Feature-only dependencies are suggested, not required."
+
+**PR 16 · Document modules for operators**
+
+Added because there is an installed base: from PR 10 on, "which features does this
+install run" becomes something an operator has to be able to answer. `docs/` is
+end-user-only (2026-05-29 decision), so this is one page — what a module is, the
+enabled set, how upgrades derive it, and what disabling one does and does not remove
+(orphan tables stay; see risk 5). The `src/modules/<name>/README.md` files stay
+contributor-facing per the 2026-08-21 decision; this is the operator-facing half.
+- Size: small. Risk: none. Do not start it before PR 10 settles the vocabulary.
 
 ---
 
@@ -419,7 +471,9 @@ PR 8  Post\save() + events  ◄─── needs PR 4, 5 (or Micropub/importers ge
            └──► PR 11 import module
                 PR 12 serializer registry
                 PR 14 export, highlight
-                     └──► PR 15 optional deps  (last: needs every module extracted)
+                     └──► PR 15 optional deps  (last: needs every module extracted,
+                          │                       and lands at a release boundary)
+                          └──► PR 16 operator docs (needs PR 10's vocabulary settled)
 ```
 
 **Stop-anywhere property.** Stages 0–1 pay for themselves with no architectural
@@ -448,7 +502,15 @@ Overall, measured against MODULARITY.md's numbers:
 | Copies of the post-list template | 3 | 1 |
 | Importer CLI scripts | 3 | 1 driver |
 | Runtime deps required by a minimal install | 8 | 4 |
+| Deps required by a *typical* install (keeps IndieWeb + feeds) | 8 | 6 |
 | Optional-feature LOC inside the core | 7,184 (44%) | ~0 |
+
+The two dependency rows are the honest pair. Most installs run the IndieWeb and feed
+features — that is why they chose Lamb — so their surface drops by two
+(`league/html-to-markdown` once `import` is extracted, `phiki` if they forgo
+highlighting), not four. The full drop to four is real but applies to the stripped
+install, not the median one. `import` supplies most of the typical win, because it is
+the one module nobody keeps using.
 
 ---
 
@@ -459,19 +521,27 @@ Overall, measured against MODULARITY.md's numbers:
    characterise before touching, and diff a real `--dry-run` import both sides.
 2. **PR 8 touches every write path.** Land the funnel with one site converted, then
    convert the rest incrementally. Do not convert nine sites in one commit.
-3. **PR 12 breaks third-party themes** that override a feed part. It is the only
-   user-visible break in the plan; announce rather than absorb it.
+3. **PR 12 would break third-party themes** that override a feed part — which, with
+   a real installed base, means someone's live blog loses its feed. Hence the
+   two-step deprecation rather than a clean cut. Do not collapse it back into one PR
+   because the fallback looks like dead weight.
 4. **PR 15 can break existing installs' `composer install`.** Boot-time probe with an
-   actionable message, or don't ship it.
-5. **RedBean fluid mode means "disabled" is not "uninstalled."** `webmention`,
+   actionable message, at a release boundary, or don't ship it.
+5. **The upgrade path is the part most likely to be skipped, and the most expensive
+   to get wrong.** Defaulting a module to off for an install already using the
+   feature silently removes it — webmentions stop being delivered and nothing errors.
+   Every extraction PR needs a boot-time derivation test against a config that
+   predates it, not just a fresh-install test. This risk did not exist when the plan
+   assumed one install; it is now the top operational risk in Stages 4–6.
+6. **RedBean fluid mode means "disabled" is not "uninstalled."** `webmention`,
    `webmentionoutbox` and `feedstatus` are created lazily on first write; disabling a
    module leaves orphan tables. Acceptable — but say it in the module READMEs so it
    isn't discovered as a bug.
-6. **CI must pin the enabled module set from PR 10 onward.** Five acceptance Cests
+7. **CI must pin the enabled module set from PR 10 onward.** Five acceptance Cests
    (`MicropubDiscoveryCest`, `MicropubMediaCest`, `WebmentionCest`, `UploadCest`,
    `TagFeedCest`) exercise routes that become module-provided; coverage drops
    silently otherwise.
-7. **Philosophy drift is the real long-term risk.** "Simple over complex",
+8. **Philosophy drift is the real long-term risk.** "Simple over complex",
    "opinionated defaults over settings". The moment this grows hook priorities, a
    filter chain, or a plugin settings page, it has stopped being this plan. The
    non-goals above are the guardrail; revisit them at Stage 4, which is where the


### PR DESCRIPTION
Two documents, no code changes.

- **`PLAN.md`** — 11 PRs across 5 stages, each with its failing test, gates, size, risk and rollback.
- **`MODULARITY.md`** — the findings it cites, with file:line evidence for all ten duplication hotspots.

Lamb keeps producing the same kinds of bug because ten jobs in the codebase have two or three implementations each, and the copies drift. This plan collapses each of them to one.

## What has more than one way to do it

Ranked by likely bug production. Most are documented *by the code's own comments* — the divergence is a maintained convention, not an oversight.

1. **Saving a post — 9 entry points, 3 tiers of completeness.** Each independently decides whether to re-render, finalize the slug, notify subscribers. `wordpress.php:203` and `known.php:307` carry the same hand-maintained comment about not notifying. Underneath: **"published" is not an event** — `Webmention\process_outbound()` checks `is_publicly_visible()`, while `Websub\ping_scheduled_publishes()` infers publication from a `created > updated` watermark heuristic. Two definitions of one moment.
2. **5 HTTP transports**, one SSRF-guarded — and `Http\post_form()` has **zero callers**, while the two sites that would use it carry comments explaining why they don't.
3. **4 HTML sanitizers, 5 escapers** — including a *global* `escape()` declared inside `themes/base/feed.php` behind `function_exists()`, shadowing the namespaced helper.
4. **2 front-matter engines behind 4 assemblers**, 14 call sites across 8 files. Front matter *is* the post format.
5. **3 upload pipelines.** `response/upload.php:320-333` records the fallout: assets landed `0600` on one path and `0666 & ~umask` on the others, so a static-file server couldn't read images the site was serving.
6. **5 visibility expressions.** Docblocks record two already-shipped bugs from this.
7. **5 output serializers, 2 of them theme parts** — a theme owns the syndication contract.
8. **`2024/_items.php` and `2026/_items.php` differ by two lines, one a comment**, and both diverged from base. `_related.php:31` shows a fix hand-ported between copies.
9. 3 near-identical importer CLIs. 10. 6 config sources.

## Two live bugs found along the way

**1. Notify-after-failed-write, fixed on one save path only.** `redirect_edited()` (`response/posts.php:317-329`) carries this on its catch block:

> *"Falling through on a failed write … announced the unsaved content to webmention receivers and the WebSub hub."*

`redirect_created()` (`response/posts.php:48-58`) still calls `notify_post_subscribers($bean)` outside its try/catch. Narrower but live: `finalize_and_store_post()` stores twice, and if the *second* store throws (SQLite locked by a concurrent `/_cron` — the case that comment names) the bean already has an id, so neither `enqueue_for_post()` nor `ping_for_post()` early-returns. Webmentions get queued against an unstored slug and the hub is pinged for content that wasn't persisted. That's PR 1.

**2. `/_cron` can silently stop delivering webmentions.** `process_feeds()` (`network.php:102-149`) runs five jobs in one straight line with both notification drains **last**, then writes the run watermark. Nothing in the repo calls `set_time_limit()`, so `/_cron` inherits the host's PHP limit — typically 30s under the FPM setups the repo ships — while one feed fetch may take `FEED_FETCH_TIMEOUT` (15s). **Two slow feeds end the request inside the crawl loop**, skipping both drains *and* the watermark write; the next run is immediately due and walks into the same wall. One persistently slow feed stops outbound webmention delivery indefinitely, with no symptom but replies never arriving at their targets. The per-feed crawl is also unguarded — `network/ingest.php:116,141` catches `SQL` around individual stores, nothing wraps `crawl_feed()`. That's Stage 3.

## Plan shape

| Stage | PRs | What |
|---|---|---|
| 0 | 1 | The notify-after-failed-write twin |
| 1 | 2–7 | Convergence: dead code, one escaper, one front-matter engine, one upload store, theme-part dedupe, one `data_dir()` |
| 2 | 8 | `Post\save()` + lifecycle events — the D1 fix, largest change in the plan |
| 3 | 9 | `/_cron` ordering, per-feed guards, `finally`-scoped watermark, explicit time limit |
| 4 | 10 | Importer registry + one `bin/lamb import` driver (D9) |
| 5 | 11 | Atom/JSON Feed move from theme parts into code (D7), two-step deprecation |

Only one real dependency edge in the plan (PR 8 after PRs 4–5). Any subset is coherent on its own.

## Scope boundaries

`src/` stays flat — optional features are not moved into a module tree, and the 44% of `src/` that is optional features stays where it is. Lamb promises a plug-and-play install, so anything that would make a feature set something an operator selects is out of scope by design.

Nothing operator-visible: no new configuration, no toggles, no dependency changes. An install upgrading through all 11 PRs sees the same routes, the same features and the same `composer install`. The only intended operator-visible effect is a bug stopping happening. The one developer-visible change is PR 11, which is why it ships as a two-step deprecation rather than a cut — a theme overriding a feed part is someone's live blog.

## Verification

Documentation only — no code touched. Worth knowing for the plan's assumptions: PHPStan is at **level 8 with an empty baseline** and coverage is gated at **70%**. Both are load-bearing safety nets for the refactors proposed, and every stage's exit criteria assume they stay that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ALrRmJaWTastLiW7WvDeb