### PR TITLE
Delegate deleted-post checks to is_deleted()

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -888,7 +888,7 @@ function is_publicly_visible(OODBBean $post): bool
  */
 function preview_token_valid(OODBBean $post, ?string $token): bool
 {
-    if (empty($post->id) || $post->deleted == 1) {
+    if (empty($post->id) || is_deleted($post)) {
         return false;
     }
     if (empty($post->preview_token) || $token === null || $token === '') {

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -13,6 +13,7 @@ use Taproot\Micropub\MicropubAdapter;
 
 use function Lamb\add_body_tags;
 use function Lamb\get_tags;
+use function Lamb\is_deleted;
 use function Lamb\is_publicly_visible;
 use function Lamb\is_scheduled;
 use function Lamb\normalize_datetime;
@@ -489,7 +490,7 @@ class LambMicropubAdapter extends MicropubAdapter
         // restored via the delete-scoped undeleteCallback(); treating it the
         // same as "no such post" here also means this can't be used to tell
         // a trashed post's id apart from a nonexistent one.
-        if ($bean === null || (int) $bean->deleted === 1) {
+        if ($bean === null || is_deleted($bean)) {
             return 'invalid_request';
         }
 


### PR DESCRIPTION
## Summary

Two call sites re-derived "is this post deleted" with their own inline comparison instead of calling the canonical `is_deleted()` helper (`src/lamb.php`), which every other visibility check (`is_viewable()`, `is_publicly_visible()`) already delegates to:

- `preview_token_valid()` (`src/lamb.php:891`) — `$post->deleted == 1`
- `LambMicropubAdapter::updateCallback()` (`src/micropub.php:492`) — `(int) $bean->deleted === 1`

Both are behaviorally identical to `is_deleted()` today (`($post->deleted ?? null) == 1`), so this changes no behavior. The point is removing the drift risk: a future change to what "deleted" means (e.g. a soft-delete grace period, or treating a missing column differently) would only need to touch `is_deleted()` — these two call sites would otherwise silently keep the old definition. `micropub.php` already imports `is_deleted()`'s siblings `is_publicly_visible()`/`is_scheduled()` from the same namespace, so this also makes the file consistent with itself.

Swept the rest of `src/` for other direct `->deleted` checks: the remaining ones are either assignments (`restore.php`, `response/posts.php`) or template display toggles (`theme.php`, `themes/base/parts/edit.php`, `themes/base/parts/_items.php`) deciding which button to show — not visibility/security gates, so left as-is to keep this change minimal.

## Test plan

- [x] Existing coverage already exercises both call sites and continues to pass unchanged: `MicropubAdapterTest::testUpdateCallbackReturnsInvalidRequestForTrashedPost` and the `PreviewTokenTest` suite.
- [x] `vendor/bin/codecept run Unit` — 2127 tests, 3920 assertions, all green.
- [x] `composer lint` and `composer analyse` — clean.

---
Found by the scheduled bug-scan routine (category 2: code that recomputes state another component already knows).


---
_Generated by [Claude Code](https://claude.ai/code/session_01E719zBqXmeyoKY1fcrRQ8t)_