### PR TITLE
Back latest_content_timestamp() with a monotonic stored mark (#669)

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1537,9 +1537,15 @@ function micropub_error(int $status, string $error, string $description, ?string
  * Handles Micropub media endpoint requests (POST multipart/form-data with a 'file' field).
  * Validates the bearer token, saves the uploaded file, and returns HTTP 201 + Location.
  *
+ * @param LambMicropubAdapter|null $adapter The adapter to verify the bearer token against;
+ *     defaults to a new LambMicropubAdapter. Injectable so tests can stub token
+ *     introspection instead of hitting the real token endpoint over HTTP. Typed to
+ *     the concrete class, not the MicropubAdapter base, because this function relies
+ *     on LambMicropubAdapter's narrower verifyAccessTokenCallback() return shape
+ *     (array{me, scope}|false) rather than the base's array|string|false|ResponseInterface.
  * @return void
  */
-function respond_micropub_media(): void
+function respond_micropub_media(?LambMicropubAdapter $adapter = null): void
 {
     $headers = getallheaders() ?: [];
     $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
@@ -1563,7 +1569,7 @@ function respond_micropub_media(): void
         micropub_error(401, 'unauthorized', 'Missing bearer token.', bearer_challenge());
     }
 
-    $adapter = new LambMicropubAdapter();
+    $adapter ??= new LambMicropubAdapter();
     if (mp_debug_enabled()) {
         $adapter->logger = mp_adapter_logger();
     }

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -1537,6 +1537,10 @@ function micropub_error(int $status, string $error, string $description, ?string
  * Handles Micropub media endpoint requests (POST multipart/form-data with a 'file' field).
  * Validates the bearer token, saves the uploaded file, and returns HTTP 201 + Location.
  *
+ * @param mixed $args The router's positional route arguments. Unused — this
+ *     endpoint reads $_FILES/$_POST directly — but declared first because
+ *     call_route() invokes every handler as $callback($args); a typed first
+ *     parameter would receive that array and fatal (a 500 on every request).
  * @param LambMicropubAdapter|null $adapter The adapter to verify the bearer token against;
  *     defaults to a new LambMicropubAdapter. Injectable so tests can stub token
  *     introspection instead of hitting the real token endpoint over HTTP. Typed to
@@ -1545,7 +1549,7 @@ function micropub_error(int $status, string $error, string $description, ?string
  *     (array{me, scope}|false) rather than the base's array|string|false|ResponseInterface.
  * @return void
  */
-function respond_micropub_media(?LambMicropubAdapter $adapter = null): void
+function respond_micropub_media(mixed $args = null, ?LambMicropubAdapter $adapter = null): void
 {
     $headers = getallheaders() ?: [];
     $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -566,6 +566,10 @@ class LambMicropubAdapter extends MicropubAdapter
         }
         R::store($bean);
 
+        // A Micropub update is a content change: advance the monotonic mark so
+        // the 304 validator does not serve a stale cache for it (#669).
+        \Lamb\Response\bump_content_timestamp();
+
         notify_post_subscribers($bean);
 
         return true;

--- a/src/post.php
+++ b/src/post.php
@@ -889,6 +889,12 @@ function save(OODBBean $bean, array $context = []): void
         R::store($bean);
     }
 
+    // save() is the write funnel, so the content high-water mark must advance
+    // here too — not only in finalize_and_store_post(), which the funnel does
+    // not call (#669). Without this, posts saved through save() (the #692 site
+    // and every #717 conversion) would never move latest_content_timestamp().
+    \Lamb\Response\bump_content_timestamp();
+
     emit($is_new ? 'post.created' : 'post.updated', $bean);
     if ($context['notify']) {
         emit('post.published', $bean);

--- a/src/post.php
+++ b/src/post.php
@@ -757,6 +757,9 @@ function finalize_and_store_post(OODBBean $bean): void
     if (finalize_slug($bean)) {
         R::store($bean);
     }
+    // Funnel point for every create/edit path: bumps the monotonic content
+    // high-water mark latest_content_timestamp() reads (#669).
+    \Lamb\Response\bump_content_timestamp();
 }
 
 /**

--- a/src/response.php
+++ b/src/response.php
@@ -8,9 +8,11 @@ use JetBrains\PhpStorm\NoReturn;
 use RedBeanPHP\R;
 use RedBeanPHP\RedException\SQL;
 
+use function Lamb\get_option;
 use function Lamb\parse_bean;
 use function Lamb\Post\inject_title_matter;
 use function Lamb\Post\parse_matter;
+use function Lamb\set_option;
 
 // The built-in dev server (`composer serve`) does not load .env, so read it here
 // before LOGIN_PASSWORD is captured. Restricted to the cli-server SAPI so it only
@@ -47,19 +49,59 @@ function get_cookie_options(int $expires): array
 }
 
 /**
- * Returns the Unix timestamp of the most recently updated published post.
+ * Option key holding the monotonic content high-water mark (#669).
  *
- * Used as a coarse, monotonic content validator for conditional GETs: any post
- * edit/publish moves it forward, so anonymous pages revalidate; the max-age
- * window covers edge cases (config edits, scheduled posts going live).
+ * A plain MAX(updated) over published posts moves backwards when the post
+ * holding that max gets trashed, which could serve a stale 304 to a
+ * date-only cache/client for content that has since changed. This mark is
+ * bumped forward-only by the content-mutation chokepoints instead
+ * (finalize_and_store_post(), soft_delete_post(), restore_post()), so trash/
+ * restore can never pull the validator backwards.
+ */
+const CONTENT_MODIFIED_TS = 'content_modified_ts';
+
+/**
+ * Advances the stored content high-water mark to a value strictly greater
+ * than its current one.
+ *
+ * Mirrors save_ini_text()'s config-timestamp idiom: max(time(), previous + 1)
+ * guarantees forward movement even when two mutations land in the same
+ * wall-clock second, so the conditional-GET validator always changes on a
+ * content mutation.
+ *
+ * @return void
+ */
+function bump_content_timestamp(): void
+{
+    $option = get_option(CONTENT_MODIFIED_TS, 0);
+    $previous = (int) ($option->value ?: 0);
+    set_option($option, max(time(), $previous + 1));
+}
+
+/**
+ * Returns the Unix timestamp of the content high-water mark: the most recent
+ * of any published post's `updated` and any trash/restore, tracked via the
+ * stored, monotonic mark (see bump_content_timestamp()).
+ *
+ * Lazily backfills the mark from the current MAX(updated) the first time it's
+ * read as unset, so an install upgrading to #669 doesn't have its validator
+ * reset to 0 (which would look like "everything just changed" to every
+ * client). After that, the mark is authoritative and never recomputed here.
  *
  * @return int Unix timestamp, or 0 when there is no published content yet.
  */
 function latest_content_timestamp(): int
 {
-    $latest = R::findOne('post', \Lamb\SQL_PUBLISHED . ' ORDER BY updated DESC LIMIT 1');
-    $post_ts = ($latest !== null && !empty($latest->updated)) ? (strtotime($latest->updated) ?: 0) : 0;
-    return max($post_ts, \Lamb\Config\config_modified_timestamp());
+    $option = get_option(CONTENT_MODIFIED_TS, 0);
+    $mark = (int) ($option->value ?: 0);
+    if ($mark === 0) {
+        $latest = R::findOne('post', \Lamb\SQL_PUBLISHED . ' ORDER BY updated DESC LIMIT 1');
+        $mark = ($latest !== null && !empty($latest->updated)) ? (strtotime($latest->updated) ?: 0) : 0;
+        if ($mark > 0) {
+            set_option($option, $mark);
+        }
+    }
+    return max($mark, \Lamb\Config\config_modified_timestamp());
 }
 
 /**

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -345,6 +345,10 @@ function redirect_edited(): void
         return;
     }
 
+    // An edit is a content change: advance the monotonic mark so the 304
+    // validator does not serve a stale cache for the just-edited post (#669).
+    bump_content_timestamp();
+
     $new_slug = $bean->slug;
     if (!empty($old_slug) && $old_slug !== $new_slug) {
         store_slug_change_redirect((string) $old_slug, (string) $new_slug);

--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -246,6 +246,10 @@ function soft_delete_post(OODBBean $post): void
     // Re-send any webmentions this post previously sent so receivers re-fetch
     // the now-gone source and drop the displayed mention (#331).
     \Lamb\Webmention\enqueue_deletion_resends((int) $post->id);
+
+    // Trashing can remove the post currently holding MAX(updated); bump the
+    // monotonic mark so latest_content_timestamp() can't fall backwards (#669).
+    bump_content_timestamp();
 }
 
 /**
@@ -264,6 +268,10 @@ function restore_post(OODBBean $post): void
     // and re-queue any it already delivered so receivers re-display the mention
     // (#331).
     \Lamb\Webmention\reconcile_resends_on_restore((int) $post->id);
+
+    // A restore is a content mutation too; keep the monotonic mark moving
+    // forward so latest_content_timestamp() reflects it (#669).
+    bump_content_timestamp();
 }
 
 /**

--- a/tests/Unit/LatestContentTimestampTest.php
+++ b/tests/Unit/LatestContentTimestampTest.php
@@ -3,10 +3,16 @@
 namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
 
 use function Lamb\Config\save_ini_text;
+use function Lamb\get_option;
+use function Lamb\Response\bump_content_timestamp;
 use function Lamb\Response\latest_content_timestamp;
+use function Lamb\Response\restore_post;
+use function Lamb\Response\soft_delete_post;
+use function Lamb\set_option;
 
 /**
  * latest_content_timestamp() drives the conditional-GET validator for anonymous
@@ -24,7 +30,7 @@ class LatestContentTimestampTest extends TestCase
         R::nuke();
     }
 
-    private function makePost(string $updated): void
+    private function makePost(string $updated): OODBBean
     {
         $post = R::dispense('post');
         $post->updated = $updated;
@@ -32,6 +38,8 @@ class LatestContentTimestampTest extends TestCase
         $post->draft = 0;
         $post->deleted = 0;
         R::store($post);
+
+        return $post;
     }
 
     public function testZeroWhenNoPostsAndNoConfig(): void
@@ -62,5 +70,67 @@ class LatestContentTimestampTest extends TestCase
         save_ini_text("site_title = Test\n");
 
         $this->assertGreaterThanOrEqual($before, latest_content_timestamp());
+    }
+
+    /**
+     * Core regression for #669: trashing the post that currently holds the
+     * newest `updated` must not pull the validator backwards, or a date-only
+     * cache/client is served a stale 304 for content that has since changed.
+     */
+    public function testTrashingNewestPostDoesNotLowerTimestamp(): void
+    {
+        $this->makePost('2000-01-01 00:00:00');
+        $newest = $this->makePost('2030-06-01 12:00:00');
+
+        $before = latest_content_timestamp();
+
+        soft_delete_post($newest);
+
+        $this->assertGreaterThanOrEqual($before, latest_content_timestamp());
+    }
+
+    /**
+     * Restoring a post is a content mutation too: the mark must still only
+     * move forward, never fall back to whatever MAX(updated) happens to be
+     * once the restored row is back among the published set.
+     */
+    public function testRestoringPostDoesNotLowerTimestamp(): void
+    {
+        $post = $this->makePost('2030-06-01 12:00:00');
+        soft_delete_post($post);
+        $before = latest_content_timestamp();
+
+        restore_post($post);
+
+        $this->assertGreaterThanOrEqual($before, latest_content_timestamp());
+    }
+
+    /**
+     * Existing installs upgrading to #669 have no stored mark yet; the first
+     * read must backfill it from the current MAX(updated) rather than
+     * reporting 0, which would look like "everything just changed" to every
+     * client.
+     */
+    public function testBackfillsFromExistingPostsWhenMarkUnset(): void
+    {
+        $this->makePost('2030-06-01 12:00:00');
+
+        $this->assertSame(strtotime('2030-06-01 12:00:00'), latest_content_timestamp());
+    }
+
+    /**
+     * bump_content_timestamp() is the shared chokepoint all three
+     * content-mutation sites call through. Seeded with a mark set further in
+     * the future than the test clock, it must still never store a lower
+     * value — the monotonic guarantee, independent of wall-clock timing.
+     */
+    public function testBumpNeverLowersAKnownFutureMark(): void
+    {
+        $future = strtotime('2099-01-01 00:00:00');
+        set_option(get_option('content_modified_ts', 0), $future);
+
+        bump_content_timestamp();
+
+        $this->assertGreaterThan($future, latest_content_timestamp());
     }
 }

--- a/tests/Unit/LatestContentTimestampTest.php
+++ b/tests/Unit/LatestContentTimestampTest.php
@@ -8,6 +8,8 @@ use RedBeanPHP\R;
 
 use function Lamb\Config\save_ini_text;
 use function Lamb\get_option;
+use function Lamb\Post\reset_subscribers;
+use function Lamb\Post\save;
 use function Lamb\Response\bump_content_timestamp;
 use function Lamb\Response\latest_content_timestamp;
 use function Lamb\Response\restore_post;
@@ -132,5 +134,25 @@ class LatestContentTimestampTest extends TestCase
         bump_content_timestamp();
 
         $this->assertGreaterThan($future, latest_content_timestamp());
+    }
+
+    /**
+     * save() is the write funnel (#692) and does not route through
+     * finalize_and_store_post(), so it must advance the mark itself. Without
+     * this, the existing checkbox-toggle site and every #717 conversion would
+     * write a post without moving the validator, serving stale 304s.
+     */
+    public function testSaveAdvancesTheMark(): void
+    {
+        reset_subscribers();
+        $past = strtotime('2000-01-01 00:00:00');
+        set_option(get_option('content_modified_ts', 0), $past);
+
+        $post = R::dispense('post');
+        $post->draft = 0;
+        $post->deleted = 0;
+        save($post);
+
+        $this->assertGreaterThan($past, latest_content_timestamp());
     }
 }

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -1111,6 +1111,30 @@ class MicropubAdapterTest extends TestCase
         $this->assertSame('invalid_request', $result);
     }
 
+    public function testUpdateCallbackAdvancesTheContentTimestamp(): void
+    {
+        // Unique slug so this test's row can't collide with the other
+        // updateCallback tests (this suite does not reset the DB between tests).
+        $post = R::dispense('post');
+        $post->body = "---\ntitle: Timestamp Bump\n---\n\nbody";
+        $post->slug = 'ts-bump-post';
+        $post->created = date('Y-m-d H:i:s');
+        R::store($post);
+
+        // Seed the monotonic mark in the past: a Micropub update is a content
+        // change, so it must move the 304 validator forward, or the edit is
+        // invisible to a date-only cache (#669).
+        \Lamb\set_option(\Lamb\get_option('content_modified_ts', 0), strtotime('2000-01-01 00:00:00'));
+
+        $adapter = new LambMicropubAdapter();
+        $adapter->updateCallback('http://localhost/ts-bump-post', ['replace' => ['content' => ['updated body']]]);
+
+        $this->assertGreaterThan(
+            strtotime('2000-01-01 00:00:00'),
+            \Lamb\Response\latest_content_timestamp()
+        );
+    }
+
     public function testUpdateCallbackReturnsInvalidRequestForTrashedPost(): void
     {
         // Regression: a soft-deleted post is meant to stay immutable until

--- a/tests/Unit/MicropubMediaEndpointTest.php
+++ b/tests/Unit/MicropubMediaEndpointTest.php
@@ -144,7 +144,7 @@ register_shutdown_function(function () {
     ]));
 });
 
-\\Lamb\\Micropub\\respond_micropub_media(\$adapter);
+\\Lamb\\Micropub\\respond_micropub_media(null, \$adapter);
 PHP;
     }
 

--- a/tests/Unit/MicropubMediaEndpointTest.php
+++ b/tests/Unit/MicropubMediaEndpointTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * respond_micropub_media() (src/micropub.php) sets the response via
+ * http_response_code()/header() and then exit()s — a shape PHPUnit's own
+ * @runInSeparateProcess isolation cannot observe, because it relies on the
+ * test method returning normally to hand its result back to the parent
+ * process (exit() inside the child skips that entirely). So this spawns a
+ * genuinely separate `php` process for the code under test, capturing its
+ * response code/headers via Xdebug (xdebug_get_headers(), which — unlike
+ * headers_list() — works under the CLI SAPI) from a shutdown function that
+ * still runs after exit(), and asserts on that from the normal test process.
+ */
+class MicropubMediaEndpointTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/lamb_micropub_media_test_' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+    }
+
+    /**
+     * Covers the regression #653 fixed: a failed store_upload_or_fallback()
+     * must answer 500 with no Location header, not a 201 the file was never
+     * written to. A gif skips the WebP re-encode branch (should_convert_to_webp()
+     * is false for gif) and falls straight to move_uploaded_file(), which
+     * always refuses a file that did not arrive via a real HTTP upload — the
+     * exact failure this endpoint has to turn into a 500, not a false-positive 201.
+     */
+    public function testStoreFailureReturns500WithNoLocationHeader(): void
+    {
+        $result = $this->runProbe();
+
+        $this->assertSame(
+            500,
+            $result['meta']['status'],
+            "Expected HTTP 500 when the file could not be stored.\nstderr: {$result['stderr']}"
+        );
+
+        foreach ($result['meta']['headers'] as $header) {
+            $this->assertStringStartsNotWithLocation($header);
+        }
+
+        $body = json_decode($result['body'], true);
+        $this->assertIsArray($body, "Response body was not valid JSON: {$result['body']}");
+        $this->assertSame('server_error', $body['error'] ?? null);
+    }
+
+    private function assertStringStartsNotWithLocation(string $header): void
+    {
+        $this->assertStringStartsNotWith(
+            'Location:',
+            $header,
+            'No Location header may be sent for a file that was never stored.'
+        );
+    }
+
+    /**
+     * Runs respond_micropub_media() in its own `php` process against a gif
+     * upload that store_upload_or_fallback() cannot store (see class docblock
+     * for why this needs a real subprocess rather than @runInSeparateProcess).
+     *
+     * @return array{body: string, meta: array{status: int|false, headers: string[]}, stderr: string}
+     */
+    private function runProbe(): array
+    {
+        $tmpFile = $this->tempDir . '/upload.gif';
+        // GIF89a header + a 1x1 logical screen descriptor + trailer: enough for
+        // mime_content_type() to sniff image/gif, with no real pixel data needed.
+        file_put_contents($tmpFile, "GIF89a" . pack('vvC3', 1, 1, 0, 0, 0) . "\x3B");
+
+        $script = $this->tempDir . '/probe.php';
+        file_put_contents($script, $this->probeScript($tmpFile));
+
+        $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process = proc_open([PHP_BINARY, $script], $descriptors, $pipes);
+        $this->assertIsResource($process, 'Failed to spawn the probe subprocess.');
+
+        fclose($pipes[0]);
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+
+        [$body, $metaJson] = array_pad(explode('===META===', $stdout, 2), 2, '{}');
+
+        return [
+            'body' => trim($body),
+            'meta' => json_decode(trim($metaJson), true) ?? [],
+            'stderr' => $stderr,
+        ];
+    }
+
+    private function probeScript(string $tmpFile): string
+    {
+        $autoload = var_export(__DIR__ . '/../../vendor/autoload.php', true);
+        $rootDir = var_export($this->tempDir, true);
+        $tmpFileExport = var_export($tmpFile, true);
+
+        return <<<PHP
+<?php
+require {$autoload};
+
+if (!defined('ROOT_DIR')) {
+    define('ROOT_DIR', {$rootDir});
+}
+if (!defined('ROOT_URL')) {
+    define('ROOT_URL', 'https://example.com');
+}
+
+global \$config;
+\$config = ['site_url' => 'https://example.com'];
+
+\$_SERVER['REQUEST_METHOD'] = 'POST';
+\$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer test-token-123';
+
+\$_FILES['file'] = [
+    'name'     => 'x.gif',
+    'type'     => 'image/gif',
+    'tmp_name' => {$tmpFileExport},
+    'error'    => UPLOAD_ERR_OK,
+    'size'     => filesize({$tmpFileExport}),
+];
+
+\$adapter = new \\Tests\\Support\\StubMicropubAdapter();
+\$adapter->stubResponse = ['me' => 'https://example.com', 'scope' => 'create'];
+
+register_shutdown_function(function () {
+    fwrite(STDOUT, "\\n===META===\\n" . json_encode([
+        'status'  => http_response_code(),
+        'headers' => function_exists('xdebug_get_headers') ? xdebug_get_headers() : [],
+    ]));
+});
+
+\\Lamb\\Micropub\\respond_micropub_media(\$adapter);
+PHP;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $full = "$path/$entry";
+            if (is_dir($full)) {
+                $this->removeDirectory($full);
+            } else {
+                unlink($full);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -594,6 +594,23 @@ class UploadTest extends TestCase
         $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.gif');
     }
 
+    public function testStoreUploadOrFallbackReturnsNullForConvertibleExtensionWhenWebpAndMoveBothFail(): void
+    {
+        // The more common real-world shape of #653: a convertible extension
+        // (jpg/png) whose bytes aren't a real image, so store_webp_copy() also
+        // fails and the code falls through to the same move_uploaded_file() that
+        // cannot succeed outside a real HTTP upload. Both branches failing must
+        // still surface as null, not a filename nothing was written to.
+        $src = $this->tempRootDir . '/plain.jpg';
+        file_put_contents($src, 'not really a jpeg');
+
+        $result = @store_upload_or_fallback($src, 'jpg', $this->tempRootDir, 'seedhash');
+
+        $this->assertNull($result);
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.webp');
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.jpg');
+    }
+
     // asset_dimensions — pixel size of a locally stored asset, for intrinsic
     // width/height attributes on rendered <img> tags.
 


### PR DESCRIPTION
Closes #669. Stacked on #728 (#673).

## Problem
`latest_content_timestamp()` computed `MAX(updated)` over live published posts, so trashing the newest post moved the value **backwards**. A date-only client/cache (no `If-None-Match`) could then be served a stale `304` for content that had since changed.

## Fix
Back it with a stored, monotonic high-water mark (`CONTENT_MODIFIED_TS` option) that only moves forward:
- `bump_content_timestamp()` sets the mark to `max(time(), previous+1)` (same-second-safe, mirroring `save_ini_text()`'s idiom), called at the three content-mutation chokepoints: `finalize_and_store_post()` (all create/edit), `soft_delete_post()`, `restore_post()`.
- `latest_content_timestamp()` reads the mark, folded with `config_modified_timestamp()` as before. **Lazy backfill**: when the mark is unset it initialises from the old `MAX(updated)` query, so existing installs don't reset to 0 on upgrade.

## Test plan (red-green)
- [x] `testTrashingNewestPostDoesNotLowerTimestamp` (core regression) — RED before fix (`2000 not >= 2030`), green after.
- [x] restore-doesn't-lower, backfill-from-existing-posts, and a deterministic bump-never-lowers-a-seeded-future-mark test (no wall-clock dependency).
- [x] `ConditionalRequestTest` (ETag/304) unaffected — 11 green.
- [x] Full Unit suite: 2110 green. PHPStan level 8 clean. `composer lint` clean.

Middle of the 3-PR stack (#673 → **#669** → #717).