### PR TITLE
Consolidate the draft-or-scheduled predicate into is_unpublished()

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -815,6 +815,19 @@ function is_draft(OODBBean $post): bool
 }
 
 /**
+ * Returns true when a post is not yet publicly visible: a draft, or
+ * scheduled for the future. Deleted is deliberately not part of this — a
+ * trashed post is a separate state from "not published yet".
+ *
+ * @param OODBBean $post The post to inspect.
+ * @return bool
+ */
+function is_unpublished(OODBBean $post): bool
+{
+    return is_draft($post) || is_scheduled($post);
+}
+
+/**
  * Returns true when a post is soft-deleted. The in-memory counterpart to
  * SQL_NOT_DELETED: an unset column is not deleted, matching the SQL listings.
  *
@@ -914,7 +927,7 @@ function preview_token_valid(OODBBean $post, ?string $token): bool
  */
 function ensure_preview_token(OODBBean $post): void
 {
-    if ($post->draft != 1 && !is_scheduled($post)) {
+    if (!is_unpublished($post)) {
         return;
     }
     $expires = $post->preview_token_expires ?? '';

--- a/src/micropub.php
+++ b/src/micropub.php
@@ -14,7 +14,7 @@ use Taproot\Micropub\MicropubAdapter;
 use function Lamb\add_body_tags;
 use function Lamb\get_tags;
 use function Lamb\is_publicly_visible;
-use function Lamb\is_scheduled;
+use function Lamb\is_unpublished;
 use function Lamb\normalize_datetime;
 use function Lamb\parse_bean;
 use function Lamb\permalink;
@@ -387,7 +387,7 @@ class LambMicropubAdapter extends MicropubAdapter
         // Unpublished posts 404 anonymously (#284), but clients GET the Location
         // URL we return to show the just-created post. Attach a short-lived
         // preview token so that URL works without a Lamb session (#285).
-        $needs_preview = $bean->draft == 1 || is_scheduled($bean);
+        $needs_preview = is_unpublished($bean);
         \Lamb\ensure_preview_token($bean);
 
         // Stores, pins the final slug, and emits post.published — the slug must

--- a/src/theme.php
+++ b/src/theme.php
@@ -103,7 +103,7 @@ function action_preview(OODBBean $bean): string
     if (!\Lamb\preview_token_valid($bean, (string) $bean->preview_token)) {
         return '';
     }
-    if ($bean->draft != 1 && !\Lamb\is_scheduled($bean)) {
+    if (!\Lamb\is_unpublished($bean)) {
         return '';
     }
 

--- a/tests/Unit/PostVisibilityTest.php
+++ b/tests/Unit/PostVisibilityTest.php
@@ -8,6 +8,7 @@ use RedBeanPHP\R;
 use function Lamb\is_deleted;
 use function Lamb\is_draft;
 use function Lamb\is_publicly_visible;
+use function Lamb\is_unpublished;
 use function Lamb\is_viewable;
 use function Lamb\Response\respond_post;
 use function Lamb\Response\respond_status;
@@ -149,6 +150,22 @@ class PostVisibilityTest extends TestCase
         $this->assertTrue(is_draft($this->makePost(['draft' => '1'])), 'a string "1" counts, as SQL "draft != 1" would');
         $this->assertFalse(is_draft($this->makePost(['draft' => 0])));
         $this->assertFalse(is_draft(R::dispense('post')), 'an unset draft column is not a draft');
+    }
+
+    public function testIsUnpublishedIsTrueForADraft(): void
+    {
+        $this->assertTrue(is_unpublished($this->makePost(['draft' => 1])));
+    }
+
+    public function testIsUnpublishedIsTrueForAScheduledPost(): void
+    {
+        $future = $this->makePost(['created' => date('Y-m-d H:i:s', time() + 3600)]);
+        $this->assertTrue(is_unpublished($future));
+    }
+
+    public function testIsUnpublishedIsFalseForAPublishedPost(): void
+    {
+        $this->assertFalse(is_unpublished($this->makePost([])));
     }
 
     public function testIsDeletedMatchesSqlNullSafeSemantics(): void


### PR DESCRIPTION
## Summary

Three call sites independently spelled out "is this post a draft or scheduled for the future" instead of sharing one helper:

- `theme.php:106` (`action_preview()`) — `$bean->draft != 1 && !\Lamb\is_scheduled($bean)`
- `lamb.php:930` (`ensure_preview_token()`) — `$post->draft != 1 && !is_scheduled($post)`
- `micropub.php:390` (`createCallback()`) — `$bean->draft == 1 || is_scheduled($bean)` (the positive form, by De Morgan's law the same predicate)

All three agree on the definition today, so this changes no behavior. The risk is drift: a future change to what "unpublished" means (e.g. adding a third unpublished state) would need the same edit made correctly in three separate files to actually take effect everywhere, and nothing would flag a spot that got missed.

## Fix

Added `is_unpublished()` next to `is_draft()`/`is_scheduled()` in `lamb.php` (`is_draft($post) || is_scheduled($post)`) and pointed all three call sites at it. Deleted is deliberately excluded — a trashed post is a separate state from "not published yet," matching how `is_viewable()`/`is_publicly_visible()` already treat the two as independent checks.

Swept the rest of `src/` for other `->draft` comparisons: only the SQL fragment `SQL_NOT_DRAFT` and `is_draft()`'s own body remain, both of which are already the canonical definitions, not duplicates of it.

## Test plan

- [x] Red-green: `PostVisibilityTest::testIsUnpublishedIsTrueForADraft` / `testIsUnpublishedIsTrueForAScheduledPost` / `testIsUnpublishedIsFalseForAPublishedPost` failed (undefined function) before the fix, pass after.
- [x] `vendor/bin/codecept run Unit` — 2130 tests, 3923 assertions, all green.
- [x] `composer lint` and `composer analyse` — clean.

---
Found by the scheduled bug-scan routine (category 2: code that recomputes state another component already knows).


---
_Generated by [Claude Code](https://claude.ai/code/session_01E719zBqXmeyoKY1fcrRQ8t)_