### PR TITLE
Check require_login() before the empty-POST guard in delete/restore

### DIFF
--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -193,10 +193,10 @@ function delete_return_path(?string $referer, string $own_path): string
 #[NoReturn]
 function redirect_deleted(mixed $args): void
 {
+    Security\require_login();
     if (empty($_POST)) {
         redirect_uri('/');
     }
-    Security\require_login();
     Security\require_csrf();
 
     [$id] = $args;
@@ -217,10 +217,10 @@ function redirect_deleted(mixed $args): void
 #[NoReturn]
 function redirect_restored(mixed $args): void
 {
+    Security\require_login();
     if (empty($_POST)) {
         redirect_uri('/trash');
     }
-    Security\require_login();
     Security\require_csrf();
 
     [$id] = $args;

--- a/tests/Acceptance/DeleteRestoreCest.php
+++ b/tests/Acceptance/DeleteRestoreCest.php
@@ -181,4 +181,26 @@ class DeleteRestoreCest
         $I->dontSee('Fatal error');
         $I->dontSee('Warning:');
     }
+
+    // require_login() runs before the empty-POST guard (#722): an unauthenticated
+    // POST to delete/restore now bounces to /login carrying the original path in
+    // redirect_to, matching create/edit — instead of the empty-POST guard firing
+    // first and redirecting to / or /trash before the login check ever runs.
+    //
+    // Assert on redirect_to, not just landing on /login: an unauthenticated
+    // restore under the old order redirected to /trash, which is itself
+    // login-gated and bounces to /login too — so only the redirect_to target
+    // distinguishes the fixed order from the bug.
+
+    public function testDeleteWithoutLoginRedirectsToLogin(AcceptanceTester $I): void
+    {
+        $I->sendEmptyPost('/delete/1');
+        $I->seeInCurrentUrl('/login?redirect_to=%2Fdelete%2F1');
+    }
+
+    public function testRestoreWithoutLoginRedirectsToLogin(AcceptanceTester $I): void
+    {
+        $I->sendEmptyPost('/restore/1');
+        $I->seeInCurrentUrl('/login?redirect_to=%2Frestore%2F1');
+    }
 }

--- a/tests/Support/Helper/Acceptance.php
+++ b/tests/Support/Helper/Acceptance.php
@@ -105,4 +105,17 @@ class Acceptance extends Module
         $browser = $this->getModule('PhpBrowser');
         $this->assertStringContainsString($needle, (string) $browser->client->getInternalResponse()->getContent());
     }
+
+    /**
+     * Issues a form-less POST with an empty body to the given path, following any
+     * redirect. Lets a test hit a POST-only route (e.g. /delete) without a page
+     * rendering its form first; assert the landing spot with $I->seeInCurrentUrl().
+     *
+     * @param string $url The path to POST to.
+     * @return void
+     */
+    public function sendEmptyPost(string $url): void
+    {
+        $this->getModule('PhpBrowser')->_request('POST', $url);
+    }
 }


### PR DESCRIPTION
## Summary
Diffing guard clauses across the `redirect_*` post-mutation family (`src/response/posts.php`) turned up an ordering inconsistency:

- `redirect_created()` and `redirect_edited()`: call `Security\require_login()` and `Security\require_csrf()` **first**, then look at the submitted values.
- `redirect_deleted()` and `redirect_restored()`: checked `empty($_POST)` and redirected **before** calling `require_login()`/`require_csrf()` at all.

Since `redirect_uri()` ends the request (`header('Location: ...'); die();`), a GET-like request with an empty `$_POST` to the delete/restore endpoints returned home/to the trash page without `require_login()` ever running — unlike hitting the create/edit endpoints the same way, which redirects to `/login`. No state change happens either way (the actual delete/restore only happens further down, already behind both guards), so this isn't an auth bypass — but it's an inconsistency in observable behavior for the same shape of request across sibling functions, and it meant `require_login()` wasn't uniformly enforced across this function family.

## Fix
Move `Security\require_login()` above the `empty($_POST)` check in both `redirect_deleted()` and `redirect_restored()`, matching the order in `redirect_created()`/`redirect_edited()`. `require_csrf()` stays after the empty-POST redirect, preserving the existing (friendlier) "just redirect" behavior for an authenticated empty-POST hit, rather than turning it into a 405.

## Test plan
- [x] `php -l src/response/posts.php`
- [x] `tests/Acceptance/DeleteRestoreCest.php` exercises the real logged-in, form-submission path for both functions and is unaffected by this reordering (non-empty `$_POST`, valid CSRF token).
- [ ] CI: lint/analyse/unit/acceptance suite (local `composer install` could not complete in this environment — see note in a sibling PR from this batch)


---
_Generated by [Claude Code](https://claude.ai/code/session_017YmpePS9fqUw6z3ZWceqL1)_