### PR TITLE
Use Theme\escape_xml() for the sitemap host substitution (#752)

### DIFF
--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -257,7 +257,7 @@ function emit_sitemap(string $path): void
 
     echo str_replace(
         SITEMAP_ROOT,
-        htmlspecialchars(ROOT_URL, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE),
+        \Lamb\Theme\escape_xml(ROOT_URL),
         $template
     );
 

--- a/tests/Unit/SitemapTest.php
+++ b/tests/Unit/SitemapTest.php
@@ -310,6 +310,22 @@ class SitemapTest extends TestCase
         $this->assertStringNotContainsString(SITEMAP_ROOT, $body);
     }
 
+    // The host substituted on the way out is escaped through the one XML
+    // escaper (Theme\escape_xml()), not an inline copy of its flags — so both
+    // <loc> call sites in this file stay converged (#752).
+    public function testSubstitutedHostIsEscapedViaEscapeXml(): void
+    {
+        $this->makePost(['slug' => 'hello']);
+        $path = $this->cacheDir() . '/sitemap-escape.xml';
+
+        $body = $this->emit($path);
+
+        $this->assertStringContainsString(
+            '<loc>' . \Lamb\Theme\escape_xml(ROOT_URL) . '/hello</loc>',
+            $body
+        );
+    }
+
     public function testStoringACopyRemovesTheOlderOnes(): void
     {
         $dir = $this->cacheDir();


### PR DESCRIPTION
Closes #752.

`emit_sitemap()` (`src/response/discovery.php:260`) inlined `htmlspecialchars(ROOT_URL, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE)` — `Theme\escape_xml()`'s exact flags. The #701 convergence to one XML escaper only touched the other `<loc>` site (`discovery.php:106`), leaving this one behind.

Swaps the inline call for `\Lamb\Theme\escape_xml(ROOT_URL)` and adds `testSubstitutedHostIsEscapedViaEscapeXml`, pinning the emitted host to the shared escaper.

Behaviour-identical (the helper wraps exactly those flags). `vendor/bin/phpunit tests/Unit/SitemapTest.php` — 26 pass.