### PR TITLE
570: Add a "Write your first post" tutorial

### DIFF
--- a/docs/drafts.md
+++ b/docs/drafts.md
@@ -19,6 +19,7 @@ Feed ingested posts are saved as drafts by default to prioritize authorship over
 
 ## Related
 
+- [Write your first post]({{ site.baseurl }}{% link first-post.md %}): A ten-minute walkthrough that ends by saving a draft.
 - [Post Types]({{ site.baseurl }}{% link post-types.md %}): Front-matter is used to set `draft: true`.
 - [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Hide a post until a future `created` date.
 - [Cross-posting]({{ site.baseurl }}{% link cross-posting.md %}): Feed ingestion that produces drafts.

--- a/docs/first-post.md
+++ b/docs/first-post.md
@@ -1,0 +1,71 @@
+---
+title: Write your first post
+parent: Content
+nav_order: 1
+---
+
+# Write your first post
+
+This tutorial walks you through your first ten minutes with Lamb: logging in, publishing a status, adding a hashtag and an image, turning a post into a page, and saving a draft. Follow it start to finish and you will have used every part of the writing flow once.
+
+It assumes Lamb is already installed and running. If it isn't, start with [Installation & hosting]({{ site.baseurl }}{% link installation.md %}).
+
+## Log in
+
+Go to `/login` and enter your password. Lamb has a single author — you — so there is no username. Once you are in, the homepage gains a text box at the top. Everything below happens from there.
+
+## Publish a status
+
+Type a sentence into the box and press **Publish**. That's a status post, and it's already live at its own address, `/status/<number>`.
+
+The box takes Markdown, so `**bold**`, `_italic_`, and `- ` lists all work. You don't need any of it for a status — plain text is a complete post — but it's there when you want it.
+
+## Add a hashtag
+
+Write a word with a `#` in front of it, like `#coffee`, anywhere in a post. Lamb turns it into a link automatically. Publish the post, then select the hashtag: it takes you to `/tag/coffee`, an archive of every post with that tag. Tags are lower-cased in the link, so `#Coffee` and `#coffee` land on the same archive.
+
+You don't create tags anywhere — writing one is enough.
+
+## Drag in an image
+
+Drag an image file from your desktop onto the text box. Lamb uploads it and drops a Markdown image link at your cursor, so you can keep typing around it. Pasting an image from the clipboard — a screenshot, say — does the same thing.
+
+JPEG and PNG files are re-encoded to WebP on upload to keep them small; the link points at the converted file. GIF, WebP, and AVIF are kept as they are. For the full picture, including video and size limits, see [Media]({{ site.baseurl }}{% link media.md %}).
+
+## Turn a post into a page
+
+So far every post has been a status with an automatic `/status/<number>` address. To make a lasting page instead — an about page, say — give it a title in front matter at the very top of the box:
+
+```markdown
+---
+title: About me
+---
+
+I write about coffee and code.
+```
+
+Publish it, and the post becomes a page with a readable address built from its title, like `/about-me`, instead of a numbered status. Front matter is metadata: the `title` block itself isn't shown in the post body. [Post Types]({{ site.baseurl }}{% link post-types.md %}) covers the difference in full.
+
+## Save a draft
+
+To hold a post back instead of publishing it, add `draft: true` to the front matter:
+
+```markdown
+---
+draft: true
+---
+
+Still thinking about this one.
+```
+
+The post is saved but not shown on your blog. Every draft is listed at `/drafts` while you are logged in, each with an **Edit** link to finish it and a **Preview** link you can share with someone who isn't logged in. See [Drafts]({{ site.baseurl }}{% link drafts.md %}) for how previews and their expiring links work.
+
+## Where to go next
+
+You have now published a status, tagged it, added an image, made a page, and saved a draft. Each of those has a reference page with the details this tutorial skipped:
+
+- [Post Types]({{ site.baseurl }}{% link post-types.md %}) — statuses, pages, task lists, and front matter.
+- [Media]({{ site.baseurl }}{% link media.md %}) — images and video, formats, and upload limits.
+- [Drafts]({{ site.baseurl }}{% link drafts.md %}) — drafts, previews, and shareable links.
+- [Scheduling]({{ site.baseurl }}{% link scheduling.md %}) — publish a post at a future date.
+- [Reply posts]({{ site.baseurl }}{% link replies.md %}) — reply to another page and join the conversation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,3 +109,4 @@ Devtools / local environments / sandbox:
 * [Trash]({{ site.baseurl }}{% link trash.md %})
 * [Upgrading]({{ site.baseurl }}{% link upgrading.md %})
 * [WordPress import]({{ site.baseurl }}{% link wordpress-import.md %})
+* [Write your first post]({{ site.baseurl }}{% link first-post.md %})

--- a/docs/media.md
+++ b/docs/media.md
@@ -112,6 +112,7 @@ If WebP support is missing and you want it, install or enable the WebP-capable G
 
 ## Related
 
+* [Write your first post]({{ site.baseurl }}{% link first-post.md %}): A ten-minute walkthrough that includes dragging in your first image.
 * [Post Types]({{ site.baseurl }}{% link post-types.md %}): Add images and video to status and page posts.
 * [Micropub]({{ site.baseurl }}{% link micropub.md %}): Publish posts and upload photos from external apps.
 * [Social Embeds]({{ site.baseurl }}{% link social-embeds.md %}): A post's first image becomes its social preview card; video-only posts fall back to the default card.

--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -94,6 +94,7 @@ The following sections of the site are special:
 
 ## Related
 
+* [Write your first post]({{ site.baseurl }}{% link first-post.md %}): A ten-minute walkthrough of publishing a status, tagging it, adding an image, and making a page.
 * [Media]({{ site.baseurl }}{% link media.md %}): Add images and video by drag-and-drop or paste; JPEG/PNG are converted to WebP, video is stored as-is.
 * [Drafts]({{ site.baseurl }}{% link drafts.md %}): Add `draft: true` to front-matter to save a post as a draft.
 * [Scheduling]({{ site.baseurl }}{% link scheduling.md %}): Add a future `created:` date to publish a post later.


### PR DESCRIPTION
Closes #570.

## The gap
In [Diátaxis](https://diataxis.fr/) terms the manual had strong **reference** and **how-to** content and decent **explanation**, but **no tutorial**. `index.md` installed Lamb and stopped; no page walked a new author through actually using it — an odd gap when frictionless writing is the pitch.

## The page
`docs/first-post.md`, written as one continuous ten-minute session rather than a feature list:

1. Log in at `/login`.
2. Publish a status from the homepage box.
3. Add a `#hashtag` and follow it to `/tag/…`.
4. Drag in an image; note the automatic WebP conversion.
5. Give a post a `title` in front matter to make it a page with a slug.
6. Save one with `draft: true`, find it at `/drafts`.
7. Link out to the reference pages for depth.

Every mechanic was checked against the code (tag archives are `/tag/<lowercased>`, statuses are `/status/<id>`, pages get a slug URL) and the existing reference pages, so the walkthrough matches real behaviour and links out rather than duplicating.

## Placement decision
The issue suggested a flat `nav_order: 9`, but `docs/` has since moved to **sectioned nav** (`parent:`), and no page uses a top-level `nav_order`. The faithful translation is to place the tutorial as the **lead of the Content section** (`parent: Content`, `nav_order: 1`) — right at the boundary between installing and writing, with every page it links to (post-types, media, drafts) as a sibling.

Wired into `index.md`'s Main Topics and the `## Related` lists of `post-types.md`, `media.md`, and `drafts.md`, per the issue.

Docs-only; no code touched.