### PR TITLE
Remove two what-restating comments in theme templates

### DIFF
--- a/src/themes/2026/parts/_related.php
+++ b/src/themes/2026/parts/_related.php
@@ -42,7 +42,6 @@ $primary_tag = $tags[0] ?? null;
             $permalink = \Lamb\permalink_path($bean);
             $title = trim(strip_tags($bean->title ?? ''));
             $excerpt = trim(strip_tags($bean->description ?? ''));
-            // If the post has no title, promote a short excerpt to the title slot.
             if ($title === '' && $excerpt !== '') {
                 $title = mb_strimwidth($excerpt, 0, 90, '…');
                 $excerpt = '';

--- a/src/themes/base/parts/_pagination.php
+++ b/src/themes/base/parts/_pagination.php
@@ -2,8 +2,6 @@
 
 use function Lamb\Theme\escape;
 
-// Render pagination if available in the page data
-
 $pagination = $data['pagination'] ?? $GLOBALS['data']['pagination'] ?? null;
 if (!empty($pagination)) :
     $current = (int)($pagination['current'] ?? 1);


### PR DESCRIPTION
## What this does

Removes two code comments that restate the line directly below them:

- `src/themes/base/parts/_pagination.php` — `// Render pagination if available in the page data` above the `if (!empty($pagination))` guard.
- `src/themes/2026/parts/_related.php` — `// If the post has no title, promote a short excerpt to the title slot.` above the `if ($title === '')` fallback.

## Why it's small

I audited `src/` against the comment standard (comment *why* not *what*; delete comments that restate the line below; don't let a paragraph-long comment stand in for documentation; match the file's idiom). The finding: the codebase already follows it.

- Short comments are overwhelmingly *why* — a constraint, a rejected alternative, a bug that forced the code, or a security ceiling. A scan for short *what*-only comments came back almost empty.
- The ~120 docblocks with 8+ prose lines are the deliberate, consistent house style, and each carries genuine *why* (for example the XML control-character handling in `theme/formatting.php` and the task-checkbox XSS history in `LambDown.php`). The standard says to match that idiom, so flattening them would remove value, not add it.

The two comments here are the only clear *what*-restatements found, so this is the whole fix rather than a repo-wide rewrite.

## Test plan

- [x] `php -l` on both files
- [x] phpcs clean
- [x] CI (comment-only template change; no behaviour affected)
