### PR TITLE
Check ZipArchive::addFromString() return value in build_export_archive()

### DIFF
--- a/src/export.php
+++ b/src/export.php
@@ -262,8 +262,12 @@ function build_manifest(array $posts, array $assets, string $exported_at, array 
  *
  * @param list<array<string, mixed>> $posts Rows from collect_posts().
  * @param array<string, mixed>       $site  Descriptive site info for the manifest.
+ * @param ZipArchive|null $zip Injected for tests that need to force a write
+ *                             failure; production callers leave this null.
  * @return array<string, mixed> The manifest as written.
- * @throws RuntimeException When the archive cannot be created or finalised.
+ * @throws RuntimeException When the archive cannot be created, a post or the
+ *                           manifest cannot be written, or the archive cannot
+ *                           be finalised.
  * @throws JsonException
  */
 function build_export_archive(
@@ -271,9 +275,10 @@ function build_export_archive(
     string $assets_root,
     string $zip_path,
     string $exported_at,
-    array $site = []
+    array $site = [],
+    ?ZipArchive $zip = null
 ): array {
-    $zip = new ZipArchive();
+    $zip ??= new ZipArchive();
     if ($zip->open($zip_path, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
         throw new RuntimeException("Could not create export archive at $zip_path");
     }
@@ -284,7 +289,12 @@ function build_export_archive(
     foreach ($posts as $post) {
         $path = post_export_path($post, $taken);
         $body = (string) ($post['body'] ?? '');
-        $zip->addFromString($path, $body);
+        // Checked: an unnoticed failure here would still add a manifest entry
+        // for a post whose file never made it into the archive — an export
+        // that reports success while silently dropping a post from the backup.
+        if (!$zip->addFromString($path, $body)) {
+            throw new RuntimeException("Could not write post export file: $path");
+        }
         $entries[] = manifest_post_entry($post, $path);
         foreach (referenced_assets($body) as $relative) {
             $referenced[$relative] = true;
@@ -314,7 +324,9 @@ function build_export_archive(
         JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
         | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR
     );
-    $zip->addFromString('manifest.json', $json . "\n");
+    if (!$zip->addFromString('manifest.json', $json . "\n")) {
+        throw new RuntimeException("Could not write export manifest");
+    }
 
     if (!$zip->close()) {
         throw new RuntimeException("Could not finalise export archive at $zip_path");

--- a/tests/Unit/ExportTest.php
+++ b/tests/Unit/ExportTest.php
@@ -327,6 +327,42 @@ class ExportTest extends TestCase
         $zip->close();
     }
 
+    public function testAFailedPostWriteAbortsTheExportInsteadOfProducingABlankManifestEntry(): void
+    {
+        // Regression: ZipArchive::addFromString()'s return value was discarded,
+        // so a post whose entry libzip failed to buffer still got a manifest
+        // entry pointing at it — a restore would later see that entry's file
+        // missing and silently drop the post, while the export itself reported
+        // success. This double is a stand-in for that failure mode (real
+        // triggers: memory pressure during buffering, a libzip write error);
+        // it can't be provoked through the real filesystem in a test.
+        $failing_path = 'posts/2026/07/hello-world.md';
+        $zip = new class ($failing_path) extends ZipArchive {
+            public function __construct(private string $failPath)
+            {
+            }
+
+            public function addFromString($name, $content, $flags = 0): bool
+            {
+                if ($name === $this->failPath) {
+                    return false;
+                }
+                return parent::addFromString($name, $content, $flags);
+            }
+        };
+
+        $this->expectException(\RuntimeException::class);
+
+        build_export_archive(
+            [$this->post()],
+            $this->tmp_dir . '/assets',
+            $this->tmp_dir . '/export.zip',
+            '2026-07-26T14:00:00+00:00',
+            [],
+            $zip
+        );
+    }
+
     public function testAMissingAssetDoesNotAbortTheExport(): void
     {
         mkdir($this->tmp_dir . '/assets', 0777, true);


### PR DESCRIPTION
## Summary

- `build_export_archive()` (`src/export.php`) discarded the return value of `ZipArchive::addFromString()` for both a post's body file and `manifest.json`, unlike the sibling `addFile()` call for assets three lines below (already checked, non-fatal by design) and `ZipArchive::close()` (already checked, fatal by design).
- If `addFromString()` fails to buffer an entry (e.g. under memory pressure), the manifest still gets an entry pointing at that post's path even though the file never made it into the archive. The export reports success (200 download); a later restore would see that entry's file missing and silently drop the post — a post quietly missing from a backup with no error on either side.
- Fix: check both `addFromString()` calls and throw `RuntimeException` on failure, matching the archive-cannot-be-created/finalised checks already in the same function. `respond_export()` already wraps the whole call in `try/catch (Throwable)` and turns it into a logged 500, so the failure path is already handled correctly by the caller.
- libzip buffers `addFromString()` writes in memory and doesn't fail through the real filesystem in practice, so the failure can't be provoked directly in a test. Added an optional `?ZipArchive $zip = null` parameter (production callers pass nothing, unchanged behavior) so the regression test can inject a small test double that forces one entry's write to fail.

## Test plan

- [x] Added `testAFailedPostWriteAbortsTheExportInsteadOfProducingABlankManifestEntry` (red before the fix: no exception thrown, manifest entry recorded anyway; green after — `RuntimeException` is thrown before that entry is added).
- [x] `vendor/bin/codecept run Unit tests/Unit/ExportTest.php` — 29 tests, 72 assertions, all green.
- [x] `composer analyse` (phpstan) and `composer lint` (phpcs) clean on the changed file.

Found via a scheduled bug-scan pass over unchecked return values on side-effecting calls.


---
_Generated by [Claude Code](https://claude.ai/code/session_013HG2GeBbdHcuvWhXdtZDqY)_