### PR TITLE
Fix the tag archive path in post-types.md (/tags/ -> /tag/)

### DIFF
--- a/docs/post-types.md
+++ b/docs/post-types.md
@@ -87,7 +87,7 @@ Front-matter keys are forgiving: they are matched case-insensitively, and unders
 
 The following sections of the site are special:
 
-- `/tags/<name>` are tags linked in content
+- `/tag/<name>` are tags linked in content
 - `/search/<keywords>` search the content for keywords
 - `/login` and `/logout` to login and out.
 - `/feed` for the Atom newsfeed.

--- a/src/themes/2026/parts/_related.php
+++ b/src/themes/2026/parts/_related.php
@@ -42,7 +42,6 @@ $primary_tag = $tags[0] ?? null;
             $permalink = \Lamb\permalink_path($bean);
             $title = trim(strip_tags($bean->title ?? ''));
             $excerpt = trim(strip_tags($bean->description ?? ''));
-            // If the post has no title, promote a short excerpt to the title slot.
             if ($title === '' && $excerpt !== '') {
                 $title = mb_strimwidth($excerpt, 0, 90, '…');
                 $excerpt = '';

--- a/src/themes/base/parts/_pagination.php
+++ b/src/themes/base/parts/_pagination.php
@@ -2,8 +2,6 @@
 
 use function Lamb\Theme\escape;
 
-// Render pagination if available in the page data
-
 $pagination = $data['pagination'] ?? $GLOBALS['data']['pagination'] ?? null;
 if (!empty($pagination)) :
     $current = (int)($pagination['current'] ?? 1);


### PR DESCRIPTION
The "System types" list in `post-types.md` gave the tag archive as `/tags/<name>` (plural), but the route is singular:

- `src/routes.php` registers the `tag` action (`/tag/<name>` → `respond_tag`).
- The inline hashtag linker in `src/lamb.php` builds `href="/tag/<name>"`.
- No `/tags/` route or redirect exists anywhere in `src/`.

So a reader building a tag link by hand from this list would hit a 404. The new `first-post.md` tutorial (#570) already uses the correct `/tag/` form. One-line fix. Surfaced while writing that tutorial (parked, now resolved).