### PR TITLE
Sanitize multi-word tags so they round-trip through get_tags()

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -117,11 +117,31 @@ function parse_tags(string $html): string
 }
 
 /**
+ * Normalizes an arbitrary string into a single hashtag-safe token: a run of
+ * characters get_tags() cannot parse past (TAG_TERMINATORS) collapses to one
+ * hyphen. Without this, a multi-word Micropub category like "day trip"
+ * appended verbatim as `#day trip` splits into the hashtag `#day` plus the
+ * bare, unlinked, silently-dropped-from-round-trip text ` trip`.
+ *
+ * @param string $tag
+ * @return string The sanitized tag, or '' if nothing tag-safe remained.
+ */
+function sanitize_tag_name(string $tag): string
+{
+    $safe = preg_replace('/[' . TAG_TERMINATORS . ']+/u', '-', trim($tag));
+
+    return trim($safe ?? '', '-');
+}
+
+/**
  * Appends the given tags to a body as trailing hashtags, skipping ones the
  * body already carries. Returns the body unchanged when nothing is missing.
  *
  * Counterpart of get_tags(): used by Micropub category `add` updates, where
- * categories live in the body as hashtags rather than in a column.
+ * categories live in the body as hashtags rather than in a column. Each tag
+ * is passed through sanitize_tag_name() first, so what get_tags() recovers
+ * from the result always matches what was asked for — see that function's
+ * docblock for why this is necessary.
  *
  * "Already carries" is case-insensitive, and a tag repeated in $tags is added
  * once: `#PHP` and `#php` are one tag everywhere else (the link parse_tags()
@@ -137,6 +157,7 @@ function add_body_tags(string $body, array $tags): string
     $present = array_map('mb_strtolower', get_tags($body));
     $to_add = [];
     foreach ($tags as $tag) {
+        $tag = sanitize_tag_name($tag);
         $key = mb_strtolower($tag);
         if ($tag === '' || in_array($key, $present, true)) {
             continue;

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -19,6 +19,7 @@ use function Lamb\normalize_datetime;
 use function Lamb\parse_bean;
 use function Lamb\permalink;
 use function Lamb\remove_body_tags;
+use function Lamb\sanitize_tag_name;
 use function Lamb\strip_trailing_body_tags;
 use function Lamb\Post\build_matter;
 use function Lamb\Post\matter_string;
@@ -1218,7 +1219,10 @@ class LambMicropubAdapter extends MicropubAdapter
      */
     private function buildTags(array $categories): string
     {
-        $tags = self::textValues($categories);
+        $tags = array_values(array_filter(array_map(
+            sanitize_tag_name(...),
+            self::textValues($categories)
+        ), fn(string $c) => $c !== ''));
 
         return $tags === [] ? '' : implode(' ', array_map(fn(string $c) => '#' . $c, $tags));
     }

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -48,6 +48,21 @@ class LambTest extends TestCase
         $this->assertSame('Hello #foo', add_body_tags('Hello', ['foo', 'foo', 'FOO']));
     }
 
+    public function testAddBodyTagsSanitizesASpaceInATag()
+    {
+        // A Micropub category with a space is real (e.g. "day trip"): appended
+        // verbatim it splits into a bare hashtag plus stray unlinked text, and
+        // get_tags() can only ever recover the part before the space — this
+        // must round-trip instead of silently losing the rest of the tag.
+        $this->assertSame('Hello #day-trip', add_body_tags('Hello', ['day trip']));
+    }
+
+    public function testAddBodyTagsSanitizedTagIsRecoverableByGetTags()
+    {
+        $body = add_body_tags('Hello', ['day trip']);
+        $this->assertSame(['day-trip'], get_tags($body));
+    }
+
     // strip_trailing_body_tags
 
     public function testStripTrailingBodyTagsRemovesTrailingRun()

--- a/tests/Unit/MicropubAdapterTest.php
+++ b/tests/Unit/MicropubAdapterTest.php
@@ -417,6 +417,27 @@ class MicropubAdapterTest extends TestCase
         $this->assertStringContainsString('#test2', $post->body);
     }
 
+    public function testCreateCallbackSanitizesMultiWordCategory(): void
+    {
+        // A category with a space ("day trip") appended verbatim as `#day trip`
+        // split into the hashtag `#day` plus stray, unlinked body text — and
+        // get_tags() could only ever recover "day", silently dropping "trip"
+        // from every source query. sanitize_tag_name() must run here too, not
+        // just in add_body_tags()'s update path.
+        $adapter = new LambMicropubAdapter();
+        $data = [
+            'type' => ['h-entry'],
+            'properties' => [
+                'content'  => ['A post about a day trip'],
+                'category' => ['day trip'],
+            ],
+        ];
+        $adapter->createCallback($data);
+        $post = R::findOne('post', ' body LIKE ? ', ['%#day-trip%']);
+        $this->assertNotNull($post);
+        $this->assertStringNotContainsString('#day trip', $post->body);
+    }
+
     public function testCreateCallbackHtmlContentIsRenderedNotEscaped(): void
     {
         $adapter = new LambMicropubAdapter();


### PR DESCRIPTION
## Summary

`add_body_tags()` (`src/lamb.php`) is documented as the "counterpart of `get_tags()`" — a round-trip: whatever it appends should be exactly what `get_tags()` recovers back out. It never validated that a tag was free of the characters `get_tags()` treats as a tag boundary (`TAG_TERMINATORS`: whitespace, `#&.,!?;:()[]{}<>"'`=/\`) before turning it into `'#' . $tag` and appending it. Micropub's `buildTags()` (`src/micropub.php`, used at post creation) had the identical flaw — both build a hashtag from an arbitrary client-supplied category string with no filtering.

Concretely, a Micropub `category` of `"day trip"` (a normal thing to post — multi-word categories/tags are common) appended as `#day trip`:

```
body:  "Went on a nice trip today."
tags:  ["day trip"]
add_body_tags() -> "Went on a nice trip today. #day trip"
get_tags()      -> ["day"]        // "trip" is lost, left as bare unlinked text
```

`" trip"` becomes plain, unlinked post-body text instead of part of the tag, and any later `get_tags()` call — including the Micropub source query (`beanToMf2Properties()`) reporting `category` back to a client, and the `/tag/` page listing — only ever sees `"day"`. Silent, permanent data loss for any IndieWeb client that posts a multi-word category, reachable from untrusted third-party client input via both post creation and category-`add` updates.

## Fix

Added `sanitize_tag_name()` next to `TAG_TERMINATORS`/`get_tags()`: collapses a run of boundary characters to a single hyphen (`"day trip"` → `"day-trip"`), so the appended hashtag and what `get_tags()` recovers always agree. Used it in both `add_body_tags()` and `buildTags()` — the two places that turn a raw string into a hashtag.

## Test plan

- [x] Red-green: `LambTest::testAddBodyTagsSanitizesASpaceInATag` / `testAddBodyTagsSanitizedTagIsRecoverableByGetTags` and `MicropubAdapterTest::testCreateCallbackSanitizesMultiWordCategory` all failed before the fix, pass after.
- [x] `vendor/bin/codecept run Unit` — 2130 tests, 3924 assertions, all green.
- [x] `composer lint` and `composer analyse` — clean.

---
Found by the scheduled bug-scan routine (category 7: property fuzzing — checked whether `add_body_tags`/`get_tags` form a true round-trip, per `add_body_tags()`'s own docblock claim of being `get_tags()`'s counterpart).


---
_Generated by [Claude Code](https://claude.ai/code/session_01E719zBqXmeyoKY1fcrRQ8t)_