### PR TITLE
Consolidate the media-endpoint and /upload store-or-fallback into one helper

### DIFF
--- a/src/http.php
+++ b/src/http.php
@@ -426,38 +426,6 @@ function parse_status_line(string $line): int
 }
 
 /**
- * POST a www-form-urlencoded body and return the response HTTP status code.
- *
- * The shared outbound notification primitive: webmention sending and WebSub
- * hub pings both POST a small form and only care about the status (WebSub
- * ignores even that — it is fire-and-forget). Built on {@see fetch};
- * follow_location/max_redirects are omitted so PHP's stream defaults apply,
- * matching the hand-rolled contexts this replaces.
- *
- * @param string               $url        The endpoint to POST to.
- * @param array<string, mixed> $fields     Form fields for the request body.
- * @param int                  $timeout    Socket timeout in seconds.
- * @param string               $user_agent User-Agent header value.
- * @return int HTTP status code, or 0 on transport failure.
- */
-function post_form(string $url, array $fields, int $timeout, string $user_agent): int
-{
-    $result = fetch($url, [
-        'method' => 'POST',
-        'headers' => [
-            'Content-Type: application/x-www-form-urlencoded',
-            'User-Agent: ' . $user_agent,
-        ],
-        'content' => http_build_query($fields),
-        'timeout' => $timeout,
-        'follow_location' => null,
-        'max_redirects' => null,
-    ]);
-
-    return $result === null ? 0 : $result['status'];
-}
-
-/**
  * Perform a single HTTP request pinned to a specific IP via curl, so the
  * connection reaches the exact address {@see resolve_validated_ip} validated
  * instead of letting the transport re-resolve the host itself (the
@@ -568,7 +536,7 @@ function fetch_pinned(string $url, array $opts, array $pin): ?array
  *
  * Pass `pin => ['host' => string, 'ip' => string]` to route the request
  * through {@see fetch_pinned} instead — see its docblock for why. Every
- * other caller (`post_form()`, Micropub's `introspectToken`) is unaffected.
+ * other caller (Micropub's `introspectToken`) is unaffected.
  *
  * @param string               $url
  * @param array<string, mixed> $opts

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1576,15 +1576,12 @@ function respond_micropub_media(): void
     $seed      = sha1((\Lamb\Http\request_string($file['name'] ?? null) ?? '') . uniqid('', true));
 
     // Re-encode JPEG/PNG to WebP, falling back to the original bytes on failure.
-    $filename = \Lamb\Response\store_webp_copy($file['tmp_name'], $ext, $uploadDir, $seed);
+    $filename = \Lamb\Response\store_upload_or_fallback($file['tmp_name'], $ext, $uploadDir, $seed);
     if ($filename === null) {
-        $filename = $seed . ".$ext";
-        if (!move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $filename)) {
-            // Same reasoning as the web upload endpoint (response/upload.php): a
-            // 201 with a Location the file was never written to would tell the
-            // client its upload durably succeeded when it didn't.
-            micropub_error(500, 'server_error', 'Failed to store the uploaded file.');
-        }
+        // Same reasoning as the web upload endpoint (response/upload.php): a
+        // 201 with a Location the file was never written to would tell the
+        // client its upload durably succeeded when it didn't.
+        micropub_error(500, 'server_error', 'Failed to store the uploaded file.');
     }
 
     // The media endpoint hands this URL back to an external Micropub client, so

--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -99,11 +99,11 @@ function render_sitemap(array $urls): string
     ];
     foreach ($urls as $url) {
         $lines[] = '  <url>';
-        // Match the Atom feed's escaping (themes/base/feed.php): ENT_SUBSTITUTE
-        // means a malformed UTF-8 byte degrades to U+FFFD instead of making
-        // htmlspecialchars() return '' for the whole string — which would emit
-        // an empty, invalid <loc>.
-        $lines[] = '    <loc>' . htmlspecialchars($url['loc'], ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE) . '</loc>';
+        // Theme\escape_xml() is the one XML escaper (ENT_XML1|ENT_QUOTES|
+        // ENT_SUBSTITUTE): a malformed UTF-8 byte degrades to U+FFFD instead of
+        // making htmlspecialchars() return '' for the whole string — which would
+        // emit an empty, invalid <loc>.
+        $lines[] = '    <loc>' . \Lamb\Theme\escape_xml($url['loc']) . '</loc>';
         if (!empty($url['lastmod'])) {
             $lines[] = '    <lastmod>' . $url['lastmod'] . '</lastmod>';
         }

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -47,13 +47,22 @@ function redirect_created(): void
 
     try {
         finalize_and_store_post($bean);
-        // Remove any existing redirect for this slug — the new post takes priority
-        if (!empty($bean->slug)) {
-            delete_redirect_for_slug($bean->slug);
-            warn_if_manual_redirect((string) $bean->slug);
-        }
     } catch (SQL $e) {
+        // Return, matching redirect_edited(): everything below is a consequence
+        // of the create having been saved. finalize_and_store_post() stores
+        // twice, and if the second store throws (a locked SQLite file while
+        // /_cron holds it is the realistic case) the bean already has an id, so
+        // falling through announced the unsaved post to webmention receivers and
+        // the WebSub hub — a mention whose permalink 404s (#685).
         $_SESSION['flash'][] = 'Failed to save: ' . $e->getMessage();
+
+        return;
+    }
+
+    // Remove any existing redirect for this slug — the new post takes priority
+    if (!empty($bean->slug)) {
+        delete_redirect_for_slug($bean->slug);
+        warn_if_manual_redirect((string) $bean->slug);
     }
     notify_post_subscribers($bean);
     redirect_uri('/');

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -67,20 +67,16 @@ function respond_upload(array $_args): void
 
         // Re-encode JPEG/PNG to WebP for smaller files; fall back to the original
         // bytes if conversion fails (assume success, communicate failure).
-        $new_fn = store_webp_copy($f['tmp_name'], $f['ext'], $dir, $seed);
+        $new_fn = store_upload_or_fallback($f['tmp_name'], $f['ext'], $dir, $seed);
         if ($new_fn === null) {
-            $new_fn = $seed . '.' . $f['ext'];
-            $new_fp = sprintf("%s/%s", $dir, $new_fn);
-            if (!move_uploaded_file($f['tmp_name'], $new_fp)) {
-                // Same reasoning as the batch check: the request is failing, so
-                // the files that did land are unreachable. Take them with it.
-                foreach ($stored as $orphan) {
-                    @unlink($orphan);
-                }
-                header('HTTP/1.1 500 Internal Server Error');
-                echo json_encode('Move upload error: ' . $f['tmp_name'], JSON_THROW_ON_ERROR);
-                die();
+            // Same reasoning as the batch check: the request is failing, so
+            // the files that did land are unreachable. Take them with it.
+            foreach ($stored as $orphan) {
+                @unlink($orphan);
             }
+            header('HTTP/1.1 500 Internal Server Error');
+            echo json_encode('Move upload error: ' . $f['tmp_name'], JSON_THROW_ON_ERROR);
+            die();
         }
         $stored[] = $dir . '/' . $new_fn;
         $out .= sprintf("![%s](%s)", $f['name'], asset_url($sub_path, $new_fn));
@@ -364,6 +360,40 @@ function store_webp_copy(string $src_path, string $ext, string $dest_dir, string
     }
 
     return null;
+}
+
+/**
+ * Stores an uploaded image: a WebP copy when convertible, otherwise the original
+ * bytes moved into place under "$seed.$ext".
+ *
+ * The store-or-fall-back sequence shared by the two move_uploaded_file() upload
+ * paths — the /upload handler and the Micropub media endpoint. (The Micropub
+ * inline-photo path stores from a PSR-7 UploadedFileInterface via
+ * persist_image_bytes(), a different move semantic, so it is not folded in here.)
+ * Returns the stored filename (basename), or null when the fallback move fails —
+ * each caller reports that its own way (its own error shape and orphan cleanup),
+ * so the failure is surfaced rather than swallowed (#653: never report a file the
+ * move did not store).
+ *
+ * @param string $tmp_name The uploaded file's temp path ($_FILES[...]['tmp_name']).
+ * @param string $ext      The lower-case extension from safe_upload_extension().
+ * @param string $dest_dir The upload directory from get_upload_dir() (no trailing slash).
+ * @param string $seed     The hashed base filename (without extension).
+ * @return string|null The stored filename, or null when the file could not be stored.
+ */
+function store_upload_or_fallback(string $tmp_name, string $ext, string $dest_dir, string $seed): ?string
+{
+    $filename = store_webp_copy($tmp_name, $ext, $dest_dir, $seed);
+    if ($filename !== null) {
+        return $filename;
+    }
+
+    $filename = $seed . '.' . $ext;
+    if (!move_uploaded_file($tmp_name, sprintf('%s/%s', $dest_dir, $filename))) {
+        return null;
+    }
+
+    return $filename;
 }
 
 /**

--- a/src/theme/formatting.php
+++ b/src/theme/formatting.php
@@ -16,6 +16,23 @@ function escape(string $html): string
 }
 
 /**
+ * Escapes a string for safe XML output (Atom feed, sitemap).
+ *
+ * Uses ENT_XML1 rather than ENT_HTML5 so a single quote becomes `&apos;` (a
+ * defined XML entity) and no HTML-only named entities are emitted. ENT_SUBSTITUTE
+ * keeps a malformed UTF-8 byte from making htmlspecialchars() return '' for the
+ * whole string — it degrades to U+FFFD instead, so one bad byte cannot empty an
+ * entire <loc> or <title>.
+ *
+ * @param string $xml The raw string to escape.
+ * @return string XML-safe escaped string.
+ */
+function escape_xml(string $xml): string
+{
+    return htmlspecialchars($xml, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE);
+}
+
+/**
  * Re-levels a post body's headings so its highest heading sits at $top, keeping
  * the levels relative to each other. Open and close tags shift identically,
  * attributes are preserved, and a body with no headings is returned unchanged.

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -3,21 +3,14 @@
 global $config;
 global $data;
 
-if (!function_exists('escape')) {
-    function escape(string $html): string
-    {
-        return htmlspecialchars($html, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE);
-    }
-}
-
 header('Content-type: application/atom+xml');
 $channel_link = $data['feed_url'] ?? ROOT_URL . '/feed';
 
 $Xml = new SimpleXMLElement(
     '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0"></feed>'
 );
-$Xml->addChild('title', escape($data['title'] ?? $config['site_title']));
-$Xml->addChild('id', escape($channel_link));
+$Xml->addChild('title', \Lamb\Theme\escape_xml($data['title'] ?? $config['site_title']));
+$Xml->addChild('id', \Lamb\Theme\escape_xml($channel_link));
 $Xml->addChild('updated', date(DATE_ATOM, strtotime($data['updated'])));
 $Xml->addChild('generator', 'Lamb');
 
@@ -28,7 +21,7 @@ $Xml->addChild('generator', 'Lamb');
 if (defined('ROOT_DIR')) {
     foreach (['favicon.png' => 'icon', 'logo.png' => 'logo'] as $file => $element) {
         if (file_exists(ROOT_DIR . '/' . $file)) {
-            $Xml->addChild($element, escape(ROOT_URL . '/' . $file));
+            $Xml->addChild($element, \Lamb\Theme\escape_xml(ROOT_URL . '/' . $file));
         }
     }
 }
@@ -47,7 +40,7 @@ foreach (Lamb\Websub\hub_urls($config) as $websub_hub) {
 }
 
 $Author = $Xml->addChild('author');
-$Author->addChild('name', escape($config['author_name']));
+$Author->addChild('name', \Lamb\Theme\escape_xml($config['author_name']));
 $Author->addChild('uri', ROOT_URL);
 
 foreach ($data['posts'] as $bean) {
@@ -55,8 +48,8 @@ foreach ($data['posts'] as $bean) {
     // addChild(), unlike addAttribute(), does not escape: a permalink carrying a
     // `&` (a slug is stored close to verbatim) raised "unterminated entity
     // reference" and emitted an empty <id/>, making the whole feed malformed.
-    $Entry->addChild('id', escape(Lamb\permalink($bean)));
-    $Entry->addChild('title', escape($bean->title ?: ''));
+    $Entry->addChild('id', \Lamb\Theme\escape_xml(Lamb\permalink($bean)));
+    $Entry->addChild('title', \Lamb\Theme\escape_xml($bean->title ?: ''));
     $Entry->addChild('published', date(DATE_ATOM, strtotime($bean->created)));
     $Entry->addChild('updated', date(DATE_ATOM, strtotime($bean->updated)));
     // The reply context travels inside <content>, not only in the theme: thr:

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -775,9 +775,9 @@ function fetch_target(string $url): ?array
  */
 function send_webmention(string $endpoint, string $source, string $target): int
 {
-    // Unlike Http\post_form(), fetch_guarded() re-validates the destination
-    // on every redirect hop — needed here because $endpoint came from the
-    // target page's own (attacker-influenced) endpoint discovery.
+    // Every outbound POST goes through fetch_guarded(), which re-validates the
+    // destination on every redirect hop — needed here because $endpoint came
+    // from the target page's own (attacker-influenced) endpoint discovery.
     $result = fetch_guarded($endpoint, request_options([
         'method'  => 'POST',
         'headers' => ['Content-Type: application/x-www-form-urlencoded'],

--- a/src/websub.php
+++ b/src/websub.php
@@ -102,10 +102,9 @@ function ping_for_post(OODBBean $bean, ?array $config = null, ?callable $sender 
  */
 function send_ping(string $hub, string $topic): void
 {
-    // fetch_guarded() rather than post_form(): it refuses loopback/private/
-    // link-local destinations and re-validates every redirect hop, so a hub URL
-    // cannot aim the publish request at an internal service. Every other outbound
-    // sink already goes through it; this was the last one that did not.
+    // Every outbound POST goes through fetch_guarded(): it refuses loopback/
+    // private/link-local destinations and re-validates every redirect hop, so a
+    // hub URL cannot aim the publish request at an internal service.
     \Lamb\Http\fetch_guarded($hub, [
         'method' => 'POST',
         'headers' => [

--- a/tests/Unit/HttpFetchTest.php
+++ b/tests/Unit/HttpFetchTest.php
@@ -11,7 +11,6 @@ use function Lamb\Http\is_private_ip;
 use function Lamb\Http\is_public_http_url;
 use function Lamb\Http\is_valid_http_url;
 use function Lamb\Http\parse_status_line;
-use function Lamb\Http\post_form;
 use function Lamb\Http\request_timeout;
 use function Lamb\Http\resolve_redirect_location;
 use function Lamb\Http\resolve_validated_ip;
@@ -299,14 +298,6 @@ class HttpFetchTest extends TestCase
         $this->assertFalse(is_valid_http_url('/relative/path'));
         $this->assertFalse(is_valid_http_url('not a url'));
         $this->assertFalse(is_valid_http_url(''));
-    }
-
-    // post_form ---------------------------------------------------------------
-
-    public function testPostFormReturnsZeroOnTransportFailure(): void
-    {
-        $status = @post_form('file:///nonexistent/path/at/all', ['a' => 'b'], 1, 'Lamb-Test');
-        $this->assertSame(0, $status);
     }
 
     // is_private_ip -----------------------------------------------------------

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -330,6 +330,89 @@ class ResponsePostsTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // redirect_created — a failed save must have no side effects
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates the `redirect` and `webmentionoutbox` tables (empty), so a count
+     * of them means "none were written" rather than "the table does not exist".
+     */
+    private function seedNotifyTables(): void
+    {
+        $redirect = R::dispense('redirect');
+        $redirect->from_slug = '';
+        $redirect->to_url = '';
+        R::store($redirect);
+        R::exec('DELETE FROM redirect');
+
+        $outbox = R::dispense('webmentionoutbox');
+        $outbox->source = '';
+        $outbox->target = '';
+        $outbox->status = '';
+        R::store($outbox);
+        R::exec('DELETE FROM webmentionoutbox');
+    }
+
+    /**
+     * Submits a create whose second write fails.
+     *
+     * A post already owns the slug `taken`, so finalize_slug() suffixes the new
+     * post's slug and pins the changed value into its body — the second of
+     * finalize_and_store_post()'s two R::store() calls. Blocking only UPDATE lets
+     * the first store (INSERT) mint the id and makes the second throw, which is
+     * the #685 shape: the bean already has an id, so the notify guards that
+     * early-return on `!id` do not fire.
+     */
+    private function submitCreateWithFailingSecondWrite(): void
+    {
+        $existing = R::dispense('post');
+        $existing->body        = "---\nslug: taken\n---\n\ntaken\n";
+        $existing->transformed = '<p>taken</p>';
+        $existing->slug        = 'taken';
+        $existing->created     = date('Y-m-d H:i:s', time() - 3600);
+        $existing->updated     = date('Y-m-d H:i:s', time() - 3600);
+        $existing->version     = POST_VERSION;
+        R::store($existing);
+
+        $_SESSION[SESSION_LOGIN]    = true;
+        $_SESSION[HIDDEN_CSRF_NAME] = 'ctok';
+        $_POST[HIDDEN_CSRF_NAME]    = 'ctok';
+        $_POST['submit']            = SUBMIT_CREATE;
+        $_POST['contents']          = "---\nslug: taken\n---\n\nsee [elsewhere](https://other.example/a)\n";
+
+        R::exec("CREATE TRIGGER post_block_update BEFORE UPDATE ON post BEGIN SELECT RAISE(ABORT, 'database is locked'); END");
+        try {
+            redirect_created();
+        } finally {
+            R::exec('DROP TRIGGER IF EXISTS post_block_update');
+        }
+    }
+
+    public function testRedirectCreatedFlashesWhenTheSaveFails(): void
+    {
+        $this->seedNotifyTables();
+
+        $this->submitCreateWithFailingSecondWrite();
+
+        $this->assertNotEmpty(array_filter(
+            $_SESSION['flash'] ?? [],
+            fn ($m) => str_contains((string) $m, 'Failed to save')
+        ));
+    }
+
+    public function testRedirectCreatedDoesNotNotifySubscribersWhenTheSaveFails(): void
+    {
+        // Announcing a create that was not stored: the queued mention carries a
+        // permalink built from the unsaved slug, so a receiver fetching it to
+        // verify the mention gets a 404.
+        $this->seedNotifyTables();
+
+        $this->submitCreateWithFailingSecondWrite();
+
+        $this->assertCount(0, R::findAll('webmentionoutbox'));
+    }
+
+    // -------------------------------------------------------------------------
     // redirect_edited — the post id is read from $_POST
     // -------------------------------------------------------------------------
     // FILTER_SANITIZE_NUMBER_INT over $_POST, as filter_input(INPUT_POST, ...)

--- a/tests/Unit/ThemeTest.php
+++ b/tests/Unit/ThemeTest.php
@@ -8,6 +8,7 @@ use RedBeanPHP\R;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\admin_toolbar_html;
 use function Lamb\Theme\escape;
+use function Lamb\Theme\escape_xml;
 use function Lamb\Theme\format_past_date;
 use function Lamb\Theme\human_time;
 use function Lamb\Theme\og_escape;
@@ -111,6 +112,33 @@ class ThemeTest extends TestCase
     public function testEscapeConvertsAmpersand()
     {
         $this->assertSame('foo &amp; bar', escape('foo & bar'));
+    }
+
+    // escape_xml
+
+    public function testEscapeXmlConvertsAmpersand()
+    {
+        $this->assertSame('foo &amp; bar', escape_xml('foo & bar'));
+    }
+
+    public function testEscapeXmlConvertsAngleBrackets()
+    {
+        $this->assertSame('&lt;loc&gt;', escape_xml('<loc>'));
+    }
+
+    public function testEscapeXmlConvertsSingleQuoteToApos()
+    {
+        // ENT_XML1 encodes the single quote as the defined XML entity &apos;.
+        $this->assertSame('it&apos;s', escape_xml("it's"));
+    }
+
+    public function testEscapeXmlSubstitutesInvalidUtf8ByteInsteadOfEmptyingTheString()
+    {
+        // ENT_SUBSTITUTE: a lone invalid byte degrades to U+FFFD rather than
+        // making htmlspecialchars() return '' for the whole value.
+        $result = escape_xml("ok\xB1");
+        $this->assertNotSame('', $result);
+        $this->assertSame("ok\u{FFFD}", $result);
     }
 
     // og_escape

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -17,6 +17,7 @@ use function Lamb\Response\safe_upload_extension;
 use function Lamb\Response\upload_subpath;
 use function Lamb\Response\scaled_dimensions;
 use function Lamb\Response\should_convert_to_webp;
+use function Lamb\Response\store_upload_or_fallback;
 use function Lamb\Response\store_webp_copy;
 
 class UploadTest extends TestCase
@@ -560,6 +561,37 @@ class UploadTest extends TestCase
 
         $this->assertNull($result);
         $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.webp');
+    }
+
+    // store_upload_or_fallback — the store-or-fall-back sequence shared by the
+    // /upload handler and the Micropub media endpoint: a WebP copy when
+    // convertible, otherwise move_uploaded_file() the original bytes into place.
+
+    public function testStoreUploadOrFallbackReturnsWebpFilenameForConvertibleImage(): void
+    {
+        $src = $this->makePng(40, 30);
+
+        $result = store_upload_or_fallback($src, 'png', $this->tempRootDir, 'seedhash');
+
+        $this->assertSame('seedhash.webp', $result);
+        $this->assertFileExists($this->tempRootDir . '/seedhash.webp');
+        $this->assertSame('image/webp', mime_content_type($this->tempRootDir . '/seedhash.webp'));
+    }
+
+    public function testStoreUploadOrFallbackReturnsNullWhenConversionSkippedAndMoveFails(): void
+    {
+        // A non-convertible extension skips the WebP path, so the code falls back
+        // to move_uploaded_file() — which refuses a path that did not arrive via
+        // an HTTP upload, so the helper returns null and stores nothing. (The
+        // successful-move branch needs a real upload; it is covered by the e2e
+        // suite, see #673.)
+        $src = $this->tempRootDir . '/plain.gif';
+        file_put_contents($src, 'GIF89a not really');
+
+        $result = @store_upload_or_fallback($src, 'gif', $this->tempRootDir, 'seedhash');
+
+        $this->assertNull($result);
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.gif');
     }
 
     // asset_dimensions — pixel size of a locally stored asset, for intrinsic


### PR DESCRIPTION
`respond_upload()` and `respond_micropub_media()` repeated the same `store_webp_copy()`-then-`move_uploaded_file()` fallback. #653 fixed a dropped return value in one copy but left the two apart to avoid conflicting with #651's batch-upload rework.

#651 has landed, so this folds both into `Response\store_upload_or_fallback()`, which returns the stored filename or `null` when the fallback move fails — leaving each caller its own error shape and orphan cleanup (so #653's "never report a file the move did not store" holds structurally).

**Scope:** only the two `move_uploaded_file()` paths. The Micropub inline-photo path stores from a PSR-7 `UploadedFileInterface` via `persist_image_bytes()` (a different move semantic) and is deliberately left separate.

Tests: the helper returns the `.webp` name for a convertible image, and `null` when conversion is skipped and the move fails. The successful-move branch needs a real HTTP upload and is left to the e2e suite (#673). UploadTest + MicropubAdapterTest pass.

Closes #672

---
**Stacked on #688.** Stack: #687 ← #685 ← #688 ← **#672** ← #686.