### PR TITLE
Emit private cache headers on Micropub responses

### DIFF
--- a/src/micropub.php
+++ b/src/micropub.php
@@ -12,6 +12,7 @@ use Psr\Log\AbstractLogger;
 use Taproot\Micropub\MicropubAdapter;
 
 use function Lamb\add_body_tags;
+use function Lamb\Bootstrap\cache_headers;
 use function Lamb\get_tags;
 use function Lamb\is_publicly_visible;
 use function Lamb\is_scheduled;
@@ -1392,6 +1393,15 @@ function token_fingerprint(string $token): string
  */
 function respond_micropub(): void
 {
+    // index.php's pre-route cache_headers() call only sees the session cookie, so
+    // it always emits the anonymous max-age=300 header here — Micropub auth is a
+    // bearer token, never that cookie. Override before touching the request: every
+    // code path below (draft source queries, write results, error bodies) carries
+    // bearer-token-gated content that a shared cache must never store or replay.
+    foreach (cache_headers(true) as $cache_header) {
+        header($cache_header);
+    }
+
     $headers = getallheaders() ?: [];
     $rawBody = file_get_contents('php://input') ?: null;
 
@@ -1544,6 +1554,13 @@ function micropub_error(int $status, string $error, string $description, ?string
  */
 function respond_micropub_media(mixed $args = null, ?LambMicropubAdapter $adapter = null): void
 {
+    // Same override as respond_micropub() above, and for the same reason: this
+    // endpoint is bearer-token-gated, not session-cookie-gated, so index.php's
+    // pre-route cache_headers() call always guesses "anonymous" here.
+    foreach (cache_headers(true) as $cache_header) {
+        header($cache_header);
+    }
+
     $headers = getallheaders() ?: [];
     $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
     $lcHeaders = array_change_key_case($headers, CASE_LOWER);

--- a/tests/Acceptance/CacheHeadersCest.php
+++ b/tests/Acceptance/CacheHeadersCest.php
@@ -79,4 +79,29 @@ class CacheHeadersCest
         $I->seeResponseHeaderContains('Cache-Control', 'max-age=300');
         $I->dontSeeResponseHeaderContains('Set-Cookie', 'LAMBSESSID');
     }
+
+    /**
+     * Micropub auth is a bearer token, never the session cookie index.php's
+     * pre-route cache_headers() call inspects — so without an override every
+     * Micropub response (draft source queries, write results, error bodies)
+     * got the same public max-age=300 header as an anonymous homepage view,
+     * letting a shared cache in front of the install store and replay it.
+     * No valid token is needed to observe this: even the 401 "missing bearer
+     * token" response was marked publicly cacheable before the fix.
+     */
+    public function micropubResponsesAreNotPubliclyCacheable(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/micropub?q=config');
+        $I->seeResponseCodeIs(401);
+        $I->seeResponseHeaderContains('Cache-Control', 'no-store');
+        $I->dontSeeResponseHeaderContains('Cache-Control', 'max-age=300');
+    }
+
+    public function micropubMediaResponsesAreNotPubliclyCacheable(AcceptanceTester $I): void
+    {
+        $I->sendAjaxPostRequest('/micropub-media', []);
+        $I->seeResponseCodeIs(401);
+        $I->seeResponseHeaderContains('Cache-Control', 'no-store');
+        $I->dontSeeResponseHeaderContains('Cache-Control', 'max-age=300');
+    }
 }


### PR DESCRIPTION
## Summary

`index.php` decides `Cache-Control` before routing, based solely on whether `$_SESSION[SESSION_LOGIN]` is set:

```php
foreach (Bootstrap\cache_headers(isset($_SESSION[SESSION_LOGIN])) as $cache_header) {
    header($cache_header);
}
```

Every other authenticated surface (`/settings`, `/upload`, post edit/delete) is gated by the `LAMBSESSID`/`lamb_logged_in` session cookie, so by the time this runs `$_SESSION[SESSION_LOGIN]` is already correct. Micropub is the one authenticated surface that uses a bearer token instead (`Authorization: Bearer …`, or `access_token` in the POST body) — `micropub.php` never touches `$_SESSION` — so `/micropub` and `/micropub-media` always got the anonymous `Cache-Control: max-age=300` header, regardless of what the request actually did.

Concretely: `GET /micropub?q=source&url=/some-draft-slug` with a valid bearer token returns a draft's Markdown source with `max-age=300` and no `Authorization`-aware cache directive — a conformant shared cache (or a CDN sitting in front of the install) can legitimately store and replay that response to a different, unauthenticated caller. The same applies to write results and to every Micropub error body (confirmed: even the plain 401 "missing bearer token" response was marked publicly cacheable).

## Fix

Override to the private/no-store headers at the very top of both `respond_micropub()` and `respond_micropub_media()`, before either function does anything else. Both use `\Lamb\Bootstrap\cache_headers(true)` — the same helper `index.php` uses for the logged-in branch — so the private header set lives in one place. Placing the override first means it covers every exit path, including the guard-clause `micropub_error()` calls in the media endpoint that return early.

## Test plan

- [x] Added `CacheHeadersCest::micropubResponsesAreNotPubliclyCacheable` and `micropubMediaResponsesAreNotPubliclyCacheable` — hit both endpoints with no bearer token (so no stub token endpoint is needed) and assert `Cache-Control` is `no-store`, not `max-age=300`.
- [x] Verified red: reverted the fix locally and confirmed both endpoints served `Cache-Control: max-age=300` over a real `php -S` dev server.
- [x] Verified green: `vendor/bin/codecept run Acceptance CacheHeadersCest` — 8/8 passing.
- [x] `vendor/bin/codecept run Unit` — 2127 tests, 3920 assertions, all green.
- [x] `composer lint` and `composer analyse` — clean.

---
Found by the scheduled bug-scan routine (category 6: executable HTTP harness for upload/auth/header findings — this needed a real request/response cycle since `header()` calls are no-ops when tested outside an HTTP SAPI context).


---
_Generated by [Claude Code](https://claude.ai/code/session_01E719zBqXmeyoKY1fcrRQ8t)_