### PR TITLE
Converge the is_menu_item() listing backstop to one definition (D6, #731)

### DIFF
--- a/src/theme.php
+++ b/src/theme.php
@@ -397,6 +397,30 @@ function syndication_links(OODBBean $bean): string
 }
 
 /**
+ * Returns true when a post-list row should be hidden for being a menu page —
+ * a post pinned in [menu_items] and reachable from the nav instead of the
+ * chronological stream.
+ *
+ * Public listings already exclude menu pages in SQL (public_posts_clause());
+ * this is the backstop for owner-only views that deliberately query
+ * everything (drafts, trash, scheduled). Never hides on a permalink
+ * ($template === 'status'): there the menu page *is* the requested post, so
+ * hiding it would render an empty page.
+ *
+ * The single definition shared by render_post_list() (2024/2026 themes) and
+ * the base theme's parts/_items.php, which each hand-copied this check
+ * before (#731).
+ *
+ * @param string|null $template The current template name.
+ * @param OODBBean    $bean     The post bean being considered for the listing.
+ * @return bool
+ */
+function is_hidden_menu_item(?string $template, OODBBean $bean): bool
+{
+    return $template !== 'status' && is_menu_item((string) ($bean->slug ?? ''));
+}
+
+/**
  * Renders the post-list loop shared by the 2024 and 2026 themes' _items.php.
  *
  * Wraps the posts in <ul>/<li> when there is more than one, skips menu pages
@@ -429,9 +453,7 @@ function render_post_list(bool $hide_author): void
         endif;
         foreach ($data['posts'] as $bean) :
             /** @var \RedBeanPHP\OODBBean $bean */
-            if ($template !== 'status' && is_menu_item((string) ($bean->slug ?? ''))) :
-                # Backstop for the owner-only views that query everything (drafts,
-                # trash, scheduled); public listings exclude menu pages in SQL.
+            if (is_hidden_menu_item($template, $bean)) :
                 continue;
             endif;
             if ($is_list) :

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -8,10 +8,10 @@ use function Lamb\Theme\action_edit;
 use function Lamb\Theme\action_preview;
 use function Lamb\Theme\action_restore;
 use function Lamb\Theme\date_created;
-use function Lamb\Config\is_menu_item;
 use function Lamb\Theme\anchor_headings;
 use function Lamb\Theme\author_card;
 use function Lamb\Theme\escape;
+use function Lamb\Theme\is_hidden_menu_item;
 use function Lamb\Theme\link_source;
 use function Lamb\Theme\syndication_links;
 use function Lamb\Theme\the_reply_context;
@@ -23,12 +23,8 @@ if (empty($data['posts'])) :
 else :
     foreach ($data['posts'] as $bean) :
         /** @var \RedBeanPHP\OODBBean $bean */
-        // Menu pages stay out of listings. Public listings already exclude them
-        // in SQL (public_posts_clause), so this is the backstop for the owner-only
-        // views that deliberately query everything — drafts, trash, scheduled. The
-        // `status` guard is load-bearing: on a permalink the menu page *is* the
-        // requested post, so skipping it there renders an empty page.
-        if ($template !== 'status' && is_menu_item((string) ($bean->slug ?? ''))) :
+        // See Lamb\Theme\is_hidden_menu_item() for why this check exists.
+        if (is_hidden_menu_item($template, $bean)) :
             continue;
         endif;
         ?>

--- a/tests/Unit/HiddenMenuItemTest.php
+++ b/tests/Unit/HiddenMenuItemTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Theme\is_hidden_menu_item;
+
+/**
+ * Characterisation test for the menu-page listing backstop (issue #731).
+ *
+ * Before this, the same check — "skip this bean unless we're on its own
+ * permalink" — was hand-copied into both the base theme's parts/_items.php
+ * and Lamb\Theme\render_post_list() (used by the 2024/2026 themes). This
+ * pins the one shared predicate both call sites now use; the rendering
+ * behaviour itself stays covered by ThemeMenuItemsTest.
+ */
+class HiddenMenuItemTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+
+        global $config;
+        $config = ['menu_items' => ['About' => 'about']];
+    }
+
+    protected function tearDown(): void
+    {
+        global $config;
+        $config = [];
+    }
+
+    private function makeBean(?string $slug): \RedBeanPHP\OODBBean
+    {
+        $bean       = R::dispense('post');
+        $bean->slug = $slug;
+        return $bean;
+    }
+
+    public function testMenuPageIsHiddenOutsideItsOwnPermalink(): void
+    {
+        $this->assertTrue(is_hidden_menu_item('tag', $this->makeBean('about')));
+    }
+
+    public function testMenuPageIsNotHiddenOnItsOwnPermalink(): void
+    {
+        $this->assertFalse(is_hidden_menu_item('status', $this->makeBean('about')));
+    }
+
+    public function testOrdinaryPostIsNeverHidden(): void
+    {
+        $this->assertFalse(is_hidden_menu_item('tag', $this->makeBean('hello-world')));
+    }
+
+    public function testUnsluggedPostIsNeverHidden(): void
+    {
+        $this->assertFalse(is_hidden_menu_item('tag', $this->makeBean(null)));
+    }
+}


### PR DESCRIPTION
Closes #731 — the last piece of hotspot D6 from epic #684.

## What was already converged

Mapping the five expressions #731 names against the current code (after
#726) found four already routed through a single source:

- `visible_clause()` / `public_posts_clause()` — `public_posts_clause()`
  already builds on `visible_clause()` plus a menu-slug exclusion.
- `is_viewable()` / `is_publicly_visible()` / `is_scheduled()` — already
  compose `is_draft()` / `is_deleted()` / `is_scheduled()` (added in #726).
- `websub.php`'s scheduled-publish sweep — already queries with the
  `SQL_PUBLISHED` constant rather than re-assembling it inline.

## What was genuinely still duplicated

The `is_menu_item()` backstop — "skip a menu page in a listing unless we're
on its own permalink" — was hand-copied identically (bar comment style) into:

- `src/themes/base/parts/_items.php`
- `Lamb\Theme\render_post_list()` in `src/theme.php` (shared by the 2024 and
  2026 themes since #718)

This extracts `Lamb\Theme\is_hidden_menu_item(?string $template, OODBBean $bean): bool`
as the one definition and routes both call sites through it. `is_menu_item()`
itself (the config-slug lookup in `Lamb\Config`) is untouched and not
addressed by name elsewhere, so no deprecation shim is needed.

## Test plan (red-green, no behaviour change)

- [x] `tests/Unit/HiddenMenuItemTest.php` — new characterisation test for
      `is_hidden_menu_item()`, written first and confirmed red (undefined
      function) before the implementation landed.
- [x] `tests/Unit/ThemeMenuItemsTest.php` and `ThemeModernItemsPartTest.php`
      — pre-existing tests already pinning this exact backstop across the
      base/2024/2026 themes — unmodified, still green.
- [x] Full unit suite: 2122 tests green (2 pre-existing unrelated skips).

## Gates

- `composer lint` — clean
- `composer analyse` (level 8) — no errors, baseline stays empty
- `vendor/bin/codecept run` (Unit) — 2122 tests, 3916 assertions, green
- `composer coverage` — 84.43% (≥70% threshold)
- `composer audit` — no advisories
- `pnpm test` — not run; no JS touched

## Scope note

Kept to the `is_menu_item()` backstop only, per #731's note that PR #690 is
also in flight against theme `_items.php` files, to minimise conflict
surface.