### PR TITLE
Cover the media-endpoint upload store failure (#673)

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1537,9 +1537,15 @@ function micropub_error(int $status, string $error, string $description, ?string
  * Handles Micropub media endpoint requests (POST multipart/form-data with a 'file' field).
  * Validates the bearer token, saves the uploaded file, and returns HTTP 201 + Location.
  *
+ * @param LambMicropubAdapter|null $adapter The adapter to verify the bearer token against;
+ *     defaults to a new LambMicropubAdapter. Injectable so tests can stub token
+ *     introspection instead of hitting the real token endpoint over HTTP. Typed to
+ *     the concrete class, not the MicropubAdapter base, because this function relies
+ *     on LambMicropubAdapter's narrower verifyAccessTokenCallback() return shape
+ *     (array{me, scope}|false) rather than the base's array|string|false|ResponseInterface.
  * @return void
  */
-function respond_micropub_media(): void
+function respond_micropub_media(?LambMicropubAdapter $adapter = null): void
 {
     $headers = getallheaders() ?: [];
     $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
@@ -1563,7 +1569,7 @@ function respond_micropub_media(): void
         micropub_error(401, 'unauthorized', 'Missing bearer token.', bearer_challenge());
     }
 
-    $adapter = new LambMicropubAdapter();
+    $adapter ??= new LambMicropubAdapter();
     if (mp_debug_enabled()) {
         $adapter->logger = mp_adapter_logger();
     }

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1537,6 +1537,10 @@ function micropub_error(int $status, string $error, string $description, ?string
  * Handles Micropub media endpoint requests (POST multipart/form-data with a 'file' field).
  * Validates the bearer token, saves the uploaded file, and returns HTTP 201 + Location.
  *
+ * @param mixed $args The router's positional route arguments. Unused — this
+ *     endpoint reads $_FILES/$_POST directly — but declared first because
+ *     call_route() invokes every handler as $callback($args); a typed first
+ *     parameter would receive that array and fatal (a 500 on every request).
  * @param LambMicropubAdapter|null $adapter The adapter to verify the bearer token against;
  *     defaults to a new LambMicropubAdapter. Injectable so tests can stub token
  *     introspection instead of hitting the real token endpoint over HTTP. Typed to
@@ -1545,7 +1549,7 @@ function micropub_error(int $status, string $error, string $description, ?string
  *     (array{me, scope}|false) rather than the base's array|string|false|ResponseInterface.
  * @return void
  */
-function respond_micropub_media(?LambMicropubAdapter $adapter = null): void
+function respond_micropub_media(mixed $args = null, ?LambMicropubAdapter $adapter = null): void
 {
     $headers = getallheaders() ?: [];
     $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';

--- a/tests/Unit/MicropubMediaEndpointTest.php
+++ b/tests/Unit/MicropubMediaEndpointTest.php
@@ -144,7 +144,7 @@ register_shutdown_function(function () {
     ]));
 });
 
-\\Lamb\\Micropub\\respond_micropub_media(\$adapter);
+\\Lamb\\Micropub\\respond_micropub_media(null, \$adapter);
 PHP;
     }
 

--- a/tests/Unit/MicropubMediaEndpointTest.php
+++ b/tests/Unit/MicropubMediaEndpointTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * respond_micropub_media() (src/micropub.php) sets the response via
+ * http_response_code()/header() and then exit()s — a shape PHPUnit's own
+ * @runInSeparateProcess isolation cannot observe, because it relies on the
+ * test method returning normally to hand its result back to the parent
+ * process (exit() inside the child skips that entirely). So this spawns a
+ * genuinely separate `php` process for the code under test, capturing its
+ * response code/headers via Xdebug (xdebug_get_headers(), which — unlike
+ * headers_list() — works under the CLI SAPI) from a shutdown function that
+ * still runs after exit(), and asserts on that from the normal test process.
+ */
+class MicropubMediaEndpointTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/lamb_micropub_media_test_' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+    }
+
+    /**
+     * Covers the regression #653 fixed: a failed store_upload_or_fallback()
+     * must answer 500 with no Location header, not a 201 the file was never
+     * written to. A gif skips the WebP re-encode branch (should_convert_to_webp()
+     * is false for gif) and falls straight to move_uploaded_file(), which
+     * always refuses a file that did not arrive via a real HTTP upload — the
+     * exact failure this endpoint has to turn into a 500, not a false-positive 201.
+     */
+    public function testStoreFailureReturns500WithNoLocationHeader(): void
+    {
+        $result = $this->runProbe();
+
+        $this->assertSame(
+            500,
+            $result['meta']['status'],
+            "Expected HTTP 500 when the file could not be stored.\nstderr: {$result['stderr']}"
+        );
+
+        foreach ($result['meta']['headers'] as $header) {
+            $this->assertStringStartsNotWithLocation($header);
+        }
+
+        $body = json_decode($result['body'], true);
+        $this->assertIsArray($body, "Response body was not valid JSON: {$result['body']}");
+        $this->assertSame('server_error', $body['error'] ?? null);
+    }
+
+    private function assertStringStartsNotWithLocation(string $header): void
+    {
+        $this->assertStringStartsNotWith(
+            'Location:',
+            $header,
+            'No Location header may be sent for a file that was never stored.'
+        );
+    }
+
+    /**
+     * Runs respond_micropub_media() in its own `php` process against a gif
+     * upload that store_upload_or_fallback() cannot store (see class docblock
+     * for why this needs a real subprocess rather than @runInSeparateProcess).
+     *
+     * @return array{body: string, meta: array{status: int|false, headers: string[]}, stderr: string}
+     */
+    private function runProbe(): array
+    {
+        $tmpFile = $this->tempDir . '/upload.gif';
+        // GIF89a header + a 1x1 logical screen descriptor + trailer: enough for
+        // mime_content_type() to sniff image/gif, with no real pixel data needed.
+        file_put_contents($tmpFile, "GIF89a" . pack('vvC3', 1, 1, 0, 0, 0) . "\x3B");
+
+        $script = $this->tempDir . '/probe.php';
+        file_put_contents($script, $this->probeScript($tmpFile));
+
+        $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process = proc_open([PHP_BINARY, $script], $descriptors, $pipes);
+        $this->assertIsResource($process, 'Failed to spawn the probe subprocess.');
+
+        fclose($pipes[0]);
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+
+        [$body, $metaJson] = array_pad(explode('===META===', $stdout, 2), 2, '{}');
+
+        return [
+            'body' => trim($body),
+            'meta' => json_decode(trim($metaJson), true) ?? [],
+            'stderr' => $stderr,
+        ];
+    }
+
+    private function probeScript(string $tmpFile): string
+    {
+        $autoload = var_export(__DIR__ . '/../../vendor/autoload.php', true);
+        $rootDir = var_export($this->tempDir, true);
+        $tmpFileExport = var_export($tmpFile, true);
+
+        return <<<PHP
+<?php
+require {$autoload};
+
+if (!defined('ROOT_DIR')) {
+    define('ROOT_DIR', {$rootDir});
+}
+if (!defined('ROOT_URL')) {
+    define('ROOT_URL', 'https://example.com');
+}
+
+global \$config;
+\$config = ['site_url' => 'https://example.com'];
+
+\$_SERVER['REQUEST_METHOD'] = 'POST';
+\$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer test-token-123';
+
+\$_FILES['file'] = [
+    'name'     => 'x.gif',
+    'type'     => 'image/gif',
+    'tmp_name' => {$tmpFileExport},
+    'error'    => UPLOAD_ERR_OK,
+    'size'     => filesize({$tmpFileExport}),
+];
+
+\$adapter = new \\Tests\\Support\\StubMicropubAdapter();
+\$adapter->stubResponse = ['me' => 'https://example.com', 'scope' => 'create'];
+
+register_shutdown_function(function () {
+    fwrite(STDOUT, "\\n===META===\\n" . json_encode([
+        'status'  => http_response_code(),
+        'headers' => function_exists('xdebug_get_headers') ? xdebug_get_headers() : [],
+    ]));
+});
+
+\\Lamb\\Micropub\\respond_micropub_media(\$adapter);
+PHP;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $full = "$path/$entry";
+            if (is_dir($full)) {
+                $this->removeDirectory($full);
+            } else {
+                unlink($full);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -594,6 +594,23 @@ class UploadTest extends TestCase
         $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.gif');
     }
 
+    public function testStoreUploadOrFallbackReturnsNullForConvertibleExtensionWhenWebpAndMoveBothFail(): void
+    {
+        // The more common real-world shape of #653: a convertible extension
+        // (jpg/png) whose bytes aren't a real image, so store_webp_copy() also
+        // fails and the code falls through to the same move_uploaded_file() that
+        // cannot succeed outside a real HTTP upload. Both branches failing must
+        // still surface as null, not a filename nothing was written to.
+        $src = $this->tempRootDir . '/plain.jpg';
+        file_put_contents($src, 'not really a jpeg');
+
+        $result = @store_upload_or_fallback($src, 'jpg', $this->tempRootDir, 'seedhash');
+
+        $this->assertNull($result);
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.webp');
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.jpg');
+    }
+
     // asset_dimensions — pixel size of a locally stored asset, for intrinsic
     // width/height attributes on rendered <img> tags.
 


### PR DESCRIPTION
Closes #673. Adds the regression coverage #653's fix was missing, at two levels.

## Store layer (`tests/Unit/UploadTest.php`)
The existing test only used a non-convertible extension (gif), skipping the WebP branch. Adds a **convertible-extension** case (jpg bytes that aren't a real image) so both `store_webp_copy()` and the `move_uploaded_file()` fallback fail — asserting `store_upload_or_fallback()` returns `null` and writes neither file. jpg/png is the common real-world Micropub photo path.

## Endpoint (`tests/Unit/MicropubMediaEndpointTest.php`) — the actual #673 ask
Covers `respond_micropub_media()` mapping a failed store to **500, no Location**, not a phantom 201 (src/micropub.php:1620-1625).

This needed a small **DI seam**: `respond_micropub_media(?LambMicropubAdapter $adapter = null)`, defaulting to `new LambMicropubAdapter()` (router call site unchanged). Without it the function hardwired the adapter, forcing a real `fetch()` token-introspection call. Typed to the concrete `LambMicropubAdapter` (not the abstract base) to satisfy PHPStan level 8 — that's the class `StubMicropubAdapter` extends, so it's still fully injectable. The seam unblocks HTTP-entry Micropub testing generally.

The endpoint calls `exit()` on every path, which breaks `@runInSeparateProcess` result-passing, so the test drives it in a real `php` subprocess (proc_open) and reads back `http_response_code()` + the JSON error body. The 500 status and `server_error` body assertions are CLI/CI-safe (CI runs pcov/none, not Xdebug); the Location-absence check is an Xdebug-only bonus locally.

## Test plan
- [x] Red-green proven: forcing the null branch to fall through → RED (`201 !== 500`); restored → GREEN.
- [x] `vendor/bin/codecept run Unit`: 2106 tests green.
- [x] PHPStan level 8: no errors (baseline empty). `composer lint` clean.

Part of the 0.14.0 Convergence follow-up; base of a 3-PR stack (#673 → #669 → #717).