### PR TITLE
Filter menu pages from related posts in the query (#101)

### DIFF
--- a/src/theme.php
+++ b/src/theme.php
@@ -22,7 +22,7 @@ use function Lamb\permalink;
 use function Lamb\permalink_path;
 use function Lamb\Post\body_has_tag;
 use function Lamb\Post\get_tag_search_conditions;
-use function Lamb\visible_clause;
+use function Lamb\Response\public_posts_clause;
 
 /**
  * Returns true when the user is authenticated and the bean has an ID.
@@ -286,7 +286,11 @@ function get_posts_by_tags(array $tags, int $exclude_id = 0, int $limit = 10): a
     $related_posts = [];
     foreach ($tags as $tag) {
         $conditions = get_tag_search_conditions($tag);
-        $visible = visible_clause();
+        // public_posts_clause(), not visible_clause(): related posts appear on
+        // public permalinks and must also exclude menu pages. The two
+        // _related.php templates used to attempt this filter themselves, on a
+        // non-existent $bean->is_menu_item property, so it never fired (#101).
+        $visible = public_posts_clause();
         $sql = '(' . $conditions['sql'] . ') AND' . $visible['sql'];
         $params = array_merge($conditions['params'], $visible['params']);
         if ($exclude_id > 0) {

--- a/src/themes/2026/parts/_related.php
+++ b/src/themes/2026/parts/_related.php
@@ -21,11 +21,6 @@ $current_id = (int) $current->id;
 $body = (string) $current->body;
 $related = related_posts($body, $current_id)['posts'];
 
-// Hide menu items from the related list.
-$related = array_values(array_filter($related, static function ($bean) {
-    return empty($bean->is_menu_item);
-}));
-
 if (empty($related)) {
     return;
 }

--- a/src/themes/base/parts/_related.php
+++ b/src/themes/base/parts/_related.php
@@ -24,8 +24,7 @@ if (!empty($related_posts['posts'])) :
                 if (!isset($bean->title)) :
                     $bean->title = '';
                 endif;
-                if (empty($bean->is_menu_item)) :
-                    ?>
+                ?>
                     <li>
                         <?php if (!empty($bean->title)) : ?>
                             <?php // mb_strimwidth(), as the 2026 theme's own _related.php uses:
@@ -45,7 +44,6 @@ if (!empty($related_posts['posts'])) :
                         </p>
                     </li>
                     <?php
-                endif;
             endforeach;
             ?>
             </ul>

--- a/tests/Unit/ThemeExtendedTest.php
+++ b/tests/Unit/ThemeExtendedTest.php
@@ -461,4 +461,31 @@ class ThemeExtendedTest extends TestCase
         $result = get_posts_by_tags(['scheduleme']);
         $this->assertCount(0, $result);
     }
+
+    public function testGetPostsByTagsExcludesMenuItems(): void
+    {
+        // Related posts appear on public permalinks; a menu page (pinned in the
+        // nav) has no business in the "related" list. The two _related.php
+        // templates used to filter on a non-existent $bean->is_menu_item
+        // property, so the exclusion never fired (issue #101). It belongs in the
+        // query, like every other visibility rule.
+        global $config;
+        $config['menu_items'] = ['About' => 'about'];
+
+        $bean = R::dispense('post');
+        $bean->body = 'Menu page about #menume end';
+        $bean->slug = 'about';
+        $bean->version = 1;
+        $bean->draft = 0;
+        $bean->deleted = 0;
+        $bean->created = date('Y-m-d H:i:s');
+        R::store($bean);
+
+        try {
+            $result = get_posts_by_tags(['menume']);
+            $this->assertCount(0, $result);
+        } finally {
+            unset($config['menu_items']);
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Both `_related.php` templates (base and 2026) tried to keep menu pages out of the "related posts" list by testing `$bean->is_menu_item`. Nothing ever sets that bean property, so `empty($bean->is_menu_item)` was always true — the exclusion never fired, and menu pages showed up in related lists on any post sharing a tag with them.

## Fix

Move the exclusion into the query, where every other visibility rule already lives. `Theme\get_posts_by_tags()` now builds on `Response\public_posts_clause()` (`visible_clause()` + menu-slug exclusion) instead of `visible_clause()`. This fixes every theme at the source, so both dead template guards are deleted:

- `src/themes/base/parts/_related.php` — removed the `if (empty($bean->is_menu_item))` wrapper
- `src/themes/2026/parts/_related.php` — removed the `array_filter` on the same property

Related posts only render on public permalinks (`$template === 'status'`), so `public_posts_clause()` is the right clause — the same one the public listing already uses.

## Test plan

- [x] Red-green: `testGetPostsByTagsExcludesMenuItems` in `ThemeExtendedTest` — a menu-slug post sharing a tag was returned before (size 1), excluded after (size 0). Sits alongside the existing draft/trash/scheduled exclusion tests.
- [x] `composer analyse` (phpstan level 8) — clean
- [x] `composer lint` (phpcs) — clean
- [x] `vendor/bin/codecept run` (Unit + Functional + Acceptance) — 2221 tests, 2 pre-existing skips