### PR TITLE
Suppress kin-openapi advisory under every id Trivy reports it by

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,14 +1,30 @@
 # Advisories the image scans must not block on, each with the date its
 # suppression lapses. Trivy reads this file only when a scan names it in
 # `trivyignores`; see AGENTS.md for what to do when an entry expires.
+#
+# Trivy matches only the exact id it prints in the Vulnerability column, and
+# which id that is depends on its vuln DB: the CI runner reports these under
+# their CVE ids, a newer local Trivy under the GHSA alias. It does not cross-map
+# one to the other, so list every id an advisory can surface under.
 
 vulnerabilities:
+  # kin-openapi ValidationHandler.Load() fail-open authentication bypass, in
+  # frankenphp's kin-openapi v0.140.0. Lamb's Caddyfile enables no OpenAPI
+  # validation, so the handler is never constructed. Same advisory under its
+  # GHSA and CVE ids; clears when the base image ships kin-openapi 0.141.0+.
   - id: GHSA-r277-6w6q-xmqw
+    statement: kin-openapi fail-open auth bypass; unreachable, no OpenAPI in the Caddyfile.
+    expired_at: 2026-10-15
+  - id: CVE-2026-76905
+    statement: kin-openapi fail-open auth bypass; unreachable, no OpenAPI in the Caddyfile.
+    expired_at: 2026-10-15
+
+  - id: CVE-2026-77354
     statement: >-
-      kin-openapi ValidationHandler.Load() fail-open authentication bypass, in
-      frankenphp's kin-openapi v0.140.0. Lamb's Caddyfile enables no OpenAPI
-      validation, so the handler is never constructed. Clears when the base
-      image ships kin-openapi 0.144.0 or newer.
+      Second kin-openapi advisory in the same frankenphp v0.140.0 dependency;
+      same rationale — Lamb constructs no OpenAPI validator, so the vulnerable
+      path is unreachable. Clears when the base image ships kin-openapi 0.142.0
+      or newer.
     expired_at: 2026-10-15
 
   - id: GHSA-hrxh-6v49-42gf


### PR DESCRIPTION
## Problem

Cutting **0.14.0** published the release and tarball but **the Docker image never pushed**: `release-artifacts.yml`'s Trivy step gates the push (`exit-code: 1`) and failed on two HIGH `kin-openapi` advisories in FrankenPHP's transitive `v0.140.0` dependency.

`.trivyignore.yaml` already suppressed the fail-open bypass — but keyed by its **GHSA id** (`GHSA-r277-6w6q-xmqw`). Trivy matches the exact id it prints and does **not** cross-map GHSA ↔ CVE. The CI runner's DB reports these under **CVE ids**, so the entry never matched; a newer local Trivy reports the *same* advisory under the **GHSA id**. Which id surfaces is DB/version-dependent.

Also, a **second** advisory on the same dependency (`CVE-2026-77354`, fixed 0.142.0) wasn't listed at all.

## Fix

List every id each advisory can appear under: `GHSA-r277-6w6q-xmqw`, `CVE-2026-76905`, and `CVE-2026-77354`. Rationale unchanged and in-policy — Lamb's Caddyfile enables no OpenAPI validation, so the vulnerable handler is never constructed; kin-openapi is a base-image transitive dep we can't patch. Entries keep their `expired_at` and clear when the base image ships kin-openapi 0.141.0+/0.142.0+.

## Verification

Built `.docker/Dockerfile.release` locally and scanned the real image with the same args CI uses:

```
trivy image --ignorefile .trivyignore.yaml --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 lamb:trivy-check
→ 0 findings across debian / composer-vendor / gobinary, exit 0
```

Before the fix the same scan reported the advisory and exited 1.