### PR TITLE
Sort get_posts_by_tags() results by date across tags, not just within one

### DIFF
--- a/src/theme.php
+++ b/src/theme.php
@@ -319,7 +319,15 @@ function get_posts_by_tags(array $tags, int $exclude_id = 0, int $limit = 10): a
         }
     }
 
-    return array_slice(array_values($related_posts), 0, $limit);
+    // Each tag's own rows arrive created-DESC from SQL, but merging tag by tag
+    // leaves the *combined* list ordered by which tag matched first, not by
+    // date — a post found only via the second tag lands after every post the
+    // first tag matched, however new it is. Re-sort the merged set so the
+    // promised created-DESC order holds across tags too.
+    $posts = array_values($related_posts);
+    usort($posts, static fn(OODBBean $a, OODBBean $b): int => strcmp((string) $b->created, (string) $a->created));
+
+    return array_slice($posts, 0, $limit);
 }
 
 /**

--- a/tests/Unit/ThemeExtendedTest.php
+++ b/tests/Unit/ThemeExtendedTest.php
@@ -212,6 +212,38 @@ class ThemeExtendedTest extends TestCase
     }
 
     /**
+     * Each tag's own SQL query already returns its rows created-DESC, but that
+     * only sorts within one tag: a post matched solely by the *second* tag used
+     * to be appended after every post the first tag matched, however much
+     * newer it was, because the per-tag results were merged in tag order and
+     * never re-sorted. A post with two hashtags — the ordinary case — could
+     * therefore surface its related posts out of date order.
+     */
+    public function testGetPostsByTagsOrdersAcrossTagsByCreatedDate(): void
+    {
+        $older = R::dispense('post');
+        $older->body = 'Older post about #alpha end';
+        $older->version = 1;
+        $older->created = '2020-01-01 00:00:00';
+        R::store($older);
+
+        $newer = R::dispense('post');
+        $newer->body = 'Newer post about #beta end';
+        $newer->version = 1;
+        $newer->created = '2026-01-01 00:00:00';
+        R::store($newer);
+
+        // 'alpha' (matching only the older post) is searched first, 'beta'
+        // (matching only the newer post) second — the order get_tags() would
+        // hand back for a post reading "... #alpha ... #beta ...".
+        $result = get_posts_by_tags(['alpha', 'beta']);
+
+        $this->assertCount(2, $result);
+        $this->assertSame((int) $newer->id, (int) $result[0]->id, 'the newer post must sort first');
+        $this->assertSame((int) $older->id, (int) $result[1]->id, 'the older post must sort last');
+    }
+
+    /**
      * The block shows ten links; it used to read every row the LIKE matched to
      * find them. On a common tag that is the whole archive, on the most-visited
      * anonymous page there is: 58 MB for one post page at 8,000 posts sharing a


### PR DESCRIPTION
## Summary
- `get_posts_by_tags()`'s docblock (`src/theme.php`) claims results are "ordered by created date descending." Each tag's own SQL query is correctly `ORDER BY created DESC`, but results for different tags are merged into `$related_posts` tag-by-tag with no re-sort afterward.
- Consequence: a post matched only by the second (or later) tag in the list lands after every post the first tag matched, however much newer it is.
- Reachable in the ordinary case, not an edge case: `related_posts()` (used by the "Related" block on every post's theme partial) calls this with `get_tags($body)` — the post's own hashtags in body order. Any post with two or more hashtags that each match different other posts can render its related-posts list out of date order.
- Fix: re-sort the merged set by `created` descending (stable `usort`, matching the tie-break convention already used elsewhere, e.g. `all_post_ids_by_tag()`) before slicing to the limit.

## Test plan
- [x] Added `testGetPostsByTagsOrdersAcrossTagsByCreatedDate()` to `tests/Unit/ThemeExtendedTest.php` — two posts, deliberately searched with the older post's tag first, asserting the newer post sorts first.
- [x] `vendor/bin/codecept run tests/Unit/ThemeExtendedTest.php` — 32 tests, 52 assertions, all pass.
- [x] Full unit suite (`vendor/bin/codecept run Unit`) — 2142 tests, 3941 assertions, 2 pre-existing skips, 0 failures. No regressions.
- [x] `vendor/bin/phpcs`/`vendor/bin/phpstan analyse` on `src/theme.php` — clean.
- [x] Confirmed red before the fix (test fails with the old code) and green after.

Found via the scheduled bug-scan routine's category 1 (docblock absolute-claim sweep): the function's own "ordered by created date descending" claim didn't hold once more than one tag was involved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYkChacXseDQQgaGZvZJ3q)_