### PR TITLE
Fix mkdir() race in ensure_feed_cache()

### DIFF
--- a/src/network/sources.php
+++ b/src/network/sources.php
@@ -152,7 +152,7 @@ class SafeFile extends SimplePieFile
  */
 function ensure_feed_cache(string $dir): string|false
 {
-    if (!is_dir($dir) && !mkdir($dir, 0775, true)) {
+    if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
         return false;
     }
     return is_writable($dir) ? $dir : false;


### PR DESCRIPTION
## Summary
- `ensure_feed_cache()` (`src/network/sources.php`) treated a failed `mkdir()` as fatal without rechecking whether the directory now exists.
- Every other `mkdir()` call site in the codebase (`bootstrap.php:74`, `bootstrap.php:400`, `import.php:674`, `restore.php:491`, `response/discovery.php:210`) rechecks `is_dir($dir)` after a failed `mkdir()` specifically to handle the case where a concurrent process created the directory first (`EEXIST`). This one was missing that recheck.
- Effect: two cron runs (or a cron run racing another process) creating the SimplePie cache directory at the same time could cause the loser to see `mkdir()` fail and disable feed caching for that run — even though the directory the winner created is perfectly usable.

## Fix
Add the same `&& !is_dir($dir)` recheck used everywhere else in the codebase.

## Test plan
- [x] `php -l src/network/sources.php`
- [x] Existing unit coverage (`tests/Unit/NetworkFeedTest.php`, `testEnsureFeedCacheCreatesMissingDirectory` / `testEnsureFeedCacheReturnsFalseWhenNotCreatable`) continues to describe the two non-race paths; the race itself isn't practical to simulate deterministically in a unit test, same as it isn't at the other five call sites.
- [ ] CI: lint/analyse/unit suite (could not run `composer install` locally — see PR description note below)

Note: this environment's `composer install` could not complete (GitHub API auth/rate-limit issue unrelated to this change), so I verified the change with `php -l` and by reading all five sibling call sites rather than running the full local test suite. CI should validate normally.


---
_Generated by [Claude Code](https://claude.ai/code/session_017YmpePS9fqUw6z3ZWceqL1)_