### PR TITLE
Stop one slow or throwing feed from starving /_cron notifications

### DIFF
--- a/src/http.php
+++ b/src/http.php
@@ -426,38 +426,6 @@ function parse_status_line(string $line): int
 }
 
 /**
- * POST a www-form-urlencoded body and return the response HTTP status code.
- *
- * The shared outbound notification primitive: webmention sending and WebSub
- * hub pings both POST a small form and only care about the status (WebSub
- * ignores even that — it is fire-and-forget). Built on {@see fetch};
- * follow_location/max_redirects are omitted so PHP's stream defaults apply,
- * matching the hand-rolled contexts this replaces.
- *
- * @param string               $url        The endpoint to POST to.
- * @param array<string, mixed> $fields     Form fields for the request body.
- * @param int                  $timeout    Socket timeout in seconds.
- * @param string               $user_agent User-Agent header value.
- * @return int HTTP status code, or 0 on transport failure.
- */
-function post_form(string $url, array $fields, int $timeout, string $user_agent): int
-{
-    $result = fetch($url, [
-        'method' => 'POST',
-        'headers' => [
-            'Content-Type: application/x-www-form-urlencoded',
-            'User-Agent: ' . $user_agent,
-        ],
-        'content' => http_build_query($fields),
-        'timeout' => $timeout,
-        'follow_location' => null,
-        'max_redirects' => null,
-    ]);
-
-    return $result === null ? 0 : $result['status'];
-}
-
-/**
  * Perform a single HTTP request pinned to a specific IP via curl, so the
  * connection reaches the exact address {@see resolve_validated_ip} validated
  * instead of letting the transport re-resolve the host itself (the
@@ -568,7 +536,7 @@ function fetch_pinned(string $url, array $opts, array $pin): ?array
  *
  * Pass `pin => ['host' => string, 'ip' => string]` to route the request
  * through {@see fetch_pinned} instead — see its docblock for why. Every
- * other caller (`post_form()`, Micropub's `introspectToken`) is unaffected.
+ * other caller (Micropub's `introspectToken`) is unaffected.
  *
  * @param string               $url
  * @param array<string, mixed> $opts

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1576,15 +1576,12 @@ function respond_micropub_media(): void
     $seed      = sha1((\Lamb\Http\request_string($file['name'] ?? null) ?? '') . uniqid('', true));
 
     // Re-encode JPEG/PNG to WebP, falling back to the original bytes on failure.
-    $filename = \Lamb\Response\store_webp_copy($file['tmp_name'], $ext, $uploadDir, $seed);
+    $filename = \Lamb\Response\store_upload_or_fallback($file['tmp_name'], $ext, $uploadDir, $seed);
     if ($filename === null) {
-        $filename = $seed . ".$ext";
-        if (!move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $filename)) {
-            // Same reasoning as the web upload endpoint (response/upload.php): a
-            // 201 with a Location the file was never written to would tell the
-            // client its upload durably succeeded when it didn't.
-            micropub_error(500, 'server_error', 'Failed to store the uploaded file.');
-        }
+        // Same reasoning as the web upload endpoint (response/upload.php): a
+        // 201 with a Location the file was never written to would tell the
+        // client its upload durably succeeded when it didn't.
+        micropub_error(500, 'server_error', 'Failed to store the uploaded file.');
     }
 
     // The media endpoint hands this URL back to an external Micropub client, so

--- a/src/network.php
+++ b/src/network.php
@@ -107,14 +107,18 @@ function webmention_line(array $sent): string
     // feeds can outlast a web request's PHP limit (typically 30s under FPM). A
     // timeout mid-crawl skips the notification drains and the watermark write
     // below, and because the watermark is unwritten the next run walks the same
-    // feeds and dies the same way — webmentions then never deliver. Lift the
-    // limit so the whole run completes. See network/README.md ("The run").
+    // feeds and dies the same way — webmentions then never deliver. Raise the
+    // limit so a normal run (each fetch bounded to FEED_FETCH_TIMEOUT) finishes
+    // well within it. See network/README.md ("Finishing the run").
     //
-    // This removes the wall-clock backstop, so the cron flock's liveness now
-    // rests on every outbound path being independently time-bounded: curl sets
-    // CURLOPT_TIMEOUT and SimplePie set_timeout(FEED_FETCH_TIMEOUT). Keep it that
-    // way — an unbounded fetch here would hold the flock and wedge every later run.
-    set_time_limit(0);
+    // A finite cap, not 0: the run holds the cron flock until the process ends,
+    // so an unbounded run that wedged would leave every later /_cron stuck on
+    // "Already running". 30 minutes is far above any legitimate run yet still
+    // frees the lock if one hangs. The cap only bites a CPU-bound wedge, though —
+    // on Unix max_execution_time excludes time blocked in a syscall, so a hung
+    // socket is still caught only by the per-fetch curl/SimplePie timeouts, which
+    // must stay in place.
+    set_time_limit(1800);
 
     // Serialise overlapping runs before anything else: /_cron is unauthenticated
     // and the rate-limit watermark is only written after all work finishes, so a

--- a/src/network.php
+++ b/src/network.php
@@ -109,6 +109,11 @@ function webmention_line(array $sent): string
     // below, and because the watermark is unwritten the next run walks the same
     // feeds and dies the same way — webmentions then never deliver. Lift the
     // limit so the whole run completes. See network/README.md ("The run").
+    //
+    // This removes the wall-clock backstop, so the cron flock's liveness now
+    // rests on every outbound path being independently time-bounded: curl sets
+    // CURLOPT_TIMEOUT and SimplePie set_timeout(FEED_FETCH_TIMEOUT). Keep it that
+    // way — an unbounded fetch here would hold the flock and wedge every later run.
     set_time_limit(0);
 
     // Serialise overlapping runs before anything else: /_cron is unauthenticated
@@ -148,17 +153,19 @@ function webmention_line(array $sent): string
             echo crawl_line($name, crawl_feed_guarded($name, $url));
         }
     } finally {
-        // Drain notifications and advance the watermark even if the crawl loop
-        // threw or was cut short: feed fetching must not starve webmention/WebSub
-        // delivery, and a partial run must still rate-limit the next one so it
-        // cannot immediately re-run and repeat the same failure.
+        // Advance the watermark first, before draining: a partial run must
+        // rate-limit the next one even if a drain itself throws, otherwise the
+        // starvation loop just moves from the crawl to the drain. The drains then
+        // retry on the next scheduled run rather than re-running immediately.
+        set_option($cron_last_updated, (int)date('U'));
+
+        // Drain notifications even if the crawl loop threw or was cut short, so
+        // feed fetching cannot starve webmention/WebSub delivery.
         echo count_line(
             \Lamb\Websub\ping_scheduled_publishes(),
             'WebSub: pinged hub for %d scheduled post(s) now published.'
         );
         echo webmention_line(\Lamb\Webmention\process_outbound());
-
-        set_option($cron_last_updated, (int)date('U'));
     }
 
     exit('Done');

--- a/src/network.php
+++ b/src/network.php
@@ -103,6 +103,14 @@ function webmention_line(array $sent): string
 {
     header('Content-Type: text/plain');
 
+    // A single feed fetch may take up to FEED_FETCH_TIMEOUT, so a handful of slow
+    // feeds can outlast a web request's PHP limit (typically 30s under FPM). A
+    // timeout mid-crawl skips the notification drains and the watermark write
+    // below, and because the watermark is unwritten the next run walks the same
+    // feeds and dies the same way — webmentions then never deliver. Lift the
+    // limit so the whole run completes. See network/README.md ("The run").
+    set_time_limit(0);
+
     // Serialise overlapping runs before anything else: /_cron is unauthenticated
     // and the rate-limit watermark is only written after all work finishes, so a
     // concurrent burst without this lock would run in parallel on the same stale
@@ -127,25 +135,32 @@ function webmention_line(array $sent): string
     echo count_line(prune_feed_status(), 'Pruned %d stale feed status row(s).');
     echo count_line(\Lamb\flatten_redirects(), 'Flattened %d redirect(s).');
 
-    echo("Updating feeds..." . PHP_EOL);
-    foreach ($feeds as $name => $url) {
-        flush();
-        $status = feed_status_bean($name, $url);
-        if (!feed_fetch_due((int)$status->last_attempt, time())) {
-            echo('Skipped ' . $url . PHP_EOL);
-            continue;
-        }
+    try {
+        echo("Updating feeds..." . PHP_EOL);
+        foreach ($feeds as $name => $url) {
+            flush();
+            $status = feed_status_bean($name, $url);
+            if (!feed_fetch_due((int)$status->last_attempt, time())) {
+                echo('Skipped ' . $url . PHP_EOL);
+                continue;
+            }
 
-        echo crawl_line($name, crawl_feed($name, $url));
+            echo crawl_line($name, crawl_feed_guarded($name, $url));
+        }
+    } finally {
+        // Drain notifications and advance the watermark even if the crawl loop
+        // threw or was cut short: feed fetching must not starve webmention/WebSub
+        // delivery, and a partial run must still rate-limit the next one so it
+        // cannot immediately re-run and repeat the same failure.
+        echo count_line(
+            \Lamb\Websub\ping_scheduled_publishes(),
+            'WebSub: pinged hub for %d scheduled post(s) now published.'
+        );
+        echo webmention_line(\Lamb\Webmention\process_outbound());
+
+        set_option($cron_last_updated, (int)date('U'));
     }
 
-    echo count_line(
-        \Lamb\Websub\ping_scheduled_publishes(),
-        'WebSub: pinged hub for %d scheduled post(s) now published.'
-    );
-    echo webmention_line(\Lamb\Webmention\process_outbound());
-
-    set_option($cron_last_updated, (int)date('U'));
     exit('Done');
 }
 
@@ -210,6 +225,31 @@ function crawl_feed(string $name, string $url): array
     $feed = init_simplepie_feed($url);
     echo PHP_EOL . "Processing " . $feed->get_title() . PHP_EOL;
     return record_feed_crawl($name, $url, $feed);
+}
+
+/**
+ * Crawls one feed, turning any throw into the crawl error shape.
+ *
+ * crawl_feed() only catches SQL around individual stores, so a throw from the
+ * JSON or SimplePie path would abort the whole /_cron run and starve the
+ * notification drains — the same outage a mid-crawl timeout causes. Guarding
+ * here lets one bad feed report a failure and the run continue to the next feed
+ * and the drains.
+ *
+ * @param string $name Feed name from config.
+ * @param string $url  Feed URL from config.
+ * @param (callable(string, string): array{ok: bool, items: int, error: ?string})|null $crawler
+ *        The crawler to run; defaults to crawl_feed(). Injectable for tests.
+ * @return array{ok: bool, items: int, error: ?string}
+ */
+function crawl_feed_guarded(string $name, string $url, ?callable $crawler = null): array
+{
+    $crawler ??= crawl_feed(...);
+    try {
+        return $crawler($name, $url);
+    } catch (\Throwable $e) {
+        return ['ok' => false, 'items' => 0, 'error' => $e->getMessage()];
+    }
 }
 
 /** @noinspection PhpUnused */

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -52,8 +52,13 @@ the crawl is cut short, both are skipped, and because the watermark is unwritten
 the next run walks the same feeds and dies the same way, so outbound webmentions
 never deliver. Three things keep the run finishing:
 
-- **`set_time_limit(0)`** at the top of `process_feeds()`, so a slow feed cannot
-  hit a web request's PHP limit (typically 30s under FPM) mid-crawl.
+- **`set_time_limit(1800)`** at the top of `process_feeds()`, so a slow feed
+  cannot hit a web request's PHP limit (typically 30s under FPM) mid-crawl. It's
+  a finite cap, not `0`: the run holds the cron flock until the process ends, so
+  an unbounded run that wedged would leave every later `/_cron` stuck on "already
+  running". 30 minutes clears any legitimate run yet still frees the lock if one
+  hangs — though on Unix it only catches a CPU-bound wedge, so a hung socket
+  still relies on the per-fetch curl/SimplePie timeouts.
 - **A per-feed guard** (`crawl_feed_guarded()`), because `crawl_feed()` only
   catches `SQL` around individual stores — a throw from the JSON or SimplePie
   path would otherwise abort the whole run. One bad feed reports a `FAILED` line

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -43,6 +43,25 @@ an external scheduler — so it defends itself three ways:
    the last **attempt**, not the last success — so a failing feed is retried on
    schedule instead of locked out, and a healthy one isn't re-fetched early.
 
+## Finishing the run
+
+The crawl loop can run for a long time — up to `FEED_FETCH_TIMEOUT` per feed —
+while the notification drains (`Websub\ping_scheduled_publishes()`,
+`Webmention\process_outbound()`) and the rate-limit watermark come after it. If
+the crawl is cut short, both are skipped, and because the watermark is unwritten
+the next run walks the same feeds and dies the same way, so outbound webmentions
+never deliver. Three things keep the run finishing:
+
+- **`set_time_limit(0)`** at the top of `process_feeds()`, so a slow feed cannot
+  hit a web request's PHP limit (typically 30s under FPM) mid-crawl.
+- **A per-feed guard** (`crawl_feed_guarded()`), because `crawl_feed()` only
+  catches `SQL` around individual stores — a throw from the JSON or SimplePie
+  path would otherwise abort the whole run. One bad feed reports a `FAILED` line
+  and the loop continues.
+- **The drains and the watermark run in a `finally`**, so feed fetching can never
+  starve notification delivery, and a partial run still advances the watermark
+  and so cannot immediately re-run and repeat the same failure.
+
 ## The watermark model (the crux)
 
 Three timestamps on the `feedstatus` bean do three different jobs. Conflating

--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -99,11 +99,11 @@ function render_sitemap(array $urls): string
     ];
     foreach ($urls as $url) {
         $lines[] = '  <url>';
-        // Match the Atom feed's escaping (themes/base/feed.php): ENT_SUBSTITUTE
-        // means a malformed UTF-8 byte degrades to U+FFFD instead of making
-        // htmlspecialchars() return '' for the whole string — which would emit
-        // an empty, invalid <loc>.
-        $lines[] = '    <loc>' . htmlspecialchars($url['loc'], ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE) . '</loc>';
+        // Theme\escape_xml() is the one XML escaper (ENT_XML1|ENT_QUOTES|
+        // ENT_SUBSTITUTE): a malformed UTF-8 byte degrades to U+FFFD instead of
+        // making htmlspecialchars() return '' for the whole string — which would
+        // emit an empty, invalid <loc>.
+        $lines[] = '    <loc>' . \Lamb\Theme\escape_xml($url['loc']) . '</loc>';
         if (!empty($url['lastmod'])) {
             $lines[] = '    <lastmod>' . $url['lastmod'] . '</lastmod>';
         }

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -47,13 +47,22 @@ function redirect_created(): void
 
     try {
         finalize_and_store_post($bean);
-        // Remove any existing redirect for this slug — the new post takes priority
-        if (!empty($bean->slug)) {
-            delete_redirect_for_slug($bean->slug);
-            warn_if_manual_redirect((string) $bean->slug);
-        }
     } catch (SQL $e) {
+        // Return, matching redirect_edited(): everything below is a consequence
+        // of the create having been saved. finalize_and_store_post() stores
+        // twice, and if the second store throws (a locked SQLite file while
+        // /_cron holds it is the realistic case) the bean already has an id, so
+        // falling through announced the unsaved post to webmention receivers and
+        // the WebSub hub — a mention whose permalink 404s (#685).
         $_SESSION['flash'][] = 'Failed to save: ' . $e->getMessage();
+
+        return;
+    }
+
+    // Remove any existing redirect for this slug — the new post takes priority
+    if (!empty($bean->slug)) {
+        delete_redirect_for_slug($bean->slug);
+        warn_if_manual_redirect((string) $bean->slug);
     }
     notify_post_subscribers($bean);
     redirect_uri('/');

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -67,20 +67,16 @@ function respond_upload(array $_args): void
 
         // Re-encode JPEG/PNG to WebP for smaller files; fall back to the original
         // bytes if conversion fails (assume success, communicate failure).
-        $new_fn = store_webp_copy($f['tmp_name'], $f['ext'], $dir, $seed);
+        $new_fn = store_upload_or_fallback($f['tmp_name'], $f['ext'], $dir, $seed);
         if ($new_fn === null) {
-            $new_fn = $seed . '.' . $f['ext'];
-            $new_fp = sprintf("%s/%s", $dir, $new_fn);
-            if (!move_uploaded_file($f['tmp_name'], $new_fp)) {
-                // Same reasoning as the batch check: the request is failing, so
-                // the files that did land are unreachable. Take them with it.
-                foreach ($stored as $orphan) {
-                    @unlink($orphan);
-                }
-                header('HTTP/1.1 500 Internal Server Error');
-                echo json_encode('Move upload error: ' . $f['tmp_name'], JSON_THROW_ON_ERROR);
-                die();
+            // Same reasoning as the batch check: the request is failing, so
+            // the files that did land are unreachable. Take them with it.
+            foreach ($stored as $orphan) {
+                @unlink($orphan);
             }
+            header('HTTP/1.1 500 Internal Server Error');
+            echo json_encode('Move upload error: ' . $f['tmp_name'], JSON_THROW_ON_ERROR);
+            die();
         }
         $stored[] = $dir . '/' . $new_fn;
         $out .= sprintf("![%s](%s)", $f['name'], asset_url($sub_path, $new_fn));
@@ -364,6 +360,40 @@ function store_webp_copy(string $src_path, string $ext, string $dest_dir, string
     }
 
     return null;
+}
+
+/**
+ * Stores an uploaded image: a WebP copy when convertible, otherwise the original
+ * bytes moved into place under "$seed.$ext".
+ *
+ * The store-or-fall-back sequence shared by the two move_uploaded_file() upload
+ * paths — the /upload handler and the Micropub media endpoint. (The Micropub
+ * inline-photo path stores from a PSR-7 UploadedFileInterface via
+ * persist_image_bytes(), a different move semantic, so it is not folded in here.)
+ * Returns the stored filename (basename), or null when the fallback move fails —
+ * each caller reports that its own way (its own error shape and orphan cleanup),
+ * so the failure is surfaced rather than swallowed (#653: never report a file the
+ * move did not store).
+ *
+ * @param string $tmp_name The uploaded file's temp path ($_FILES[...]['tmp_name']).
+ * @param string $ext      The lower-case extension from safe_upload_extension().
+ * @param string $dest_dir The upload directory from get_upload_dir() (no trailing slash).
+ * @param string $seed     The hashed base filename (without extension).
+ * @return string|null The stored filename, or null when the file could not be stored.
+ */
+function store_upload_or_fallback(string $tmp_name, string $ext, string $dest_dir, string $seed): ?string
+{
+    $filename = store_webp_copy($tmp_name, $ext, $dest_dir, $seed);
+    if ($filename !== null) {
+        return $filename;
+    }
+
+    $filename = $seed . '.' . $ext;
+    if (!move_uploaded_file($tmp_name, sprintf('%s/%s', $dest_dir, $filename))) {
+        return null;
+    }
+
+    return $filename;
 }
 
 /**

--- a/src/theme/formatting.php
+++ b/src/theme/formatting.php
@@ -16,6 +16,23 @@ function escape(string $html): string
 }
 
 /**
+ * Escapes a string for safe XML output (Atom feed, sitemap).
+ *
+ * Uses ENT_XML1 rather than ENT_HTML5 so a single quote becomes `&apos;` (a
+ * defined XML entity) and no HTML-only named entities are emitted. ENT_SUBSTITUTE
+ * keeps a malformed UTF-8 byte from making htmlspecialchars() return '' for the
+ * whole string — it degrades to U+FFFD instead, so one bad byte cannot empty an
+ * entire <loc> or <title>.
+ *
+ * @param string $xml The raw string to escape.
+ * @return string XML-safe escaped string.
+ */
+function escape_xml(string $xml): string
+{
+    return htmlspecialchars($xml, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE);
+}
+
+/**
  * Re-levels a post body's headings so its highest heading sits at $top, keeping
  * the levels relative to each other. Open and close tags shift identically,
  * attributes are preserved, and a body with no headings is returned unchanged.

--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -3,21 +3,14 @@
 global $config;
 global $data;
 
-if (!function_exists('escape')) {
-    function escape(string $html): string
-    {
-        return htmlspecialchars($html, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE);
-    }
-}
-
 header('Content-type: application/atom+xml');
 $channel_link = $data['feed_url'] ?? ROOT_URL . '/feed';
 
 $Xml = new SimpleXMLElement(
     '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0"></feed>'
 );
-$Xml->addChild('title', escape($data['title'] ?? $config['site_title']));
-$Xml->addChild('id', escape($channel_link));
+$Xml->addChild('title', \Lamb\Theme\escape_xml($data['title'] ?? $config['site_title']));
+$Xml->addChild('id', \Lamb\Theme\escape_xml($channel_link));
 $Xml->addChild('updated', date(DATE_ATOM, strtotime($data['updated'])));
 $Xml->addChild('generator', 'Lamb');
 
@@ -28,7 +21,7 @@ $Xml->addChild('generator', 'Lamb');
 if (defined('ROOT_DIR')) {
     foreach (['favicon.png' => 'icon', 'logo.png' => 'logo'] as $file => $element) {
         if (file_exists(ROOT_DIR . '/' . $file)) {
-            $Xml->addChild($element, escape(ROOT_URL . '/' . $file));
+            $Xml->addChild($element, \Lamb\Theme\escape_xml(ROOT_URL . '/' . $file));
         }
     }
 }
@@ -47,7 +40,7 @@ foreach (Lamb\Websub\hub_urls($config) as $websub_hub) {
 }
 
 $Author = $Xml->addChild('author');
-$Author->addChild('name', escape($config['author_name']));
+$Author->addChild('name', \Lamb\Theme\escape_xml($config['author_name']));
 $Author->addChild('uri', ROOT_URL);
 
 foreach ($data['posts'] as $bean) {
@@ -55,8 +48,8 @@ foreach ($data['posts'] as $bean) {
     // addChild(), unlike addAttribute(), does not escape: a permalink carrying a
     // `&` (a slug is stored close to verbatim) raised "unterminated entity
     // reference" and emitted an empty <id/>, making the whole feed malformed.
-    $Entry->addChild('id', escape(Lamb\permalink($bean)));
-    $Entry->addChild('title', escape($bean->title ?: ''));
+    $Entry->addChild('id', \Lamb\Theme\escape_xml(Lamb\permalink($bean)));
+    $Entry->addChild('title', \Lamb\Theme\escape_xml($bean->title ?: ''));
     $Entry->addChild('published', date(DATE_ATOM, strtotime($bean->created)));
     $Entry->addChild('updated', date(DATE_ATOM, strtotime($bean->updated)));
     // The reply context travels inside <content>, not only in the theme: thr:

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -775,9 +775,9 @@ function fetch_target(string $url): ?array
  */
 function send_webmention(string $endpoint, string $source, string $target): int
 {
-    // Unlike Http\post_form(), fetch_guarded() re-validates the destination
-    // on every redirect hop — needed here because $endpoint came from the
-    // target page's own (attacker-influenced) endpoint discovery.
+    // Every outbound POST goes through fetch_guarded(), which re-validates the
+    // destination on every redirect hop — needed here because $endpoint came
+    // from the target page's own (attacker-influenced) endpoint discovery.
     $result = fetch_guarded($endpoint, request_options([
         'method'  => 'POST',
         'headers' => ['Content-Type: application/x-www-form-urlencoded'],

--- a/src/websub.php
+++ b/src/websub.php
@@ -102,10 +102,9 @@ function ping_for_post(OODBBean $bean, ?array $config = null, ?callable $sender 
  */
 function send_ping(string $hub, string $topic): void
 {
-    // fetch_guarded() rather than post_form(): it refuses loopback/private/
-    // link-local destinations and re-validates every redirect hop, so a hub URL
-    // cannot aim the publish request at an internal service. Every other outbound
-    // sink already goes through it; this was the last one that did not.
+    // Every outbound POST goes through fetch_guarded(): it refuses loopback/
+    // private/link-local destinations and re-validates every redirect hop, so a
+    // hub URL cannot aim the publish request at an internal service.
     \Lamb\Http\fetch_guarded($hub, [
         'method' => 'POST',
         'headers' => [

--- a/tests/Unit/HttpFetchTest.php
+++ b/tests/Unit/HttpFetchTest.php
@@ -11,7 +11,6 @@ use function Lamb\Http\is_private_ip;
 use function Lamb\Http\is_public_http_url;
 use function Lamb\Http\is_valid_http_url;
 use function Lamb\Http\parse_status_line;
-use function Lamb\Http\post_form;
 use function Lamb\Http\request_timeout;
 use function Lamb\Http\resolve_redirect_location;
 use function Lamb\Http\resolve_validated_ip;
@@ -299,14 +298,6 @@ class HttpFetchTest extends TestCase
         $this->assertFalse(is_valid_http_url('/relative/path'));
         $this->assertFalse(is_valid_http_url('not a url'));
         $this->assertFalse(is_valid_http_url(''));
-    }
-
-    // post_form ---------------------------------------------------------------
-
-    public function testPostFormReturnsZeroOnTransportFailure(): void
-    {
-        $status = @post_form('file:///nonexistent/path/at/all', ['a' => 'b'], 1, 'Lamb-Test');
-        $this->assertSame(0, $status);
     }
 
     // is_private_ip -----------------------------------------------------------

--- a/tests/Unit/NetworkFeedTest.php
+++ b/tests/Unit/NetworkFeedTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 use SimplePie\Item as SimplePieItem;
 
+use function Lamb\Network\crawl_feed_guarded;
 use function Lamb\Network\create_item;
 use function Lamb\Network\get_feeds;
 use function Lamb\Network\ingest_item;
@@ -134,6 +135,31 @@ class NetworkFeedTest extends TestCase
         $this->assertArrayNotHasKey('weird', $result);
 
         $config = $original;
+    }
+
+    // crawl_feed_guarded — one bad feed must not abort the whole /_cron run
+
+    public function testCrawlFeedGuardedReturnsTheCrawlerResult(): void
+    {
+        $result = crawl_feed_guarded('good', 'https://example.com/feed', function (string $name, string $url): array {
+            return ['ok' => true, 'items' => 3, 'error' => null];
+        });
+
+        $this->assertSame(['ok' => true, 'items' => 3, 'error' => null], $result);
+    }
+
+    public function testCrawlFeedGuardedConvertsAThrowIntoTheErrorShapeWithoutPropagating(): void
+    {
+        // A throwing crawl (a JSON/SimplePie parse blow-up, not a caught SQL
+        // error) must not escape and abort the run — it becomes a FAILED line so
+        // the loop reaches the next feed and the notification drains.
+        $result = crawl_feed_guarded('bad', 'https://example.com/feed', function (string $name, string $url): array {
+            throw new \RuntimeException('feed exploded');
+        });
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(0, $result['items']);
+        $this->assertSame('feed exploded', $result['error']);
     }
 
     // ensure_feed_cache

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -330,6 +330,89 @@ class ResponsePostsTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // redirect_created — a failed save must have no side effects
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates the `redirect` and `webmentionoutbox` tables (empty), so a count
+     * of them means "none were written" rather than "the table does not exist".
+     */
+    private function seedNotifyTables(): void
+    {
+        $redirect = R::dispense('redirect');
+        $redirect->from_slug = '';
+        $redirect->to_url = '';
+        R::store($redirect);
+        R::exec('DELETE FROM redirect');
+
+        $outbox = R::dispense('webmentionoutbox');
+        $outbox->source = '';
+        $outbox->target = '';
+        $outbox->status = '';
+        R::store($outbox);
+        R::exec('DELETE FROM webmentionoutbox');
+    }
+
+    /**
+     * Submits a create whose second write fails.
+     *
+     * A post already owns the slug `taken`, so finalize_slug() suffixes the new
+     * post's slug and pins the changed value into its body — the second of
+     * finalize_and_store_post()'s two R::store() calls. Blocking only UPDATE lets
+     * the first store (INSERT) mint the id and makes the second throw, which is
+     * the #685 shape: the bean already has an id, so the notify guards that
+     * early-return on `!id` do not fire.
+     */
+    private function submitCreateWithFailingSecondWrite(): void
+    {
+        $existing = R::dispense('post');
+        $existing->body        = "---\nslug: taken\n---\n\ntaken\n";
+        $existing->transformed = '<p>taken</p>';
+        $existing->slug        = 'taken';
+        $existing->created     = date('Y-m-d H:i:s', time() - 3600);
+        $existing->updated     = date('Y-m-d H:i:s', time() - 3600);
+        $existing->version     = POST_VERSION;
+        R::store($existing);
+
+        $_SESSION[SESSION_LOGIN]    = true;
+        $_SESSION[HIDDEN_CSRF_NAME] = 'ctok';
+        $_POST[HIDDEN_CSRF_NAME]    = 'ctok';
+        $_POST['submit']            = SUBMIT_CREATE;
+        $_POST['contents']          = "---\nslug: taken\n---\n\nsee [elsewhere](https://other.example/a)\n";
+
+        R::exec("CREATE TRIGGER post_block_update BEFORE UPDATE ON post BEGIN SELECT RAISE(ABORT, 'database is locked'); END");
+        try {
+            redirect_created();
+        } finally {
+            R::exec('DROP TRIGGER IF EXISTS post_block_update');
+        }
+    }
+
+    public function testRedirectCreatedFlashesWhenTheSaveFails(): void
+    {
+        $this->seedNotifyTables();
+
+        $this->submitCreateWithFailingSecondWrite();
+
+        $this->assertNotEmpty(array_filter(
+            $_SESSION['flash'] ?? [],
+            fn ($m) => str_contains((string) $m, 'Failed to save')
+        ));
+    }
+
+    public function testRedirectCreatedDoesNotNotifySubscribersWhenTheSaveFails(): void
+    {
+        // Announcing a create that was not stored: the queued mention carries a
+        // permalink built from the unsaved slug, so a receiver fetching it to
+        // verify the mention gets a 404.
+        $this->seedNotifyTables();
+
+        $this->submitCreateWithFailingSecondWrite();
+
+        $this->assertCount(0, R::findAll('webmentionoutbox'));
+    }
+
+    // -------------------------------------------------------------------------
     // redirect_edited — the post id is read from $_POST
     // -------------------------------------------------------------------------
     // FILTER_SANITIZE_NUMBER_INT over $_POST, as filter_input(INPUT_POST, ...)

--- a/tests/Unit/ThemeTest.php
+++ b/tests/Unit/ThemeTest.php
@@ -8,6 +8,7 @@ use RedBeanPHP\R;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\admin_toolbar_html;
 use function Lamb\Theme\escape;
+use function Lamb\Theme\escape_xml;
 use function Lamb\Theme\format_past_date;
 use function Lamb\Theme\human_time;
 use function Lamb\Theme\og_escape;
@@ -111,6 +112,33 @@ class ThemeTest extends TestCase
     public function testEscapeConvertsAmpersand()
     {
         $this->assertSame('foo &amp; bar', escape('foo & bar'));
+    }
+
+    // escape_xml
+
+    public function testEscapeXmlConvertsAmpersand()
+    {
+        $this->assertSame('foo &amp; bar', escape_xml('foo & bar'));
+    }
+
+    public function testEscapeXmlConvertsAngleBrackets()
+    {
+        $this->assertSame('&lt;loc&gt;', escape_xml('<loc>'));
+    }
+
+    public function testEscapeXmlConvertsSingleQuoteToApos()
+    {
+        // ENT_XML1 encodes the single quote as the defined XML entity &apos;.
+        $this->assertSame('it&apos;s', escape_xml("it's"));
+    }
+
+    public function testEscapeXmlSubstitutesInvalidUtf8ByteInsteadOfEmptyingTheString()
+    {
+        // ENT_SUBSTITUTE: a lone invalid byte degrades to U+FFFD rather than
+        // making htmlspecialchars() return '' for the whole value.
+        $result = escape_xml("ok\xB1");
+        $this->assertNotSame('', $result);
+        $this->assertSame("ok\u{FFFD}", $result);
     }
 
     // og_escape

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -17,6 +17,7 @@ use function Lamb\Response\safe_upload_extension;
 use function Lamb\Response\upload_subpath;
 use function Lamb\Response\scaled_dimensions;
 use function Lamb\Response\should_convert_to_webp;
+use function Lamb\Response\store_upload_or_fallback;
 use function Lamb\Response\store_webp_copy;
 
 class UploadTest extends TestCase
@@ -560,6 +561,37 @@ class UploadTest extends TestCase
 
         $this->assertNull($result);
         $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.webp');
+    }
+
+    // store_upload_or_fallback — the store-or-fall-back sequence shared by the
+    // /upload handler and the Micropub media endpoint: a WebP copy when
+    // convertible, otherwise move_uploaded_file() the original bytes into place.
+
+    public function testStoreUploadOrFallbackReturnsWebpFilenameForConvertibleImage(): void
+    {
+        $src = $this->makePng(40, 30);
+
+        $result = store_upload_or_fallback($src, 'png', $this->tempRootDir, 'seedhash');
+
+        $this->assertSame('seedhash.webp', $result);
+        $this->assertFileExists($this->tempRootDir . '/seedhash.webp');
+        $this->assertSame('image/webp', mime_content_type($this->tempRootDir . '/seedhash.webp'));
+    }
+
+    public function testStoreUploadOrFallbackReturnsNullWhenConversionSkippedAndMoveFails(): void
+    {
+        // A non-convertible extension skips the WebP path, so the code falls back
+        // to move_uploaded_file() — which refuses a path that did not arrive via
+        // an HTTP upload, so the helper returns null and stores nothing. (The
+        // successful-move branch needs a real upload; it is covered by the e2e
+        // suite, see #673.)
+        $src = $this->tempRootDir . '/plain.gif';
+        file_put_contents($src, 'GIF89a not really');
+
+        $result = @store_upload_or_fallback($src, 'gif', $this->tempRootDir, 'seedhash');
+
+        $this->assertNull($result);
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.gif');
     }
 
     // asset_dimensions — pixel size of a locally stored asset, for intrinsic


### PR DESCRIPTION
`process_feeds()` ran the notification drains (WebSub scheduled pings, outbound webmentions) and wrote the rate-limit watermark **only after** the crawl loop. A crawl that timed out or threw skipped all three; because the watermark was unwritten, the next run walked the same feeds and died the same way — so outbound webmentions and scheduled-publish pings **never** delivered, silently.

Four-part fix (all of them — doing only the first leaves the next slow feed to cause a different version of the same outage):

1. **`set_time_limit(0)`** at the top of `process_feeds()` — a slow feed can't hit a web request's PHP limit (typically 30s under FPM) mid-crawl.
2. **`crawl_feed_guarded()`** wraps each crawl: `crawl_feed()` only catches `SQL` around individual stores, so a JSON/SimplePie throw would otherwise abort the run. One bad feed reports `FAILED` and the loop continues. Injectable for tests.
3. **Drains + watermark run in a `finally`** — feed fetching can't starve notification delivery even if the loop throws.
4. **Advancing the watermark in that `finally`** means a partial run still rate-limits the next one, so it can't immediately re-run and repeat the failure.

Documented in `src/network/README.md` ("Finishing the run").

Tests: `crawl_feed_guarded()` returns the crawler's result, and converts a throw into the `FAILED` error shape without propagating. Full unit suite green (2027 passing).

Per the issue, the end-to-end behaviour (a deliberately slow feed against a real `/_cron`) is best verified against a running instance — `process_feeds()` itself isn't unit-reachable (header/lock/exit).

Closes #686

---
**Top of the stack, on #672.** Full stack: #687 ← #685 ← #688 ← #672 ← **#686**.