### PR TITLE
Support multiple in-reply-to targets

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -20,6 +20,7 @@ use RedBeanPHP\RedException\SQL;
 
 use function Lamb\Post\consume_leading_heading;
 use function Lamb\Post\matter_string;
+use function Lamb\Post\matter_url_list;
 use function Lamb\Post\normalize_frontmatter_fence;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\set_matter;
@@ -538,25 +539,31 @@ function highlight_and_link(string $markdown): string
 }
 
 /**
- * Normalises the reply target from front matter into a single string.
+ * Normalises the reply target(s) from front matter into a single
+ * space-separated string, the same storage convention `syndicated_to` uses
+ * (Theme\syndication_links() splits it back on whitespace to render it).
  *
  * Reads the `in-reply-to` key (parse_matter() has already canonicalised the
- * `in_reply_to` spelling onto it and collapsed a YAML list to its first entry
- * via matter_string()). The key is removed from the passed-by-reference front
- * matter so the hyphenated key is never written as an invalid column by the
- * blind copy in apply_frontmatter().
+ * `in_reply_to` spelling onto it, but deliberately leaves its value alone —
+ * see MATTER_TEXT_KEYS) via matter_url_list(), which keeps every entry of a
+ * YAML list rather than collapsing to the first: mf2 `u-in-reply-to` may
+ * repeat, RFC 4685 allows several `thr:in-reply-to` elements, and a Micropub
+ * client legitimately sends multiple targets (#583). A URL never contains a
+ * literal space, so joining with one round-trips losslessly. The key is
+ * removed from the passed-by-reference front matter so the hyphenated key is
+ * never written as an invalid column by the blind copy in apply_frontmatter().
  *
  * @param array<int|string, mixed> $front_matter The parsed front matter, modified in place.
- * @return string The normalised reply target, or '' when absent.
+ * @return string The normalised reply target(s), space-separated, or '' when absent.
  *
  * @internal Decomposed step of parse_bean(); not part of the public API.
  */
 function normalize_in_reply_to(array &$front_matter): string
 {
-    $in_reply_to = matter_string($front_matter['in-reply-to'] ?? null);
+    $targets = matter_url_list($front_matter['in-reply-to'] ?? null);
     unset($front_matter['in-reply-to']);
 
-    return $in_reply_to !== null ? trim($in_reply_to) : '';
+    return implode(' ', $targets);
 }
 
 /**
@@ -578,8 +585,8 @@ function normalize_in_reply_to(array &$front_matter): string
  */
 function apply_frontmatter(OODBBean $bean, array $front_matter): void
 {
-    // Normalise the reply target. Empty when absent, so removing it from front
-    // matter on edit clears the stored value.
+    // Normalise the reply target(s). Empty when absent, so removing it from
+    // front matter on edit clears the stored value.
     $bean->in_reply_to = normalize_in_reply_to($front_matter);
 
     // Normalise syndication record. Hyphenated key can't map via the loop below.

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -26,12 +26,14 @@ use function Lamb\Post\build_matter;
 use function Lamb\Post\finalize_and_store_post;
 use function Lamb\Post\finalize_slug;
 use function Lamb\Post\matter_string;
+use function Lamb\Post\matter_url_list;
 use function Lamb\Post\normalize_frontmatter_fence;
 use function Lamb\Post\parse_matter;
 use function Lamb\Post\populate_bean;
 use function Lamb\Post\set_frontmatter_key;
 use function Lamb\Post\set_reply_to;
 use function Lamb\Post\split_frontmatter;
+use function Lamb\Post\split_reply_targets;
 
 class LambMicropubAdapter extends MicropubAdapter
 {
@@ -39,7 +41,7 @@ class LambMicropubAdapter extends MicropubAdapter
      * Micropub properties an update writes to a single front-matter key.
      *
      * `in-reply-to` is deliberately absent: it needs h-cite unwrapping and its
-     * own single-target rules, so it keeps its own branch in each apply method.
+     * own multi-target rules, so it keeps its own branch in each apply method.
      */
     private const MATTER_PROPERTIES = [
         'name'            => 'title',
@@ -121,8 +123,12 @@ class LambMicropubAdapter extends MicropubAdapter
             $props['category'] = $tags;
         }
 
-        if (!empty($bean->in_reply_to)) {
-            $props['in-reply-to'] = [(string) $bean->in_reply_to];
+        // A post may record several reply targets (#583); the source query
+        // reports every one, space-separated in the stored column just like
+        // syndicated_to.
+        $reply_targets = split_reply_targets((string) ($bean->in_reply_to ?? ''));
+        if ($reply_targets !== []) {
+            $props['in-reply-to'] = $reply_targets;
         }
 
         if (!empty($bean->syndicated_to)) {
@@ -601,13 +607,14 @@ class LambMicropubAdapter extends MicropubAdapter
             if ($target === null) {
                 return false;
             }
-            // A post stores a single reply target, so adding a second one would
-            // have to either overwrite the first or be dropped; both lie about
-            // what happened.
-            if ($this->currentReplyTo($bean) !== '') {
-                return false;
+            // A post may record several reply targets (#583): `add` appends
+            // this one to whatever is already stored, rather than refusing a
+            // second target outright as it used to (#582).
+            $targets = $this->currentReplyToList($bean);
+            if (!in_array($target, $targets, true)) {
+                $targets[] = $target;
             }
-            $bean->body = set_reply_to($bean->body ?? '', $target);
+            $bean->body = set_reply_to($bean->body ?? '', $targets);
             return true;
         }
 
@@ -660,14 +667,20 @@ class LambMicropubAdapter extends MicropubAdapter
         }
 
         if ($property === 'in-reply-to') {
-            // Value-scoped delete: only the target the client named goes, so a
-            // stale value in a client's copy cannot clear the current reply.
-            $current = $this->currentReplyTo($bean);
-            foreach ($values as $value) {
-                if ($current !== '' && $this->replyTargetUrl($value) === $current) {
-                    $bean->body = set_reply_to($bean->body ?? '', '');
-                    return true;
-                }
+            // Value-scoped delete: only the target(s) the client named go, so a
+            // stale value in a client's copy cannot clear a target still in
+            // use, and (#583) deleting one of several leaves the rest intact.
+            $current = $this->currentReplyToList($bean);
+            if ($current === []) {
+                return true;
+            }
+            $remove = array_filter(
+                array_map(fn($value) => $this->replyTargetUrl($value), $values),
+                fn(?string $target) => $target !== null
+            );
+            $remaining = array_values(array_diff($current, $remove));
+            if ($remaining !== $current) {
+                $bean->body = set_reply_to($bean->body ?? '', $remaining);
             }
             return true;
         }
@@ -731,11 +744,22 @@ class LambMicropubAdapter extends MicropubAdapter
                 return true;
             }
 
-            $target = $this->replyTargetUrl($values[0] ?? null);
-            if ($target === null) {
-                return false;
+            // A post may record several reply targets (#583): every value the
+            // client sent becomes the new (deduplicated) set.
+            $targets = [];
+            foreach ($values as $value) {
+                $target = $this->replyTargetUrl($value);
+                // A value carrying no URL is a replace that cannot be
+                // honoured; reporting success for it reads to the client as
+                // "saved", as the single-target path already guarded against.
+                if ($target === null) {
+                    return false;
+                }
+                if (!in_array($target, $targets, true)) {
+                    $targets[] = $target;
+                }
             }
-            $bean->body = set_reply_to($bean->body ?? '', $target);
+            $bean->body = set_reply_to($bean->body ?? '', $targets);
             return true;
         }
 
@@ -804,20 +828,22 @@ class LambMicropubAdapter extends MicropubAdapter
     }
 
     /**
-     * The reply target currently recorded in a bean's front matter.
+     * The reply target(s) currently recorded in a bean's front matter.
      *
      * Read from the body rather than $bean->in_reply_to: an update applies a
      * sequence of operations to the body, and the column is only refreshed by
-     * the parse_bean() call at the end of updateCallback().
+     * the parse_bean() call at the end of updateCallback(). matter_url_list(),
+     * not matter_string(): a post may record several targets (#583), and
+     * collapsing to the first here would make `add`/`delete` blind to the rest.
      *
      * @param OODBBean $bean
-     * @return string The target URL, or '' when the post is not a reply.
+     * @return list<string> The target URLs, in order, or [] when the post is not a reply.
      */
-    private function currentReplyTo(OODBBean $bean): string
+    private function currentReplyToList(OODBBean $bean): array
     {
         $matter = parse_matter((string) ($bean->body ?? ''));
 
-        return trim(matter_string($matter['in-reply-to'] ?? null) ?? '');
+        return matter_url_list($matter['in-reply-to'] ?? null);
     }
 
     /**
@@ -879,18 +905,20 @@ class LambMicropubAdapter extends MicropubAdapter
      * that keys this class does not know about survive.
      *
      * @param string|null $title
-     * @param string|null $replyTo
+     * @param list<string> $replyTo One or more reply targets (#583), or [] for none.
      * @param string|null $syndicatedTo
-     * @return array<string, string>
+     * @return array<string, string|list<string>>
      */
-    private function assembleFrontMatter(?string $title, ?string $replyTo, ?string $syndicatedTo): array
+    private function assembleFrontMatter(?string $title, array $replyTo, ?string $syndicatedTo): array
     {
         $matter = [];
         if ($title !== null) {
             $matter['title'] = $title;
         }
-        if ($replyTo !== null && $replyTo !== '') {
-            $matter['in-reply-to'] = $replyTo;
+        if ($replyTo !== []) {
+            // A single target keeps the plain `in-reply-to: url` shape every
+            // existing post already has; two or more become a YAML list.
+            $matter['in-reply-to'] = count($replyTo) === 1 ? $replyTo[0] : $replyTo;
         }
         if ($syndicatedTo !== null && $syndicatedTo !== '') {
             $matter['syndicated-to'] = $syndicatedTo;
@@ -985,7 +1013,17 @@ class LambMicropubAdapter extends MicropubAdapter
         // `name`. Both reached the ?string parameters of assembleFrontMatter()
         // as arrays and 500ed the create.
         $title = matter_string($props['name'][0] ?? null);
-        $replyTo = $this->replyTargetUrl($props['in-reply-to'][0] ?? null);
+
+        // A client may legitimately send several reply targets (#583):
+        // u-in-reply-to repeats in mf2, so `in-reply-to` here can carry more
+        // than one value.
+        $replyTargets = [];
+        foreach ($props['in-reply-to'] ?? [] as $value) {
+            $target = $this->replyTargetUrl($value);
+            if ($target !== null && !in_array($target, $replyTargets, true)) {
+                $replyTargets[] = $target;
+            }
+        }
 
         $photos = $this->buildPhotos($props['photo'] ?? []);
         if ($photos !== '') {
@@ -1012,7 +1050,7 @@ class LambMicropubAdapter extends MicropubAdapter
         $syndicatedTo = !empty($syndicateTo) ? implode(' ', $syndicateTo) : null;
 
         return build_matter(
-            $this->assembleFrontMatter($title, $replyTo, $syndicatedTo),
+            $this->assembleFrontMatter($title, $replyTargets, $syndicatedTo),
             $content
         );
     }

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -600,19 +600,21 @@ class LambMicropubAdapter extends MicropubAdapter
             if ($values === []) {
                 return true;
             }
-            // But a value carrying no URL is an add that cannot be honoured, and
-            // reporting success for it reads to the client as "saved" — the same
-            // reason applyReplace() refuses it.
-            $target = $this->replyTargetUrl($values[0] ?? null);
-            if ($target === null) {
-                return false;
-            }
-            // A post may record several reply targets (#583): `add` appends
-            // this one to whatever is already stored, rather than refusing a
-            // second target outright as it used to (#582).
+            // A post may record several reply targets (#583): `add` appends every
+            // value the client sent to whatever is already stored (deduplicated),
+            // rather than refusing a second target outright as it used to (#582)
+            // or silently keeping only the first. A value carrying no URL is an
+            // add that cannot be honoured — refuse it, as applyReplace() does,
+            // rather than report a success the storage did not have.
             $targets = $this->currentReplyToList($bean);
-            if (!in_array($target, $targets, true)) {
-                $targets[] = $target;
+            foreach ($values as $value) {
+                $target = $this->replyTargetUrl($value);
+                if ($target === null) {
+                    return false;
+                }
+                if (!in_array($target, $targets, true)) {
+                    $targets[] = $target;
+                }
             }
             $bean->body = set_reply_to($bean->body ?? '', $targets);
             return true;

--- a/src/post.php
+++ b/src/post.php
@@ -182,9 +182,14 @@ function parse_matter(string $body): array
  *
  * These are the values normalize_matter_values() coerces to a string (or drops
  * as absent). Keys outside this list — `created`, `draft` — carry their own
- * type handling downstream and are left as YAML parsed them.
+ * type handling downstream and are left as YAML parsed them. `in-reply-to` is
+ * also outside it: unlike every other text key it may legitimately be a list
+ * (mf2 `u-in-reply-to` repeats, RFC 4685 allows several `thr:in-reply-to`
+ * elements — #583), and coercing it here would collapse that list to its
+ * first entry before \Lamb\normalize_in_reply_to() gets a chance to keep
+ * every target via matter_url_list().
  */
-const MATTER_TEXT_KEYS = ['title', 'slug', 'summary', 'description', 'in-reply-to', 'syndicated-to'];
+const MATTER_TEXT_KEYS = ['title', 'slug', 'summary', 'description', 'syndicated-to'];
 
 /**
  * Coerces a front-matter value to the string its readers assume, or null when
@@ -201,8 +206,8 @@ const MATTER_TEXT_KEYS = ['title', 'slug', 'summary', 'description', 'in-reply-t
  *
  * The coercion:
  *  - strings, integers and floats become their textual form;
- *  - a list collapses to its first entry — the shape `in-reply-to` already
- *    accepted, generalised, so `title: [a, b]` reads as `a`;
+ *  - a list collapses to its first entry, so `title: [a, b]` reads as `a`
+ *    (see matter_url_list() for the counterpart that keeps every entry);
  *  - dates are formatted back to the wall-clock text the author typed;
  *  - a map, a nested list, a boolean or null have no faithful text (neither
  *    "1" nor "true" is what `title: yes` meant), so they are reported as
@@ -230,6 +235,77 @@ function matter_string(mixed $value): ?string
     }
 
     return null;
+}
+
+/**
+ * Coerces a front-matter value to every one of its distinct textual entries,
+ * the list-preserving counterpart to matter_string().
+ *
+ * Where matter_string() collapses a YAML list to its first entry, this keeps
+ * them all: `in-reply-to: [a, b]` yields both targets instead of silently
+ * dropping the second (#583 — mf2 `u-in-reply-to` may repeat, RFC 4685 allows
+ * several `thr:in-reply-to` elements, and a Micropub client legitimately sends
+ * an array of targets). A scalar value is treated as a one-element list,
+ * matching matter_string()'s handling of that shape.
+ *
+ * Each list entry is coerced through matter_string()'s own scalar rules, so a
+ * date entry is formatted the same way a scalar date would be; a nested list
+ * or map entry has no single textual form and is skipped rather than aborting
+ * the whole value. Duplicate entries (after trimming) are removed, and an
+ * absent or entirely non-textual value returns [] rather than [''].
+ *
+ * @param mixed $value The raw front-matter value.
+ * @return list<string> The value's distinct textual entries, in order.
+ */
+function matter_url_list(mixed $value): array
+{
+    if (is_array($value) && !array_is_list($value)) {
+        // A map has no textual form, matching matter_string()'s handling.
+        return [];
+    }
+    $items = is_array($value) ? $value : [$value];
+
+    $entries = [];
+    foreach ($items as $item) {
+        if (is_array($item)) {
+            // A nested list/map entry carries no single URL; skip rather than
+            // guess at one of its values.
+            continue;
+        }
+        $text = matter_string($item);
+        if ($text === null) {
+            continue;
+        }
+        $text = trim($text);
+        if ($text === '' || in_array($text, $entries, true)) {
+            continue;
+        }
+        $entries[] = $text;
+    }
+
+    return $entries;
+}
+
+/**
+ * Splits a space-separated multi-target column value into its individual
+ * targets.
+ *
+ * `in_reply_to` and `syndicated_to` both store one or more targets as a
+ * space-separated string in a single column (see Theme\syndication_links()):
+ * a URL never contains a literal space, so joining with one and splitting on
+ * runs of whitespace round-trips losslessly. Every consumer of a possibly
+ * multi-target `in_reply_to` — the reply-context markup, both feed renderers,
+ * the outbound webmention queue, and the Micropub source query — goes through
+ * this rather than repeating the split.
+ *
+ * @param string $raw The raw column value.
+ * @return list<string> The individual targets, in order, with no empty entries.
+ */
+function split_reply_targets(string $raw): array
+{
+    $raw = trim($raw);
+
+    return $raw === '' ? [] : (preg_split('/\s+/', $raw) ?: []);
 }
 
 /**
@@ -419,7 +495,8 @@ function slugify(string $text): string
  * the single place that assembles a fresh front-matter block from scratch
  * (used by Micropub create/update).
  *
- * @param array<string, string> $matter Ordered front-matter key/value pairs.
+ * @param array<string, string|list<string>> $matter Ordered front-matter key/value pairs.
+ *        A list value (e.g. a multi-target `in-reply-to`, #583) dumps as a YAML list.
  * @param string $content The post content to place after the fence.
  * @return string The assembled body.
  */
@@ -528,19 +605,43 @@ function set_matter(string $body, string $key, string $value, bool $append = tru
  * outright — so it can also remove one, and cannot leave a stale YAML list
  * behind under a key whose new value is a scalar.
  *
+ * $value may be a list of strings as well as a single string, so a key that
+ * legitimately repeats (`in-reply-to`, #583) can be written with several
+ * targets. A list of zero or one entries is treated exactly like the scalar
+ * case (removes the key, or writes a plain `key: value` line) so every
+ * existing single-target caller is unaffected; two or more entries are
+ * written as a YAML list, the same shape parse_matter() already accepts.
+ *
  * @param string $body The raw post body.
  * @param string $key The front-matter key to set, in its hyphenated spelling.
- * @param string $value The value to write, or '' to remove the key.
+ * @param string|list<string> $value The value(s) to write, or '' / [] to remove the key.
  * @return string The body with its front-matter key set.
  */
-function set_frontmatter_key(string $body, string $key, string $value): string
+function set_frontmatter_key(string $body, string $key, string|array $value): string
 {
-    $body  = normalize_frontmatter_fence($body);
-    $value = trim($value);
+    $body = normalize_frontmatter_fence($body);
+
+    if (is_array($value)) {
+        $value = array_values(array_unique(array_filter(
+            array_map('trim', $value),
+            static fn(string $entry): bool => $entry !== ''
+        )));
+        // A single entry (or none) is the scalar case: writing it as a
+        // one-element list would change the on-disk shape of every existing
+        // single-target caller for no behavioural difference.
+        if (count($value) <= 1) {
+            $value = $value[0] ?? '';
+        }
+    } else {
+        $value = trim($value);
+    }
+    // The array branch above always collapses to a string when 0 or 1 entries
+    // survive filtering, so $value here is either a string or a non-empty list.
+    $is_empty = $value === '';
     [$yaml, $content] = split_frontmatter($body);
 
     if ($yaml === '') {
-        return $value === '' ? $body : build_matter([$key => $value], $body);
+        return $is_empty ? $body : build_matter([$key => $value], $body);
     }
 
     // Matches whichever spelling the author used, the way normalize_matter_keys()
@@ -567,7 +668,7 @@ function set_frontmatter_key(string $body, string $key, string $value): string
     }
 
     $new_yaml = rtrim(implode("\n", $kept), "\n");
-    if ($value !== '') {
+    if (!$is_empty) {
         $new_yaml = ($new_yaml === '' ? '' : $new_yaml . "\n") . trim(Yaml::dump([$key => $value]));
     }
 
@@ -579,13 +680,13 @@ function set_frontmatter_key(string $body, string $key, string $value): string
 }
 
 /**
- * Sets (or clears) the reply target in a body's leading YAML front-matter block.
+ * Sets (or clears) the reply target(s) in a body's leading YAML front-matter block.
  *
  * @param string $body The raw post body.
- * @param string $value The reply target URL, or '' to remove it.
- * @return string The body with its front-matter reply target set.
+ * @param string|list<string> $value The reply target URL(s), or '' / [] to remove them.
+ * @return string The body with its front-matter reply target(s) set.
  */
-function set_reply_to(string $body, string $value): string
+function set_reply_to(string $body, string|array $value): string
 {
     return set_frontmatter_key($body, 'in-reply-to', $value);
 }

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -12,6 +12,7 @@ use RedBeanPHP\R;
 use function Lamb\Http\request_string;
 use function Lamb\Post\load_posts_in_order;
 use function Lamb\Post\post_ids_by_tag;
+use function Lamb\Post\split_reply_targets;
 
 use const Lamb\SQL_IS_DELETED;
 use const Lamb\SQL_IS_DRAFT;
@@ -290,15 +291,21 @@ function render_atom_feed(array $data, array $config): void
         }
 
         // in_reply_to is not author-only (a Micropub `create` token sets it,
-        // unvalidated), so a non-http(s) scheme must not be syndicated as a link.
-        if (!empty($bean->in_reply_to) && \Lamb\Http\is_valid_http_url((string) $bean->in_reply_to)) {
+        // unvalidated), so a non-http(s) scheme must not be syndicated as a
+        // link. A post may carry several targets (#583, RFC 4685 allows
+        // multiple thr:in-reply-to elements per entry): each gets its own
+        // thr:in-reply-to and rel="related" link, independently guarded.
+        foreach (split_reply_targets((string) ($bean->in_reply_to ?? '')) as $target) {
+            if (!\Lamb\Http\is_valid_http_url($target)) {
+                continue;
+            }
             $thread = $entry->addChild('in-reply-to', null, 'http://purl.org/syndication/thread/1.0');
-            $thread->addAttribute('ref', $bean->in_reply_to);
-            $thread->addAttribute('href', $bean->in_reply_to);
+            $thread->addAttribute('ref', $target);
+            $thread->addAttribute('href', $target);
             $thread->addAttribute('type', 'text/html');
             $related = $entry->addChild('link');
             $related->addAttribute('rel', 'related');
-            $related->addAttribute('href', $bean->in_reply_to);
+            $related->addAttribute('href', $target);
         }
         $alt = $entry->addChild('link');
         $alt->addAttribute('rel', 'alternate');
@@ -361,9 +368,15 @@ function render_json_feed(array $data, array $config): void
             $item['title'] = $bean->title;
         }
         // Guarded like content_html above: the consumer links this, and
-        // in_reply_to is not author-only.
-        if (!empty($bean->in_reply_to) && \Lamb\Http\is_valid_http_url((string) $bean->in_reply_to)) {
-            $item['_microblog'] = ['in_reply_to_url' => $bean->in_reply_to];
+        // in_reply_to is not author-only. `_microblog.in_reply_to_url` is a
+        // micro.blog convention for a single target, so a post with several
+        // (#583) reports only the first valid one here — every target still
+        // reaches the reader via content_html's u-in-reply-to links above.
+        foreach (split_reply_targets((string) ($bean->in_reply_to ?? '')) as $target) {
+            if (\Lamb\Http\is_valid_http_url($target)) {
+                $item['_microblog'] = ['in_reply_to_url' => $target];
+                break;
+            }
         }
         $feed['items'][] = $item;
     }

--- a/src/theme/formatting.php
+++ b/src/theme/formatting.php
@@ -68,35 +68,41 @@ function anchor_headings(string $html, int $top): string
 
 
 /**
- * Renders the reply-context line for a post that is a reply to another URL,
- * or '' when the post has no `in_reply_to` target. The link carries the
- * `u-in-reply-to` microformats2 class so Webmention receivers categorise the
- * mention as a reply.
+ * Renders the reply-context line for a post that is a reply to one or more
+ * URLs, or '' when the post has no `in_reply_to` target. Each target gets its
+ * own link carrying the `u-in-reply-to` microformats2 class, so Webmention
+ * receivers categorise every mention as a reply (mf2 `u-in-reply-to` may
+ * repeat, and RFC 4685 allows several `thr:in-reply-to` elements — #583).
  *
  * `in_reply_to` is not author-only (a Micropub client holding just `create`
  * scope can set it) and this markup is also served inside the Atom/JSON
  * feeds' content_html, so a target that isn't a genuine http(s) URL is shown
- * as text rather than linked. See theme/README.md ("Escaping is per-context,
- * not per-file").
+ * as text rather than linked — independently per target, so one bad scheme
+ * among several valid targets only loses its own link. See theme/README.md
+ * ("Escaping is per-context, not per-file").
  *
  * @param \RedBeanPHP\OODBBean $bean
  * @return string
  */
 function the_reply_context(\RedBeanPHP\OODBBean $bean): string
 {
-    $url = trim((string) ($bean->in_reply_to ?? ''));
-    if ($url === '') {
+    $targets = \Lamb\Post\split_reply_targets((string) ($bean->in_reply_to ?? ''));
+    if ($targets === []) {
         return '';
     }
 
-    if (!\Lamb\Http\is_valid_http_url($url)) {
-        return '<p class="reply-context">In reply to ' . escape($url) . '</p>';
+    $parts = [];
+    foreach ($targets as $url) {
+        if (!\Lamb\Http\is_valid_http_url($url)) {
+            $parts[] = escape($url);
+            continue;
+        }
+        $label = parse_url($url, PHP_URL_HOST) ?: $url;
+        $parts[] = '<a class="u-in-reply-to" rel="in-reply-to" href="'
+            . escape($url) . '">' . escape($label) . '</a>';
     }
 
-    $label = parse_url($url, PHP_URL_HOST) ?: $url;
-
-    return '<p class="reply-context">In reply to <a class="u-in-reply-to" rel="in-reply-to" href="'
-        . escape($url) . '">' . escape($label) . '</a></p>';
+    return '<p class="reply-context">In reply to ' . implode(', ', $parts) . '</p>';
 }
 
 /**

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -13,6 +13,7 @@ use function Lamb\Http\is_public_http_url;
 use function Lamb\Http\is_valid_http_url;
 use function Lamb\is_scheduled;
 use function Lamb\permalink;
+use function Lamb\Post\split_reply_targets;
 
 use const ROOT_URL;
 
@@ -466,23 +467,26 @@ function enqueue_for_post(OODBBean $bean): void
  * Pending rows whose target no longer appears in the post are cancelled, so a
  * scheduled post edited to remove a link before publication does not notify it.
  *
- * The reply target (from a post's `in-reply-to` front matter) is treated as an
- * outbound link even when it does not appear in the body, so replies notify the
- * parent. It is subject to the same external-host filter as body links.
+ * The reply target(s) (from a post's `in-reply-to` front matter, space-
+ * separated when there is more than one — #583) are each treated as an
+ * outbound link even when they do not appear in the body, so every reply
+ * parent gets notified. Each is subject to the same external-host filter as
+ * body links.
  *
  * @param int    $post_id
  * @param string $source   This post's permalink.
  * @param string $html     The post's rendered HTML.
- * @param string $reply_to Optional `in-reply-to` target URL.
+ * @param string $reply_to Optional `in-reply-to` target URL(s), space-separated.
  * @return int Number of newly created queue rows.
  */
 function enqueue_outbound(int $post_id, string $source, string $html, string $reply_to = ''): int
 {
     $targets = extract_outbound_links($html);
 
-    $reply_to = trim($reply_to);
-    if ($reply_to !== '' && is_external_http_url($reply_to) && !in_array($reply_to, $targets, true)) {
-        $targets[] = $reply_to;
+    foreach (split_reply_targets($reply_to) as $target) {
+        if (is_external_http_url($target) && !in_array($target, $targets, true)) {
+            $targets[] = $target;
+        }
     }
 
     // Cancel pending rows for links the post no longer contains.

--- a/tests/Unit/FrontMatterTypesTest.php
+++ b/tests/Unit/FrontMatterTypesTest.php
@@ -125,11 +125,16 @@ class FrontMatterTypesTest extends TestCase
         $this->assertSame('https://a.example', parse_matter($body)['syndicated-to']);
     }
 
-    public function testParseMatterKeepsAListInReplyToCollapsed(): void
+    public function testParseMatterLeavesAListInReplyToUncollapsed(): void
     {
+        // Unlike every other MATTER_TEXT_KEYS entry, `in-reply-to` is
+        // deliberately excluded from that coercion (#583): a post may record
+        // several reply targets, and collapsing here would drop all but the
+        // first before Lamb\normalize_in_reply_to() (which keeps every entry
+        // via matter_url_list()) ever sees the rest.
         $body = "---\nin-reply-to:\n  - https://a.example\n  - https://b.example\n---\nBody";
 
-        $this->assertSame('https://a.example', parse_matter($body)['in-reply-to']);
+        $this->assertSame(['https://a.example', 'https://b.example'], parse_matter($body)['in-reply-to']);
     }
 
     // The save path must survive every shape

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -2211,6 +2211,26 @@ class MicropubAdapterTest extends TestCase
         );
     }
 
+    public function testUpdateAddAppendsEveryTargetInOneAddNotJustTheFirst(): void
+    {
+        // A single add carrying several in-reply-to values must store all of
+        // them — not silently keep only the first (review of #583).
+        $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nHi");
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['add' => ['in-reply-to' => ['https://a.example/post', 'https://b.example/post']]]
+        );
+
+        $this->assertTrue($result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame(
+            'https://other.example/post https://a.example/post https://b.example/post',
+            $updated->in_reply_to
+        );
+    }
+
     public function testUpdateAddDuplicateInReplyToTargetIsANoOp(): void
     {
         $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nHi");

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -1971,6 +1971,45 @@ class MicropubAdapterTest extends TestCase
         $this->assertArrayNotHasKey('in-reply-to', $result['properties']);
     }
 
+    public function testSourceQueryReturnsMultipleInReplyToTargets(): void
+    {
+        // #583: a YAML list front-matter value keeps every target in the
+        // column (space-separated); the source query reports every one, not
+        // just the first.
+        $bean = $this->storeReply(
+            "---\nin-reply-to:\n  - https://first.example/post\n  - https://second.example/post\n---\nHi"
+        );
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->sourceQueryCallback(ROOT_URL . '/status/' . $bean->id);
+
+        $this->assertSame(
+            ['https://first.example/post', 'https://second.example/post'],
+            $result['properties']['in-reply-to']
+        );
+    }
+
+    public function testCreateCallbackAcceptsMultipleInReplyToTargets(): void
+    {
+        // #583: mf2 u-in-reply-to may repeat, so a client sending an array of
+        // targets must have all of them stored, not just the first.
+        $adapter = new LambMicropubAdapter();
+        $adapter->createCallback([
+            'type'       => ['h-entry'],
+            'properties' => [
+                'content'     => ['Replying to two posts'],
+                'in-reply-to' => ['https://first.example/post', 'https://second.example/post'],
+            ],
+        ]);
+
+        $post = R::findOne('post', ' body LIKE ? ', ['%Replying to two posts%']);
+        $this->assertNotNull($post);
+        $this->assertSame(
+            'https://first.example/post https://second.example/post',
+            $post->in_reply_to
+        );
+    }
+
     public function testUpdateReplaceInReplyToSetsTarget(): void
     {
         $bean = $this->storeReply('Turning this into a reply');
@@ -2041,6 +2080,25 @@ class MicropubAdapterTest extends TestCase
         $this->assertSame('https://other.example/post', $updated->in_reply_to);
     }
 
+    public function testUpdateReplaceInReplyToSetsMultipleTargets(): void
+    {
+        // #583: replace accepts every value the client sends, not just the first.
+        $bean = $this->storeReply('Turning this into a multi-target reply');
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['replace' => ['in-reply-to' => ['https://first.example/post', 'https://second.example/post']]]
+        );
+
+        $this->assertTrue($result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame(
+            'https://first.example/post https://second.example/post',
+            $updated->in_reply_to
+        );
+    }
+
     public function testUpdateReplaceInReplyToWithEmptyValueClearsTarget(): void
     {
         $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nNo longer a reply");
@@ -2100,6 +2158,24 @@ class MicropubAdapterTest extends TestCase
         $this->assertSame('https://other.example/post', $updated->in_reply_to);
     }
 
+    public function testUpdateDeleteInReplyToValueRemovesOneOfSeveralTargets(): void
+    {
+        // #583: deleting one of several targets leaves the rest in place,
+        // rather than clearing the whole property.
+        $bean = $this->storeReply(
+            "---\nin-reply-to:\n  - https://first.example/post\n  - https://second.example/post\n---\nHi"
+        );
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['delete' => ['in-reply-to' => ['https://first.example/post']]]
+        );
+
+        $updated = R::load('post', $bean->id);
+        $this->assertSame('https://second.example/post', $updated->in_reply_to);
+    }
+
     public function testUpdateAddInReplyToSetsTargetWhenAbsent(): void
     {
         $bean = $this->storeReply('Not yet a reply');
@@ -2115,11 +2191,10 @@ class MicropubAdapterTest extends TestCase
         $this->assertSame('https://other.example/post', $updated->in_reply_to);
     }
 
-    public function testUpdateAddSecondInReplyToIsRejected(): void
+    public function testUpdateAddSecondInReplyToAppendsTarget(): void
     {
-        // Storage holds one reply target, so a second one cannot be honoured:
-        // Micropub requires an unsupported operation to fail rather than return
-        // success the client will read as "saved".
+        // #583: a post may record several reply targets, so `add`ing a second
+        // one now appends rather than being refused as it was pre-#583 (#582).
         $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nHi");
 
         $adapter = new LambMicropubAdapter();
@@ -2128,7 +2203,25 @@ class MicropubAdapterTest extends TestCase
             ['add' => ['in-reply-to' => ['https://second.example/post']]]
         );
 
-        $this->assertSame('invalid_request', $result);
+        $this->assertTrue($result);
+        $updated = R::load('post', $bean->id);
+        $this->assertSame(
+            'https://other.example/post https://second.example/post',
+            $updated->in_reply_to
+        );
+    }
+
+    public function testUpdateAddDuplicateInReplyToTargetIsANoOp(): void
+    {
+        $bean = $this->storeReply("---\nin-reply-to: https://other.example/post\n---\nHi");
+
+        $adapter = new LambMicropubAdapter();
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/' . $bean->id,
+            ['add' => ['in-reply-to' => ['https://other.example/post']]]
+        );
+
+        $this->assertTrue($result);
         $updated = R::load('post', $bean->id);
         $this->assertSame('https://other.example/post', $updated->in_reply_to);
     }

--- a/tests/Unit/ReplyContextTest.php
+++ b/tests/Unit/ReplyContextTest.php
@@ -65,12 +65,24 @@ class ReplyContextTest extends TestCase
         $this->assertNull($bean->{'reading_time'});
     }
 
-    public function testListInReplyToUsesFirstEntry(): void
+    public function testListInReplyToKeepsAllEntries(): void
     {
-        // A YAML list (Micropub clients may send multiple reply targets) collapses
-        // to its first entry rather than being stored verbatim.
+        // A YAML list (Micropub clients may send multiple reply targets, and mf2
+        // u-in-reply-to/RFC 4685 thr:in-reply-to both allow several — #583) keeps
+        // every entry, stored space-separated like syndicated_to.
         $bean = populate_bean(
             "---\nin-reply-to:\n  - https://first.example/post\n  - https://second.example/post\n---\nHi"
+        );
+        $this->assertSame(
+            'https://first.example/post https://second.example/post',
+            $bean->in_reply_to
+        );
+    }
+
+    public function testListInReplyToDedupesEntries(): void
+    {
+        $bean = populate_bean(
+            "---\nin-reply-to:\n  - https://first.example/post\n  - https://first.example/post\n---\nHi"
         );
         $this->assertSame('https://first.example/post', $bean->in_reply_to);
     }
@@ -140,6 +152,37 @@ class ReplyContextTest extends TestCase
 
         $this->assertStringContainsString('href="https://e.test/a?b=1&amp;c=2"', $html);
         $this->assertStringContainsString('u-in-reply-to', $html);
+    }
+
+    public function testReplyContextRendersEachOfMultipleTargets(): void
+    {
+        // #583: a post may reply to several URLs at once, space-separated in
+        // the stored column like syndicated_to.
+        $bean = R::dispense('post');
+        $bean->in_reply_to = 'https://first.example/post https://second.example/post';
+
+        $html = the_reply_context($bean);
+
+        $this->assertSame(2, substr_count($html, 'u-in-reply-to'));
+        $this->assertStringContainsString('href="https://first.example/post"', $html);
+        $this->assertStringContainsString('href="https://second.example/post"', $html);
+        $this->assertStringContainsString('In reply to', $html);
+    }
+
+    public function testReplyContextShowsNonHttpTargetAsTextAmongValidOnes(): void
+    {
+        // One bad scheme among several valid targets loses only its own link;
+        // the valid targets are still linked.
+        $bean = R::dispense('post');
+        $bean->in_reply_to = 'https://first.example/post javascript:alert(1) https://second.example/post';
+
+        $html = the_reply_context($bean);
+
+        $this->assertSame(2, substr_count($html, 'u-in-reply-to'));
+        $this->assertStringContainsString('href="https://first.example/post"', $html);
+        $this->assertStringContainsString('href="https://second.example/post"', $html);
+        $this->assertStringContainsString('javascript:alert(1)', $html);
+        $this->assertStringNotContainsString('href="javascript:alert(1)"', $html);
     }
 
     public function testReplyContextHelperEmptyWhenUnset(): void
@@ -220,6 +263,33 @@ class ReplyContextTest extends TestCase
         $this->assertStringContainsString('other: keep-me', $body);
         $this->assertStringContainsString('in-reply-to: https://old.example/x', $body);
         $this->assertSame('https://new.example/post', populate_bean($body)->in_reply_to);
+    }
+
+    public function testSetReplyToAcceptsMultipleTargets(): void
+    {
+        // #583: set_reply_to() (and set_frontmatter_key() underneath) can now
+        // write more than one target, as a YAML list.
+        $body = set_reply_to(
+            'Status',
+            ['https://first.example/post', 'https://second.example/post']
+        );
+
+        $bean = populate_bean($body);
+        $this->assertSame(
+            'https://first.example/post https://second.example/post',
+            $bean->in_reply_to
+        );
+    }
+
+    public function testSetReplyToSingleElementListWritesScalarShape(): void
+    {
+        // A one-element list is indistinguishable in effect from the plain
+        // scalar call: same value, same YAML shape (not a one-item list).
+        $listBody = set_reply_to('Status', ['https://first.example/post']);
+        $scalarBody = set_reply_to('Status', 'https://first.example/post');
+
+        $this->assertSame($scalarBody, $listBody);
+        $this->assertStringNotContainsString('- https://first.example/post', $listBody);
     }
 
     // Atom feed -------------------------------------------------------------
@@ -367,5 +437,81 @@ class ReplyContextTest extends TestCase
         // same relationship has to be visible in content_html as well.
         $this->assertStringContainsString('u-in-reply-to', $json['items'][0]['content_html']);
         $this->assertStringContainsString('<p>A reply</p>', $json['items'][0]['content_html']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testAtomFeedEmitsThrInReplyToAndRelatedPerTarget(): void
+    {
+        // #583: a post replying to several URLs gets one thr:in-reply-to and
+        // one rel="related" link per target, not just the first.
+        require_once __DIR__ . '/../../vendor/autoload.php';
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        $bean = R::dispense('post');
+        $bean->title = '';
+        $bean->transformed = '<p>A reply</p>';
+        $bean->in_reply_to = 'https://first.example/post https://second.example/post';
+        $bean->created = '2024-01-01 12:00:00';
+        $bean->updated = '2024-01-01 12:00:00';
+
+        global $config, $data;
+        $config = ['site_title' => 'Blog', 'author_name' => 'Author'];
+        $data = ['posts' => [$bean], 'title' => 'Blog', 'feed_url' => 'http://localhost/feed', 'updated' => '2024-01-01 12:00:00'];
+
+        ob_start();
+        \Lamb\Response\render_atom_feed($data, $config);
+        $output = ob_get_clean();
+
+        $this->assertSame(2, substr_count($output, 'thr:in-reply-to'));
+        $this->assertSame(2, substr_count($output, 'rel="related"'));
+        $this->assertStringContainsString('https://first.example/post', $output);
+        $this->assertStringContainsString('https://second.example/post', $output);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testJsonFeedMicroblogInReplyToUsesFirstValidTargetOnly(): void
+    {
+        // `_microblog.in_reply_to_url` is a micro.blog convention for a single
+        // target, so a multi-target post (#583) reports only the first —
+        // every target still reaches the reader via content_html.
+        require_once __DIR__ . '/../../vendor/autoload.php';
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        $bean = R::dispense('post');
+        $bean->title = '';
+        $bean->transformed = '<p>A reply</p>';
+        $bean->in_reply_to = 'https://first.example/post https://second.example/post';
+        $bean->created = '2024-01-01 12:00:00';
+        $bean->updated = '2024-01-01 12:00:00';
+
+        global $config, $data;
+        $config = ['site_title' => 'Blog', 'author_name' => 'Author'];
+        $data = ['posts' => [$bean], 'title' => 'Blog', 'feed_url' => 'http://localhost/feed.json', 'updated' => '2024-01-01 12:00:00'];
+
+        ob_start();
+        \Lamb\Response\render_json_feed($data, $config);
+        $output = ob_get_clean();
+
+        $json = json_decode($output, true);
+        $this->assertSame('https://first.example/post', $json['items'][0]['_microblog']['in_reply_to_url']);
+        $this->assertSame(2, substr_count($json['items'][0]['content_html'], 'u-in-reply-to'));
     }
 }

--- a/tests/Unit/WebmentionSendTest.php
+++ b/tests/Unit/WebmentionSendTest.php
@@ -184,6 +184,20 @@ class WebmentionSendTest extends TestCase
         $this->assertSame(0, R::count('webmentionoutbox'));
     }
 
+    public function testEnqueueForPostQueuesMultipleReplyTargets(): void
+    {
+        $post = $this->dispenseReply(
+            '<p>A reply with no links</p>',
+            'https://other.example/their-post https://third.example/their-post'
+        );
+
+        enqueue_for_post($post);
+
+        $this->assertNotNull(R::findOne('webmentionoutbox', ' target = ? ', ['https://other.example/their-post']));
+        $this->assertNotNull(R::findOne('webmentionoutbox', ' target = ? ', ['https://third.example/their-post']));
+        $this->assertSame(2, R::count('webmentionoutbox'));
+    }
+
     public function testEnqueueForPostDeduplicatesReplyTargetAlsoInBody(): void
     {
         $target = 'https://other.example/their-post';
@@ -223,6 +237,31 @@ class WebmentionSendTest extends TestCase
         enqueue_for_post($post);
 
         $this->assertSame(0, R::count('webmentionoutbox'));
+    }
+
+    public function testEnqueueOutboundQueuesEachSpaceSeparatedReplyTarget(): void
+    {
+        // #583: `in_reply_to` may hold several space-separated targets, the
+        // same convention `syndicated_to` uses; each becomes its own row.
+        $source = ROOT_URL . '/status/1';
+        $replyTo = 'https://other.example/a https://third.example/b';
+
+        $count = enqueue_outbound($this->postId, $source, '<p>No links</p>', $replyTo);
+
+        $this->assertSame(2, $count);
+        $this->assertNotNull(R::findOne('webmentionoutbox', ' target = ? ', ['https://other.example/a']));
+        $this->assertNotNull(R::findOne('webmentionoutbox', ' target = ? ', ['https://third.example/b']));
+    }
+
+    public function testEnqueueOutboundSkipsSameSiteTargetAmongMultiple(): void
+    {
+        $source = ROOT_URL . '/status/1';
+        $replyTo = 'https://other.example/a ' . ROOT_URL . '/status/1';
+
+        $count = enqueue_outbound($this->postId, $source, '<p>No links</p>', $replyTo);
+
+        $this->assertSame(1, $count);
+        $this->assertSame(0, R::count('webmentionoutbox', ' target = ? ', [ROOT_URL . '/status/1']));
     }
 
     // enqueue_outbound (stale rows) ------------------------------------------


### PR DESCRIPTION
Stores `in_reply_to` as a space-separated list (mirrors `syndicated_to`, no schema change) and fans out across every consumer: `the_reply_context()` (one `u-in-reply-to` link per target), `render_atom_feed()` (one `thr:in-reply-to` + `rel=related` per target), `enqueue_outbound()` (each external target queued), and the Micropub create/add/replace/delete paths (add now appends, superseding #582's refusal). `set_frontmatter_key()`/`set_reply_to()` accept `string|array` and write a YAML list for 2+. JSON feed keeps a single `_microblog.in_reply_to_url` while `content_html` carries all. Every target still passes the same is_valid_http_url / is_external_http_url guards. Single-value posts behave exactly as before. Full unit suite green (2045).

Closes #583

Stacked on #694 (uses the code feed renderers). Note: touches src/post.php's set_frontmatter_key, which #689 also refactors — expect a small merge-time conflict to resolve.