### PR TITLE
Stamp last_attempt when a feed crawl throws, so it backs off

### DIFF
--- a/src/network.php
+++ b/src/network.php
@@ -259,6 +259,13 @@ function crawl_feed_guarded(string $name, string $url, ?callable $crawler = null
     try {
         return $crawler($name, $url);
     } catch (\Throwable $e) {
+        // Stamp the attempt so a feed that throws before begin_crawl() runs backs
+        // off on the per-feed gate instead of being re-attempted every run. The
+        // Atom path fetches inside init_simplepie_feed() *before* record_feed_crawl()
+        // stamps last_attempt, so a SimplePie init() throw would otherwise leave
+        // the feed permanently due (#705). begin_crawl() is idempotent, so a throw
+        // after it already ran just re-stamps.
+        begin_crawl($name, $url);
         return ['ok' => false, 'items' => 0, 'error' => $e->getMessage()];
     }
 }

--- a/tests/Unit/NetworkFeedTest.php
+++ b/tests/Unit/NetworkFeedTest.php
@@ -162,6 +162,24 @@ class NetworkFeedTest extends TestCase
         $this->assertSame('feed exploded', $result['error']);
     }
 
+    public function testCrawlFeedGuardedStampsLastAttemptWhenTheCrawlerThrows(): void
+    {
+        // A throw before begin_crawl() (a SimplePie init() blow-up fetches before
+        // the outcome recorder stamps last_attempt) must still advance the
+        // attempt, or the per-feed 30-minute gate never engages and the feed is
+        // re-attempted every run (#705).
+        $name = 'throwing';
+        $url  = 'https://example.com/throwing';
+
+        crawl_feed_guarded($name, $url, function (string $n, string $u): array {
+            throw new \RuntimeException('init blew up before begin_crawl');
+        });
+
+        $status = R::findOne('feedstatus', ' feedkey = ? ', [md5($name . $url)]);
+        $this->assertNotNull($status);
+        $this->assertGreaterThan(0, (int) $status->last_attempt);
+    }
+
     // ensure_feed_cache
 
     public function testEnsureFeedCacheCreatesMissingDirectory(): void


### PR DESCRIPTION
Follow-up to #686. The Atom path fetches inside `init_simplepie_feed()` **before** `record_feed_crawl()` runs `begin_crawl()`, so a SimplePie `init()` throw was caught by `crawl_feed_guarded()` but left `last_attempt` unadvanced — the per-feed 30-minute gate never engaged and the feed was re-attempted every `/_cron` run.

Fix: stamp the attempt in the guard's catch. `begin_crawl()` is idempotent, so a throw after it already ran just re-stamps.

Test: a throwing crawler leaves the `feedstatus` bean's `last_attempt` advanced.

Closes #705