### PR TITLE
586: Soften the JSON Feed _microblog.in_reply_to_url claim

### DIFF
--- a/docs/replies.md
+++ b/docs/replies.md
@@ -27,7 +27,7 @@ Remove the value from the front matter and re-save to turn the post back into a 
 
 - **On the post page and in listings** a small "In reply to …" line is shown above the content, linked to the parent and marked up with `u-in-reply-to` so Webmention receivers treat it as a reply.
 - **Atom feed**: emits `<thr:in-reply-to ref="…" href="…" />` (the `http://purl.org/syndication/thread/1.0` thread extension).
-- **JSON feed**: emits `_microblog.in_reply_to_url` (the micro.blog reply convention).
+- **JSON feed**: emits `_microblog.in_reply_to_url`, a JSON Feed extension field. micro.blog outputs the `_microblog` namespace in its own API, but it is not documented to read this field from an external feed: it detects replies from external blogs through the `u-in-reply-to` microformat and Webmention. Lamb emits the field as a harmless hint, and the reply threads through the `u-in-reply-to` markup either way.
 - **Both feeds** also carry the same "In reply to …" line inside the item's HTML content, because the two metadata fields above are extensions most readers ignore, and services that thread replies look for the `u-in-reply-to` markup itself.
 
 ## Editing a reply over Micropub

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -373,7 +373,8 @@ function render_json_feed(array $data, array $config): void
             'id'             => $url,
             'url'            => $url,
             // Reply context inside content_html as well as _microblog below: the
-            // extension is a micro.blog convention, the u-in-reply-to markup is
+            // extension is a best-effort hint (micro.blog is not documented to
+            // read it from an external feed), whereas the u-in-reply-to markup is
             // what a plain reader shows and what mf2 consumers parse.
             'content_html'   => feed_item_content_html($bean),
             'date_published' => date(DATE_RFC3339, strtotime($bean->created)),
@@ -384,9 +385,10 @@ function render_json_feed(array $data, array $config): void
         }
         // Guarded like content_html above: the consumer links this, and
         // in_reply_to is not author-only. `_microblog.in_reply_to_url` is a
-        // micro.blog convention for a single target, so a post with several
-        // (#583) reports only the first valid one here — every target still
-        // reaches the reader via content_html's u-in-reply-to links above.
+        // JSON Feed extension field that carries a single target (micro.blog is
+        // not documented to read it from an external feed; #586), so a post with
+        // several (#583) reports only the first valid one here — every target
+        // still reaches the reader via content_html's u-in-reply-to links above.
         foreach (split_reply_targets((string) ($bean->in_reply_to ?? '')) as $target) {
             if (\Lamb\Http\is_valid_http_url($target)) {
                 $item['_microblog'] = ['in_reply_to_url' => $target];


### PR DESCRIPTION
Closes #586.

## Verification

The docs (`replies.md`) and code (`feeds.php`) called `_microblog.in_reply_to_url` "the micro.blog reply convention". Checking against micro.blog's own docs:

- The [micro.blog JSON API](https://help.micro.blog/t/json-api/97) documents `_microblog` as a namespace micro.blog outputs in its own API. The fields it lists are `about`, `username`, `is_following`, `is_deletable`, `is_bookmark`, and `date_relative`. There's no `in_reply_to_url`, and nothing about reading it from an inbound external feed.
- [Replies](https://book.micro.blog/replies/) and [Webmention](https://book.micro.blog/webmention/): reply detection for external blogs runs off the `u-in-reply-to` microformat plus Webmention.

So the field isn't a verifiable micro.blog input convention. The evidence indicates micro.blog doesn't consume it from an external feed.

## Decision

Keep emitting the field. It's a valid, harmless `_`-prefixed JSON Feed extension, and the reply already threads through `content_html`'s `u-in-reply-to` markup either way. Only the claim changes: `replies.md` and the two `feeds.php` comments now describe it as an extension hint that micro.blog isn't documented to read, not a documented convention.

## Scope

Docs and comments only. No behaviour change. `ReplyContextTest` still asserts the field is emitted (green).

Sources: [JSON API](https://help.micro.blog/t/json-api/97) · [Replies](https://book.micro.blog/replies/) · [Webmention](https://book.micro.blog/webmention/)
