### PR TITLE
Answer a media store failure with server_error, not invalid_request

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1583,7 +1583,7 @@ function respond_micropub_media(): void
             // Same reasoning as the web upload endpoint (response/upload.php): a
             // 201 with a Location the file was never written to would tell the
             // client its upload durably succeeded when it didn't.
-            micropub_error(500, 'invalid_request', 'Failed to store the uploaded file.');
+            micropub_error(500, 'server_error', 'Failed to store the uploaded file.');
         }
     }
 


### PR DESCRIPTION
A failed disk write in the Micropub media endpoint (`respond_micropub_media()`) is a server fault, so the 500 should carry the `server_error` code (RFC 6749 §4.1.2.1). It currently answers `invalid_request`, which §5.2 pairs with a 400 client error — a Micropub client keying on the error code sees a 500 status contradicted by a client-error code.

One-line change: `invalid_request` → `server_error` on the store-failure branch added in 00c9935.

## Testing

- `composer lint` — clean
- `composer analyse` — no errors
- `vendor/bin/codecept run Unit` — 1889 passed

No new test: the branch fires only when `move_uploaded_file()` fails, which can't be provoked in-process without a real registered upload (same constraint `MicropubMediaCest` already documents).

Supersedes #653, which proposed the same code correction on an older base.