### PR TITLE
Strip XML-1.0-invalid control characters in escape_xml()

### DIFF
--- a/src/theme/formatting.php
+++ b/src/theme/formatting.php
@@ -24,11 +24,32 @@ function escape(string $html): string
  * whole string — it degrades to U+FFFD instead, so one bad byte cannot empty an
  * entire <loc> or <title>.
  *
+ * htmlspecialchars() only ever rewrites `& < > " '` — it has no idea that XML
+ * 1.0 also forbids raw control characters (everything below U+0020 except tab,
+ * LF and CR) and the two U+FFFE/U+FFFF noncharacters, control-character or not.
+ * Those pass through htmlspecialchars() untouched, "escaped" or not, and a
+ * document containing one is not well-formed XML: DOMDocument::loadXML() fails
+ * the whole document on it (`PCDATA invalid Char value`), and
+ * SimpleXMLElement::addChild() (the Atom feed's path) instead silently drops
+ * the value, emitting an empty element. A title containing such a byte is
+ * reachable input, not theoretical: Micropub's JSON create form accepts a
+ * unicode-escaped control character in a string property (valid JSON), and
+ * json_decode() turns it into a literal control byte, with nothing between
+ * there and here stripping it. They are stripped before escaping so one bad
+ * character corrupts only itself, not the surrounding XML document, matching
+ * the "one bad byte" resilience the malformed-UTF8 handling above already
+ * gives this function.
+ *
  * @param string $xml The raw string to escape.
  * @return string XML-safe escaped string.
  */
 function escape_xml(string $xml): string
 {
+    // preg_replace() with /u requires valid UTF-8; on malformed input it
+    // returns null; fall back to $xml unchanged so htmlspecialchars() below
+    // still gets a chance to degrade the bad byte to U+FFFD as before.
+    $xml = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x{FFFE}\x{FFFF}]/u', '', $xml) ?? $xml;
+
     return htmlspecialchars($xml, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE);
 }
 

--- a/tests/Unit/ThemeTest.php
+++ b/tests/Unit/ThemeTest.php
@@ -141,6 +141,30 @@ class ThemeTest extends TestCase
         $this->assertSame("ok\u{FFFD}", $result);
     }
 
+    public function testEscapeXmlStripsControlCharactersInvalidInXml10()
+    {
+        // htmlspecialchars() only rewrites & < > " ' — a raw control byte
+        // (e.g. from a Micropub JSON title with a unicode-escaped control char) passes
+        // straight through it, and XML 1.0 forbids that byte even escaped:
+        // embedding it makes the whole document fail to parse. It must be
+        // gone from the result, not merely left "escaped".
+        $result = escape_xml("Hello\x01World");
+        $this->assertSame('HelloWorld', $result);
+
+        $document = new \DOMDocument();
+        $wellFormed = $document->loadXML('<root><title>' . $result . '</title></root>');
+        $this->assertTrue($wellFormed);
+    }
+
+    public function testEscapeXmlStripsOtherXmlInvalidControlCharactersButKeepsTabNewlineCr()
+    {
+        // Tab, LF and CR are explicitly valid in XML 1.0 and must survive;
+        // the rest of the C0 control range (and the U+FFFE/U+FFFF
+        // noncharacters) must not.
+        $result = escape_xml("a\x0Bb\x0Cc\x1Fd\tE\nF\rG\u{FFFE}h\u{FFFF}");
+        $this->assertSame("abcd\tE\nF\rGh", $result);
+    }
+
     // og_escape
 
     public function testOgEscapeConvertsAngleBrackets()


### PR DESCRIPTION
## Summary
- `escape_xml()` (`src/theme/formatting.php`) only ran input through `htmlspecialchars()`, which rewrites `& < > " '` but has no concept of XML 1.0's separate rule that raw control characters (below U+0020, excluding tab/LF/CR) and the U+FFFE/U+FFFF noncharacters are never valid — escaped or not.
- A byte in that range passed straight through unmodified. Reachable input: Micropub's JSON create endpoint accepts a unicode-escaped control character inside a string property (valid JSON), and `json_decode()` turns it into a literal control byte in `$bean->title` with nothing in the pipeline stripping it before it reaches `escape_xml()`.
- Consequence: `DOMDocument::loadXML()` (the sitemap's shape) fails the *whole document* to parse (`PCDATA invalid Char value`); `SimpleXMLElement::addChild()` (the Atom feed's shape) instead silently drops the field's content, emitting an empty element.
- Fix: strip XML-1.0-invalid control characters and noncharacters before the existing `htmlspecialchars()` call, falling back to the original string on `preg_replace()` returning `null` (malformed UTF-8) so the existing U+FFFD substitution behavior is unaffected.

## Test plan
- [x] `php -l` on both touched files
- [x] Added two regression tests to `tests/Unit/ThemeTest.php`: one confirms the control byte is stripped and the result is well-formed XML via `DOMDocument::loadXML()`; the other confirms tab/LF/CR survive while other C0 controls and the two noncharacters are stripped.
- [x] `vendor/bin/phpunit` is unavailable in this sandbox (dev deps fail to install through the environment's proxy — a pre-existing environment limitation, not related to this change). Validated instead with a standalone script reimplementing old vs. new `escape_xml()` against all assertions (new test assertions plus the four pre-existing escape_xml behaviors: ampersand/angle-bracket/quote escaping, invalid-UTF-8 substitution) — old implementation fails 2/9 checks, new implementation passes all 9.

Found via the scheduled bug-scan routine's category 7 (property fuzzing): `escape_xml()`'s implicit contract ("safe for XML output") doesn't hold for all reachable inputs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYkChacXseDQQgaGZvZJ3q)_