### PR TITLE
Sanitize tags in remove_body_tags() to match add_body_tags()

### DIFF
--- a/src/lamb.php
+++ b/src/lamb.php
@@ -211,6 +211,13 @@ function strip_trailing_body_tags(string $body): string
  * Removes the named hashtags (and their preceding whitespace) from a body,
  * wherever they appear. Used by Micropub category delete-values updates.
  *
+ * Each tag is passed through sanitize_tag_name() first, the same as
+ * add_body_tags(), so a multi-word or punctuated category names the same
+ * hashtag on delete that add_body_tags() wrote on add (e.g. "day trip" here
+ * matches the `#day-trip` add_body_tags() appended) — otherwise a client
+ * deleting a category it added earlier gets a success response with the
+ * hashtag silently left in the body.
+ *
  * @param string       $body The raw post body.
  * @param list<string> $tags Tag names (without `#`) to remove.
  * @return string The body without the named tags.
@@ -218,6 +225,7 @@ function strip_trailing_body_tags(string $body): string
 function remove_body_tags(string $body, array $tags): string
 {
     foreach ($tags as $tag) {
+        $tag = sanitize_tag_name($tag);
         // An empty name would leave a pattern that matches a bare `#`, deleting
         // a literal one out of the body. add_body_tags() skips it the same way.
         if ($tag === '') {

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -211,12 +211,10 @@ function strip_trailing_body_tags(string $body): string
  * Removes the named hashtags (and their preceding whitespace) from a body,
  * wherever they appear. Used by Micropub category delete-values updates.
  *
- * Each tag is passed through sanitize_tag_name() first, the same as
- * add_body_tags(), so a multi-word or punctuated category names the same
- * hashtag on delete that add_body_tags() wrote on add (e.g. "day trip" here
- * matches the `#day-trip` add_body_tags() appended) — otherwise a client
- * deleting a category it added earlier gets a success response with the
- * hashtag silently left in the body.
+ * Each tag goes through sanitize_tag_name() first, like add_body_tags(), so a
+ * multi-word category ("day trip") matches the hashtag add wrote (`#day-trip`).
+ * Without it, a client deleting a category it added gets a success response but
+ * the hashtag stays in the body.
  *
  * @param string       $body The raw post body.
  * @param list<string> $tags Tag names (without `#`) to remove.

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -128,11 +128,8 @@ class LambTest extends TestCase
 
     public function testRemoveBodyTagsSanitizesMultiWordTagsLikeAddBodyTags(): void
     {
-        // add_body_tags('day trip') writes `#day-trip` (sanitize_tag_name()
-        // collapses the space). A Micropub client that deletes the same
-        // category string it used to add it — "day trip", not "day-trip" —
-        // must still remove that hashtag, or a `delete: {category: [...]}`
-        // request reports success while leaving the tag in the body.
+        // Deleting with the same string used to add ("day trip") must still
+        // remove the `#day-trip` that add_body_tags() wrote.
         $body = add_body_tags('A post about a day trip', ['day trip']);
         $this->assertSame('A post about a day trip', remove_body_tags($body, ['day trip']));
     }

--- a/tests/Unit/LambTest.php
+++ b/tests/Unit/LambTest.php
@@ -126,6 +126,17 @@ class LambTest extends TestCase
         $this->assertSame('Hello #phpstan', remove_body_tags('Hello #phpstan', ['php']));
     }
 
+    public function testRemoveBodyTagsSanitizesMultiWordTagsLikeAddBodyTags(): void
+    {
+        // add_body_tags('day trip') writes `#day-trip` (sanitize_tag_name()
+        // collapses the space). A Micropub client that deletes the same
+        // category string it used to add it — "day trip", not "day-trip" —
+        // must still remove that hashtag, or a `delete: {category: [...]}`
+        // request reports success while leaving the tag in the body.
+        $body = add_body_tags('A post about a day trip', ['day trip']);
+        $this->assertSame('A post about a day trip', remove_body_tags($body, ['day trip']));
+    }
+
     public function testRemoveBodyTagsIgnoresAnEmptyTagName(): void
     {
         // An empty name would leave a pattern matching a bare `#`.


### PR DESCRIPTION
## Summary

`remove_body_tags()` (`src/lamb.php`) doesn't run its input through `sanitize_tag_name()`, unlike `add_body_tags()` and Micropub's `buildTags()`. A property-fuzzing pass (category 7 of the scheduled bug-scan) found the mismatch.

Micropub's `applyDeleteValues()` passes a client's raw `category` delete values straight to `remove_body_tags()`. `add_body_tags()` stores a multi-word or punctuated category such as `"day trip"` as the sanitised `#day-trip`. A later `delete: {category: ["day trip"]}`, sent with the same string that added the tag, no longer matches. The hashtag survives and the API still reports success.

The fix sanitises each tag in `remove_body_tags()` the way `add_body_tags()` does, so a delete matches whatever the add wrote.

## Verification

This environment has no working `vendor/autoload.php`, so the real suite can't run here. A standalone script requires `src/lamb.php` and exercises `add_body_tags()` then `remove_body_tags()` end to end:

- Before the fix: `add_body_tags('...', ['day trip'])` then `remove_body_tags($body, ['day trip'])` leaves `#day-trip` in the body.
- After the fix: the tag is removed.

The script also re-checks plain-tag, case-insensitive, punctuation-adjacent, and empty-tag removal. All still pass. `testRemoveBodyTagsSanitizesMultiWordTagsLikeAddBodyTags` in `tests/Unit/LambTest.php` runs this under CI.

## Test plan

- [x] `php -l src/lamb.php` and `php -l tests/Unit/LambTest.php`
- [x] Standalone red/green script against the real function pair
- [ ] CI: `vendor/bin/codecept run Unit`
