### PR TITLE
Do not notify webmention/WebSub after a failed create write

### DIFF
--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -47,13 +47,22 @@ function redirect_created(): void
 
     try {
         finalize_and_store_post($bean);
-        // Remove any existing redirect for this slug — the new post takes priority
-        if (!empty($bean->slug)) {
-            delete_redirect_for_slug($bean->slug);
-            warn_if_manual_redirect((string) $bean->slug);
-        }
     } catch (SQL $e) {
+        // Return, matching redirect_edited(): everything below is a consequence
+        // of the create having been saved. finalize_and_store_post() stores
+        // twice, and if the second store throws (a locked SQLite file while
+        // /_cron holds it is the realistic case) the bean already has an id, so
+        // falling through announced the unsaved post to webmention receivers and
+        // the WebSub hub — a mention whose permalink 404s (#685).
         $_SESSION['flash'][] = 'Failed to save: ' . $e->getMessage();
+
+        return;
+    }
+
+    // Remove any existing redirect for this slug — the new post takes priority
+    if (!empty($bean->slug)) {
+        delete_redirect_for_slug($bean->slug);
+        warn_if_manual_redirect((string) $bean->slug);
     }
     notify_post_subscribers($bean);
     redirect_uri('/');

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -330,6 +330,89 @@ class ResponsePostsTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // redirect_created — a failed save must have no side effects
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates the `redirect` and `webmentionoutbox` tables (empty), so a count
+     * of them means "none were written" rather than "the table does not exist".
+     */
+    private function seedNotifyTables(): void
+    {
+        $redirect = R::dispense('redirect');
+        $redirect->from_slug = '';
+        $redirect->to_url = '';
+        R::store($redirect);
+        R::exec('DELETE FROM redirect');
+
+        $outbox = R::dispense('webmentionoutbox');
+        $outbox->source = '';
+        $outbox->target = '';
+        $outbox->status = '';
+        R::store($outbox);
+        R::exec('DELETE FROM webmentionoutbox');
+    }
+
+    /**
+     * Submits a create whose second write fails.
+     *
+     * A post already owns the slug `taken`, so finalize_slug() suffixes the new
+     * post's slug and pins the changed value into its body — the second of
+     * finalize_and_store_post()'s two R::store() calls. Blocking only UPDATE lets
+     * the first store (INSERT) mint the id and makes the second throw, which is
+     * the #685 shape: the bean already has an id, so the notify guards that
+     * early-return on `!id` do not fire.
+     */
+    private function submitCreateWithFailingSecondWrite(): void
+    {
+        $existing = R::dispense('post');
+        $existing->body        = "---\nslug: taken\n---\n\ntaken\n";
+        $existing->transformed = '<p>taken</p>';
+        $existing->slug        = 'taken';
+        $existing->created     = date('Y-m-d H:i:s', time() - 3600);
+        $existing->updated     = date('Y-m-d H:i:s', time() - 3600);
+        $existing->version     = POST_VERSION;
+        R::store($existing);
+
+        $_SESSION[SESSION_LOGIN]    = true;
+        $_SESSION[HIDDEN_CSRF_NAME] = 'ctok';
+        $_POST[HIDDEN_CSRF_NAME]    = 'ctok';
+        $_POST['submit']            = SUBMIT_CREATE;
+        $_POST['contents']          = "---\nslug: taken\n---\n\nsee [elsewhere](https://other.example/a)\n";
+
+        R::exec("CREATE TRIGGER post_block_update BEFORE UPDATE ON post BEGIN SELECT RAISE(ABORT, 'database is locked'); END");
+        try {
+            redirect_created();
+        } finally {
+            R::exec('DROP TRIGGER IF EXISTS post_block_update');
+        }
+    }
+
+    public function testRedirectCreatedFlashesWhenTheSaveFails(): void
+    {
+        $this->seedNotifyTables();
+
+        $this->submitCreateWithFailingSecondWrite();
+
+        $this->assertNotEmpty(array_filter(
+            $_SESSION['flash'] ?? [],
+            fn ($m) => str_contains((string) $m, 'Failed to save')
+        ));
+    }
+
+    public function testRedirectCreatedDoesNotNotifySubscribersWhenTheSaveFails(): void
+    {
+        // Announcing a create that was not stored: the queued mention carries a
+        // permalink built from the unsaved slug, so a receiver fetching it to
+        // verify the mention gets a 404.
+        $this->seedNotifyTables();
+
+        $this->submitCreateWithFailingSecondWrite();
+
+        $this->assertCount(0, R::findAll('webmentionoutbox'));
+    }
+
+    // -------------------------------------------------------------------------
     // redirect_edited — the post id is read from $_POST
     // -------------------------------------------------------------------------
     // FILTER_SANITIZE_NUMBER_INT over $_POST, as filter_input(INPUT_POST, ...)


### PR DESCRIPTION
`redirect_created()` called `notify_post_subscribers()` **outside** its try/catch, so a failed store still announced the post. `finalize_and_store_post()` stores twice; when the second store throws (a locked SQLite file while `/_cron` holds it) the bean already has an id, so the notify guards that early-return on `!id` do not fire — queuing outbound webmentions and a WebSub ping for a permalink whose slug was never stored (a mention that 404s on verification).

Fix: move the notify into the success path and `return` early on a failed write, matching the already-fixed `redirect_edited()`.

Tests: create-path characterisation tests mirroring the edit-path ones — a failed second write flashes `Failed to save` and enqueues **no** `webmentionoutbox` row. Verified red before the fix (the buggy fall-through reaches `redirect_uri()`/`die()`), green after.

Closes #685

---
**Stacked on #687** (→ `fix/687-drop-post-form`). Stack: #687 ← **#685** ← #688 ← #672 ← #686.