### PR TITLE
docs: group the sidebar and fix accessibility issues

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -1,0 +1,8 @@
+---
+title: Content
+has_children: true
+---
+
+# Content
+
+Writing, posting, and managing what appears on your Lamb blog.

--- a/docs/cron-scheduled-tasks.md
+++ b/docs/cron-scheduled-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Cron Scheduled Tasks
+parent: Installation & hosting
 ---
 
 # Cron Scheduled Tasks

--- a/docs/cross-posting.md
+++ b/docs/cross-posting.md
@@ -1,5 +1,6 @@
 ---
 title: Cross-posting From Feeds
+parent: Content
 ---
 
 # Cross-posting From Feeds

--- a/docs/ddev.md
+++ b/docs/ddev.md
@@ -1,5 +1,6 @@
 ---
 title: DDev
+parent: Installation & hosting
 ---
 
 # DDev

--- a/docs/devbox.md
+++ b/docs/devbox.md
@@ -1,5 +1,6 @@
 ---
 title: Devbox
+parent: Installation & hosting
 ---
 
 # Devbox

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,5 +1,6 @@
 ---
 title: Docker
+parent: Installation & hosting
 ---
 
 # Docker

--- a/docs/drafts.md
+++ b/docs/drafts.md
@@ -1,5 +1,6 @@
 ---
 title: Drafts
+parent: Content
 ---
 
 # Drafts

--- a/docs/export.md
+++ b/docs/export.md
@@ -1,5 +1,6 @@
 ---
 title: Export
+parent: Import & export
 ---
 
 # Export

--- a/docs/feeds.md
+++ b/docs/feeds.md
@@ -1,5 +1,6 @@
 ---
 title: Feeds
+parent: Sharing & discovery
 ---
 
 # Feeds

--- a/docs/frankenphp.md
+++ b/docs/frankenphp.md
@@ -1,5 +1,6 @@
 ---
 title: FrankenPHP
+parent: Installation & hosting
 ---
 
 # FrankenPHP

--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -1,0 +1,8 @@
+---
+title: Import & export
+has_children: true
+---
+
+# Import & export
+
+Move content in and out of Lamb.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,8 @@
+---
+title: Installation & hosting
+has_children: true
+---
+
+# Installation & hosting
+
+Install Lamb and keep it running.

--- a/docs/known-import.md
+++ b/docs/known-import.md
@@ -1,5 +1,6 @@
 ---
 title: Known import
+parent: Import & export
 ---
 
 # Importing from Known

--- a/docs/lamb-import.md
+++ b/docs/lamb-import.md
@@ -1,6 +1,6 @@
 ---
 title: Lamb import
-nav_order: 31
+parent: Import & export
 ---
 
 # Restore a Lamb export

--- a/docs/local-php-setup.md
+++ b/docs/local-php-setup.md
@@ -1,5 +1,6 @@
 ---
 title: Local PHP setup
+parent: Installation & hosting
 ---
 
 # Local PHP setup

--- a/docs/login-security.md
+++ b/docs/login-security.md
@@ -1,5 +1,6 @@
 ---
 title: Login security
+parent: Site customisation
 ---
 
 # Login security

--- a/docs/media.md
+++ b/docs/media.md
@@ -1,5 +1,6 @@
 ---
 title: Media
+parent: Content
 ---
 
 # Media

--- a/docs/menu-items.md
+++ b/docs/menu-items.md
@@ -1,5 +1,6 @@
 ---
 title: Menu Items
+parent: Site customisation
 ---
 
 # Menu Items

--- a/docs/micropub.md
+++ b/docs/micropub.md
@@ -1,5 +1,6 @@
 ---
 title: Micropub
+parent: Sharing & discovery
 ---
 
 # Micropub

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -1,5 +1,6 @@
 ---
 title: NGINX configuration
+parent: Installation & hosting
 ---
 
 # NGINX configuration

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -1,5 +1,6 @@
 ---
 title: Post Types
+parent: Content
 ---
 
 There are two kinds of posts:

--- a/docs/preconnect.md
+++ b/docs/preconnect.md
@@ -1,5 +1,6 @@
 ---
 title: Preconnect
+parent: Site customisation
 ---
 
 # Preconnect

--- a/docs/redirections.md
+++ b/docs/redirections.md
@@ -1,5 +1,6 @@
 ---
 title: Redirections
+parent: Site customisation
 ---
 
 # Redirections

--- a/docs/replies.md
+++ b/docs/replies.md
@@ -1,5 +1,6 @@
 ---
 title: Reply posts
+parent: Content
 ---
 
 # Reply posts

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: Scheduling
+parent: Content
 ---
 
 # Scheduling

--- a/docs/search-engines.md
+++ b/docs/search-engines.md
@@ -1,5 +1,6 @@
 ---
 title: Search Engines
+parent: Sharing & discovery
 ---
 
 # Search Engines

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,5 +1,6 @@
 ---
 title: Search
+parent: Sharing & discovery
 ---
 
 # Search

--- a/docs/sharing-discovery.md
+++ b/docs/sharing-discovery.md
@@ -1,0 +1,8 @@
+---
+title: Sharing & discovery
+has_children: true
+---
+
+# Sharing & discovery
+
+Syndicate your posts and help people find them.

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Site Configuration
+parent: Site customisation
 ---
 
 # Site Configuration

--- a/docs/site-customisation.md
+++ b/docs/site-customisation.md
@@ -1,0 +1,8 @@
+---
+title: Site customisation
+has_children: true
+---
+
+# Site customisation
+
+Configure how your Lamb site looks and behaves.

--- a/docs/social-embeds.md
+++ b/docs/social-embeds.md
@@ -1,5 +1,6 @@
 ---
 title: Social Embeds
+parent: Content
 ---
 
 # Social Embeds

--- a/docs/syntax-highlighting.md
+++ b/docs/syntax-highlighting.md
@@ -1,5 +1,6 @@
 ---
 title: Syntax Highlighting
+parent: Content
 ---
 
 # Syntax Highlighting

--- a/docs/theme-functions.md
+++ b/docs/theme-functions.md
@@ -1,6 +1,9 @@
 ---
 title: Theme Functions
+parent: Site customisation
 ---
+
+# Theme Functions
 
 Lamb ships a small library of helper functions that theme parts call to render
 posts, titles, navigation, and the page `<head>`. This page is the reference for

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,5 +1,6 @@
 ---
 title: Themes
+parent: Site customisation
 ---
 
 # Themes
@@ -27,18 +28,18 @@ separately using git.
 ## Screenshots
 
 Default:
-![theme-default](https://github.com/user-attachments/assets/3d80d860-b54c-4d64-ad7b-7c548157e610)
+![Screenshot of the default Lamb theme](https://github.com/user-attachments/assets/3d80d860-b54c-4d64-ad7b-7c548157e610)
 
 
 ---
 
 2024:
-![theme-2024](https://github.com/user-attachments/assets/b9f55c5c-9d48-4357-a41f-ed71d21c0b0c)
+![Screenshot of the 2024 Lamb theme](https://github.com/user-attachments/assets/b9f55c5c-9d48-4357-a41f-ed71d21c0b0c)
 
 ---
 
 2026:
-![theme-2026]({{ site.baseurl }}/2026-theme.png)
+![Screenshot of the 2026 Lamb theme]({{ site.baseurl }}/2026-theme.png)
 
 ## Theme documentation
 

--- a/docs/trash.md
+++ b/docs/trash.md
@@ -1,5 +1,6 @@
 ---
 title: Trash
+parent: Content
 ---
 
 # Trash

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading
+parent: Installation & hosting
 ---
 
 # Upgrading

--- a/docs/webmentions.md
+++ b/docs/webmentions.md
@@ -1,5 +1,6 @@
 ---
 title: Webmentions
+parent: Sharing & discovery
 ---
 
 # Webmentions

--- a/docs/wordpress-import.md
+++ b/docs/wordpress-import.md
@@ -1,5 +1,6 @@
 ---
 title: WordPress import
+parent: Import & export
 ---
 
 # Importing from WordPress


### PR DESCRIPTION
## What

Reorganises the just-the-docs sidebar and fixes two accessibility issues found in a small audit.

### Sidebar
- **Alphabetical again.** A stray `nav_order: 31` on `lamb-import` pulled it to the top of the sidebar; removing it restores alphabetical-by-title ordering.
- **Grouped.** Five section parents — Content, Import & export, Installation & hosting, Sharing & discovery, Site customisation — with every page filed under one. Groups and pages both sort alphabetically, no `nav_order` anywhere. `Lamb` (home) and `Project Goals` stay top-level.

### Accessibility audit
The theme itself passes on structure — `lang` set, skip-to-main link, labelled `main`/`nav`/`header`/`footer` landmarks, no heading-level jumps, tables have header rows, no vague link text. Two content issues fixed:

- **`theme-functions` had no H1** — it opened at `## Using the helpers`. Added a `# Theme Functions` H1 so its heading outline starts at H1 like every other page.
- **Theme screenshots had slug alt text** (`theme-default`, `theme-2024`, `theme-2026`). Replaced with descriptive alternatives.

## Notes
Not changed: the group header only toggles from the chevron, not the whole row — that's just-the-docs' default and the expander is a proper button with `aria-expanded`, so it isn't an accessibility defect.

## Testing
Built locally with `bundle exec jekyll serve`; the remote theme renders, groups and ordering are correct, and both a11y fixes verified in the rendered HTML.
