### PR TITLE
Route the CLI importers through Bootstrap\data_dir()

### DIFF
--- a/import-known.php
+++ b/import-known.php
@@ -49,7 +49,7 @@ if (!is_readable($path)) {
     exit(1);
 }
 
-$data_dir = getenv('LAMB_DATA_DIR') ?: __DIR__ . '/data';
+$data_dir = Bootstrap\data_dir(__DIR__);
 Bootstrap\bootstrap_db($data_dir);
 
 global $config;

--- a/import-lamb.php
+++ b/import-lamb.php
@@ -53,7 +53,7 @@ try {
     exit(1);
 }
 
-$data_dir = getenv('LAMB_DATA_DIR') ?: __DIR__ . '/data';
+$data_dir = Bootstrap\data_dir(__DIR__);
 Bootstrap\bootstrap_db($data_dir);
 
 global $config;

--- a/import-wordpress.php
+++ b/import-wordpress.php
@@ -47,7 +47,7 @@ if (!is_readable($path)) {
     exit(1);
 }
 
-$data_dir = getenv('LAMB_DATA_DIR') ?: __DIR__ . '/data';
+$data_dir = Bootstrap\data_dir(__DIR__);
 Bootstrap\bootstrap_db($data_dir);
 
 global $config;

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -49,13 +49,22 @@ function load_dotenv(string $root): void
  *
  * The default is relative to the web root, which is the working directory of a
  * request (php-fpm and `php -S -t src` both chdir there). CLI entry points pass
- * their own absolute path.
+ * their own absolute path via $cli_base, whose data dir is "$cli_base/data" —
+ * relative to the repo root rather than to src/, which is why the two defaults
+ * must stay distinct.
  *
+ * @param string|null $cli_base Absolute base path for a CLI entry point (pass
+ *                              __DIR__), or null for a web request.
  * @return string The data directory path.
  */
-function data_dir(): string
+function data_dir(?string $cli_base = null): string
 {
-    return getenv('LAMB_DATA_DIR') ?: '../data';
+    $env = getenv('LAMB_DATA_DIR');
+    if ($env !== false && $env !== '') {
+        return $env;
+    }
+
+    return $cli_base !== null ? $cli_base . '/data' : '../data';
 }
 
 /**

--- a/tests/Unit/CronLockTest.php
+++ b/tests/Unit/CronLockTest.php
@@ -44,10 +44,24 @@ class CronLockTest extends TestCase
         $this->assertSame('../data', data_dir());
     }
 
+    public function testDataDirDefaultsToACliBaseSiblingForCliEntryPoints(): void
+    {
+        // The two defaults must stay distinct: the web default is relative to
+        // src/, a CLI script's is relative to the repo root it passes in.
+        putenv('LAMB_DATA_DIR');
+        $this->assertSame('/opt/lamb/data', data_dir('/opt/lamb'));
+    }
+
     public function testDataDirHonoursTheEnvironmentOverride(): void
     {
         putenv('LAMB_DATA_DIR=' . $this->tmp);
         $this->assertSame($this->tmp, data_dir());
+    }
+
+    public function testDataDirEnvironmentOverrideWinsOverTheCliBase(): void
+    {
+        putenv('LAMB_DATA_DIR=' . $this->tmp);
+        $this->assertSame($this->tmp, data_dir('/opt/lamb'));
     }
 
     public function testCronLockLivesInTheConfiguredDataDir(): void


### PR DESCRIPTION
Routes the three `import-*.php` scripts through `Bootstrap\data_dir()` instead of each re-reading `LAMB_DATA_DIR`. `data_dir()` gains an explicit `$cli_base` parameter (the easier-to-test option the issue prefers); the two distinct defaults are preserved — `../data` (relative to src/) for web, `$cli_base/data` (repo root) for CLI.

Tests cover env-set, unset+web-default, unset+cli-base, and env-wins-over-cli-base.

Closes #691