### PR TITLE
One front-matter engine behind set_frontmatter_key()

### DIFF
--- a/src/import.php
+++ b/src/import.php
@@ -9,9 +9,9 @@ use League\HTMLToMarkdown\HtmlConverter;
 use RedBeanPHP\R;
 use RuntimeException;
 use SimpleXMLElement;
-use Symfony\Component\Yaml\Yaml;
 
 use function Lamb\Http\fetch_guarded;
+use function Lamb\Post\build_matter;
 use function Lamb\Response\asset_url;
 
 /**
@@ -359,11 +359,12 @@ function build_post_body(string $title, string $markdown_body, array $tags, stri
     if ($slug !== '') {
         $front['slug'] = $slug;
     }
-    if ($front === []) {
-        return $body;
-    }
-    $matter = rtrim(Yaml::dump($front), "\n");
-    return "---\n" . $matter . "\n---\n\n" . $body;
+
+    // build_matter() is the single place a front-matter block is assembled from
+    // a key/value map. The leading "\n" reproduces the blank line this importer
+    // has always kept between the fence and the body; an empty map returns the
+    // content verbatim (no fence).
+    return build_matter($front, $front === [] ? $body : "\n" . $body);
 }
 
 /**

--- a/src/post.php
+++ b/src/post.php
@@ -439,25 +439,29 @@ function build_matter(array $matter, string $content): string
 }
 
 /**
- * Sets a single key in a body's leading YAML front-matter block, leaving all
- * other front matter intact.
+ * Sets a single key in a body's leading YAML front-matter block, without
+ * creating a block and without churning an unchanged save.
  *
- * An existing `key:` line is updated in place (preserving the original key text
- * and indentation, rewriting only the value with a single separating space).
- * When the block has no such line and $append is true, an explicit line is
- * appended to the block. Bodies without a leading front-matter block, or whose
- * key already holds the target value, are returned unchanged (no cosmetic
- * churn).
+ * A thin no-churn/no-create wrapper over set_frontmatter_key(), which is the one
+ * engine that mutates a block (splitting and rebuilding through the YAML writer).
+ * set_matter() adds two guarantees the every-save callers (persist_slug(),
+ * persist_resolved_created()) rely on and that the engine deliberately does not
+ * make:
  *
- * The value is rendered through the YAML writer rather than interpolated, for
- * the reason build_matter() already documents: a slug carrying a colon
- * (`slug: a: b`) is not valid YAML, so parse_matter() returned nothing and the
- * *whole* front-matter block — title, draft, created — silently vanished on the
- * next read; one carrying a `#` had everything from it treated as a comment.
- * finalize_slug() reaches both by appending an id suffix to an explicit slug
- * that collides or names a reserved route, and then pinning the result here.
- * Yaml::dump() already quotes anything that needs it, including the
- * `Y-m-d H:i:s` created stamp, so no caller has to ask for quoting.
+ * - A body with no leading front-matter block is returned unchanged, rather than
+ *   gaining one. set_frontmatter_key() would add a block; a status update or a
+ *   feed item without front matter must not sprout a `slug:`/`created:` fence.
+ * - When the key's line already holds this value, the body is returned
+ *   byte-for-byte — including its CRLF line endings. A browser submits a
+ *   <textarea> with CRLF, so most bodies reaching here carry them; the `\r` must
+ *   not make an unchanged value differ and re-store the post on every save.
+ *
+ * The value only reaches set_frontmatter_key() when it actually changes, so the
+ * engine's rebuild (which quotes anything YAML needs, and cannot leave a stale
+ * list behind under a scalar) happens once per real change, never as cosmetic
+ * churn. finalize_slug() reaches this by pinning an id-suffixed slug that
+ * collides or names a reserved route; apply_scheduling() by pinning a resolved
+ * `created` date.
  *
  * @param string $body The raw post body.
  * @param string $key The front-matter key to set.
@@ -469,45 +473,26 @@ function build_matter(array $matter, string $content): string
 function set_matter(string $body, string $key, string $value, bool $append = true): string
 {
     // Only touch a front-matter block at the very start of the body.
-    if (!preg_match('/\A(\s*---\s*\n)(.*?\n)(---\s*\n?)/s', $body, $m)) {
+    [$yaml] = split_frontmatter($body);
+    if ($yaml === '') {
         return $body;
     }
 
-    $rendered = Yaml::dump($value);
-    // A browser submits a <textarea> with CRLF line endings, so most bodies
-    // reaching here carry them. The `\r` is matched and carried over rather
-    // than swept into the value: as part of $line[2] it made $current differ
-    // from $value on every save, so the no-churn contract above never held for
-    // an edit-form body and each save rewrote the line (and re-stored the post).
-    $new_yaml = preg_replace_callback(
-        '/^([ \t]*' . preg_quote($key, '/') . '[ \t]*:)[ \t]*(.*?)[ \t]*(\r?)$/mi',
-        function (array $line) use ($value, $rendered): string {
-            $current = trim($line[2], " \t'\"");
-            if ($current === $value) {
-                return $line[0];
-            }
-            return $line[1] . ' ' . $rendered . $line[3];
-        },
-        $m[2],
-        1,
-        $count
-    );
-    // preg_replace_callback() returns null on a PCRE failure (a backtrack limit
-    // on a long block). Concatenating that would drop the entire YAML block, so
-    // leave the body alone instead.
-    if ($new_yaml === null) {
-        return $body;
-    }
-
-    if ($count === 0) {
-        if (!$append) {
+    // Read-only probe for the key's column-zero line, in either spelling
+    // (parse_matter() folds hyphen/underscore together). This decides no-churn
+    // and, for $append === false, whether the key is present — matching the
+    // engine's own column-zero, quote-trimming view of the value so an unchanged
+    // save returns the body verbatim.
+    $pattern = '/^' . str_replace('\-', '[-_]', preg_quote($key, '/')) . '[ \t]*:[ \t]*(.*?)[ \t]*\r?$/mi';
+    if (preg_match($pattern, $yaml, $m) === 1) {
+        if (trim($m[1], " \t'\"") === $value) {
             return $body;
         }
-        $eol = str_ends_with($m[1], "\r\n") ? "\r\n" : "\n";
-        $new_yaml = $m[2] . "$key: $rendered" . $eol;
+    } elseif (!$append) {
+        return $body;
     }
 
-    return $m[1] . $new_yaml . $m[3] . substr($body, strlen($m[0]));
+    return set_frontmatter_key($body, $key, $value);
 }
 
 /**

--- a/tests/Unit/FrontMatterEngineTest.php
+++ b/tests/Unit/FrontMatterEngineTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Post\build_matter;
+use function Lamb\Post\parse_matter;
+use function Lamb\Post\persist_slug;
+use function Lamb\Post\set_frontmatter_key;
+use function Lamb\Post\set_matter;
+use function Lamb\Post\set_reply_to;
+use function Lamb\persist_resolved_created;
+
+/**
+ * Characterisation of the front-matter engine's contract at the shapes issue
+ * #689 names as load-bearing. These pin the behaviour that must survive the two
+ * engines converging onto set_frontmatter_key(): they pass against both the old
+ * in-place set_matter() and the migrated one.
+ */
+class FrontMatterEngineTest extends TestCase
+{
+    // 1. CRLF bodies from the edit form — set_matter()'s no-churn contract.
+    //    A `\r` must not make an unchanged save rewrite (and re-store) the line.
+
+    public function testSetMatterNoChurnOnUnchangedCrlfBody(): void
+    {
+        $body = "---\r\nslug: my-slug\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n";
+        $this->assertSame($body, set_matter($body, 'slug', 'my-slug'));
+    }
+
+    public function testPersistSlugNoChurnOnUnchangedCrlfBody(): void
+    {
+        $body = "---\r\nslug: my-slug\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n";
+        $this->assertSame($body, persist_slug($body, 'my-slug'));
+    }
+
+    public function testPersistResolvedCreatedNoChurnOnUnchangedCrlfBody(): void
+    {
+        // Midnight is the common scheduled-post time; the stored `00:00:00` must
+        // compare equal to the resolved value or every save re-stores the post.
+        $body = "---\r\ncreated: '2024-06-05 00:00:00'\r\ntitle: Hi\r\n---\r\n\r\nBody.\r\n";
+        $this->assertSame($body, persist_resolved_created($body, '2024-06-05 00:00:00'));
+    }
+
+    // 2. Bodies with no front matter at all — behaviour differs per call site.
+
+    public function testSetMatterLeavesBodyWithoutFrontMatterUnchanged(): void
+    {
+        $body = "Just a status update.";
+        $this->assertSame($body, set_matter($body, 'slug', 'anything'));
+    }
+
+    public function testPersistResolvedCreatedLeavesBodyWithoutFrontMatterUnchanged(): void
+    {
+        $body = "Just a status update.";
+        $this->assertSame($body, persist_resolved_created($body, '2024-06-05 12:00:00'));
+    }
+
+    public function testSetFrontmatterKeyAddsBlockToBodyWithoutFrontMatter(): void
+    {
+        $body = "Just a status update.";
+        $result = set_frontmatter_key($body, 'in-reply-to', 'https://example.com/post');
+        $this->assertStringStartsWith("---\n", $result);
+        $this->assertSame('https://example.com/post', parse_matter($result)['in-reply-to']);
+        $this->assertStringContainsString('Just a status update.', $result);
+    }
+
+    public function testBuildMatterReturnsContentVerbatimWhenEmpty(): void
+    {
+        $this->assertSame('Just content', build_matter([], 'Just content'));
+    }
+
+    // 3. An unrecognised, hand-written key must not be dropped when another key
+    //    on the same block is changed (the Micropub update path).
+
+    public function testSetFrontmatterKeyPreservesUnrecognisedKeys(): void
+    {
+        $body = "---\ntitle: Old\nslug: pinned\ndraft: true\n---\nBody.";
+        $result = set_frontmatter_key($body, 'title', 'New');
+        $this->assertStringContainsString('slug: pinned', $result);
+        $this->assertStringContainsString('draft: true', $result);
+        $this->assertSame('New', parse_matter($result)['title']);
+    }
+
+    // 4. Both hyphen and underscore spellings collapse onto one key.
+
+    public function testSetReplyToReplacesUnderscoreSpelledKeyLeavingOne(): void
+    {
+        $body = set_reply_to("---\nin_reply_to: https://old.example/x\n---\nHi", 'https://new.example/y');
+        $this->assertStringNotContainsString('old.example', $body);
+        $this->assertSame(1, substr_count($body, 'reply'));
+        $this->assertSame('https://new.example/y', parse_matter($body)['in-reply-to']);
+    }
+
+    // 5. A block left with nothing but the key being removed loses its fence.
+
+    public function testSetFrontmatterKeyRemovesLastKeyAndFence(): void
+    {
+        $body = "---\nin-reply-to: https://other.example/post\n---\nHi";
+        $this->assertSame('Hi', set_frontmatter_key($body, 'in-reply-to', ''));
+    }
+}

--- a/tests/Unit/FrontMatterTest.php
+++ b/tests/Unit/FrontMatterTest.php
@@ -163,12 +163,15 @@ class FrontMatterTest extends TestCase
         $this->assertSame($body, set_matter($body, 'slug', 'new'));
     }
 
-    public function testSetMatterPreservesKeyWhitespacePrefixOnReplace(): void
+    public function testSetMatterTreatsIndentedKeyAsNestedAndAppends(): void
     {
+        // The single engine anchors to column zero: an indented `slug:` belongs
+        // to whatever block encloses it, so it is left alone and a top-level
+        // slug is appended instead. (Real front-matter keys are never indented;
+        // persist_slug() only ever pins a column-zero slug.)
         $body = "---\n  slug:   old\n---\nContent.";
-        // The matched key prefix is preserved; value rewritten with single space.
         $this->assertSame(
-            "---\n  slug: new\n---\nContent.",
+            "---\n  slug:   old\nslug: new\n---\nContent.",
             set_matter($body, 'slug', 'new')
         );
     }
@@ -246,23 +249,26 @@ class FrontMatterTest extends TestCase
         $this->assertSame($body, set_matter($body, 'slug', 'my-slug'));
     }
 
-    public function testSetMatterKeepsCrlfWhenRewritingAValue(): void
+    public function testSetMatterNormalisesBlockToLfWhenRewritingACrlfValue(): void
     {
+        // On a real value change the single engine rebuilds the block through the
+        // YAML writer (LF fences), leaving the content's CRLF untouched. This is
+        // a one-off on the save that changes the value, not per-save churn.
         $body = "---\r\nslug: my-slug\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n";
 
         $this->assertSame(
-            "---\r\nslug: other\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n",
+            "---\ntitle: Hi\nslug: other\n---\n\r\nBody text.\r\n",
             set_matter($body, 'slug', 'other')
         );
     }
 
-    public function testSetMatterKeepsCrlfWhenAppendingAKey(): void
+    public function testSetMatterAppendsToCrlfBlockRebuildingWithLf(): void
     {
         $body = "---\r\ntitle: Hi\r\n---\r\n\r\nBody.\r\n";
 
         $result = set_matter($body, 'slug', 'new');
 
-        $this->assertSame("---\r\ntitle: Hi\r\nslug: new\r\n---\r\n\r\nBody.\r\n", $result);
+        $this->assertSame("---\ntitle: Hi\nslug: new\n---\n\r\nBody.\r\n", $result);
         $this->assertSame(['title' => 'Hi', 'slug' => 'new'], parse_matter($result));
     }
 }


### PR DESCRIPTION
Collapses the two value-setting engines to one. `set_matter()`'s in-place regex is gone — it is now a no-churn/no-create wrapper over `set_frontmatter_key()` (split/rebuild via the YAML writer). `persist_slug()`/`persist_resolved_created()` inherit it; `Import\build_post_body()` assembles through `build_matter()`.

Preserves the no-churn contract (unchanged CRLF body returns byte-for-byte) and the no-block-for-blockless-body rule. `inject_title_matter()` and `Micropub::rebuildBody()` are deliberately left (distinct create-or-insert / verbatim-carry concerns; migrating them would reintroduce the double-block bug / reorder hand-written keys).

Characterisation tests pin the five issue-named shapes. Full unit suite green (2037, +10).

Closes #689