### PR TITLE
Delete the unused Http\post_form()

### DIFF
--- a/src/http.php
+++ b/src/http.php
@@ -426,38 +426,6 @@ function parse_status_line(string $line): int
 }
 
 /**
- * POST a www-form-urlencoded body and return the response HTTP status code.
- *
- * The shared outbound notification primitive: webmention sending and WebSub
- * hub pings both POST a small form and only care about the status (WebSub
- * ignores even that — it is fire-and-forget). Built on {@see fetch};
- * follow_location/max_redirects are omitted so PHP's stream defaults apply,
- * matching the hand-rolled contexts this replaces.
- *
- * @param string               $url        The endpoint to POST to.
- * @param array<string, mixed> $fields     Form fields for the request body.
- * @param int                  $timeout    Socket timeout in seconds.
- * @param string               $user_agent User-Agent header value.
- * @return int HTTP status code, or 0 on transport failure.
- */
-function post_form(string $url, array $fields, int $timeout, string $user_agent): int
-{
-    $result = fetch($url, [
-        'method' => 'POST',
-        'headers' => [
-            'Content-Type: application/x-www-form-urlencoded',
-            'User-Agent: ' . $user_agent,
-        ],
-        'content' => http_build_query($fields),
-        'timeout' => $timeout,
-        'follow_location' => null,
-        'max_redirects' => null,
-    ]);
-
-    return $result === null ? 0 : $result['status'];
-}
-
-/**
  * Perform a single HTTP request pinned to a specific IP via curl, so the
  * connection reaches the exact address {@see resolve_validated_ip} validated
  * instead of letting the transport re-resolve the host itself (the
@@ -568,7 +536,7 @@ function fetch_pinned(string $url, array $opts, array $pin): ?array
  *
  * Pass `pin => ['host' => string, 'ip' => string]` to route the request
  * through {@see fetch_pinned} instead — see its docblock for why. Every
- * other caller (`post_form()`, Micropub's `introspectToken`) is unaffected.
+ * other caller (Micropub's `introspectToken`) is unaffected.
  *
  * @param string               $url
  * @param array<string, mixed> $opts

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -775,9 +775,9 @@ function fetch_target(string $url): ?array
  */
 function send_webmention(string $endpoint, string $source, string $target): int
 {
-    // Unlike Http\post_form(), fetch_guarded() re-validates the destination
-    // on every redirect hop — needed here because $endpoint came from the
-    // target page's own (attacker-influenced) endpoint discovery.
+    // Every outbound POST goes through fetch_guarded(), which re-validates the
+    // destination on every redirect hop — needed here because $endpoint came
+    // from the target page's own (attacker-influenced) endpoint discovery.
     $result = fetch_guarded($endpoint, request_options([
         'method'  => 'POST',
         'headers' => ['Content-Type: application/x-www-form-urlencoded'],

--- a/src/websub.php
+++ b/src/websub.php
@@ -102,10 +102,9 @@ function ping_for_post(OODBBean $bean, ?array $config = null, ?callable $sender 
  */
 function send_ping(string $hub, string $topic): void
 {
-    // fetch_guarded() rather than post_form(): it refuses loopback/private/
-    // link-local destinations and re-validates every redirect hop, so a hub URL
-    // cannot aim the publish request at an internal service. Every other outbound
-    // sink already goes through it; this was the last one that did not.
+    // Every outbound POST goes through fetch_guarded(): it refuses loopback/
+    // private/link-local destinations and re-validates every redirect hop, so a
+    // hub URL cannot aim the publish request at an internal service.
     \Lamb\Http\fetch_guarded($hub, [
         'method' => 'POST',
         'headers' => [

--- a/tests/Unit/HttpFetchTest.php
+++ b/tests/Unit/HttpFetchTest.php
@@ -11,7 +11,6 @@ use function Lamb\Http\is_private_ip;
 use function Lamb\Http\is_public_http_url;
 use function Lamb\Http\is_valid_http_url;
 use function Lamb\Http\parse_status_line;
-use function Lamb\Http\post_form;
 use function Lamb\Http\request_timeout;
 use function Lamb\Http\resolve_redirect_location;
 use function Lamb\Http\resolve_validated_ip;
@@ -299,14 +298,6 @@ class HttpFetchTest extends TestCase
         $this->assertFalse(is_valid_http_url('/relative/path'));
         $this->assertFalse(is_valid_http_url('not a url'));
         $this->assertFalse(is_valid_http_url(''));
-    }
-
-    // post_form ---------------------------------------------------------------
-
-    public function testPostFormReturnsZeroOnTransportFailure(): void
-    {
-        $status = @post_form('file:///nonexistent/path/at/all', ['a' => 'b'], 1, 'Lamb-Test');
-        $this->assertSame(0, $status);
     }
 
     // is_private_ip -----------------------------------------------------------


### PR DESCRIPTION
Deletes `Http\post_form()`, which had zero callers. The two sites that would use it — webmention and WebSub sending — deliberately route through `fetch_guarded()`, which re-validates every redirect hop against loopback/private/link-local destinations. Keeping `post_form()` advertised the unguarded transport next to the guarded one.

- Removes the function and the `fetch()` docblock reference to it.
- Rewrites the webmention/WebSub comments to state the invariant positively (all outbound POSTs go through `fetch_guarded()`).
- Drops the `HttpFetchTest` case that exercised it.

`grep -rn post_form src/ tests/` is clean; phpcs + PHPStan level 8 pass.

Closes #687

---
**Stack (bottom → top):** #687 ← #685 ← #688 ← #672 ← #686. This is the base, targeting `main`.