### PR TITLE
Post writes go through one funnel; publication becomes an event

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -126,6 +126,20 @@ Storage follows the existing `data/cache/` convention (already gitignored, alrea
 
 ---
 
+## 2026-08-22 — Post writes go through one funnel; publication is an event
+
+**Status:** Accepted
+
+**Context:** Nine write sites each decided independently what a save entailed — whether to finalise the slug, whether to notify subscribers, whether to feed-lock — and expressed those choices by which shared helper they called or omitted (`Post\finalize_and_store_post()`, `Lamb\notify_post_subscribers()`). The asymmetry was held only by a comment copied verbatim into two importers, and that is how #685 (notifying subscribers after a failed write) came to be fixed on one save path and not its twin. Separately, "published" was not a thing that happened but a condition two subsystems each re-derived from a different signal (`Webmention` from `is_publicly_visible()`, `WebSub` from a `created > updated` watermark), with nothing structural keeping them in agreement.
+
+**Decision:** All post writes route through `Post\save(OODBBean $bean, array $context = [])`. The context flags carry the behaviours the write sites used to express by omission — `finalize_slug`, `notify`, `lock_if_feed_sourced`, `redirect_on_slug_change` — so a test can assert them instead of a convention holding by hand. Publication is an event: `save()` emits `post.created`/`post.updated`, and `post.published` when `notify` is set; subscribers register through `Post\on()` (`register_default_subscribers()` wires `Webmention\enqueue_for_post` and `Websub\ping_for_post` to `post.published`). Notification lives on the funnel's success path, so #685's fix is structural rather than a per-site habit.
+
+The conversion is deliberately incremental: this decision lands the funnel with a single call site converted (`Response\apply_checkbox_toggle()`, an existing post with an empty context, which must not notify). The other eight sites still call `finalize_and_store_post()`/`notify_post_subscribers()` directly and convert one commit at a time behind the same green suite; `post.deleted`/`post.restored` and `redirect_on_slug_change` arrive with the sites that need them. The exit criterion — `grep -rn 'notify_post_subscribers\|finalize_and_store_post' src/` hitting only `src/post.php` — is the end state of the whole conversion, not of this first step.
+
+**Consequences:** The flag-to-event matrix is executable (`tests/Unit/PostSaveTest.php`) rather than a comment. Until every site is converted, two ways to save a post coexist, and the funnel's event set grows as sites move onto it. Part of #692 / #684 (D1).
+
+---
+
 ## 2026-05-29 — `docs/` is end-user documentation only
 
 **Status:** Accepted

--- a/src/import.php
+++ b/src/import.php
@@ -9,9 +9,9 @@ use League\HTMLToMarkdown\HtmlConverter;
 use RedBeanPHP\R;
 use RuntimeException;
 use SimpleXMLElement;
-use Symfony\Component\Yaml\Yaml;
 
 use function Lamb\Http\fetch_guarded;
+use function Lamb\Post\build_matter;
 use function Lamb\Response\asset_url;
 
 /**
@@ -359,11 +359,12 @@ function build_post_body(string $title, string $markdown_body, array $tags, stri
     if ($slug !== '') {
         $front['slug'] = $slug;
     }
-    if ($front === []) {
-        return $body;
-    }
-    $matter = rtrim(Yaml::dump($front), "\n");
-    return "---\n" . $matter . "\n---\n\n" . $body;
+
+    // build_matter() is the single place a front-matter block is assembled from
+    // a key/value map. The leading "\n" reproduces the blank line this importer
+    // has always kept between the fence and the body; an empty map returns the
+    // content verbatim (no fence).
+    return build_matter($front, $front === [] ? $body : "\n" . $body);
 }
 
 /**

--- a/src/index.php
+++ b/src/index.php
@@ -12,6 +12,7 @@ require '../vendor/autoload.php';
 $data_dir = Bootstrap\data_dir();
 Bootstrap\bootstrap_db($data_dir);
 Bootstrap\bootstrap_session($data_dir);
+Post\register_default_subscribers();
 
 $config = Config\load();
 Config\apply_timezone($config);

--- a/src/post.php
+++ b/src/post.php
@@ -439,25 +439,29 @@ function build_matter(array $matter, string $content): string
 }
 
 /**
- * Sets a single key in a body's leading YAML front-matter block, leaving all
- * other front matter intact.
+ * Sets a single key in a body's leading YAML front-matter block, without
+ * creating a block and without churning an unchanged save.
  *
- * An existing `key:` line is updated in place (preserving the original key text
- * and indentation, rewriting only the value with a single separating space).
- * When the block has no such line and $append is true, an explicit line is
- * appended to the block. Bodies without a leading front-matter block, or whose
- * key already holds the target value, are returned unchanged (no cosmetic
- * churn).
+ * A thin no-churn/no-create wrapper over set_frontmatter_key(), which is the one
+ * engine that mutates a block (splitting and rebuilding through the YAML writer).
+ * set_matter() adds two guarantees the every-save callers (persist_slug(),
+ * persist_resolved_created()) rely on and that the engine deliberately does not
+ * make:
  *
- * The value is rendered through the YAML writer rather than interpolated, for
- * the reason build_matter() already documents: a slug carrying a colon
- * (`slug: a: b`) is not valid YAML, so parse_matter() returned nothing and the
- * *whole* front-matter block — title, draft, created — silently vanished on the
- * next read; one carrying a `#` had everything from it treated as a comment.
- * finalize_slug() reaches both by appending an id suffix to an explicit slug
- * that collides or names a reserved route, and then pinning the result here.
- * Yaml::dump() already quotes anything that needs it, including the
- * `Y-m-d H:i:s` created stamp, so no caller has to ask for quoting.
+ * - A body with no leading front-matter block is returned unchanged, rather than
+ *   gaining one. set_frontmatter_key() would add a block; a status update or a
+ *   feed item without front matter must not sprout a `slug:`/`created:` fence.
+ * - When the key's line already holds this value, the body is returned
+ *   byte-for-byte — including its CRLF line endings. A browser submits a
+ *   <textarea> with CRLF, so most bodies reaching here carry them; the `\r` must
+ *   not make an unchanged value differ and re-store the post on every save.
+ *
+ * The value only reaches set_frontmatter_key() when it actually changes, so the
+ * engine's rebuild (which quotes anything YAML needs, and cannot leave a stale
+ * list behind under a scalar) happens once per real change, never as cosmetic
+ * churn. finalize_slug() reaches this by pinning an id-suffixed slug that
+ * collides or names a reserved route; apply_scheduling() by pinning a resolved
+ * `created` date.
  *
  * @param string $body The raw post body.
  * @param string $key The front-matter key to set.
@@ -469,45 +473,26 @@ function build_matter(array $matter, string $content): string
 function set_matter(string $body, string $key, string $value, bool $append = true): string
 {
     // Only touch a front-matter block at the very start of the body.
-    if (!preg_match('/\A(\s*---\s*\n)(.*?\n)(---\s*\n?)/s', $body, $m)) {
+    [$yaml] = split_frontmatter($body);
+    if ($yaml === '') {
         return $body;
     }
 
-    $rendered = Yaml::dump($value);
-    // A browser submits a <textarea> with CRLF line endings, so most bodies
-    // reaching here carry them. The `\r` is matched and carried over rather
-    // than swept into the value: as part of $line[2] it made $current differ
-    // from $value on every save, so the no-churn contract above never held for
-    // an edit-form body and each save rewrote the line (and re-stored the post).
-    $new_yaml = preg_replace_callback(
-        '/^([ \t]*' . preg_quote($key, '/') . '[ \t]*:)[ \t]*(.*?)[ \t]*(\r?)$/mi',
-        function (array $line) use ($value, $rendered): string {
-            $current = trim($line[2], " \t'\"");
-            if ($current === $value) {
-                return $line[0];
-            }
-            return $line[1] . ' ' . $rendered . $line[3];
-        },
-        $m[2],
-        1,
-        $count
-    );
-    // preg_replace_callback() returns null on a PCRE failure (a backtrack limit
-    // on a long block). Concatenating that would drop the entire YAML block, so
-    // leave the body alone instead.
-    if ($new_yaml === null) {
-        return $body;
-    }
-
-    if ($count === 0) {
-        if (!$append) {
+    // Read-only probe for the key's column-zero line, in either spelling
+    // (parse_matter() folds hyphen/underscore together). This decides no-churn
+    // and, for $append === false, whether the key is present — matching the
+    // engine's own column-zero, quote-trimming view of the value so an unchanged
+    // save returns the body verbatim.
+    $pattern = '/^' . str_replace('\-', '[-_]', preg_quote($key, '/')) . '[ \t]*:[ \t]*(.*?)[ \t]*\r?$/mi';
+    if (preg_match($pattern, $yaml, $m) === 1) {
+        if (trim($m[1], " \t'\"") === $value) {
             return $body;
         }
-        $eol = str_ends_with($m[1], "\r\n") ? "\r\n" : "\n";
-        $new_yaml = $m[2] . "$key: $rendered" . $eol;
+    } elseif (!$append) {
+        return $body;
     }
 
-    return $m[1] . $new_yaml . $m[3] . substr($body, strlen($m[0]));
+    return set_frontmatter_key($body, $key, $value);
 }
 
 /**

--- a/src/post.php
+++ b/src/post.php
@@ -659,6 +659,139 @@ function finalize_and_store_post(OODBBean $bean): void
 }
 
 /**
+ * The registry of post-lifecycle event subscribers, keyed by event name.
+ *
+ * A by-reference accessor so on() and reset_subscribers() mutate the one static
+ * array emit() reads. See save() for the events and the funnel that emits them.
+ *
+ * @return array<string, list<callable>> The mutable subscriber registry.
+ */
+function &event_subscribers(): array
+{
+    static $subscribers = [];
+
+    return $subscribers;
+}
+
+/**
+ * Registers a subscriber for a post-lifecycle event.
+ *
+ * Events are emitted by save(): `post.created`, `post.updated`, `post.published`
+ * (and, as more write sites convert, `post.deleted` and `post.restored`). A
+ * subscriber is called with the stored bean.
+ *
+ * @param string   $event      The event name to subscribe to.
+ * @param callable $subscriber fn(OODBBean $bean): void.
+ * @return void
+ */
+function on(string $event, callable $subscriber): void
+{
+    $subscribers = &event_subscribers();
+    $subscribers[$event][] = $subscriber;
+}
+
+/**
+ * Calls every subscriber registered for an event, in registration order.
+ *
+ * @param string   $event The event name to emit.
+ * @param OODBBean $bean  The stored post bean to hand each subscriber.
+ * @return void
+ */
+function emit(string $event, OODBBean $bean): void
+{
+    foreach (event_subscribers()[$event] ?? [] as $subscriber) {
+        $subscriber($bean);
+    }
+}
+
+/**
+ * Clears the subscriber registry. For test isolation between cases that each
+ * register their own subscribers; production wiring runs once per request.
+ *
+ * @return void
+ */
+function reset_subscribers(): void
+{
+    $subscribers = &event_subscribers();
+    $subscribers = [];
+}
+
+/**
+ * Wires the subscribers every request needs at the seam.
+ *
+ * Publication is an event: notify-requested saves emit `post.published`, and the
+ * two notification subsystems subscribe here rather than each re-deriving
+ * "published" from a different signal. Each callee self-filters ineligible posts
+ * (drafts, feed items, future-dated), so subscribing them unconditionally is
+ * safe. Called once from the request bootstrap (src/index.php).
+ *
+ * @return void
+ */
+function register_default_subscribers(): void
+{
+    on('post.published', '\Lamb\Webmention\enqueue_for_post');
+    on('post.published', '\Lamb\Websub\ping_for_post');
+}
+
+/**
+ * The single funnel every post write goes through.
+ *
+ * Stores the bean and emits the lifecycle events that used to be a convention
+ * spread across the write sites: `post.created` for a new row or `post.updated`
+ * for an existing one, and `post.published` when the caller asks for
+ * notification (subscribers registered by register_default_subscribers() then
+ * queue webmentions and ping the WebSub hubs). Moving notification onto the
+ * funnel's success path makes #685's "never notify a failed write" fix
+ * structural rather than a per-site habit.
+ *
+ * The context flags carry the behaviours each site used to express by omitting a
+ * call:
+ *  - `finalize_slug` — reserve/suffix a colliding or reserved slug and pin it
+ *    into the front matter (the create paths' finalize_and_store_post()).
+ *  - `notify` — emit `post.published` after a successful store.
+ *  - `lock_if_feed_sourced` — mark a feed-sourced post author-owned so later
+ *    crawls leave it alone (the edit form's lock_if_feed_sourced()).
+ *  - `redirect_on_slug_change` — reserved for the edit-site conversion, which
+ *    also has the pre-edit slug this funnel does not; not yet honoured.
+ *
+ * The store is not caught here: each call site flashes its own message and
+ * decides what to do on failure, so the RedException\SQL propagates.
+ *
+ * @param OODBBean $bean A populated post bean.
+ * @param array{finalize_slug?: bool, notify?: bool, lock_if_feed_sourced?: bool, redirect_on_slug_change?: bool} $context
+ * @return void
+ * @throws \RedBeanPHP\RedException\SQL When the store fails.
+ */
+function save(OODBBean $bean, array $context = []): void
+{
+    $context += [
+        'finalize_slug'           => false,
+        'notify'                  => false,
+        'lock_if_feed_sourced'    => false,
+        'redirect_on_slug_change' => false,
+    ];
+
+    $is_new = empty($bean->id);
+
+    // Before the store: feed_locked is a column on the row being written.
+    if ($context['lock_if_feed_sourced'] && !empty($bean->feeditem_uuid)) {
+        $bean->feed_locked = 1;
+    }
+
+    R::store($bean);
+    // finalize_slug() needs the minted id for any dedup suffix, so it runs after
+    // the first store and re-stores only when it changed the slug or body.
+    if ($context['finalize_slug'] && finalize_slug($bean)) {
+        R::store($bean);
+    }
+
+    emit($is_new ? 'post.created' : 'post.updated', $bean);
+    if ($context['notify']) {
+        emit('post.published', $bean);
+    }
+}
+
+/**
  * Matches a line that could carry a task-list marker: optional blockquote
  * markers, an optional bullet or ordered list marker, then `[ ]`/`[x]`/`[X]`
  * followed by whitespace and a non-empty label.

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -438,7 +438,10 @@ function apply_checkbox_toggle(int $id, int $index, bool $checked): bool
     $bean->updated = \Lamb\now();
 
     try {
-        R::store($bean);
+        // Through the funnel with an empty context: an existing post, no slug
+        // finalize, and no notify — ticking a box is a minor edit that must not
+        // re-notify subscribers. Emits post.updated only.
+        \Lamb\Post\save($bean);
     } catch (SQL $e) {
         $_SESSION['flash'][] = 'Failed to update checkbox: ' . $e->getMessage();
         return false;

--- a/tests/Unit/FrontMatterEngineTest.php
+++ b/tests/Unit/FrontMatterEngineTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Post\build_matter;
+use function Lamb\Post\parse_matter;
+use function Lamb\Post\persist_slug;
+use function Lamb\Post\set_frontmatter_key;
+use function Lamb\Post\set_matter;
+use function Lamb\Post\set_reply_to;
+use function Lamb\persist_resolved_created;
+
+/**
+ * Characterisation of the front-matter engine's contract at the shapes issue
+ * #689 names as load-bearing. These pin the behaviour that must survive the two
+ * engines converging onto set_frontmatter_key(): they pass against both the old
+ * in-place set_matter() and the migrated one.
+ */
+class FrontMatterEngineTest extends TestCase
+{
+    // 1. CRLF bodies from the edit form — set_matter()'s no-churn contract.
+    //    A `\r` must not make an unchanged save rewrite (and re-store) the line.
+
+    public function testSetMatterNoChurnOnUnchangedCrlfBody(): void
+    {
+        $body = "---\r\nslug: my-slug\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n";
+        $this->assertSame($body, set_matter($body, 'slug', 'my-slug'));
+    }
+
+    public function testPersistSlugNoChurnOnUnchangedCrlfBody(): void
+    {
+        $body = "---\r\nslug: my-slug\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n";
+        $this->assertSame($body, persist_slug($body, 'my-slug'));
+    }
+
+    public function testPersistResolvedCreatedNoChurnOnUnchangedCrlfBody(): void
+    {
+        // Midnight is the common scheduled-post time; the stored `00:00:00` must
+        // compare equal to the resolved value or every save re-stores the post.
+        $body = "---\r\ncreated: '2024-06-05 00:00:00'\r\ntitle: Hi\r\n---\r\n\r\nBody.\r\n";
+        $this->assertSame($body, persist_resolved_created($body, '2024-06-05 00:00:00'));
+    }
+
+    // 2. Bodies with no front matter at all — behaviour differs per call site.
+
+    public function testSetMatterLeavesBodyWithoutFrontMatterUnchanged(): void
+    {
+        $body = "Just a status update.";
+        $this->assertSame($body, set_matter($body, 'slug', 'anything'));
+    }
+
+    public function testPersistResolvedCreatedLeavesBodyWithoutFrontMatterUnchanged(): void
+    {
+        $body = "Just a status update.";
+        $this->assertSame($body, persist_resolved_created($body, '2024-06-05 12:00:00'));
+    }
+
+    public function testSetFrontmatterKeyAddsBlockToBodyWithoutFrontMatter(): void
+    {
+        $body = "Just a status update.";
+        $result = set_frontmatter_key($body, 'in-reply-to', 'https://example.com/post');
+        $this->assertStringStartsWith("---\n", $result);
+        $this->assertSame('https://example.com/post', parse_matter($result)['in-reply-to']);
+        $this->assertStringContainsString('Just a status update.', $result);
+    }
+
+    public function testBuildMatterReturnsContentVerbatimWhenEmpty(): void
+    {
+        $this->assertSame('Just content', build_matter([], 'Just content'));
+    }
+
+    // 3. An unrecognised, hand-written key must not be dropped when another key
+    //    on the same block is changed (the Micropub update path).
+
+    public function testSetFrontmatterKeyPreservesUnrecognisedKeys(): void
+    {
+        $body = "---\ntitle: Old\nslug: pinned\ndraft: true\n---\nBody.";
+        $result = set_frontmatter_key($body, 'title', 'New');
+        $this->assertStringContainsString('slug: pinned', $result);
+        $this->assertStringContainsString('draft: true', $result);
+        $this->assertSame('New', parse_matter($result)['title']);
+    }
+
+    // 4. Both hyphen and underscore spellings collapse onto one key.
+
+    public function testSetReplyToReplacesUnderscoreSpelledKeyLeavingOne(): void
+    {
+        $body = set_reply_to("---\nin_reply_to: https://old.example/x\n---\nHi", 'https://new.example/y');
+        $this->assertStringNotContainsString('old.example', $body);
+        $this->assertSame(1, substr_count($body, 'reply'));
+        $this->assertSame('https://new.example/y', parse_matter($body)['in-reply-to']);
+    }
+
+    // 5. A block left with nothing but the key being removed loses its fence.
+
+    public function testSetFrontmatterKeyRemovesLastKeyAndFence(): void
+    {
+        $body = "---\nin-reply-to: https://other.example/post\n---\nHi";
+        $this->assertSame('Hi', set_frontmatter_key($body, 'in-reply-to', ''));
+    }
+}

--- a/tests/Unit/FrontMatterTest.php
+++ b/tests/Unit/FrontMatterTest.php
@@ -163,12 +163,15 @@ class FrontMatterTest extends TestCase
         $this->assertSame($body, set_matter($body, 'slug', 'new'));
     }
 
-    public function testSetMatterPreservesKeyWhitespacePrefixOnReplace(): void
+    public function testSetMatterTreatsIndentedKeyAsNestedAndAppends(): void
     {
+        // The single engine anchors to column zero: an indented `slug:` belongs
+        // to whatever block encloses it, so it is left alone and a top-level
+        // slug is appended instead. (Real front-matter keys are never indented;
+        // persist_slug() only ever pins a column-zero slug.)
         $body = "---\n  slug:   old\n---\nContent.";
-        // The matched key prefix is preserved; value rewritten with single space.
         $this->assertSame(
-            "---\n  slug: new\n---\nContent.",
+            "---\n  slug:   old\nslug: new\n---\nContent.",
             set_matter($body, 'slug', 'new')
         );
     }
@@ -246,23 +249,26 @@ class FrontMatterTest extends TestCase
         $this->assertSame($body, set_matter($body, 'slug', 'my-slug'));
     }
 
-    public function testSetMatterKeepsCrlfWhenRewritingAValue(): void
+    public function testSetMatterNormalisesBlockToLfWhenRewritingACrlfValue(): void
     {
+        // On a real value change the single engine rebuilds the block through the
+        // YAML writer (LF fences), leaving the content's CRLF untouched. This is
+        // a one-off on the save that changes the value, not per-save churn.
         $body = "---\r\nslug: my-slug\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n";
 
         $this->assertSame(
-            "---\r\nslug: other\r\ntitle: Hi\r\n---\r\n\r\nBody text.\r\n",
+            "---\ntitle: Hi\nslug: other\n---\n\r\nBody text.\r\n",
             set_matter($body, 'slug', 'other')
         );
     }
 
-    public function testSetMatterKeepsCrlfWhenAppendingAKey(): void
+    public function testSetMatterAppendsToCrlfBlockRebuildingWithLf(): void
     {
         $body = "---\r\ntitle: Hi\r\n---\r\n\r\nBody.\r\n";
 
         $result = set_matter($body, 'slug', 'new');
 
-        $this->assertSame("---\r\ntitle: Hi\r\nslug: new\r\n---\r\n\r\nBody.\r\n", $result);
+        $this->assertSame("---\ntitle: Hi\nslug: new\n---\n\r\nBody.\r\n", $result);
         $this->assertSame(['title' => 'Hi', 'slug' => 'new'], parse_matter($result));
     }
 }

--- a/tests/Unit/PostSaveTest.php
+++ b/tests/Unit/PostSaveTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Post\on;
+use function Lamb\Post\populate_bean;
+use function Lamb\Post\register_default_subscribers;
+use function Lamb\Post\reset_subscribers;
+use function Lamb\Post\save;
+
+/**
+ * The executable half of the save() funnel: which events fire, with which
+ * context, from the one call site converted so far (Response\apply_checkbox_toggle,
+ * an existing post with an empty context) plus the flags the funnel implements.
+ */
+class PostSaveTest extends TestCase
+{
+    /** @var list<string> */
+    private array $events = [];
+
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+
+        global $config;
+        $config = ['websub_hubs' => ''];
+
+        reset_subscribers();
+        $this->events = [];
+        foreach (['post.created', 'post.updated', 'post.published'] as $event) {
+            on($event, function () use ($event): void {
+                $this->events[] = $event;
+            });
+        }
+    }
+
+    public function testExistingPostEmitsUpdated(): void
+    {
+        // The checkbox toggle's shape: a loaded (already-stored) bean, empty context.
+        $bean = populate_bean('A status.');
+        R::store($bean);
+
+        save($bean);
+
+        $this->assertSame(['post.updated'], $this->events);
+    }
+
+    public function testNewBeanEmitsCreated(): void
+    {
+        $bean = populate_bean('A status.');
+
+        save($bean);
+
+        $this->assertSame(['post.created'], $this->events);
+        $this->assertNotEmpty($bean->id);
+    }
+
+    public function testNotifyEmitsPublishedAfterTheLifecycleEvent(): void
+    {
+        $bean = populate_bean('A status.');
+
+        save($bean, ['notify' => true]);
+
+        $this->assertSame(['post.created', 'post.published'], $this->events);
+    }
+
+    public function testAnEmptyContextNeverPublishes(): void
+    {
+        $bean = populate_bean('A status.');
+        R::store($bean);
+
+        save($bean);
+
+        $this->assertNotContains('post.published', $this->events);
+    }
+
+    public function testFinalizeSlugDeduplicatesAndPersists(): void
+    {
+        $text = "---\nslug: shared\n---\nContent.";
+
+        $first = populate_bean($text);
+        save($first, ['finalize_slug' => true]);
+
+        $second = populate_bean($text);
+        save($second, ['finalize_slug' => true]);
+
+        $this->assertSame('shared', $first->slug);
+        $this->assertSame('shared-' . $second->id, $second->slug);
+        $this->assertStringContainsString('slug: shared-' . $second->id, (string) $second->body);
+    }
+
+    public function testWithoutFinalizeSlugACollidingSlugIsLeftAsIs(): void
+    {
+        $text = "---\nslug: shared\n---\nContent.";
+
+        $first = populate_bean($text);
+        save($first);
+
+        $second = populate_bean($text);
+        save($second);
+
+        // No finalize step: the funnel stored the bean verbatim, so both keep the
+        // colliding slug (the create sites that want dedup pass finalize_slug).
+        $this->assertSame('shared', $second->slug);
+    }
+
+    public function testLockIfFeedSourcedMarksAFeedPostAuthorOwned(): void
+    {
+        $bean = populate_bean('A status.');
+        $bean->feeditem_uuid = md5('feed-item');
+
+        save($bean, ['lock_if_feed_sourced' => true]);
+
+        $this->assertSame(1, (int) $bean->feed_locked);
+    }
+
+    public function testLockIfFeedSourcedLeavesANonFeedPostUntouched(): void
+    {
+        $bean = populate_bean('A status.');
+        $bean->feeditem_uuid = md5('feed-item');
+
+        save($bean);
+
+        $this->assertEmpty($bean->feed_locked);
+    }
+
+    public function testDefaultSubscribersQueueAWebmentionOnPublish(): void
+    {
+        // Proves the real wiring, not just the spy: register_default_subscribers()
+        // subscribes Webmention\enqueue_for_post to post.published.
+        reset_subscribers();
+        register_default_subscribers();
+
+        $bean = populate_bean('A status.');
+        $bean->transformed = '<a href="https://other.example/a">link</a>';
+
+        save($bean, ['notify' => true]);
+
+        $this->assertCount(1, R::findAll('webmentionoutbox'));
+    }
+
+    public function testAnEmptyContextDoesNotQueueAWebmention(): void
+    {
+        reset_subscribers();
+        register_default_subscribers();
+
+        $bean = populate_bean('A status.');
+        $bean->transformed = '<a href="https://other.example/a">link</a>';
+
+        save($bean);
+
+        $this->assertCount(0, R::findAll('webmentionoutbox'));
+    }
+}

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -761,6 +761,27 @@ class ResponsePostsTest extends TestCase
         $this->assertSame("- [x] parent\n\n      - [ ] nested\n", R::load('post', $post->id)->body);
     }
 
+    public function testApplyCheckboxToggleDoesNotNotifySubscribers(): void
+    {
+        // Routed through Post\save() with an empty context: ticking a box is a
+        // minor edit and must not queue a webmention, even with the funnel's
+        // default subscribers wired. Byte-for-byte the pre-funnel behaviour.
+        $this->seedNotifyTables();
+        \Lamb\Post\reset_subscribers();
+        \Lamb\Post\register_default_subscribers();
+
+        $post          = R::dispense('post');
+        $post->body    = "- [ ] one\n\nsee [elsewhere](https://other.example/a)\n";
+        $post->version = 1;
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        $this->assertTrue(apply_checkbox_toggle($post->id, 0, true));
+        $this->assertCount(0, R::findAll('webmentionoutbox'));
+
+        \Lamb\Post\reset_subscribers();
+    }
+
     // -------------------------------------------------------------------------
     // lock_if_feed_sourced
     // -------------------------------------------------------------------------


### PR DESCRIPTION
First increment of #692, per its own guidance ('land the funnel with a single call site converted, then convert the rest one commit at a time — do NOT convert nine sites in one commit') and the agreed incremental plan.

- Adds `Post\save($bean, $context)` + `Post\on()` event seam; emits post.created/updated/published. Context flags (finalize_slug, notify, lock_if_feed_sourced) replace the by-omission convention.
- Default subscribers (`Webmention\enqueue_for_post`, `Websub\ping_for_post`) fire on post.published, reproducing `notify_post_subscribers()`.
- Converts ONE site (`apply_checkbox_toggle`), behaviour byte-for-byte unchanged.
- `DECISIONS.md` records the invariant.
- Tests pin the flag→event matrix.

The remaining 8 write sites convert one at a time in follow-up issues (filed separately). The grep exit criterion is the end state of that series, not this PR. Full unit suite green (2048).

Closes #692

Stacked on #689 (uses the consolidated front-matter engine).