### PR TITLE
Register the SessionStart hook that provisions the test toolchain

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,17 @@
       "Bash(git fetch *)",
       "Bash(lxc info *)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- `.claude/hooks/session-start.sh` has existed since PR #681. It's well-documented and handles exactly the problem every prior scheduled bug-scan run has hit: a remote session's `composer install` fails against dist-download-restrictive network policies, and it falls back to a source install with a special-cased git clone for `phpstan/phpstan` (the one dependency that ships as a dist-only phar).
- The script was never wired into `.claude/settings.json`'s `hooks` config, so it silently never runs — `CLAUDE_CODE_REMOTE=true` was true this whole time, but nothing invoked it.
- Every previous run's log entry in `.claude/bug-scan-log.md` (2026-08-24 through 2026-08-27) documents hitting "vendor/bin binaries never got generated" and falling back to hand-rolled standalone verification scripts instead of the real `vendor/bin/codecept`/`phpstan`/`phpcs`.
- This run confirmed the fix: after manually running the script's provisioning steps, `vendor/bin/codecept run Unit` ran cleanly (2142 tests, 3941 assertions, 0 failures) and `vendor/bin/phpstan analyse` / `vendor/bin/phpcs` both worked, used to validate PR #761 in this same run.
- Fix: add the missing `hooks.SessionStart` registration so the script actually executes at session start going forward.

## Test plan
- [x] `jq empty .claude/settings.json` — valid JSON.
- [x] `jq -e '.hooks.SessionStart[] | .hooks[] | select(.type == "command") | .command' .claude/settings.json` — resolves to the expected command.
- [x] Pipe-tested the hook script directly with `CLAUDE_CODE_REMOTE=true bash .claude/hooks/session-start.sh` — ran cleanly, reported `composer dependencies already present` / `pnpm install complete` / `ready`.
- [x] Confirmed (in this same run, on a fresh checkout of `origin/main`) that following the script's own documented steps turns a plain `composer install` timeout into a working `vendor/bin/` with `codecept`, `phpunit`, `phpcs`, and `phpstan` all present and usable.

Found while investigating why this scheduled bug-scan run's initial `composer install` attempts failed the same way every prior run's log describes — not one of the routine's 9 scan categories, but a configuration bug worth fixing since it's been silently defeating this exact tooling since it was added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYkChacXseDQQgaGZvZJ3q)_