### PR TITLE
Keep created on feed re-sync, only stamp it for new posts

### DIFF
--- a/src/post.php
+++ b/src/post.php
@@ -35,10 +35,20 @@ function populate_bean(string $text, Item|JsonFeedItem|null $feed_item = null, ?
     }
     $bean->body = $text;
     $bean->slug = $matter['slug'] ?? '';
-    $bean->created = \Lamb\now();
+    // Stamp `created` only when the row is new. A re-sync (feed cron update, or a
+    // manual edit) keeps the stored date, so an upstream entry being renamed —
+    // which bumps its feed date and trips update_item() — no longer re-dates the
+    // post to now and reorders created-sorted listings. `updated` always tracks
+    // the current write. Front matter can still override created via apply_scheduling().
+    $is_new = empty($bean->id);
+    if ($is_new) {
+        $bean->created = \Lamb\now();
+    }
     $bean->updated = \Lamb\now();
     if ($feed_item) {
-        $bean->created = $feed_item->get_date("Y-m-d H:i:s");
+        if ($is_new) {
+            $bean->created = $feed_item->get_date("Y-m-d H:i:s");
+        }
         $bean->updated = $feed_item->get_updated_date("Y-m-d H:i:s");
         if ($feed_name) {
             $bean->feeditem_uuid = md5($feed_name . $feed_item->get_id());

--- a/tests/Unit/PopulateBeanTest.php
+++ b/tests/Unit/PopulateBeanTest.php
@@ -289,6 +289,31 @@ class PopulateBeanTest extends TestCase
         $this->assertSame('myfeed-hello-world', $bean->slug);
     }
 
+    public function testCronUpdatePreservesOriginalCreatedDate(): void
+    {
+        // Renaming an upstream entry bumps its feed date, which trips update_item().
+        // The re-sync must keep the original `created` — only `updated` tracks the
+        // feed — or the post jumps to the top of a created-sorted listing.
+        $first = $this->createMock(SimplePieItem::class);
+        $first->method('get_date')->willReturn('2020-01-01 00:00:00');
+        $first->method('get_updated_date')->willReturn('2020-01-01 00:00:00');
+        $first->method('get_id')->willReturn('rel-1');
+
+        $bean = populate_bean('Release notes', $first, 'gh');
+        R::store($bean);
+        $this->assertSame('2020-01-01 00:00:00', $bean->created);
+
+        $renamed = $this->createMock(SimplePieItem::class);
+        $renamed->method('get_date')->willReturn('2026-08-22 12:00:00');
+        $renamed->method('get_updated_date')->willReturn('2026-08-22 12:00:00');
+        $renamed->method('get_id')->willReturn('rel-1');
+
+        $bean = populate_bean('Release notes', $renamed, 'gh', $bean);
+
+        $this->assertSame('2020-01-01 00:00:00', $bean->created);
+        $this->assertSame('2026-08-22 12:00:00', $bean->updated);
+    }
+
     public function testNonFeedPostSlugIsNotPrefixed(): void
     {
         $bean = populate_bean("---\ntitle: Hello World\n---\nContent.");


### PR DESCRIPTION
## Problem

`populate_bean()` re-stamped `created` from the feed item on **every** call, including the cron re-sync of a post that was already ingested. Renaming an upstream entry (e.g. a GitHub release) bumps its feed date, which trips `update_item()`; the re-sync then overwrote `created` with that new date, so old posts jumped to the top of the created-sorted homepage.

No duplicate posts were created — dedup on `feeditem_uuid` was already correct. The rows were the same; only their `created` column was clobbered.

## Fix

Stamp `created` only when the row is new (`empty($bean->id)`). A re-sync — and a manual edit, which also passes an existing bean — keeps the stored date. `updated` still tracks the current write, and front matter can still override `created` via `apply_scheduling()`.

## Test

`testCronUpdatePreservesOriginalCreatedDate` (red before, green after): ingest an item dated 2020, re-sync with a 2026 feed date, assert `created` stays 2020 and `updated` becomes 2026.