### PR TITLE
Close the login-throttle check-then-act race before bcrypt runs

### DIFF
--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -54,7 +54,9 @@ function redirect_login(): array
 
     // Refuse a client that has already burned through its attempts, before
     // bcrypt runs (issue #443). A refused attempt is not itself recorded, so
-    // retrying can't extend the block indefinitely.
+    // retrying can't extend the block indefinitely. This is a cheap, unlocked
+    // early exit only — the real, race-free gate is reserve_login_attempt()
+    // below, which runs immediately before bcrypt.
     $ip  = client_ip();
     $now = time();
     $retry_after = login_throttle_retry_after($ip, $now);
@@ -74,10 +76,17 @@ function redirect_login(): array
         return login_page_data('Login is not configured on this site.');
     }
 
+    // Reserve a slot for this attempt atomically, immediately before bcrypt
+    // runs: see reserve_login_attempt()'s docblock for why the peek above is
+    // not enough on its own.
+    $retry_after = reserve_login_attempt($ip, $now);
+    if ($retry_after > 0) {
+        return throttled_login_response($retry_after);
+    }
+
     $user_pass = \Lamb\Http\request_string($_POST['password'] ?? null) ?? '';
     if (!password_verify($user_pass, base64_decode(LOGIN_PASSWORD))) {
         log_failed_login();
-        record_login_failure($ip, $now);
         // Re-render the login page in place with the error: /login is sessionless
         // now, so there is no flash to carry the message across a redirect (#462).
         return login_page_data('Password is incorrect, please try again.');
@@ -330,6 +339,11 @@ function throttle_retry_after(array $state, int $now): int
 /**
  * Reads a client's counter and returns how long it must wait (0 = go ahead).
  *
+ * An unlocked peek, not the enforcement point: it exists only as a cheap
+ * early exit before the CSRF/config checks in redirect_login(). The actual,
+ * race-free gate is reserve_login_attempt(), called immediately before
+ * bcrypt runs.
+ *
  * @param string $ip  Client address.
  * @param int    $now Current Unix timestamp.
  * @return int Seconds to wait.
@@ -342,47 +356,65 @@ function login_throttle_retry_after(string $ip, int $now): int
 }
 
 /**
- * Records a failed attempt for a client, starting a fresh window when the
- * previous one has lapsed, and prunes rows left behind by other clients.
+ * Reserves an attempt slot for a client, atomically with the threshold check,
+ * starting a fresh window when the previous one has lapsed, and prunes rows
+ * left behind by other clients.
  *
  * Pruning rides on the write path because that is the only thing that creates
  * these rows: a burst of attempts from many addresses cleans up after itself
  * once each window lapses, so the `option` table doesn't keep a permanent row
  * per address that ever probed the login form.
  *
- * The read-increment-write below runs inside `BEGIN IMMEDIATE`, which takes
- * SQLite's write lock before the read: without it, concurrent wrong-password
- * requests from the same IP each read the same stale counter and each write
- * back +1, so parallel failures undercount and more than
- * LOGIN_THROTTLE_MAX_FAILURES real password_verify() calls get through per
- * window. R::begin()/R::commit() are no-ops in this app's fluid mode (see
+ * This must run — and its BEGIN IMMEDIATE/COMMIT must both complete — before
+ * password_verify(), not after it. The counter used to be incremented only on
+ * an actual wrong-password result, checked against a separate, unlocked peek
+ * taken before bcrypt ran (login_throttle_retry_after()). That let concurrent
+ * requests from the same IP all read the same under-the-limit count, all run
+ * bcrypt, and only serialize on the write afterwards — by which point every
+ * one of them had already spent a real password_verify() call, so a
+ * sufficiently concurrent burst blew well past LOGIN_THROTTLE_MAX_FAILURES
+ * attempts per window regardless of how correctly the write itself was
+ * locked. Checking and incrementing together, before bcrypt, closes that:
+ * each concurrent request either wins the lock and reserves a slot against
+ * the up-to-date count, or is refused before bcrypt runs at all.
+ *
+ * R::begin()/R::commit() are no-ops in this app's fluid mode (see
  * RedBeanPHP\Facade::begin()), so the lock is taken with a raw statement
  * instead.
  *
  * @param string $ip  Client address.
  * @param int    $now Current Unix timestamp.
- * @return void
+ * @return int Seconds to wait before the client may attempt again (0 = reserved, go ahead).
  */
-function record_login_failure(string $ip, int $now): void
+function reserve_login_attempt(string $ip, int $now): int
 {
     prune_login_throttle($now);
 
     try {
         R::exec('BEGIN IMMEDIATE');
     } catch (SQL $e) {
-        // Another request already holds the write lock: let this one attempt
-        // go uncounted rather than fail the login response over a throttle
-        // counter — bcrypt already ran for it either way.
-        return;
+        // Another request already holds the write lock: refuse this attempt
+        // rather than let it through unreserved — doing so would reopen
+        // exactly the race this function exists to close. A short wait costs
+        // a legitimate concurrent request one retry and costs an attacker
+        // nothing more than the reserved slot they were refused anyway.
+        return 1;
     }
 
     $bean  = \Lamb\get_option(login_throttle_key($ip), '');
     $state = decode_throttle_state($bean->value);
-    $count = $state['expires'] > $now ? $state['count'] + 1 : 1;
+    $retry_after = throttle_retry_after($state, $now);
+    if ($retry_after > 0) {
+        R::exec('COMMIT');
+        return $retry_after;
+    }
 
+    $count = $state['expires'] > $now ? $state['count'] + 1 : 1;
     \Lamb\set_option($bean, encode_throttle_state($count, $now + LOGIN_THROTTLE_WINDOW));
 
     R::exec('COMMIT');
+
+    return 0;
 }
 
 /**

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -54,9 +54,8 @@ function redirect_login(): array
 
     // Refuse a client that has already burned through its attempts, before
     // bcrypt runs (issue #443). A refused attempt is not itself recorded, so
-    // retrying can't extend the block indefinitely. This is a cheap, unlocked
-    // early exit only — the real, race-free gate is reserve_login_attempt()
-    // below, which runs immediately before bcrypt.
+    // retrying can't extend the block indefinitely. Cheap early exit only;
+    // reserve_login_attempt() below is the race-free gate.
     $ip  = client_ip();
     $now = time();
     $retry_after = login_throttle_retry_after($ip, $now);
@@ -365,18 +364,13 @@ function login_throttle_retry_after(string $ip, int $now): int
  * once each window lapses, so the `option` table doesn't keep a permanent row
  * per address that ever probed the login form.
  *
- * This must run — and its BEGIN IMMEDIATE/COMMIT must both complete — before
- * password_verify(), not after it. The counter used to be incremented only on
- * an actual wrong-password result, checked against a separate, unlocked peek
- * taken before bcrypt ran (login_throttle_retry_after()). That let concurrent
- * requests from the same IP all read the same under-the-limit count, all run
- * bcrypt, and only serialize on the write afterwards — by which point every
- * one of them had already spent a real password_verify() call, so a
- * sufficiently concurrent burst blew well past LOGIN_THROTTLE_MAX_FAILURES
- * attempts per window regardless of how correctly the write itself was
- * locked. Checking and incrementing together, before bcrypt, closes that:
- * each concurrent request either wins the lock and reserves a slot against
- * the up-to-date count, or is refused before bcrypt runs at all.
+ * The check and increment are atomic and must both complete before
+ * password_verify(). The old design peeked at an unlocked counter before
+ * bcrypt and incremented only after a wrong password, so a concurrent burst
+ * from one IP could all read the same under-limit count, all run bcrypt, and
+ * only serialise on the write — spending far more than
+ * LOGIN_THROTTLE_MAX_FAILURES real password_verify() calls per window.
+ * Reserving the slot before bcrypt refuses the surplus up front.
  *
  * R::begin()/R::commit() are no-ops in this app's fluid mode (see
  * RedBeanPHP\Facade::begin()), so the lock is taken with a raw statement
@@ -394,10 +388,8 @@ function reserve_login_attempt(string $ip, int $now): int
         R::exec('BEGIN IMMEDIATE');
     } catch (SQL $e) {
         // Another request already holds the write lock: refuse this attempt
-        // rather than let it through unreserved — doing so would reopen
-        // exactly the race this function exists to close. A short wait costs
-        // a legitimate concurrent request one retry and costs an attacker
-        // nothing more than the reserved slot they were refused anyway.
+        // rather than let it through unreserved, which would reopen the exact
+        // race this function exists to close. The refused client just retries.
         return 1;
     }
 

--- a/tests/Unit/LoginThrottleTest.php
+++ b/tests/Unit/LoginThrottleTest.php
@@ -13,7 +13,7 @@ use function Lamb\Response\encode_throttle_state;
 use function Lamb\Response\login_throttle_key;
 use function Lamb\Response\login_throttle_retry_after;
 use function Lamb\Response\prune_login_throttle;
-use function Lamb\Response\record_login_failure;
+use function Lamb\Response\reserve_login_attempt;
 use function Lamb\Response\throttle_message;
 use function Lamb\Response\throttle_retry_after;
 
@@ -125,7 +125,7 @@ class LoginThrottleTest extends TestCase
     {
         $now = 1_000;
         for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES - 1; $i++) {
-            record_login_failure('203.0.113.7', $now);
+            reserve_login_attempt('203.0.113.7', $now);
         }
 
         $this->assertSame(0, login_throttle_retry_after('203.0.113.7', $now));
@@ -135,7 +135,7 @@ class LoginThrottleTest extends TestCase
     {
         $now = 1_000;
         for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
-            record_login_failure('203.0.113.7', $now);
+            reserve_login_attempt('203.0.113.7', $now);
         }
 
         $this->assertSame(LOGIN_THROTTLE_WINDOW, login_throttle_retry_after('203.0.113.7', $now));
@@ -145,7 +145,7 @@ class LoginThrottleTest extends TestCase
     {
         $now = 1_000;
         for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
-            record_login_failure('203.0.113.7', $now);
+            reserve_login_attempt('203.0.113.7', $now);
         }
 
         // The owner, on a different address, must still be able to log in — a
@@ -157,7 +157,7 @@ class LoginThrottleTest extends TestCase
     {
         $now = 1_000;
         for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
-            record_login_failure('203.0.113.7', $now);
+            reserve_login_attempt('203.0.113.7', $now);
         }
 
         $this->assertSame(0, login_throttle_retry_after('203.0.113.7', $now + LOGIN_THROTTLE_WINDOW));
@@ -167,7 +167,7 @@ class LoginThrottleTest extends TestCase
     {
         $now = 1_000;
         for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
-            record_login_failure('203.0.113.7', $now);
+            reserve_login_attempt('203.0.113.7', $now);
         }
         clear_login_failures('203.0.113.7');
 
@@ -179,8 +179,8 @@ class LoginThrottleTest extends TestCase
 
     public function testPruneDropsExpiredRowsAndKeepsLiveOnes(): void
     {
-        record_login_failure('203.0.113.7', 1_000);
-        record_login_failure('198.51.100.9', 1_500);
+        reserve_login_attempt('203.0.113.7', 1_000);
+        reserve_login_attempt('198.51.100.9', 1_500);
 
         $pruned = prune_login_throttle(1_000 + LOGIN_THROTTLE_WINDOW);
 
@@ -192,7 +192,7 @@ class LoginThrottleTest extends TestCase
     public function testPruneLeavesUnrelatedOptionsAlone(): void
     {
         \Lamb\set_option(\Lamb\get_option('site_config_ini', 'site_title = Lamb'), 'site_title = Lamb');
-        record_login_failure('203.0.113.7', 1_000);
+        reserve_login_attempt('203.0.113.7', 1_000);
 
         prune_login_throttle(1_000 + LOGIN_THROTTLE_WINDOW);
 
@@ -201,16 +201,17 @@ class LoginThrottleTest extends TestCase
 
     public function testRecordingAFailurePrunesExpiredRows(): void
     {
-        record_login_failure('203.0.113.7', 1_000);
-        record_login_failure('198.51.100.9', 1_000 + LOGIN_THROTTLE_WINDOW);
+        reserve_login_attempt('203.0.113.7', 1_000);
+        reserve_login_attempt('198.51.100.9', 1_000 + LOGIN_THROTTLE_WINDOW);
 
         $this->assertNull(R::findOne('option', ' name = ? ', [login_throttle_key('203.0.113.7')]));
     }
 
-    // Concurrent-write safety — the counter must not lose an increment (or
-    // crash the request) when another connection already holds the write lock
+    // Concurrent-write safety — a contended lock must refuse the attempt (not
+    // throw, and not let it through unreserved) when another connection
+    // already holds the write lock
 
-    public function testRecordLoginFailureSkipsCountingRatherThanThrowingWhenTheWriteLockIsHeld(): void
+    public function testReserveLoginAttemptRefusesRatherThanThrowingWhenTheWriteLockIsHeld(): void
     {
         // A single shared connection can't simulate this: SQLite silently
         // accepts a nested BEGIN IMMEDIATE on the same connection, so the
@@ -218,27 +219,54 @@ class LoginThrottleTest extends TestCase
         $lock = $this->holdWriteLockOnAContendedConnection();
 
         try {
-            record_login_failure('203.0.113.7', 1_000);
+            $retry_after = reserve_login_attempt('203.0.113.7', 1_000);
         } finally {
             $lock->exec('COMMIT');
         }
 
+        // Refused (not silently let through): a contended reservation must
+        // fail *closed*, otherwise the very race this function exists to
+        // close reopens under lock contention.
+        $this->assertGreaterThan(0, $retry_after);
         $this->assertNull(R::findOne('option', ' name = ? ', [login_throttle_key('203.0.113.7')]));
     }
 
-    public function testRecordLoginFailureStillCountsOnceTheLockIsFree(): void
+    public function testReserveLoginAttemptStillCountsOnceTheLockIsFree(): void
     {
         $lock = $this->holdWriteLockOnAContendedConnection();
-        record_login_failure('203.0.113.7', 1_000); // Contended: skipped, no row.
+        reserve_login_attempt('203.0.113.7', 1_000); // Contended: refused, no row.
         $lock->exec('COMMIT'); // Release the lock.
 
-        // The skipped attempt above left no row; this one, with no contention,
+        // The refused attempt above left no row; this one, with no contention,
         // must still start a fresh counter rather than staying silently broken.
-        record_login_failure('203.0.113.7', 1_000);
+        reserve_login_attempt('203.0.113.7', 1_000);
 
         $bean = R::findOne('option', ' name = ? ', [login_throttle_key('203.0.113.7')]);
         $this->assertNotNull($bean);
         $this->assertSame(['count' => 1, 'expires' => 1_000 + LOGIN_THROTTLE_WINDOW], decode_throttle_state($bean->value));
+    }
+
+    public function testReserveLoginAttemptCapsConcurrentAdmissionsAtTheLimit(): void
+    {
+        // The bug this fix closes: a peek-then-later-increment split lets
+        // concurrent requests all read the same under-the-limit count and all
+        // proceed to bcrypt, undercounting in exactly the way the old
+        // record_login_failure()'s docblock warned about for its own write
+        // step alone. Simulating true OS-level concurrency isn't possible
+        // in-process, but the property that must hold either way is: calling
+        // reserve_login_attempt() one at a time, in a loop, never admits more
+        // than LOGIN_THROTTLE_MAX_FAILURES attempts before refusing — the
+        // check and the increment happen together, so no interleaving of
+        // calls (concurrent or not) can ever see a stale count.
+        $now = 1_000;
+        $admitted = 0;
+        for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES + 5; $i++) {
+            if (reserve_login_attempt('203.0.113.7', $now) === 0) {
+                $admitted++;
+            }
+        }
+
+        $this->assertSame(LOGIN_THROTTLE_MAX_FAILURES, $admitted);
     }
 
     /**

--- a/tests/Unit/LoginThrottleTest.php
+++ b/tests/Unit/LoginThrottleTest.php
@@ -248,16 +248,10 @@ class LoginThrottleTest extends TestCase
 
     public function testReserveLoginAttemptCapsConcurrentAdmissionsAtTheLimit(): void
     {
-        // The bug this fix closes: a peek-then-later-increment split lets
-        // concurrent requests all read the same under-the-limit count and all
-        // proceed to bcrypt, undercounting in exactly the way the old
-        // record_login_failure()'s docblock warned about for its own write
-        // step alone. Simulating true OS-level concurrency isn't possible
-        // in-process, but the property that must hold either way is: calling
-        // reserve_login_attempt() one at a time, in a loop, never admits more
-        // than LOGIN_THROTTLE_MAX_FAILURES attempts before refusing — the
-        // check and the increment happen together, so no interleaving of
-        // calls (concurrent or not) can ever see a stale count.
+        // Real OS-level concurrency can't be simulated in-process, but the
+        // property that guards the race holds either way: because the check and
+        // increment happen together, calling reserve_login_attempt() in a loop
+        // never admits more than LOGIN_THROTTLE_MAX_FAILURES before refusing.
         $now = 1_000;
         $admitted = 0;
         for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES + 5; $i++) {

--- a/tests/Unit/ResponseAuthTest.php
+++ b/tests/Unit/ResponseAuthTest.php
@@ -195,7 +195,7 @@ class ResponseAuthTest extends TestCase
         $_SERVER['REMOTE_ADDR'] = '203.0.113.9';
         // One short of the limit, so recording a single failure would trip it.
         for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES - 1; $i++) {
-            \Lamb\Response\record_login_failure('203.0.113.9', time());
+            \Lamb\Response\reserve_login_attempt('203.0.113.9', time());
         }
 
         $token = \Lamb\Response\issue_login_csrf();
@@ -217,7 +217,7 @@ class ResponseAuthTest extends TestCase
     {
         $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
         for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
-            \Lamb\Response\record_login_failure('203.0.113.7', time());
+            \Lamb\Response\reserve_login_attempt('203.0.113.7', time());
         }
 
         $token = \Lamb\Response\issue_login_csrf();
@@ -242,7 +242,7 @@ class ResponseAuthTest extends TestCase
         $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
         $now = time();
         for ($i = 0; $i < LOGIN_THROTTLE_MAX_FAILURES; $i++) {
-            \Lamb\Response\record_login_failure('203.0.113.7', $now);
+            \Lamb\Response\reserve_login_attempt('203.0.113.7', $now);
         }
         $before = \Lamb\Response\login_throttle_retry_after('203.0.113.7', $now);
 


### PR DESCRIPTION
## Summary

`record_login_failure()` (`src/response/auth.php`) claims in its docblock that the `BEGIN IMMEDIATE`-wrapped read-increment-write stops more than `LOGIN_THROTTLE_MAX_FAILURES` real `password_verify()` calls per window. That holds only for the write step.

The actual gate, `login_throttle_retry_after()`, is an unlocked peek taken in `redirect_login()` before bcrypt runs and before the locked write. Concurrent `/login` POSTs from one IP read the same under-limit count, all pass the gate, all run bcrypt, and only serialise on the write afterwards. By then each has already spent a real `password_verify()` call. A concurrent burst can push well past the documented 10-per-window cap before the counter catches up.

The fix folds the threshold check and the increment into one atomic step, `reserve_login_attempt()`, that runs immediately before bcrypt instead of after it. A contended lock now fails closed (refuses the attempt) rather than the old fail-open behaviour. This app's SQLite connections use `busy_timeout = 0`, so contention is the common case under a real burst, not a rare edge. Failing open there would reopen the race this closes.

`record_login_failure()` becomes `reserve_login_attempt()`. It now returns an `int`: seconds to wait, `0` means reserved. It runs right after the `LOGIN_PASSWORD` misconfiguration check and before `password_verify()`, so a misconfigured install still doesn't burn a throttle slot. `login_throttle_retry_after()` stays as a cheap unlocked early-exit peek before the CSRF and config checks. It's now an optimisation, not the enforcement point.

## Verification

This environment has no working `vendor/autoload.php`, so the PHPUnit/Codeception suite can't run here.

A standalone multi-process reproduction uses separate `php` CLI processes sharing one file-backed SQLite database, so real cross-connection locking applies. 30 concurrent login attempts against a limit of 10:

- Old check-then-act split: 21/30 reached the simulated bcrypt call.
- New atomic reservation: exactly 10/30 reached it. The rest refused first.

Test changes:

- Updated `LoginThrottleTest` and `ResponseAuthTest` call sites for the rename.
- Updated the two contended-lock tests for the fail-closed change. They previously asserted the contended attempt went through uncounted; they now assert it's refused.
- Added `testReserveLoginAttemptCapsConcurrentAdmissionsAtTheLimit` to pin the sequential-admission property under PHPUnit.
- Ran `php -l` on all four changed files.

## Test plan

- [x] `php -l` on the four changed files
- [x] Standalone multi-process concurrency reproduction
- [ ] CI: `vendor/bin/codecept run Unit`
