### PR TITLE
Skip anchor text when hashtag-linking rendered HTML

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -99,9 +99,23 @@ function parse_tags(string $html): string
         return $html;
     }
 
+    // A hashtag can also be the visible text of a link Markdown already built,
+    // e.g. `[#42](https://…/issues/42)`. TAG_PATTERN matches at the start of a
+    // text segment regardless of what preceded it, so without this the anchor's
+    // own text got hashtag-linked too, nesting an `<a>` inside an `<a>` — HTML5
+    // parsers de-nest that, silently breaking the author's link.
+    $anchor_depth = 0;
     foreach ($parts as $i => $part) {
         // Odd indices are the captured tags themselves — never rewritten.
-        if ($i % 2 === 1 || !str_contains($part, '#')) {
+        if ($i % 2 === 1) {
+            if (preg_match('/^<a[\s>]/i', $part) === 1) {
+                $anchor_depth++;
+            } elseif (preg_match('/^<\/a\s*>$/i', $part) === 1) {
+                $anchor_depth = max(0, $anchor_depth - 1);
+            }
+            continue;
+        }
+        if ($anchor_depth > 0 || !str_contains($part, '#')) {
             continue;
         }
         $parts[$i] = preg_replace_callback(TAG_PATTERN, function ($matches) {

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -242,6 +242,29 @@ class LambTest extends TestCase
         $this->assertStringNotContainsString('href="/tag/foo&amp"', $result);
         $this->assertStringContainsString('href="/tag/foo"', $result);
     }
+
+    public function testParseTagsDoesNotLinkHashtagShapedAnchorText(): void
+    {
+        // A Markdown link whose visible text starts with "#" (e.g. referencing a
+        // GitHub issue: `[#42](https://.../issues/42)`) renders as
+        // <a href="...">#42</a>. Without an anchor-text guard, the "#42" text
+        // segment matched TAG_PATTERN on its own and got hashtag-linked too,
+        // nesting an <a> inside the author's own <a> — invalid HTML5 that
+        // browsers de-nest, breaking the intended link.
+        $result = parse_tags('<p>See <a href="https://example.com/issues/42">#42</a> for details.</p>');
+        $this->assertSame(
+            '<p>See <a href="https://example.com/issues/42">#42</a> for details.</p>',
+            $result
+        );
+    }
+
+    public function testParseTagsStillLinksHashtagsOutsideAnAnchor(): void
+    {
+        // The anchor-text guard must not swallow ordinary hashtags that merely
+        // follow a link in the same paragraph.
+        $result = parse_tags('<p>See <a href="/x">a link</a> about #php.</p>');
+        $this->assertStringContainsString('<a href="/tag/php">#php</a>', $result);
+    }
     private function connect(): void
     {
         if (!R::testConnection()) {


### PR DESCRIPTION
## Summary

Scheduled bug-scan run, category 7 (property fuzzing — idempotence/involution checks on rendering functions).

`Lamb\parse_tags()` (`src/lamb.php`) splits already-rendered HTML on tag boundaries and hashtag-links any `#word` found in a "text" segment, matching `TAG_PATTERN` which fires at the start of a segment (`^`) or after whitespace/`>`. That's enough to keep a hashtag out of an *attribute* value (the function's existing XSS guard, still intact and untouched here), but it does not know a text segment can be the **inner text of an `<a>` element Markdown itself just built** — e.g. a link referencing a GitHub issue by number: `[#42](https://github.com/x/y/issues/42)`.

Confirmed with the real render pipeline (`LambDown` → `parse_tags`):

```
Input:  See [#42](https://github.com/x/y/issues/42) for details.
Output: <p>See <a href="https://github.com/x/y/issues/42"><a href="/tag/42">#42</a></a> for details.</p>
```

The nested `<a>` is invalid per the HTML5 parsing algorithm; browsers de-nest it via the adoption-agency algorithm, so the author's intended external link silently breaks for readers — typically only the inner `/tag/42` link survives as clickable. This is cached permanently in the post's `transformed` column and served to every visitor as-is. Referencing an issue/PR by number as link text is a common pattern on a developer's blog (Lamb ships syntax highlighting, code blocks, etc., for exactly that audience).

More generally, this is also an idempotence violation: calling `parse_tags()` on its own prior output for an ordinary standalone hashtag (`#php` → `<a href="/tag/php">#php</a>`) nests a second `<a>` around the existing one on a second pass.

## Fix

Track anchor depth while iterating the tag-split segments (already how the function distinguishes tag/attribute position from text position) and skip hashtag-linking for any text segment inside an `<a>...</a>` pair. Ordinary hashtags elsewhere in the same paragraph, including right after a link, are unaffected.

## Test plan

- Added `LambTest::testParseTagsDoesNotLinkHashtagShapedAnchorText` (the bug case) and `testParseTagsStillLinksHashtagsOutsideAnAnchor` (regression guard on the surrounding behavior).
- Verified the fix logic against a standalone extraction of the function (same regexes/algorithm) covering: the bug case, an ordinary hashtag, a hashtag following a link, and idempotence on an already-linked hashtag — all pass.
- `php -l` passes on both changed files.
- **Note:** this sandbox could not run `composer install` (dev dependencies fail to download: "Could not authenticate against github.com" through the environment's proxy), so `vendor/bin/codecept run Unit`, `composer lint`, and `composer analyse` could not be executed directly. Please confirm green in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DB2yF5aioNru6xgvqAZCpc)_