### PR TITLE
Derive get_cookie_options()'s secure flag from the request scheme

### DIFF
--- a/src/response.php
+++ b/src/response.php
@@ -26,6 +26,12 @@ define('LOGIN_PASSWORD', getenv("LAMB_LOGIN_PASSWORD") ?: '');
 /**
  * Returns cookie options with the given expiry timestamp.
  *
+ * `secure` tracks the connection scheme rather than being forced on, matching
+ * the session cookie (Bootstrap\configure_session()): a cookie marked secure
+ * over plain HTTP is silently dropped by the browser, which would otherwise
+ * break login persistence on any install served without TLS (e.g. behind a
+ * proxy that never sets HTTPS=on, or during initial local setup).
+ *
  * @param int $expires Unix timestamp for cookie expiry.
  * @return array<string, mixed> Cookie options array.
  */
@@ -34,7 +40,7 @@ function get_cookie_options(int $expires): array
     return [
         'expires'  => $expires,
         'path'     => '/',
-        'secure'   => true,
+        'secure'   => (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on'),
         'httponly' => true,
         'samesite' => 'Strict',
     ];

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -130,8 +130,8 @@ function login_csrf_secret(string $loginHash): string
 /**
  * Returns options for the /login CSRF cookie, reusing the hardened defaults.
  *
- * Like the session cookie (configure_session()), `secure` tracks the connection
- * scheme rather than being forced on: the token this cookie replaces — the
+ * get_cookie_options() already derives `secure` from the connection scheme
+ * rather than forcing it on: the token this cookie replaces — the
  * session-backed CSRF token — rode in LAMBSESSID, which is only marked secure
  * under HTTPS, so a plain-HTTP dev server still round-trips it. SameSite=Strict
  * is the load-bearing control: a cross-site POST never carries the cookie, so the
@@ -142,9 +142,7 @@ function login_csrf_secret(string $loginHash): string
  */
 function login_csrf_cookie_options(int $expires): array
 {
-    $options = get_cookie_options($expires);
-    $options['secure'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on');
-    return $options;
+    return get_cookie_options($expires);
 }
 
 /**

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -15,6 +15,12 @@ use function Lamb\Response\upgrade_posts;
 
 class ResponseTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTPS']);
+        parent::tearDown();
+    }
+
     // get_cookie_options
 
     public function testGetCookieOptionsReturnsArray()
@@ -47,8 +53,19 @@ class ResponseTest extends TestCase
         $this->assertSame('Strict', get_cookie_options(time())['samesite']);
     }
 
-    public function testGetCookieOptionsSecureIsTrue()
+    public function testGetCookieOptionsSecureIsFalseOverPlainHttp()
     {
+        unset($_SERVER['HTTPS']);
+        $this->assertFalse(
+            get_cookie_options(time())['secure'],
+            'A secure cookie is silently dropped by the browser over plain HTTP, which would '
+                . 'break login persistence on any install served without TLS'
+        );
+    }
+
+    public function testGetCookieOptionsSecureIsTrueOverHttps()
+    {
+        $_SERVER['HTTPS'] = 'on';
         $this->assertTrue(get_cookie_options(time())['secure']);
     }
 


### PR DESCRIPTION
## Summary
`get_cookie_options()` (`src/response.php`) hardcoded `'secure' => true`, unconditionally. It backs the `lamb_logged_in` login-marker cookie (`set_login_marker()` / `redirect_logout()` in `src/response/auth.php`).

A cookie marked `Secure` is silently refused by the browser over plain HTTP. `Bootstrap\should_start_session()` (`src/bootstrap.php`) requires a **valid `lamb_logged_in` marker** to resume a session at all. So on any Lamb install served without TLS terminating as `HTTPS=on` (behind a proxy that doesn't set that header, or during initial local/LAN setup) — the sequence is:

1. Visitor submits the correct password.
2. Server sets `lamb_logged_in` with `Secure` — browser drops it (connection is plain HTTP).
3. Next request carries no valid marker → `should_start_session()` returns false → treated as anonymous.

Login silently never persists past the first request, even though the password check passed.

This was already fixed correctly in two sibling places, which is what made the third stand out:
- `Bootstrap\configure_session()` (session cookie) derives `secure` from `$_SERVER['HTTPS'] === 'on'`.
- `login_csrf_cookie_options()` (`src/response/auth.php`) does the same and even says in its own docblock it does this "like the session cookie" — but then had to override `get_cookie_options()`'s hardcoded value to do so.

## Fix
- `get_cookie_options()` now derives `secure` from the request scheme, matching `configure_session()`.
- `login_csrf_cookie_options()` no longer needs to recompute and override it — it now just returns `get_cookie_options()` directly, removing the duplicate scheme check.

## Test plan
- [x] `php -l` on both changed source files
- [x] Updated `tests/Unit/ResponseTest.php`: replaced `testGetCookieOptionsSecureIsTrue` (which is no longer universally true) with `testGetCookieOptionsSecureIsFalseOverPlainHttp` and `testGetCookieOptionsSecureIsTrueOverHttps`, covering both branches.
- [ ] CI: lint/analyse/unit suite (local `composer install` could not complete in this environment — see note below)

Note: this environment's `composer install` failed on a handful of packages with "Could not authenticate against github.com" (looks like GitHub API rate limiting through the sandbox's egress proxy, unrelated to this change), so I could not run the suite locally. I verified with `php -l` and by tracing every call site of the two touched functions. CI should validate normally.


---
_Generated by [Claude Code](https://claude.ai/code/session_017YmpePS9fqUw6z3ZWceqL1)_