### PR TITLE
Add scheduled image scan for base-image CVEs (#746)

### DIFF
--- a/src/response/posts.php
+++ b/src/response/posts.php
@@ -18,7 +18,6 @@ use function Lamb\Post\populate_bean;
 use function Lamb\Post\sanitize_explicit_slug;
 use function Lamb\Post\save;
 use function Lamb\Post\toggle_rendered_checkbox;
-use function Lamb\Route\is_reserved_route;
 
 /**
  * Handles post creation from a form submission.
@@ -314,15 +313,12 @@ function redirect_edited(): void
     $bean->version = POST_VERSION;
     $bean->updated = \Lamb\now();
 
-    if (is_reserved_route($bean->slug)) {
-        $_SESSION['flash'][] = 'Failed to save, slug is in use: "' . $bean->slug . '"';
-
-        return;
-    }
-
     try {
-        // finalize_slug: a slug claimed by another post gets an id suffix,
-        // pinned into the body's front matter so the edit form shows it.
+        // finalize_slug: a slug claimed by another post, or a reserved route
+        // name (e.g. renaming a post's title to "Search"), gets an id suffix,
+        // pinned into the body's front matter so the edit form shows it —
+        // same as redirect_created(), so a reserved-route slug is suffixed
+        // rather than silently discarding the edit.
         // lock_if_feed_sourced: editing a feed-sourced post through the form
         // marks it author-owned, so later crawls stop overwriting it.
         // redirect_on_slug_change/old_slug: records the 301 from the pre-edit
@@ -335,8 +331,8 @@ function redirect_edited(): void
             'old_slug'                => (string) $old_slug,
         ]);
     } catch (SQL $e) {
-        // Return, like the reserved-slug check above: everything below this
-        // point is a consequence of the edit having been saved. Falling through
+        // Return: everything below this point is a consequence of the edit
+        // having been saved. Falling through
         // on a failed write — a locked SQLite file while /_cron holds it is the
         // realistic one — pointed the post's live URL at a slug that was never
         // stored (a 301 to a 404), and announced the unsaved content to

--- a/tests/Unit/ResponsePostsTest.php
+++ b/tests/Unit/ResponsePostsTest.php
@@ -228,6 +228,36 @@ class ResponsePostsTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // redirect_edited — a reserved-route slug is suffixed, not rejected
+    // -------------------------------------------------------------------------
+    // Matches redirect_created(): finalize_slug() already suffixes a reserved
+    // route name with the post's id (SlugFinalizeTest), so the edit path must
+    // delegate to it instead of independently rejecting the whole edit.
+
+    public function testRedirectEditedSuffixesReservedRouteSlugInsteadOfRejectingTheEdit(): void
+    {
+        \Lamb\Route\register_route('search', 'strlen');
+        $id = $this->seedEditablePost();
+
+        $_SESSION[SESSION_LOGIN]    = true;
+        $_SESSION[HIDDEN_CSRF_NAME] = 'restok';
+        $_POST[HIDDEN_CSRF_NAME]    = 'restok';
+        $_POST['submit']            = SUBMIT_EDIT;
+        $_POST['id']                = (string) $id;
+        $_POST['contents']          = "# Search\n\nRenamed content.\n";
+
+        redirect_edited();
+
+        $bean = R::load('post', $id);
+        $this->assertSame('search-' . $id, $bean->slug);
+        $this->assertStringContainsString('Renamed content.', $bean->body);
+        $this->assertEmpty(array_filter(
+            $_SESSION['flash'] ?? [],
+            fn ($m) => str_contains((string) $m, 'slug is in use')
+        ));
+    }
+
+    // -------------------------------------------------------------------------
     // redirect_edited — a failed save must have no side effects
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #746.

## What

A weekly (+ manual) workflow that rebuilds the release image and scans it with Trivy, then opens or auto-closes a single tracking issue when fixable HIGH/CRITICAL advisories appear.

## Why not the alternatives

- **Blocking CI's `image-scan`** would gate only `.docker/`-touching PRs — exactly the authors who can't fix a base-image OS/Go CVE, and vulnerable to the #744 id-matching flake turning a green PR red with no code change.
- **Dependabot** doesn't scan image contents, and the base image is already a floating tag (`dunglas/frankenphp:php8.4`), so there's no version bump to propose. It can't see this class of problem.

A scheduled scan catches a fresh advisory *before* a release is cut, without touching any PR.

## Behaviour

- Same scan rules as the release gate (`HIGH,CRITICAL`, `ignore-unfixed`, honouring `.trivyignore.yaml`).
- Findings → opens a tracking issue (or comments on the existing open one), labelled `security`, with the Trivy table.
- Clean run → closes the tracking issue if one is open.
- Never fails the run or gates a PR.