### PR TITLE
Docs: note stacked-PR awareness for bulk PR operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -647,6 +647,8 @@ When a task's work is complete and pushed, open a pull request for it by default
 
 After opening a pull request, watch its activity and automatically fix failing CI checks — diagnose the failure, push a fix, and repeat until the checks pass — without waiting to be asked. Address clear-cut review feedback the same way; check in before acting only when a fix is ambiguous or architecturally significant.
 
+Before any bulk PR operation — merging, rebasing, or force-pushing across several PRs — check whether the branches are stacked. Branches can be built on each other even when every PR targets `main`, so a diff or a squash can carry a lower branch's content, and a PR's real base may be another feature branch (check `baseRefName`). Merge stacked PRs bottom-up, re-check each remaining PR's mergeable state after every merge (earlier merges turn later ones `DIRTY`), and never force-push a shared branch without confirming the remote tip is what you expect — another session or GitHub's base-retargeting may have moved it. Prefer merging `main` into the branch over rebasing, so the push stays a fast-forward. When resolving the merge, keep the content the stacked branch legitimately owns rather than blindly taking `main`'s side, and run the tests locally before pushing.
+
 ## Philosophy (from README)
 
 - Simple over complex


### PR DESCRIPTION
Adds guidance to AGENTS.md's Pull Requests section on handling stacked branches during bulk merge/rebase/force-push operations.

Prompted by a merge where PR #715 (multiple in-reply-to) was based on #712's branch rather than main, so bulk-merging carried and conflicted on stacked content.

Covers: checking `baseRefName`, merging bottom-up, re-checking mergeable state after each merge, confirming the remote tip before force-pushing, preferring merge-main-in over rebase, keeping the stacked branch's legitimate content, and testing locally before pushing.