### PR TITLE
Bound DNS resolution in the outbound fetch path (#707)

### DIFF
--- a/src/http.php
+++ b/src/http.php
@@ -201,6 +201,18 @@ const DEFAULT_USER_AGENT = 'Lamb-Webmention';
 const DEFAULT_FETCH_TIMEOUT = 30;
 
 /**
+ * Per-query ceiling for the DNS lookup in {@see resolve_host_ips}, in seconds.
+ *
+ * That lookup runs before curl connects, and neither dns_get_record() nor
+ * gethostbyname() takes a timeout — while on Unix set_time_limit() does not
+ * count time blocked in a syscall. Left unbounded, a black-holed resolver would
+ * stall a /_cron run and hold its flock the whole time, so every later run
+ * reports "Already running" (#707). Applied as RES_OPTIONS with attempts:2, so
+ * ~10s worst case per nameserver — comfortably under FEED_FETCH_TIMEOUT.
+ */
+const DNS_RESOLVE_TIMEOUT = 5;
+
+/**
  * The timeout a single request runs under: the caller's when it named one,
  * DEFAULT_FETCH_TIMEOUT otherwise.
  *
@@ -325,6 +337,12 @@ function is_private_ip(string $ip): bool
  */
 function resolve_host_ips(string $host): array
 {
+    // Bound the resolver: neither call below takes a timeout, so a black-holed
+    // nameserver would otherwise block unbounded and hold the /_cron flock the
+    // whole time (#707). glibc honours RES_OPTIONS; where it does not (musl) the
+    // libc default is already finite, so this only ever tightens the wait.
+    putenv('RES_OPTIONS=timeout:' . DNS_RESOLVE_TIMEOUT . ' attempts:2');
+
     $records = @dns_get_record($host, DNS_A + DNS_AAAA);
     if (is_array($records) && $records !== []) {
         return array_values(array_filter(array_map(

--- a/tests/Unit/HttpTest.php
+++ b/tests/Unit/HttpTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 use function Lamb\Http\extract_page_segment;
 use function Lamb\Http\get_request_uri;
+use function Lamb\Http\resolve_host_ips;
 use function Lamb\Http\page_path;
 use function Lamb\Http\request_string;
 use function Lamb\Http\requested_path;
@@ -176,5 +177,16 @@ class HttpTest extends TestCase
     {
         $this->assertSame('42', request_string(42));
         $this->assertSame('1.5', request_string(1.5));
+    }
+
+    // resolve_host_ips() runs before curl connects, and neither dns_get_record()
+    // nor gethostbyname() takes a timeout — so it caps the resolver via
+    // RES_OPTIONS, keeping a black-holed nameserver from holding the /_cron flock
+    // unbounded (#707). '.invalid' never resolves, so this needs no live network.
+    public function testResolveHostIpsBoundsTheResolver(): void
+    {
+        resolve_host_ips('nonexistent.invalid');
+
+        $this->assertStringContainsString('timeout:5 attempts:2', (string) getenv('RES_OPTIONS'));
     }
 }


### PR DESCRIPTION
Closes #707. Follow-up from #686 (opus review finding 2).

## Problem

`process_feeds()` (`/_cron`) holds a non-blocking flock for the whole run. #686 capped the run with `set_time_limit(1800)`, but on Unix `max_execution_time` does not count time blocked in a syscall, so each outbound step needs its own ceiling. The fetch itself is covered (curl `CURLOPT_TIMEOUT`, SimplePie `set_timeout`), but the SSRF pre-resolution that runs *before* curl connects was not:

`resolve_host_ips()` (`src/http.php`) resolves the host with `dns_get_record()` / `gethostbyname()` to validate every address is public before pinning curl to it. Neither takes a timeout, so a black-holed resolver could stall the run — and hold the cron flock while it does, leaving every later `/_cron` stuck on "Already running". Low likelihood, but the one remaining unbounded path the flock's liveness depended on.

## Fix

Cap the resolver via `RES_OPTIONS=timeout:DNS_RESOLVE_TIMEOUT attempts:2`, set in `resolve_host_ips()` — the shared function every DNS-resolving caller routes through (cron feed fetches *and* interactive webmention/endpoint verification), so all of them are bounded, not just `/_cron`.

Why this mechanism:
- **Web-SAPI-safe.** `/_cron` is documented as `curl https://…/_cron`, so it runs under php-fpm/Apache where `pcntl`/`SIGALRM` is typically not built — a `pcntl_alarm()` timeout would silently no-op in production. `RES_OPTIONS` needs no extension.
- **Strictly non-worsening.** glibc honours `RES_OPTIONS` and tightens the wait; where it is ignored (musl/Alpine) the libc default is already finite, so this only ever shortens the wait. No failure mode worse than today.
- **Smallest diff, no new dependency.** One constant + one `putenv`, at the root cause.

`DNS_RESOLVE_TIMEOUT` (5s) is the tunable knob, well under `FEED_FETCH_TIMEOUT` (15s).

## Testing

Red-green: `testResolveHostIpsBoundsTheResolver` asserts the bound is applied (resolves `.invalid`, no live network). Full suite green — `vendor/bin/codecept run`: 2242 tests, 4146 assertions, 0 failures.