### PR TITLE
Drop the superseded rel="in-reply-to" from the reply context

### DIFF
--- a/src/theme/formatting.php
+++ b/src/theme/formatting.php
@@ -95,7 +95,11 @@ function the_reply_context(\RedBeanPHP\OODBBean $bean): string
 
     $label = parse_url($url, PHP_URL_HOST) ?: $url;
 
-    return '<p class="reply-context">In reply to <a class="u-in-reply-to" rel="in-reply-to" href="'
+    // No rel="in-reply-to": the rel-in-reply-to proposal is superseded by the
+    // u-in-reply-to h-entry property (which this already carries), the value is
+    // not a registered HTML link type, and nothing consumes it that does not
+    // already read u-in-reply-to. See #585.
+    return '<p class="reply-context">In reply to <a class="u-in-reply-to" href="'
         . escape($url) . '">' . escape($label) . '</a></p>';
 }
 

--- a/tests/Unit/ReplyContextTest.php
+++ b/tests/Unit/ReplyContextTest.php
@@ -148,6 +148,20 @@ class ReplyContextTest extends TestCase
         $this->assertSame('', the_reply_context($bean));
     }
 
+    public function testReplyContextDoesNotEmitSupersededRelInReplyTo(): void
+    {
+        // rel="in-reply-to" is superseded by the u-in-reply-to h-entry property
+        // and is not a registered HTML link type — validators flag it and nothing
+        // reads it that does not already read the class (#585).
+        $bean = R::dispense('post');
+        $bean->in_reply_to = 'https://other.example/post';
+
+        $html = the_reply_context($bean);
+
+        $this->assertStringContainsString('u-in-reply-to', $html);
+        $this->assertStringNotContainsString('rel="in-reply-to"', $html);
+    }
+
     // set_reply_to helper ----------------------------------------------------
 
     public function testSetReplyToAddsFrontMatterBlockToPlainBody(): void


### PR DESCRIPTION
Removes `rel="in-reply-to"` from `the_reply_context()`. It is superseded by the `u-in-reply-to` h-entry property (already emitted), is not a registered HTML link type (validators flag it), and nothing reads it that does not already read the class.

Part 2 (h-cite with parent author/name) is intentionally left out — it requires fetching/caching the target page; the bare link is sufficient for webmention categorisation.

Test asserts the markup keeps `u-in-reply-to` and no longer contains `rel="in-reply-to"`.

Closes #585