### PR TITLE
Do not notify webmention/WebSub after a failed create write

### DIFF
--- a/src/http.php
+++ b/src/http.php
@@ -426,38 +426,6 @@ function parse_status_line(string $line): int
 }
 
 /**
- * POST a www-form-urlencoded body and return the response HTTP status code.
- *
- * The shared outbound notification primitive: webmention sending and WebSub
- * hub pings both POST a small form and only care about the status (WebSub
- * ignores even that — it is fire-and-forget). Built on {@see fetch};
- * follow_location/max_redirects are omitted so PHP's stream defaults apply,
- * matching the hand-rolled contexts this replaces.
- *
- * @param string               $url        The endpoint to POST to.
- * @param array<string, mixed> $fields     Form fields for the request body.
- * @param int                  $timeout    Socket timeout in seconds.
- * @param string               $user_agent User-Agent header value.
- * @return int HTTP status code, or 0 on transport failure.
- */
-function post_form(string $url, array $fields, int $timeout, string $user_agent): int
-{
-    $result = fetch($url, [
-        'method' => 'POST',
-        'headers' => [
-            'Content-Type: application/x-www-form-urlencoded',
-            'User-Agent: ' . $user_agent,
-        ],
-        'content' => http_build_query($fields),
-        'timeout' => $timeout,
-        'follow_location' => null,
-        'max_redirects' => null,
-    ]);
-
-    return $result === null ? 0 : $result['status'];
-}
-
-/**
  * Perform a single HTTP request pinned to a specific IP via curl, so the
  * connection reaches the exact address {@see resolve_validated_ip} validated
  * instead of letting the transport re-resolve the host itself (the
@@ -568,7 +536,7 @@ function fetch_pinned(string $url, array $opts, array $pin): ?array
  *
  * Pass `pin => ['host' => string, 'ip' => string]` to route the request
  * through {@see fetch_pinned} instead — see its docblock for why. Every
- * other caller (`post_form()`, Micropub's `introspectToken`) is unaffected.
+ * other caller (Micropub's `introspectToken`) is unaffected.
  *
  * @param string               $url
  * @param array<string, mixed> $opts

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -47,13 +47,22 @@ function redirect_created(): void
 
     try {
         finalize_and_store_post($bean);
-        // Remove any existing redirect for this slug — the new post takes priority
-        if (!empty($bean->slug)) {
-            delete_redirect_for_slug($bean->slug);
-            warn_if_manual_redirect((string) $bean->slug);
-        }
     } catch (SQL $e) {
+        // Return, matching redirect_edited(): everything below is a consequence
+        // of the create having been saved. finalize_and_store_post() stores
+        // twice, and if the second store throws (a locked SQLite file while
+        // /_cron holds it is the realistic case) the bean already has an id, so
+        // falling through announced the unsaved post to webmention receivers and
+        // the WebSub hub — a mention whose permalink 404s (#685).
         $_SESSION['flash'][] = 'Failed to save: ' . $e->getMessage();
+
+        return;
+    }
+
+    // Remove any existing redirect for this slug — the new post takes priority
+    if (!empty($bean->slug)) {
+        delete_redirect_for_slug($bean->slug);
+        warn_if_manual_redirect((string) $bean->slug);
     }
     notify_post_subscribers($bean);
     redirect_uri('/');

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -775,9 +775,9 @@ function fetch_target(string $url): ?array
  */
 function send_webmention(string $endpoint, string $source, string $target): int
 {
-    // Unlike Http\post_form(), fetch_guarded() re-validates the destination
-    // on every redirect hop — needed here because $endpoint came from the
-    // target page's own (attacker-influenced) endpoint discovery.
+    // Every outbound POST goes through fetch_guarded(), which re-validates the
+    // destination on every redirect hop — needed here because $endpoint came
+    // from the target page's own (attacker-influenced) endpoint discovery.
     $result = fetch_guarded($endpoint, request_options([
         'method'  => 'POST',
         'headers' => ['Content-Type: application/x-www-form-urlencoded'],

--- a/src/websub.php
+++ b/src/websub.php
@@ -102,10 +102,9 @@ function ping_for_post(OODBBean $bean, ?array $config = null, ?callable $sender 
  */
 function send_ping(string $hub, string $topic): void
 {
-    // fetch_guarded() rather than post_form(): it refuses loopback/private/
-    // link-local destinations and re-validates every redirect hop, so a hub URL
-    // cannot aim the publish request at an internal service. Every other outbound
-    // sink already goes through it; this was the last one that did not.
+    // Every outbound POST goes through fetch_guarded(): it refuses loopback/
+    // private/link-local destinations and re-validates every redirect hop, so a
+    // hub URL cannot aim the publish request at an internal service.
     \Lamb\Http\fetch_guarded($hub, [
         'method' => 'POST',
         'headers' => [

--- a/tests/Unit/HttpFetchTest.php
+++ b/tests/Unit/HttpFetchTest.php
@@ -11,7 +11,6 @@ use function Lamb\Http\is_private_ip;
 use function Lamb\Http\is_public_http_url;
 use function Lamb\Http\is_valid_http_url;
 use function Lamb\Http\parse_status_line;
-use function Lamb\Http\post_form;
 use function Lamb\Http\request_timeout;
 use function Lamb\Http\resolve_redirect_location;
 use function Lamb\Http\resolve_validated_ip;
@@ -299,14 +298,6 @@ class HttpFetchTest extends TestCase
         $this->assertFalse(is_valid_http_url('/relative/path'));
         $this->assertFalse(is_valid_http_url('not a url'));
         $this->assertFalse(is_valid_http_url(''));
-    }
-
-    // post_form ---------------------------------------------------------------
-
-    public function testPostFormReturnsZeroOnTransportFailure(): void
-    {
-        $status = @post_form('file:///nonexistent/path/at/all', ['a' => 'b'], 1, 'Lamb-Test');
-        $this->assertSame(0, $status);
     }
 
     // is_private_ip -----------------------------------------------------------

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -330,6 +330,89 @@ class ResponsePostsTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // redirect_created — a failed save must have no side effects
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates the `redirect` and `webmentionoutbox` tables (empty), so a count
+     * of them means "none were written" rather than "the table does not exist".
+     */
+    private function seedNotifyTables(): void
+    {
+        $redirect = R::dispense('redirect');
+        $redirect->from_slug = '';
+        $redirect->to_url = '';
+        R::store($redirect);
+        R::exec('DELETE FROM redirect');
+
+        $outbox = R::dispense('webmentionoutbox');
+        $outbox->source = '';
+        $outbox->target = '';
+        $outbox->status = '';
+        R::store($outbox);
+        R::exec('DELETE FROM webmentionoutbox');
+    }
+
+    /**
+     * Submits a create whose second write fails.
+     *
+     * A post already owns the slug `taken`, so finalize_slug() suffixes the new
+     * post's slug and pins the changed value into its body — the second of
+     * finalize_and_store_post()'s two R::store() calls. Blocking only UPDATE lets
+     * the first store (INSERT) mint the id and makes the second throw, which is
+     * the #685 shape: the bean already has an id, so the notify guards that
+     * early-return on `!id` do not fire.
+     */
+    private function submitCreateWithFailingSecondWrite(): void
+    {
+        $existing = R::dispense('post');
+        $existing->body        = "---\nslug: taken\n---\n\ntaken\n";
+        $existing->transformed = '<p>taken</p>';
+        $existing->slug        = 'taken';
+        $existing->created     = date('Y-m-d H:i:s', time() - 3600);
+        $existing->updated     = date('Y-m-d H:i:s', time() - 3600);
+        $existing->version     = POST_VERSION;
+        R::store($existing);
+
+        $_SESSION[SESSION_LOGIN]    = true;
+        $_SESSION[HIDDEN_CSRF_NAME] = 'ctok';
+        $_POST[HIDDEN_CSRF_NAME]    = 'ctok';
+        $_POST['submit']            = SUBMIT_CREATE;
+        $_POST['contents']          = "---\nslug: taken\n---\n\nsee [elsewhere](https://other.example/a)\n";
+
+        R::exec("CREATE TRIGGER post_block_update BEFORE UPDATE ON post BEGIN SELECT RAISE(ABORT, 'database is locked'); END");
+        try {
+            redirect_created();
+        } finally {
+            R::exec('DROP TRIGGER IF EXISTS post_block_update');
+        }
+    }
+
+    public function testRedirectCreatedFlashesWhenTheSaveFails(): void
+    {
+        $this->seedNotifyTables();
+
+        $this->submitCreateWithFailingSecondWrite();
+
+        $this->assertNotEmpty(array_filter(
+            $_SESSION['flash'] ?? [],
+            fn ($m) => str_contains((string) $m, 'Failed to save')
+        ));
+    }
+
+    public function testRedirectCreatedDoesNotNotifySubscribersWhenTheSaveFails(): void
+    {
+        // Announcing a create that was not stored: the queued mention carries a
+        // permalink built from the unsaved slug, so a receiver fetching it to
+        // verify the mention gets a 404.
+        $this->seedNotifyTables();
+
+        $this->submitCreateWithFailingSecondWrite();
+
+        $this->assertCount(0, R::findAll('webmentionoutbox'));
+    }
+
+    // -------------------------------------------------------------------------
     // redirect_edited — the post id is read from $_POST
     // -------------------------------------------------------------------------
     // FILTER_SANITIZE_NUMBER_INT over $_POST, as filter_input(INPUT_POST, ...)


### PR DESCRIPTION
Replaces #700 (auto-closed when its stacked base branch fix/687 was deleted on merge of #699). Same change.

`redirect_created()` called `notify_post_subscribers()` outside its try/catch, so a failed store still announced the post. Moved into the success path with an early return on a failed write, matching `redirect_edited()`. Create-path characterisation tests added.

Closes #685