### PR TITLE
Check update scope before existence in Micropub updateCallback()

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -484,6 +484,16 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     public function updateCallback(string $url, array $actions)
     {
+        // Checked before existence, matching deleteCallback()/undeleteCallback():
+        // an insufficient-scope token gets the same insufficient_scope response
+        // whether $url names a post at all. Checking existence first would let
+        // any token — whatever its own scope — tell a draft/scheduled/trashed
+        // post's id apart from an unused one by the 403-vs-invalid_request split.
+        $rejection = $this->scopeRejection('update');
+        if ($rejection !== null) {
+            return $rejection;
+        }
+
         $bean = $this->findPostByUrl($url);
         // A soft-deleted post is meant to stay immutable until explicitly
         // restored via the delete-scoped undeleteCallback(); treating it the
@@ -491,11 +501,6 @@ class LambMicropubAdapter extends MicropubAdapter
         // a trashed post's id apart from a nonexistent one.
         if ($bean === null || (int) $bean->deleted === 1) {
             return 'invalid_request';
-        }
-
-        $rejection = $this->scopeRejection('update');
-        if ($rejection !== null) {
-            return $rejection;
         }
 
         // Captured before any operation runs: whether this update *mints* a

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -1806,6 +1806,32 @@ class MicropubAdapterTest extends TestCase
         );
     }
 
+    public function testUpdateCallbackReturnsInsufficientScopeForNonexistentUrlWhenTokenLacksScope(): void
+    {
+        // Regression: updateCallback() used to check existence before scope, so
+        // a token without 'update' scope got 'invalid_request' for a URL with no
+        // post but 403 insufficient_scope for one that does exist (draft,
+        // scheduled, or published) — letting any token, of any scope, probe
+        // whether a hidden post id is taken. Checking scope first (matching
+        // deleteCallback()/undeleteCallback()) makes the response identical
+        // whether or not the post exists, so it can no longer be used to enumerate ids.
+        $adapter = new LambMicropubAdapter();
+        $adapter->user = [
+            'me'    => ROOT_URL . '/',
+            'scope' => ['create'],
+        ];
+
+        $result = $adapter->updateCallback(
+            ROOT_URL . '/status/999999',
+            ['replace' => ['content' => ['New content']]]
+        );
+
+        $this->assertInstanceOf(\Psr\Http\Message\ResponseInterface::class, $result);
+        $this->assertSame(403, $result->getStatusCode());
+        $body = json_decode((string) $result->getBody(), true);
+        $this->assertSame('insufficient_scope', $body['error']);
+    }
+
     // --- bearer_challenge (RFC 6750 §3 WWW-Authenticate value) ---
 
     public function testBearerChallengeWithNoArgumentsOmitsErrorCode(): void


### PR DESCRIPTION
## Summary

- `updateCallback()` in `src/micropub.php` checked post existence/deleted-state *before* the `update` scope, unlike its siblings `deleteCallback()` and `undeleteCallback()`, which check scope first.
- Effect: a token that lacked `update` scope (any valid token, including one only granted `create`) got `invalid_request` (→ 400-ish) for a URL naming no post, but `insufficient_scope` (403) for a URL naming an existing draft, scheduled, or published post. Since URL ids are sequential, this let any token enumerate whether a hidden (draft/scheduled) post existed at a given id — the same class of leak the codebase's own comment on `sourceQueryCallback()` explicitly warns about, but which `updateCallback()`'s check ordering reintroduced.
- Fix: check `scopeRejection('update')` first, then existence — matching `deleteCallback()`/`undeleteCallback()`. An insufficient-scope token now gets the identical `insufficient_scope` response regardless of whether the target post exists, is hidden, or is trashed. Behavior for tokens that *do* hold `update` scope is unchanged (existing `testUpdateCallbackReturnsInvalidRequestForTrashedPost` still passes).

## Test plan

- [x] Added `testUpdateCallbackReturnsInsufficientScopeForNonexistentUrlWhenTokenLacksScope` (red before the fix: got `invalid_request` string instead of a 403 `insufficient_scope` response; green after).
- [x] `vendor/bin/codecept run Unit tests/Unit/MicropubAdapterTest.php` — 152 tests, 346 assertions, all green.
- [x] `composer analyse` (phpstan) and `composer lint` (phpcs) clean on the changed file.

Found via a scheduled bug-scan pass over guard-clause consistency across name-similar handler families.


---
_Generated by [Claude Code](https://claude.ai/code/session_013HG2GeBbdHcuvWhXdtZDqY)_