### PR TITLE
Delegate ping_for_post()'s scheduled-post check to is_scheduled()

### DIFF
--- a/src/websub.php
+++ b/src/websub.php
@@ -8,6 +8,7 @@ use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
 
 use function Lamb\get_option;
+use function Lamb\is_scheduled;
 use function Lamb\set_option;
 
 use const Lamb\SQL_PUBLISHED;
@@ -86,7 +87,7 @@ function ping_for_post(OODBBean $bean, ?array $config = null, ?callable $sender 
     if (!$bean->id || !empty($bean->feed_name) || !empty($bean->draft)) {
         return;
     }
-    if (!empty($bean->created) && strtotime((string) $bean->created) > time()) {
+    if (is_scheduled($bean)) {
         return;
     }
 


### PR DESCRIPTION
## Summary
`Websub\ping_for_post()` (`src/websub.php`) reimplemented the "is this post scheduled for the future" predicate inline:

```php
if (!empty($bean->created) && strtotime((string) $bean->created) > time()) {
    return;
}
```

instead of calling the canonical `is_scheduled()` helper in `src/lamb.php` that every other caller (webmention.php, micropub.php, theme.php) uses:

```php
function is_scheduled(OODBBean $post): bool {
    return !empty($post->created) && $post->created > now();
}
```

Same result today, but two different comparison strategies (`strtotime()` timestamp vs. string comparison against `now()`) for the same concept is exactly the kind of thing that drifts: if `is_scheduled()`'s semantics ever change (a grace period, timezone handling, treating an equal timestamp differently), this call site would silently keep the old behavior — pinging WebSub for a post out of step with when webmention delivery and the public listings consider it live.

## Fix
Import and call `is_scheduled()` instead of reimplementing it. No behavior change.

## Test plan
- [x] `php -l src/websub.php`
- [x] `tests/Unit/WebsubTest.php::testPingForPostSkipsDraftsFeedItemsAndScheduledPosts` already sets a future `created` and asserts no ping — this covers the refactored branch as a regression check.
- [ ] CI: lint/analyse/unit suite (local `composer install` could not complete in this environment — see note in a sibling PR from this batch)


---
_Generated by [Claude Code](https://claude.ai/code/session_017YmpePS9fqUw6z3ZWceqL1)_