### PR TITLE
Atom threading polish for reply entries (RFC 4685)

### DIFF
--- a/src/themes/base/feed.php
+++ b/src/themes/base/feed.php
@@ -83,6 +83,13 @@ foreach ($data['posts'] as $bean) {
         $Thread = $Entry->addChild('in-reply-to', null, 'http://purl.org/syndication/thread/1.0');
         $Thread->addAttribute('ref', $bean->in_reply_to);
         $Thread->addAttribute('href', $bean->in_reply_to);
+        // The RFC 4685 media-type hint for the resource being retrieved.
+        $Thread->addAttribute('type', 'text/html');
+        // Belt-and-braces for readers that ignore the thr: namespace: a plain
+        // rel="related" makes the reply relationship visible to them too.
+        $Related = $Entry->addChild('link');
+        $Related->addAttribute('rel', 'related');
+        $Related->addAttribute('href', $bean->in_reply_to);
     }
     $Link = $Entry->addChild('link');
     $Link->addAttribute('rel', 'alternate');

--- a/tests/Unit/FeedTemplateTest.php
+++ b/tests/Unit/FeedTemplateTest.php
@@ -177,6 +177,51 @@ class FeedTemplateTest extends TestCase
         $this->assertNotEmpty((string) $link['href']);
     }
 
+    public function testReplyEntryCarriesThreadTypeAndRelatedLink(): void
+    {
+        $target = 'https://other.example/post';
+        $xml = $this->renderFeedWithPost([
+            'title'       => 'A reply',
+            'transformed' => '<p>Replying</p>',
+            'in_reply_to' => $target,
+        ]);
+
+        // RFC 4685 item 1: the thr:in-reply-to carries ref/href and the
+        // text/html media-type hint.
+        $thr = $xml->entry[0]->children('http://purl.org/syndication/thread/1.0');
+        $inReplyTo = $thr->{'in-reply-to'};
+        // ref/href/type are in no namespace, so read them off attributes() rather
+        // than $inReplyTo[...] (which resolves in the thr: namespace context here).
+        $attrs = $inReplyTo->attributes();
+        $this->assertSame($target, (string) $attrs->ref);
+        $this->assertSame($target, (string) $attrs->href);
+        $this->assertSame('text/html', (string) $attrs->type);
+
+        // Item 4: a plain rel="related" link for readers that ignore the thr: ns.
+        $related = null;
+        foreach ($xml->entry[0]->link as $link) {
+            if ((string) $link['rel'] === 'related') {
+                $related = $link;
+            }
+        }
+        $this->assertNotNull($related, 'entry should carry a rel="related" link');
+        $this->assertSame($target, (string) $related['href']);
+    }
+
+    public function testNonReplyEntryHasNoThreadOrRelatedLink(): void
+    {
+        $xml = $this->renderFeedWithPost([
+            'title'       => 'Not a reply',
+            'transformed' => '<p>Body</p>',
+        ]);
+
+        $thr = $xml->entry[0]->children('http://purl.org/syndication/thread/1.0');
+        $this->assertSame(0, $thr->{'in-reply-to'}->count());
+        foreach ($xml->entry[0]->link as $link) {
+            $this->assertNotSame('related', (string) $link['rel']);
+        }
+    }
+
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled
@@ -351,6 +396,7 @@ class FeedTemplateTest extends TestCase
         $bean->title = $fields['title'] ?? '';
         $bean->description = $fields['description'] ?? '';
         $bean->transformed = $fields['transformed'] ?? '';
+        $bean->in_reply_to = $fields['in_reply_to'] ?? '';
         $bean->created = '2024-01-01 12:00:00';
         $bean->updated = '2024-01-01 12:00:00';
         R::store($bean);


### PR DESCRIPTION
Two conformance-neutral RFC 4685 improvements to the `thr:in-reply-to` emission in the Atom feed:

- **`type="text/html"`** on `thr:in-reply-to` — the RFC media-type hint for the retrieved resource.
- **`<link rel="related" href="…"/>`** on the entry, so readers that ignore the `thr:` namespace still see the reply relationship.

Items 2 (`ref` = parent `atom:id`) and 3 (`source`) are left out — both need parent-feed discovery and are not worth it for a microblog.

Tests: a reply entry carries `ref`/`href`/`type` on `thr:in-reply-to` plus a `rel="related"` link; a non-reply entry carries neither.

Closes #584