### PR TITLE
Reclaim the acceptance test port before starting the dev server

### DIFF
--- a/tests/Acceptance.suite.yml
+++ b/tests/Acceptance.suite.yml
@@ -25,7 +25,14 @@ extensions:
         # every later request then fails with cURL "Operation timed out after 30s"
         # (a 0-byte read). Sending the log to a file keeps the pipe empty (and the
         # log inspectable) so a long suite no longer wedges the server.
-        0: sh -c "env LAMB_DATA_DIR=../tests/Support/Data LAMB_LOGIN_PASSWORD='%LAMB_LOGIN_PASSWORD%' php -S 0.0.0.0:%LAMB_TEST_PORT% -t src 2> tests/_output/dev-server.log"
+        #
+        # `fuser -k` first frees the port. An interrupted run (Ctrl-C/crash)
+        # orphans this child, and the next run's bind then fails silently into
+        # dev-server.log while PhpBrowser talks to the stale zombie — every
+        # route 404s from a wrong data dir (#116). `;` not `&&`, so php still
+        # starts when the port was already free (fuser exits non-zero then).
+        # ponytail: fuser is Linux-only; on macOS use `lsof -ti tcp:<port> | xargs -r kill`.
+        0: sh -c "fuser -k %LAMB_TEST_PORT%/tcp 2>/dev/null; env LAMB_DATA_DIR=../tests/Support/Data LAMB_LOGIN_PASSWORD='%LAMB_LOGIN_PASSWORD%' php -S 0.0.0.0:%LAMB_TEST_PORT% -t src 2> tests/_output/dev-server.log"
         sleep: 1
 step_decorators:
   - Codeception\Step\ConditionalAssertion


### PR DESCRIPTION
## Problem

The acceptance suite starts its own `php -S` on `LAMB_TEST_PORT` via `RunProcess`. An interrupted run (Ctrl-C/crash) orphans that child, so it keeps holding the port. The next run's bind then fails — but `Address already in use` only lands in `tests/_output/dev-server.log`, never in the test output. `PhpBrowser` then talks to the stale zombie (wrong data dir / empty state), so every route 404s and the suite fails with dozens of errors that point nowhere near the cause.

Seen in practice: 85 phantom failures from a 10-hour-old orphan.

## Fix

Prepend `fuser -k %LAMB_TEST_PORT%/tcp` to the launcher so each run frees the port before starting. Chained with `;` (not `&&`), so `php` still starts when the port was already free. An orphan on the dedicated test port is abandoned by definition, and the suite is about to bind that port anyway.

`fuser` is Linux-only (CI/devbox/dev are all Linux); a `ponytail:` comment notes the macOS alternative.

## Verification

Planted a stale `php -S` on 8747, then ran `vendor/bin/codecept run Acceptance`:
- Without the fix that setup gives 85 failures.
- With it: the zombie is killed at start-up, the suite's server binds, `OK (96 tests, 191 assertions)`, and `dev-server.log` has no `Address already in use`.

Closes #116 (parked item).