### PR TITLE
Converge LAMB_LOGIN_PASSWORD onto one resolver (D10, #732)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -29,5 +29,13 @@ parameters:
         - RedBeanPHP\OODBBean
     # ROOT_URL is derived from site config at runtime; don't constant-fold the
     # placeholder value defined in phpstan-bootstrap.php.
+    #
+    # LOGIN_PASSWORD is derived from LAMB_LOGIN_PASSWORD at runtime via
+    # Bootstrap\login_password(). Routing it through a named function (rather
+    # than the inline `getenv(...) ?: ''` this replaced) makes PHPStan actually
+    # call it while resolving the define() value — unset in the analysis
+    # environment, so it folds to the literal '', which makes auth.php's
+    # `LOGIN_PASSWORD === ''` misconfiguration check look like dead code.
     dynamicConstantNames:
         - ROOT_URL
+        - LOGIN_PASSWORD

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -68,6 +68,23 @@ function data_dir(?string $cli_base = null): string
 }
 
 /**
+ * The per-install login credential: a base64-encoded bcrypt hash of the admin
+ * password, read from LAMB_LOGIN_PASSWORD.
+ *
+ * response.php's LOGIN_PASSWORD constant and should_start_session()'s marker
+ * verification used to call getenv('LAMB_LOGIN_PASSWORD') independently —
+ * the same "read independently" duplication LAMB_DATA_DIR had before
+ * data_dir() converged it (issue #732, building on #691). Both now go
+ * through this single resolver.
+ *
+ * @return string The bcrypt hash (base64-encoded), or '' when unset.
+ */
+function login_password(): string
+{
+    return (string) (getenv('LAMB_LOGIN_PASSWORD') ?: '');
+}
+
+/**
  * Initializes the database by configuring the SQLite connection and setting up the writer cache.
  *
  * @param string $data_dir The directory path where the database file will be stored.
@@ -362,7 +379,7 @@ function should_start_session(array $cookies): bool
     if (!is_string($marker)) {
         return false;
     }
-    return valid_login_marker($marker, (string) getenv('LAMB_LOGIN_PASSWORD'));
+    return valid_login_marker($marker, login_password());
 }
 
 /**

--- a/src/response.php
+++ b/src/response.php
@@ -21,7 +21,7 @@ if (PHP_SAPI === 'cli-server') {
     \Lamb\Bootstrap\load_dotenv(dirname(__DIR__));
 }
 
-define('LOGIN_PASSWORD', getenv("LAMB_LOGIN_PASSWORD") ?: '');
+define('LOGIN_PASSWORD', \Lamb\Bootstrap\login_password());
 
 // IMAGE_FILES is defined in constants.php
 

--- a/tests/Unit/LoginPasswordTest.php
+++ b/tests/Unit/LoginPasswordTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use function Lamb\Bootstrap\login_password;
+
+/**
+ * LAMB_LOGIN_PASSWORD used to be resolved independently in two places —
+ * response.php's LOGIN_PASSWORD constant and should_start_session()'s marker
+ * verification (bootstrap.php) each called getenv() themselves — the same
+ * "read independently" duplication LAMB_DATA_DIR had before Bootstrap\data_dir()
+ * converged it (issue #732, building on #691). login_password() is the
+ * equivalent single resolver for the login credential; this pins its
+ * behaviour against the getenv() reads it replaces.
+ */
+class LoginPasswordTest extends TestCase
+{
+    private const SECRET = 'test-login-password-secret';
+
+    private string|false $previous_env;
+
+    protected function setUp(): void
+    {
+        $this->previous_env = getenv('LAMB_LOGIN_PASSWORD');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previous_env === false) {
+            putenv('LAMB_LOGIN_PASSWORD');
+        } else {
+            putenv('LAMB_LOGIN_PASSWORD=' . $this->previous_env);
+        }
+    }
+
+    public function testDefaultsToEmptyStringWhenUnset(): void
+    {
+        putenv('LAMB_LOGIN_PASSWORD');
+        $this->assertSame('', login_password());
+    }
+
+    public function testHonoursTheEnvironmentValue(): void
+    {
+        putenv('LAMB_LOGIN_PASSWORD=' . self::SECRET);
+        $this->assertSame(self::SECRET, login_password());
+    }
+
+    public function testEmptyEnvironmentValueIsTreatedAsUnset(): void
+    {
+        // getenv() ?: '' — an explicitly empty LAMB_LOGIN_PASSWORD='' behaves
+        // the same as not setting it at all, matching the pre-convergence
+        // behaviour of both getenv() call sites this replaces.
+        putenv('LAMB_LOGIN_PASSWORD=');
+        $this->assertSame('', login_password());
+    }
+}


### PR DESCRIPTION
Closes #732

## Context

Issue #732 (sub-issue of epic #684, hotspot D10) asks to converge Lamb's six config sources — `.env`/`getenv()`, `config.ini`, the `option.site_config_ini` DB row, built-in defaults, `constants.php`, and runtime `define()`s — onto one resolver per value, with every caller (web and CLI) going through it.

Most of D10 is already done on `main`:
- `LAMB_DATA_DIR` is fully converged behind `Bootstrap\data_dir()` (#691) — every caller (`index.php`, `bin/lamb`, `network.php`, `micropub.php`, `network/sources.php`, `response/discovery.php`) already goes through it.
- The importer CLIs unified into one `bin/lamb` driver (#693), which already calls `Bootstrap\data_dir()` and `Config\load()` exactly like the web path.
- `config.ini` / the DB row / built-in defaults already resolve through one pipeline: `Config\load()` → `compose_config()` → `get_ini_text()`/`get_default_ini_text()`.

The one still-open duplication: `LAMB_LOGIN_PASSWORD` was read independently in two places — `response.php`'s `LOGIN_PASSWORD` constant and `Bootstrap\should_start_session()`'s marker verification each called `getenv('LAMB_LOGIN_PASSWORD')` themselves. Same "read independently" pattern the issue names for `LAMB_DATA_DIR`, just the one instance of it #691 didn't touch.

## Change

- Add `Bootstrap\login_password(): string`, mirroring `Bootstrap\data_dir()` — the single resolver for this value.
- Route both existing callers (`response.php`'s `LOGIN_PASSWORD` define, and `should_start_session()`) through it.
- Characterisation test (`tests/Unit/LoginPasswordTest.php`) pins the pre-existing behaviour (env set / unset / empty-string-as-unset) before the refactor, per red-green TDD — no behaviour change, just one code path.
- `phpstan.neon`: add `LOGIN_PASSWORD` to `dynamicConstantNames`, alongside the existing `ROOT_URL` entry (same comment explains why). Wrapping the `getenv()` call in a named function made PHPStan actually invoke it while resolving the `define()` value in the analysis environment (where `LAMB_LOGIN_PASSWORD` is unset), folding the constant to a literal `''` and flagging `auth.php`'s `LOGIN_PASSWORD === ''` misconfiguration check as dead code.

Nothing operator-visible: no new config keys, no toggles, no dependency changes, same precedence.

## Gates

- `composer lint` — pass
- `composer analyse` (level 8, empty baseline) — pass
- `vendor/bin/codecept run` (Unit + Functional + Acceptance) — pass, 2215 tests
- `composer coverage` — 84.43% (≥70% required)
- `composer audit` — no advisories
- `pnpm test` — not run (no JS touched)

## Test plan

- [x] `tests/Unit/LoginPasswordTest.php` written first and confirmed red before the resolver existed
- [x] Full `vendor/bin/codecept run` green after the refactor
- [x] `composer analyse` clean with an empty baseline