### PR TITLE
Converge visibility predicates: one NULL-safe draft/deleted check (D6, #684)

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -802,6 +802,31 @@ function is_scheduled(OODBBean $post): bool
 }
 
 /**
+ * Returns true when a post is a draft. The in-memory counterpart to
+ * SQL_NOT_DRAFT: an unset column is not a draft, so a loaded bean and a SQL
+ * listing agree on the definition.
+ *
+ * @param OODBBean $post The post to inspect.
+ * @return bool
+ */
+function is_draft(OODBBean $post): bool
+{
+    return ($post->draft ?? null) == 1;
+}
+
+/**
+ * Returns true when a post is soft-deleted. The in-memory counterpart to
+ * SQL_NOT_DELETED: an unset column is not deleted, matching the SQL listings.
+ *
+ * @param OODBBean $post The post to inspect.
+ * @return bool
+ */
+function is_deleted(OODBBean $post): bool
+{
+    return ($post->deleted ?? null) == 1;
+}
+
+/**
  * Returns true when a post may be shown for a direct permalink request
  * (/status/<id> or a slug URL).
  *
@@ -816,13 +841,13 @@ function is_scheduled(OODBBean $post): bool
  */
 function is_viewable(OODBBean $post): bool
 {
-    if (empty($post->id) || $post->deleted == 1) {
+    if (empty($post->id) || is_deleted($post)) {
         return false;
     }
     if (isset($_SESSION[SESSION_LOGIN])) {
         return true;
     }
-    return $post->draft != 1 && !is_scheduled($post);
+    return !is_draft($post) && !is_scheduled($post);
 }
 
 /**
@@ -842,7 +867,7 @@ function is_viewable(OODBBean $post): bool
  */
 function is_publicly_visible(OODBBean $post): bool
 {
-    if (empty($post->id) || $post->deleted == 1 || $post->draft == 1) {
+    if (empty($post->id) || is_deleted($post) || is_draft($post)) {
         return false;
     }
     return !is_scheduled($post);

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -11,6 +11,8 @@ use RedBeanPHP\R;
 use function Lamb\Http\fetch_guarded;
 use function Lamb\Http\is_public_http_url;
 use function Lamb\Http\is_valid_http_url;
+use function Lamb\is_deleted;
+use function Lamb\is_draft;
 use function Lamb\is_scheduled;
 use function Lamb\permalink;
 use function Lamb\Post\split_reply_targets;
@@ -691,7 +693,7 @@ function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender
         // 410/404 source and drops the mention. If the post is alive again
         // (restored before this ran), abandon the re-send rather than falsely
         // report it as deleted.
-        if ($post->id && $post->deleted != 1) {
+        if ($post->id && !is_deleted($post)) {
             $row->status = 'sent';
             $row->resend = 0;
             $row->processed_at = \Lamb\now();
@@ -699,7 +701,7 @@ function process_outbound_row(OODBBean $row, callable $fetcher, callable $sender
             return 'cancelled';
         }
     } else {
-        if (!$post->id || $post->deleted == 1 || $post->draft == 1) {
+        if (!$post->id || is_deleted($post) || is_draft($post)) {
             $row->status = 'cancelled';
             $row->processed_at = \Lamb\now();
             R::store($row);

--- a/tests/Unit/PostVisibilityTest.php
+++ b/tests/Unit/PostVisibilityTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\is_deleted;
+use function Lamb\is_draft;
 use function Lamb\is_publicly_visible;
 use function Lamb\is_viewable;
 use function Lamb\Response\respond_post;
@@ -134,6 +136,27 @@ class PostVisibilityTest extends TestCase
     {
         $bean = R::load('post', 999999);
         $this->assertFalse(is_publicly_visible($bean));
+    }
+
+    // ---- is_draft() / is_deleted() predicates ------------------------------
+    // NULL-safe, mirroring SQL_NOT_DRAFT / SQL_NOT_DELETED: an unset column is
+    // "not draft" / "not deleted", so the SQL listings and the PHP checks agree
+    // on one definition (D6, #684).
+
+    public function testIsDraftMatchesSqlNullSafeSemantics(): void
+    {
+        $this->assertTrue(is_draft($this->makePost(['draft' => 1])));
+        $this->assertTrue(is_draft($this->makePost(['draft' => '1'])), 'a string "1" counts, as SQL "draft != 1" would');
+        $this->assertFalse(is_draft($this->makePost(['draft' => 0])));
+        $this->assertFalse(is_draft(R::dispense('post')), 'an unset draft column is not a draft');
+    }
+
+    public function testIsDeletedMatchesSqlNullSafeSemantics(): void
+    {
+        $this->assertTrue(is_deleted($this->makePost(['deleted' => 1])));
+        $this->assertTrue(is_deleted($this->makePost(['deleted' => '1'])));
+        $this->assertFalse(is_deleted($this->makePost(['deleted' => 0])));
+        $this->assertFalse(is_deleted(R::dispense('post')), 'an unset deleted column is not deleted');
     }
 
     // ---- respond_status (/status/<id>) ------------------------------------


### PR DESCRIPTION
Closes the last open hotspot of the Convergence epic **#684** — D6, "deciding a post is visible".

## What D6 actually needed
A map of all five visibility expressions showed the codebase is already largely converged: the SQL side single-sources draft/deleted via `SQL_NOT_DRAFT` / `SQL_NOT_DELETED` → `SQL_PUBLISHED` → `visible_clause()`/`public_posts_clause()`, and the PHP predicates already compose `is_scheduled()`. Several apparent duplicates are **deliberate, documented distinctions, not drift** — left untouched:
- `is_viewable()`'s logged-in preview exception (permalink view) vs `is_publicly_visible()` (external/webmention).
- The WebSub sweep's `created > updated` watermark + `feed_name` filter.
- The `is_menu_item()` theme backstop for owner-only views.

## The genuine drift, fixed
- The PHP predicates open-coded `draft != 1` / `deleted == 1` in three places.
- The **webmention outbox** (`webmention.php:~700`) reimplemented the draft/deleted predicate inline, even though `target_post_id()` right above it uses `is_publicly_visible()`.

This adds `is_draft()` / `is_deleted()` mirroring the SQL constants (NULL-safe: an unset column is not draft / not deleted) and routes `is_viewable()`, `is_publicly_visible()`, and the webmention outbox through them — one definition of "draft" and "deleted" across SQL and PHP.

## Test plan (red-green, no behaviour change)
- [x] Characterisation tests for `is_draft()`/`is_deleted()` (NULL-safe semantics) — written first, confirmed red (undefined function), then green.
- [x] `Unit:PostVisibilityTest` (16), `WebmentionTest` (33), `WebmentionSendTest` (36), `WebsubTest`, `WebsubScheduledTest`, `ScheduledPostTest`, `ResponseTest` — all green, behaviour preserved.
- [x] Full unit suite: 2104 tests green.
- [x] PHPStan level 8: no errors (baseline stays empty).
- [x] `composer lint` clean.