### PR TITLE
670: Bound webmentions_for_post() reads on the post page

### DIFF
--- a/src/webmention.php
+++ b/src/webmention.php
@@ -235,8 +235,8 @@ function source_mentions_target(string $html, string $target): bool
  */
 function webmentions_for_post(int $post_id): array
 {
-    // Read the newest mentions (DESC + LIMIT), then restore oldest-first order
-    // for display. A plain ASC LIMIT would drop the newest mentions instead.
+    // Newest-first in SQL to keep the newest under the LIMIT, then reversed for
+    // the oldest-first display. A plain ASC LIMIT would drop the newest instead.
     $rows = array_values(
         R::find(
             'webmention',

--- a/src/webmention.php
+++ b/src/webmention.php
@@ -50,6 +50,26 @@ const WEBMENTION_FETCH_MAX_BYTES = 2_000_000;
 const OUTBOX_SCAN_LIMIT = 500;
 
 /**
+ * Most webmentions rendered on a single post page.
+ *
+ * webmentions_for_post() feeds the author-only mentions list. A popular post can
+ * accumulate an unbounded number of verified mentions, and rendering them all
+ * loads every row and its content into one request. This caps that read at the
+ * newest mentions, which is far more than any real conversation shows at once.
+ */
+const WEBMENTION_DISPLAY_LIMIT = 100;
+
+/**
+ * Longest content snippet kept for a webmention.
+ *
+ * extract_meta() derives the snippet from the source page's <title>, bounded
+ * only by WEBMENTION_FETCH_MAX_BYTES until it hits this cap. A title is meant to
+ * be a short label; anything past this is truncated rather than stored and
+ * re-rendered in full on the post page.
+ */
+const WEBMENTION_CONTENT_MAX = 280;
+
+/**
  * Route handler for POST /webmention.
  *
  * Accepts `source` and `target` form parameters per the Webmention spec,
@@ -207,14 +227,25 @@ function source_mentions_target(string $html, string $target): bool
 /**
  * Return verified webmentions for a post, oldest first.
  *
+ * Bounded to the newest WEBMENTION_DISPLAY_LIMIT mentions so a heavily mentioned
+ * post cannot make the page load an unbounded number of rows.
+ *
  * @param int $post_id
  * @return OODBBean[]
  */
 function webmentions_for_post(int $post_id): array
 {
-    return array_values(
-        R::find('webmention', ' post_id = ? AND verified_at IS NOT NULL ORDER BY created ASC ', [$post_id])
+    // Read the newest mentions (DESC + LIMIT), then restore oldest-first order
+    // for display. A plain ASC LIMIT would drop the newest mentions instead.
+    $rows = array_values(
+        R::find(
+            'webmention',
+            ' post_id = ? AND verified_at IS NOT NULL ORDER BY created DESC LIMIT ? ',
+            [$post_id, WEBMENTION_DISPLAY_LIMIT]
+        )
     );
+
+    return array_reverse($rows);
 }
 
 /**
@@ -237,6 +268,9 @@ function extract_meta(string $html): array
     $content = null;
     if (preg_match('/<title[^>]*>(.*?)<\/title>/is', $html, $m)) {
         $content = trim(html_entity_decode(strip_tags($m[1]), ENT_QUOTES | ENT_HTML5)) ?: null;
+        if ($content !== null && mb_strlen($content) > WEBMENTION_CONTENT_MAX) {
+            $content = mb_substr($content, 0, WEBMENTION_CONTENT_MAX);
+        }
     }
 
     return ['author' => $author, 'content' => $content];

--- a/tests/Unit/WebmentionTest.php
+++ b/tests/Unit/WebmentionTest.php
@@ -15,6 +15,8 @@ use function Lamb\Webmention\verify_and_store;
 use function Lamb\Webmention\webmentions_for_post;
 
 use const Lamb\Webmention\WEBMENTION_FETCH_TIMEOUT;
+use const Lamb\Webmention\WEBMENTION_DISPLAY_LIMIT;
+use const Lamb\Webmention\WEBMENTION_CONTENT_MAX;
 
 class WebmentionTest extends TestCase
 {
@@ -226,6 +228,38 @@ class WebmentionTest extends TestCase
         $mentions = webmentions_for_post($id);
         $this->assertCount(1, $mentions);
         $this->assertSame('https://other.example/reply', $mentions[0]->source);
+    }
+
+    public function testWebmentionsForPostBoundsResultCount(): void
+    {
+        $id = $this->makePost();
+        $overflow = WEBMENTION_DISPLAY_LIMIT + 5;
+        for ($i = 0; $i < $overflow; $i++) {
+            $m = R::dispense('webmention');
+            $m->source = 'https://other.example/reply/' . $i;
+            $m->target = ROOT_URL . '/status/' . $id;
+            $m->post_id = $id;
+            $m->type = 'mention';
+            // Ascending created so the highest index is the newest mention.
+            $m->created = date('Y-m-d H:i:s', strtotime('2026-01-01 00:00:00') + $i);
+            $m->verified_at = '2026-01-01 12:00:00';
+            R::store($m);
+        }
+
+        $mentions = webmentions_for_post($id);
+
+        $this->assertCount(WEBMENTION_DISPLAY_LIMIT, $mentions);
+        // The bound keeps the newest mentions, still oldest-first for display.
+        $newest = end($mentions);
+        $this->assertSame('https://other.example/reply/' . ($overflow - 1), $newest->source);
+    }
+
+    public function testExtractMetaCapsContentLength(): void
+    {
+        $title = str_repeat('a', WEBMENTION_CONTENT_MAX + 500);
+        $meta = extract_meta('<title>' . $title . '</title>');
+        $this->assertNotNull($meta['content']);
+        $this->assertLessThanOrEqual(WEBMENTION_CONTENT_MAX, mb_strlen($meta['content']));
     }
 
     // is_external_http_url --------------------------------------------------


### PR DESCRIPTION
Closes #670.

## Problem

`webmentions_for_post()` read every verified mention for a post with no `LIMIT`, and the title-derived `content` snippet had no length cap. A heavily mentioned post could load an unbounded number of rows, each with an unbounded snippet. #665 fixed the same unbounded read on the tag path but deferred this one.

## Change

- `webmentions_for_post()` reads the newest `WEBMENTION_DISPLAY_LIMIT` (100) mentions with `ORDER BY created DESC LIMIT`, then `array_reverse` to keep the template's oldest-first order. A plain `ASC LIMIT` would drop the newest mentions instead.
- `extract_meta()` truncates the snippet at `WEBMENTION_CONTENT_MAX` (280) chars, bounding storage and render at the source.

This is simpler than #665: every matching row here is displayable, so a plain `LIMIT` works without the PHP-side filtering the tag path needed.

## Tests

- `testWebmentionsForPostBoundsResultCount` stores limit+5 verified mentions and asserts the count is capped and the newest survive.
- `testExtractMetaCapsContentLength` uses an oversized title and asserts the snippet is truncated to the cap.

Full unit suite green (2147). PHPStan level 8 clean. phpcs clean.
