### PR TITLE
Dedupe parts/_items.php across the 2024 and 2026 themes

### DIFF
--- a/src/theme.php
+++ b/src/theme.php
@@ -15,6 +15,7 @@ use RedBeanPHP\R;
 use RuntimeException;
 
 use function Lamb\get_tags;
+use function Lamb\Config\is_menu_item;
 use function Lamb\Http\is_valid_http_url;
 use function Lamb\Network\get_feeds;
 use function Lamb\permalink;
@@ -393,6 +394,83 @@ function syndication_links(OODBBean $bean): string
         return '';
     }
     return '<small>Also on: ' . implode(', ', $links) . '</small>';
+}
+
+/**
+ * Renders the post-list loop shared by the 2024 and 2026 themes' _items.php.
+ *
+ * Wraps the posts in <ul>/<li> when there is more than one, skips menu pages
+ * outside their own permalink, and prints each post as an h-entry. The only
+ * difference between the two themes is whether the per-post author is shown
+ * inline (2024) or kept screen-reader-only (2026), controlled by $hide_author.
+ *
+ * @param bool $hide_author Hide the per-post author visually instead of showing it inline.
+ * @return void
+ */
+function render_post_list(bool $hide_author): void
+{
+    global $data;
+    global $template;
+
+    // Column positions below intentionally mirror the original per-theme
+    // _items.php templates: the leading whitespace of any line adjacent to a
+    // PHP tag is part of the rendered HTML, so it cannot be re-indented for
+    // being nested inside a function without changing the output.
+    if (empty($data['posts'])) :
+        ?><p>Sorry no items found.</p>
+    <?php // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect -- leading whitespace here is literal output, preserved from the pre-extraction template
+    else :
+        if (count($data['posts']) > 1) :
+            echo '<ul>';
+        endif;
+        foreach ($data['posts'] as $bean) :
+            /** @var \RedBeanPHP\OODBBean $bean */
+            if ($template !== 'status' && is_menu_item((string) ($bean->slug ?? ''))) :
+                # Backstop for the owner-only views that query everything (drafts,
+                # trash, scheduled); public listings exclude menu pages in SQL.
+                continue;
+            endif;
+            if (count($data['posts']) > 1) :
+                echo '<li>';
+            endif;
+
+            ?>
+
+        <article class="h-entry" data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
+            <header>
+                <?php // On a post page the h1 already shows the title, and the
+                      // stylesheet hides this h2 — but the h-entry still needs a
+                      // p-name, so the element is emitted and hidden rather than
+                      // skipped. Same expression as the base theme.
+                ?>
+                <?php if (!empty($bean->title)) : ?>
+                    <h2><?= $template !== 'status' ? title_link($bean) : '<span class="p-name">' . escape($bean->title) . '</span>' ?></h2>
+                <?php endif; ?>
+                <div class="meta">
+                    <?= ($hide_author
+                        ? '<span itemprop="author" class="screen-reader-text">' . author_card() . '</span>'
+                        : '<span itemprop="author">' . author_card() . '</span> @') . "\n" ?>
+                    <?= date_created($bean) ?>
+                </div>
+            </header>
+            <?= the_reply_context($bean) ?>
+            <?php // List view renders the post title at h2, so the body's top heading sits at h3; otherwise h2 under the site h1. ?>
+            <div class="e-content"><?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
+            <?= syndication_links($bean) ?>
+
+            <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
+                <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
+            <?php endif; ?>
+        </article>
+        <?php // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect -- leading whitespace here is literal output, preserved from the pre-extraction template
+            if (count($data['posts']) > 1) :
+                echo '</li>';
+            endif;
+        endforeach;
+        if (count($data['posts']) > 1) :
+            echo '</ul>';
+        endif;
+    endif;
 }
 
 /**

--- a/src/theme.php
+++ b/src/theme.php
@@ -420,7 +420,11 @@ function render_post_list(bool $hide_author): void
         ?><p>Sorry no items found.</p>
     <?php // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect -- leading whitespace here is literal output, preserved from the pre-extraction template
     else :
-        if (count($data['posts']) > 1) :
+        // Wrap the list in <ul>/<li> only when there is more than one post, so a
+        // single post renders as a bare <article>. Computed once; the menu-item
+        // skip below uses `continue`, so this matches the pre-extraction total.
+        $is_list = count($data['posts']) > 1;
+        if ($is_list) :
             echo '<ul>';
         endif;
         foreach ($data['posts'] as $bean) :
@@ -430,7 +434,7 @@ function render_post_list(bool $hide_author): void
                 # trash, scheduled); public listings exclude menu pages in SQL.
                 continue;
             endif;
-            if (count($data['posts']) > 1) :
+            if ($is_list) :
                 echo '<li>';
             endif;
 
@@ -463,11 +467,11 @@ function render_post_list(bool $hide_author): void
             <?php endif; ?>
         </article>
         <?php // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect -- leading whitespace here is literal output, preserved from the pre-extraction template
-            if (count($data['posts']) > 1) :
+            if ($is_list) :
                 echo '</li>';
             endif;
         endforeach;
-        if (count($data['posts']) > 1) :
+        if ($is_list) :
             echo '</ul>';
         endif;
     endif;

--- a/src/themes/2024/parts/_items.php
+++ b/src/themes/2024/parts/_items.php
@@ -1,72 +1,7 @@
 <?php
 
-global $data;
-global $config;
-global $template;
+use function Lamb\Theme\render_post_list;
 
-use function Lamb\Theme\action_delete;
-use function Lamb\Theme\action_edit;
-use function Lamb\Theme\action_preview;
-use function Lamb\Theme\action_restore;
-use function Lamb\Theme\author_card;
-use function Lamb\Theme\date_created;
-use function Lamb\Theme\anchor_headings;
-use function Lamb\Theme\escape;
-use function Lamb\Config\is_menu_item;
-use function Lamb\Theme\link_source;
-use function Lamb\Theme\syndication_links;
-use function Lamb\Theme\the_reply_context;
-use function Lamb\Theme\title_link;
-
-if (empty($data['posts'])) :
-    ?><p>Sorry no items found.</p>
-    <?php
-else :
-    if (count($data['posts']) > 1) :
-        echo '<ul>';
-    endif;
-    foreach ($data['posts'] as $bean) :
-        /** @var \RedBeanPHP\OODBBean $bean */
-        if ($template !== 'status' && is_menu_item((string) ($bean->slug ?? ''))) :
-            # Hide from timeline
-            continue;
-        endif;
-        if (count($data['posts']) > 1) :
-            echo '<li>';
-        endif;
-
-        ?>
-
-        <article class="h-entry" data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
-            <header>
-                <?php // On a post page the h1 already shows the title, and the
-                      // stylesheet hides this h2 — but the h-entry still needs a
-                      // p-name, so the element is emitted and hidden rather than
-                      // skipped. Same expression as the base theme.
-                ?>
-                <?php if (!empty($bean->title)) : ?>
-                    <h2><?= $template !== 'status' ? title_link($bean) : '<span class="p-name">' . escape($bean->title) . '</span>' ?></h2>
-                <?php endif; ?>
-                <div class="meta">
-                    <span itemprop="author"><?= author_card() ?></span> @
-                    <?= date_created($bean) ?>
-                </div>
-            </header>
-            <?= the_reply_context($bean) ?>
-            <?php // List view renders the post title at h2, so the body's top heading sits at h3; otherwise h2 under the site h1. ?>
-            <div class="e-content"><?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
-            <?= syndication_links($bean) ?>
-
-            <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
-                <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
-            <?php endif; ?>
-        </article>
-        <?php
-        if (count($data['posts']) > 1) :
-            echo '</li>';
-        endif;
-    endforeach;
-    if (count($data['posts']) > 1) :
-        echo '</ul>';
-    endif;
-endif;
+// 2024 shows the per-post author inline (see the 2026 theme's screen-reader-
+// only variant). The shared loop/markup live in Lamb\Theme\render_post_list().
+render_post_list(false);

--- a/src/themes/2026/parts/_items.php
+++ b/src/themes/2026/parts/_items.php
@@ -1,73 +1,8 @@
 <?php
 
-global $data;
-global $config;
-global $template;
+use function Lamb\Theme\render_post_list;
 
-use function Lamb\Theme\action_delete;
-use function Lamb\Theme\action_edit;
-use function Lamb\Theme\action_preview;
-use function Lamb\Theme\action_restore;
-use function Lamb\Theme\author_card;
-use function Lamb\Theme\date_created;
-use function Lamb\Theme\anchor_headings;
-use function Lamb\Theme\escape;
-use function Lamb\Config\is_menu_item;
-use function Lamb\Theme\link_source;
-use function Lamb\Theme\syndication_links;
-use function Lamb\Theme\the_reply_context;
-use function Lamb\Theme\title_link;
-
-if (empty($data['posts'])) :
-    ?><p>Sorry no items found.</p>
-    <?php
-else :
-    if (count($data['posts']) > 1) :
-        echo '<ul>';
-    endif;
-    foreach ($data['posts'] as $bean) :
-        /** @var \RedBeanPHP\OODBBean $bean */
-        if ($template !== 'status' && is_menu_item((string) ($bean->slug ?? ''))) :
-            # Backstop for the owner-only views that query everything (drafts,
-            # trash, scheduled); public listings exclude menu pages in SQL.
-            continue;
-        endif;
-        if (count($data['posts']) > 1) :
-            echo '<li>';
-        endif;
-
-        ?>
-
-        <article class="h-entry" data-post-id="<?= (int) $bean->id ?>" itemscope itemtype="https://schema.org/BlogPosting">
-            <header>
-                <?php // On a post page the h1 already shows the title, and the
-                      // stylesheet hides this h2 — but the h-entry still needs a
-                      // p-name, so the element is emitted and hidden rather than
-                      // skipped. Same expression as the base theme.
-                ?>
-                <?php if (!empty($bean->title)) : ?>
-                    <h2><?= $template !== 'status' ? title_link($bean) : '<span class="p-name">' . escape($bean->title) . '</span>' ?></h2>
-                <?php endif; ?>
-                <div class="meta">
-                    <span itemprop="author" class="screen-reader-text"><?= author_card() ?></span>
-                    <?= date_created($bean) ?>
-                </div>
-            </header>
-            <?= the_reply_context($bean) ?>
-            <?php // List view renders the post title at h2, so the body's top heading sits at h3; otherwise h2 under the site h1. ?>
-            <div class="e-content"><?= anchor_headings($bean->transformed, ($template !== 'status' && !empty($bean->title)) ? 3 : 2) ?></div>
-            <?= syndication_links($bean) ?>
-
-            <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
-                <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
-            <?php endif; ?>
-        </article>
-        <?php
-        if (count($data['posts']) > 1) :
-            echo '</li>';
-        endif;
-    endforeach;
-    if (count($data['posts']) > 1) :
-        echo '</ul>';
-    endif;
-endif;
+// 2026 hides the per-post author visually, keeping it for crawlers via
+// screen-reader-text (see the 2024 theme's inline variant). The shared
+// loop/markup live in Lamb\Theme\render_post_list().
+render_post_list(true);

--- a/tests/Support/Data/theme-items/multiple.html
+++ b/tests/Support/Data/theme-items/multiple.html
@@ -1,0 +1,23 @@
+<ul><li>
+        <article class="h-entry" data-post-id="1" itemscope itemtype="https://schema.org/BlogPosting">
+            <header>
+                                                    <h2><a class="p-name title-link" href="http://localhost/status/1">First Post</a></h2>
+                                <div class="meta">
+                    {{AUTHOR_SPAN}}
+                    <a href="/status/1" class="u-url" title="Timestamp: 2024-03-01 09:00:00"><time class="dt-published" datetime="2024-03-01 09:00:00">NORMALIZED</time></a>                </div>
+            </header>
+                                    <div class="e-content"><p>First body.</p></div>
+            
+                    </article>
+        </li><li>
+        <article class="h-entry" data-post-id="2" itemscope itemtype="https://schema.org/BlogPosting">
+            <header>
+                                                    <h2><a class="p-name title-link" href="http://localhost/status/2">Second Post</a></h2>
+                                <div class="meta">
+                    {{AUTHOR_SPAN}}
+                    <a href="/status/2" class="u-url" title="Timestamp: 2024-03-02 10:00:00"><time class="dt-published" datetime="2024-03-02 10:00:00">NORMALIZED</time></a>                </div>
+            </header>
+                                    <div class="e-content"><p>Second body.</p></div>
+            
+                    </article>
+        </li></ul>

--- a/tests/Support/Data/theme-items/status_single.html
+++ b/tests/Support/Data/theme-items/status_single.html
@@ -1,0 +1,12 @@
+
+        <article class="h-entry" data-post-id="1" itemscope itemtype="https://schema.org/BlogPosting">
+            <header>
+                                                    <h2><span class="p-name">Status Post Title</span></h2>
+                                <div class="meta">
+                    {{AUTHOR_SPAN}}
+                    <a href="/status/1" class="u-url" title="Timestamp: 2024-02-02 08:30:00"><time class="dt-published" datetime="2024-02-02 08:30:00">NORMALIZED</time></a>                </div>
+            </header>
+                                    <div class="e-content"><p>Status update text.</p></div>
+            
+                    </article>
+        

--- a/tests/Support/Data/theme-items/titled_single.html
+++ b/tests/Support/Data/theme-items/titled_single.html
@@ -1,0 +1,12 @@
+
+        <article class="h-entry" data-post-id="1" itemscope itemtype="https://schema.org/BlogPosting">
+            <header>
+                                                    <h2><a class="p-name title-link" href="http://localhost/status/1">Hello World</a></h2>
+                                <div class="meta">
+                    {{AUTHOR_SPAN}}
+                    <a href="/status/1" class="u-url" title="Timestamp: 2024-01-01 12:00:00"><time class="dt-published" datetime="2024-01-01 12:00:00">NORMALIZED</time></a>                </div>
+            </header>
+                                    <div class="e-content"><p>Body text.</p></div>
+            
+                    </article>
+        

--- a/tests/Unit/ThemeModernItemsPartTest.php
+++ b/tests/Unit/ThemeModernItemsPartTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\OODBBean;
+use RedBeanPHP\R;
+
+use function Lamb\Theme\author_card;
+
+/**
+ * Characterisation test for the 2024 and 2026 themes' _items.php.
+ *
+ * The two files are identical markup apart from one line (the per-post
+ * author is shown inline in 2024, screen-reader-only in 2026 — see #690).
+ * These tests pin the exact rendered HTML of both themes before the shared
+ * markup is extracted into Lamb\Theme\render_post_list(), so the extraction
+ * is verified byte-for-byte rather than eyeballed.
+ *
+ * Fixtures live in tests/Support/Data/theme-items/*.html, captured from the
+ * pre-extraction files with the one differing line replaced by a
+ * `{{AUTHOR_SPAN}}` placeholder (see expectedAuthorSpan()) and the
+ * relative "human time" text normalised (it drifts with the current time).
+ */
+class ThemeModernItemsPartTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        global $data, $template, $config;
+        $_SESSION = [];
+        $data     = [];
+        $template = null;
+        $config   = [];
+    }
+
+    /**
+     * @param array<int, OODBBean> $posts
+     */
+    private function render(string $theme, string $templateName, array $posts): string
+    {
+        global $data, $template, $config;
+        $config   = ['author_name' => 'Jane Doe', 'menu_items' => []];
+        $data     = ['posts' => $posts];
+        $template = $templateName;
+
+        ob_start();
+        include dirname(__DIR__, 2) . "/src/themes/$theme/parts/_items.php";
+        return (string) ob_get_clean();
+    }
+
+    private function makeBean(string $title, string $body, string $created): OODBBean
+    {
+        $bean              = R::dispense('post');
+        $bean->title       = $title;
+        $bean->transformed = $body;
+        $bean->created     = $created;
+        $bean->deleted     = false;
+        R::store($bean);
+        return $bean;
+    }
+
+    /**
+     * Masks the relative "human time" text (e.g. "3 years ago"), which
+     * changes with the current date, while leaving the absolute
+     * datetime/title attributes intact.
+     */
+    private function normalize(string $html): string
+    {
+        return (string) preg_replace(
+            '/(<time class="dt-published" datetime="[^"]*">)[^<]*(<\/time>)/',
+            '$1NORMALIZED$2',
+            $html
+        );
+    }
+
+    private function loadFixture(string $name): string
+    {
+        return (string) file_get_contents(
+            dirname(__DIR__) . "/Support/Data/theme-items/$name.html"
+        );
+    }
+
+    /**
+     * Builds the one line that legitimately differs between the two themes,
+     * from the real author_card() output, so the fixture doesn't have to
+     * hardcode it.
+     */
+    private function expectedAuthorSpan(string $theme): string
+    {
+        global $config;
+        $config = ['author_name' => 'Jane Doe', 'menu_items' => []];
+        $author = author_card();
+
+        return $theme === '2026'
+            ? '<span itemprop="author" class="screen-reader-text">' . $author . '</span>'
+            : '<span itemprop="author">' . $author . '</span> @';
+    }
+
+    private function assertRendersFixture(string $fixture, string $theme, string $templateName, string $title, string $body, string $created): void
+    {
+        $bean     = $this->makeBean($title, $body, $created);
+        $html     = $this->normalize($this->render($theme, $templateName, [$bean]));
+        $expected = str_replace('{{AUTHOR_SPAN}}', $this->expectedAuthorSpan($theme), $this->loadFixture($fixture));
+
+        $this->assertSame($expected, $html);
+    }
+
+    public function test2024RendersTitledPost(): void
+    {
+        $this->assertRendersFixture('titled_single', '2024', 'tag', 'Hello World', '<p>Body text.</p>', '2024-01-01 12:00:00');
+    }
+
+    public function test2024RendersStatusPost(): void
+    {
+        $this->assertRendersFixture('status_single', '2024', 'status', 'Status Post Title', '<p>Status update text.</p>', '2024-02-02 08:30:00');
+    }
+
+    public function test2024RendersMultiplePostsWrappedInAList(): void
+    {
+        $b1 = $this->makeBean('First Post', '<p>First body.</p>', '2024-03-01 09:00:00');
+        $b2 = $this->makeBean('Second Post', '<p>Second body.</p>', '2024-03-02 10:00:00');
+        $html     = $this->normalize($this->render('2024', 'tag', [$b1, $b2]));
+        $expected = str_replace('{{AUTHOR_SPAN}}', $this->expectedAuthorSpan('2024'), $this->loadFixture('multiple'));
+
+        $this->assertSame($expected, $html);
+    }
+
+    public function test2026RendersTitledPost(): void
+    {
+        $this->assertRendersFixture('titled_single', '2026', 'tag', 'Hello World', '<p>Body text.</p>', '2024-01-01 12:00:00');
+    }
+
+    public function test2026RendersStatusPost(): void
+    {
+        $this->assertRendersFixture('status_single', '2026', 'status', 'Status Post Title', '<p>Status update text.</p>', '2024-02-02 08:30:00');
+    }
+
+    public function test2026RendersMultiplePostsWrappedInAList(): void
+    {
+        $b1 = $this->makeBean('First Post', '<p>First body.</p>', '2024-03-01 09:00:00');
+        $b2 = $this->makeBean('Second Post', '<p>Second body.</p>', '2024-03-02 10:00:00');
+        $html     = $this->normalize($this->render('2026', 'tag', [$b1, $b2]));
+        $expected = str_replace('{{AUTHOR_SPAN}}', $this->expectedAuthorSpan('2026'), $this->loadFixture('multiple'));
+
+        $this->assertSame($expected, $html);
+    }
+}

--- a/tests/Unit/ThemeModernItemsPartTest.php
+++ b/tests/Unit/ThemeModernItemsPartTest.php
@@ -158,4 +158,48 @@ class ThemeModernItemsPartTest extends TestCase
 
         $this->assertSame($expected, $html);
     }
+
+    // The author line is the ONE line the two themes differ on and the whole
+    // point of the refactor to preserve. The fixture tests above substitute the
+    // same literal the implementation builds, so a typo there would be copied
+    // into both sides and pass — pin it here with hardcoded literals instead.
+    public function test2024ShowsTheAuthorInlineWithTrailingAt(): void
+    {
+        $html = $this->render('2024', 'tag', [$this->makeBean('T', '<p>b</p>', '2024-01-01 12:00:00')]);
+        $this->assertStringContainsString('<span itemprop="author">', $html);
+        $this->assertStringContainsString('</span> @', $html);
+        $this->assertStringNotContainsString('screen-reader-text', $html);
+    }
+
+    public function test2026HidesTheAuthorForScreenReadersWithNoTrailingAt(): void
+    {
+        $html = $this->render('2026', 'tag', [$this->makeBean('T', '<p>b</p>', '2024-01-01 12:00:00')]);
+        $this->assertStringContainsString('<span itemprop="author" class="screen-reader-text">', $html);
+        $this->assertStringNotContainsString('</span> @', $html);
+    }
+
+    public function testEmptyPostsRendersTheNoItemsMessageIdenticallyForBothThemes(): void
+    {
+        $html2024 = $this->render('2024', 'tag', []);
+        $html2026 = $this->render('2026', 'tag', []);
+
+        $this->assertStringContainsString('<p>Sorry no items found.</p>', $html2024);
+        $this->assertStringNotContainsString('<article', $html2024);
+        // Both themes share the one implementation, so the empty branch is byte-identical.
+        $this->assertSame($html2024, $html2026);
+    }
+
+    public function testLoggedInAuthorGetsTheActionsFooterAnonymousDoesNot(): void
+    {
+        // The actions <small> block is the only <small> in this markup and is
+        // gated on the login session — pins the moved logged-in hunk.
+        $bean = $this->makeBean('T', '<p>b</p>', '2024-01-01 12:00:00');
+
+        $anon = $this->render('2026', 'tag', [$bean]);
+        $this->assertStringNotContainsString('<small>', $anon);
+
+        $_SESSION[SESSION_LOGIN] = true;
+        $loggedIn = $this->render('2026', 'tag', [$bean]);
+        $this->assertStringContainsString('<small>', $loggedIn);
+    }
 }


### PR DESCRIPTION
The two modern themes' `_items.php` were identical except one design line (author span: 2024 visible, 2026 `screen-reader-text`). Extracted the shared markup into `Theme\render_post_list(bool $hide_author)`; each theme part is now a two-line call. **`base/parts/_items.php` untouched** (its own distinct markup) — the agreed minimal scope, avoiding a change to base's output.

Characterisation tests pin both themes' rendered HTML (titled/status/multi-post shapes) byte-for-byte before and after. Full unit suite green (2033).

Note: cosmetic, so a `pnpm run screenshot` / Playwright visual pass before merge is still worth doing (I can't run it headless).

Closes #690