### PR TITLE
Correct DNS_RESOLVE_TIMEOUT's worst-case claim for multi-nameserver hosts

### DIFF
--- a/src/http.php
+++ b/src/http.php
@@ -208,7 +208,17 @@ const DEFAULT_FETCH_TIMEOUT = 30;
  * count time blocked in a syscall. Left unbounded, a black-holed resolver would
  * stall a /_cron run and hold its flock the whole time, so every later run
  * reports "Already running" (#707). Applied as RES_OPTIONS with attempts:2, so
- * ~10s worst case per nameserver — comfortably under FEED_FETCH_TIMEOUT.
+ * ~10s worst case per nameserver queried.
+ *
+ * Not "comfortably under FEED_FETCH_TIMEOUT" in general: glibc's resolver
+ * cycles through every nameserver listed in resolv.conf in turn, retrying
+ * this same ~10s budget against each one before giving up, so the total DNS
+ * preflight for one host can run to roughly 10s times however many
+ * nameservers are configured (commonly 2-3) — on top of, not counted
+ * against, the curl-side FEED_FETCH_TIMEOUT that starts only once DNS
+ * resolves. Still finite either way: bounded by process_feeds()'s overall
+ * 1800s /_cron time limit (see network.php), just a larger per-feed delay
+ * than FEED_FETCH_TIMEOUT alone suggests when a resolver is unreachable.
  */
 const DNS_RESOLVE_TIMEOUT = 5;
 


### PR DESCRIPTION
## Summary

A docblock-claims sweep (category 1) on the new `DNS_RESOLVE_TIMEOUT` constant (`src/http.php`, added in #763/#707) found a wrong worst-case claim. The docblock said the `RES_OPTIONS timeout:5 attempts:2` budget (~10s worst case) sits "comfortably under `FEED_FETCH_TIMEOUT`" (15s).

That holds only for a resolver with one configured nameserver. glibc applies the `timeout`/`attempts` budget per nameserver and cycles through every nameserver in `resolv.conf` before giving up. A host with the common 2-3 nameservers can spend ~20-30s on DNS preflight against a black-holed resolver. That happens before curl's `FEED_FETCH_TIMEOUT` starts, so it isn't counted against it.

This isn't a behaviour bug and doesn't reopen the unbounded-hang issue (#707) the constant fixed. `process_feeds()` still bounds the whole `/_cron` run at 1800s. The worst case is a larger-than-documented per-feed delay, not an unbounded one.

The fix corrects the docblock rather than the timeout values. Tightening the DNS budget to fit under `FEED_FETCH_TIMEOUT` in the worst case would trade away resilience to a single slow-but-live nameserver. That's an operator tuning tradeoff, not a bug-scan change.

## Verification

This is a documentation-only correction. The claim is about glibc resolver behaviour across multiple nameservers, which no unit test can exercise here — nothing in this repo controls or mocks `resolv.conf`. Ran `php -l` on the changed file. No behaviour or test changes.

## Test plan

- [x] `php -l src/http.php`
- [x] Confirmed no code path or test asserts the old wording
