### PR TITLE
Split sitemap.xml into a sitemap index past 50,000 URLs (#671)

### DIFF
--- a/docs/search-engines.md
+++ b/docs/search-engines.md
@@ -36,6 +36,15 @@ Unlike the timeline, the sitemap **does** include
 The sitemap is cached and supports conditional requests, so crawlers that
 revisit it only re-download it when your content has actually changed.
 
+### Large sites
+
+[sitemaps.org](https://www.sitemaps.org/) caps a single sitemap document at
+50,000 URLs. Once your site passes that, `/sitemap.xml` automatically becomes
+a sitemap index instead of a plain sitemap: it lists child sitemaps at
+`/sitemap.xml/page/1`, `/sitemap.xml/page/2`, and so on, each holding up to
+50,000 URLs. Crawlers that follow sitemap indexes (all major ones do) pick
+this up with no configuration change on your part.
+
 ## robots.txt
 
 `/robots.txt` allows crawling, advertises the sitemap, and asks crawlers not to

--- a/src/constants.php
+++ b/src/constants.php
@@ -54,3 +54,7 @@ define('SESSION_LOGIN', 'logged_in');
 define('SUBMIT_CREATE', 'Create post');
 define('SUBMIT_EDIT', 'Update post');
 define('SUBMIT_LOGIN', 'Log in');
+// sitemaps.org caps a single sitemap document at 50,000 URLs. /sitemap.xml
+// splits into a sitemap index of /sitemap.xml/page/N children once the site's
+// visible URL count passes this.
+define('SITEMAP_MAX_URLS', 50000);

--- a/src/response/README.md
+++ b/src/response/README.md
@@ -200,11 +200,27 @@ The sitemap is served from disk. `respond_sitemap()` reads the validator
 first — one indexed row for the newest visible `updated`, plus the config
 timestamp — so a crawler revalidating a copy it already holds is answered 304
 without the document being built at all. Those same two values, together with
-`ROOT_URL`, key a cached copy under `data/cache/sitemap-<key>.xml`, so a
+`ROOT_URL`, key a cached copy under `data/cache/sitemap-<key>-<page>.xml`, so a
 request that does get a 200 streams a file instead of rebuilding 25,000
 entries. Keying on the content is what keeps the cache honest: it turns over
 exactly when the ETag does, so the bytes sent always match the validator sent
-with them, and there is no staleness window to reason about. The cached copy is host-independent: it
+with them, and there is no staleness window to reason about.
+
+Past `SITEMAP_MAX_URLS` visible entries — sitemaps.org's 50,000-URL cap on a
+single document — `/sitemap.xml` itself becomes a `<sitemapindex>`
+(`render_sitemap_index()`) and each `/sitemap.xml/page/N` (the site's usual
+`/page/N` pagination convention) serves one `SITEMAP_MAX_URLS`-sized slice,
+sliced in SQL via `LIMIT`/`OFFSET` (`sitemap_urls()`'s `$page`/`$cap`
+arguments) rather than loading everything and cutting it down, for the same
+memory reason described below. `<page>` in the cache filename keeps each
+page's copy distinct so storing one page's cache can't evict another's; only
+an older generation's files (a different `<key>`) get pruned. A page number
+that doesn't exist for the current split — any page at all under the cap, or
+one past the last page once split — 404s like any other unmatched route.
+Under the cap there is exactly one page and behaviour is unchanged from
+before the split existed.
+
+The cached copy is host-independent: it
 holds a `{ROOT}` placeholder where the site root belongs, and the current
 `ROOT_URL` is substituted on the way out. That matters because with no
 `site_url` configured `ROOT_URL` comes from the request's own `Host`, which

--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -459,7 +459,10 @@ function respond_sitemap(): array
     }
 
     header('Content-Type: application/xml; charset=UTF-8');
-    feed_cache($updated);
+    // Pass page_count as the shape discriminator: a change between index/urlset
+    // or in child-page count must invalidate the 304/ETag the same way it
+    // invalidates the disk cache key below, even when $updated is unchanged.
+    feed_cache($updated, $page_count);
     $path = sitemap_cache_path(
         sitemap_cache_key($updated, \Lamb\Config\config_modified_timestamp(), $page_count),
         $page

--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -9,6 +9,7 @@ use RedBeanPHP\R;
 
 use const ROOT_DIR;
 use const ROOT_URL;
+use const SITEMAP_MAX_URLS;
 
 /**
  * Formats a stored `Y-m-d H:i:s` datetime as a W3C/ISO-8601 string for a sitemap
@@ -49,18 +50,45 @@ function sitemap_date(?string $datetime): ?string
  * resolves to, so the rule stays in one place without a bean per row — making
  * one cost about 130 ms of this response at 30,000 posts.
  *
+ * $page splits the same ordered list into sitemaps.org-sized slices instead of
+ * returning it whole, for a site past SITEMAP_MAX_URLS (see respond_sitemap()).
+ * Entry 0 is the home page and entries 1.. are posts newest-first, so page 1
+ * carries the home page plus a $cap-1 slice of posts and page 2 onwards carries
+ * a $cap slice with no home entry. The slicing is done in SQL via LIMIT/OFFSET
+ * rather than fetching everything and array_slice()ing it, for the same memory
+ * reason the whole function avoids loading post beans (see below).
+ *
  * @param string $root The site root each `<loc>` is built from. Defaults to
  *                     this request's ROOT_URL; respond_sitemap() passes
  *                     SITEMAP_ROOT so the cached copy is host-independent.
+ * @param int    $page Which sitemap page to return; 0 (the default) returns
+ *                     every entry, unpaginated.
+ * @param int    $cap  Entries per page when $page is set. Defaults to
+ *                     SITEMAP_MAX_URLS; overridable so tests can exercise
+ *                     pagination without seeding 50,000 posts.
  * @return list<array{loc: string, lastmod: string|null}>
  */
-function sitemap_urls(string $root = ROOT_URL): array
+function sitemap_urls(string $root = ROOT_URL, int $page = 0, int $cap = SITEMAP_MAX_URLS): array
 {
     $visible = \Lamb\visible_clause();
-    $rows = R::getAll(
-        'SELECT id, slug, updated FROM post WHERE ' . $visible['sql'] . 'ORDER BY updated DESC',
-        $visible['params']
-    );
+    $sql = 'SELECT id, slug, updated FROM post WHERE ' . $visible['sql'] . 'ORDER BY updated DESC';
+    $params = $visible['params'];
+
+    if ($page >= 1) {
+        // Entry 0 is the home page, so post index i is global entry i + 1: page 1's
+        // post slice is one shorter (it also carries the home entry) and starts at
+        // offset 0, while page k > 1 starts one post short of ($page - 1) * $cap.
+        $sql .= ' LIMIT ? OFFSET ?';
+        if ($page === 1) {
+            $params[] = max(0, $cap - 1);
+            $params[] = 0;
+        } else {
+            $params[] = $cap;
+            $params[] = ($page - 1) * $cap - 1;
+        }
+    }
+
+    $rows = R::getAll($sql, $params);
 
     $entries = [];
     $seen = [];
@@ -77,12 +105,46 @@ function sitemap_urls(string $root = ROOT_URL): array
     }
 
     // Home page first; its lastmod tracks the freshest post (null when empty).
-    array_unshift($entries, [
-        'loc'     => $root . '/',
-        'lastmod' => $entries[0]['lastmod'] ?? null,
-    ]);
+    // Only pages 0 (everything) and 1 (the first slice) carry it — its rows
+    // start at offset 0, so entries[0] is still the newest post overall.
+    if ($page <= 1) {
+        array_unshift($entries, [
+            'loc'     => $root . '/',
+            'lastmod' => $entries[0]['lastmod'] ?? null,
+        ]);
+    }
 
     return $entries;
+}
+
+/**
+ * Counts the publicly visible posts a sitemap would list (excluding the home
+ * page entry sitemap_urls() prepends) — the same visible_clause() allow-list,
+ * read as one row instead of the whole list.
+ *
+ * @return int
+ */
+function count_visible_posts(): int
+{
+    $visible = \Lamb\visible_clause();
+    return (int) R::getCell(
+        'SELECT COUNT(*) FROM post WHERE ' . $visible['sql'],
+        $visible['params']
+    );
+}
+
+/**
+ * The number of sitemap pages (P) a $total-entry sitemap needs at $cap URLs
+ * per page — sitemaps.org's cap on a single document.
+ *
+ * @param int $total The total number of sitemap entries (posts + the home page).
+ * @param int $cap   Entries per page. Defaults to SITEMAP_MAX_URLS; overridable
+ *                   so tests can exercise the split with a tiny cap.
+ * @return int
+ */
+function sitemap_page_count(int $total, int $cap = SITEMAP_MAX_URLS): int
+{
+    return $cap > 0 ? (int) ceil($total / $cap) : 1;
 }
 
 /**
@@ -110,6 +172,46 @@ function render_sitemap(array $urls): string
         $lines[] = '  </url>';
     }
     $lines[] = '</urlset>';
+    return implode("\n", $lines) . "\n";
+}
+
+/**
+ * Renders a sitemaps.org 0.9 sitemap index: one `<sitemap>` entry per child
+ * page, for a site whose visible URL count has passed SITEMAP_MAX_URLS.
+ *
+ * Child locs follow the site's existing pagination convention
+ * (`/sitemap.xml/page/N`) rather than page_path(), which would collapse page 1
+ * to the bare `/sitemap.xml` — the wrong URL here, since page 1 is a child
+ * page, not the index itself.
+ *
+ * Every child shares the one $lastmod given (the sitemap's newest lastmod, as
+ * newest_visible_update()/sitemap_date() produce it) rather than each computing
+ * its own: page 1 always holds the newest entry, so a per-page value would only
+ * ever be current for that one child.
+ *
+ * @param string      $root       The site root each child `<loc>` is built
+ *                                from. SITEMAP_ROOT for the cached copy, like
+ *                                render_sitemap().
+ * @param int         $page_count The number of child pages (P).
+ * @param string|null $lastmod    ISO-8601 lastmod applied to every child entry,
+ *                                or null to omit it.
+ * @return string The complete XML document.
+ */
+function render_sitemap_index(string $root, int $page_count, ?string $lastmod): string
+{
+    $lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ];
+    for ($page = 1; $page <= $page_count; $page++) {
+        $lines[] = '  <sitemap>';
+        $lines[] = '    <loc>' . \Lamb\Theme\escape_xml($root . '/sitemap.xml/page/' . $page) . '</loc>';
+        if (!empty($lastmod)) {
+            $lines[] = '    <lastmod>' . $lastmod . '</lastmod>';
+        }
+        $lines[] = '  </sitemap>';
+    }
+    $lines[] = '</sitemapindex>';
     return implode("\n", $lines) . "\n";
 }
 
@@ -170,15 +272,44 @@ function sitemap_cache_key(string $updated, int $config_ts): string
 const SITEMAP_ROOT = '{ROOT}';
 
 /**
- * Where the cached sitemap for $key lives — under the same `data/cache/`
- * directory the feed cache already uses (see Network\ensure_feed_cache()).
+ * Where the cached sitemap for $key/$page lives — under the same
+ * `data/cache/` directory the feed cache already uses (see
+ * Network\ensure_feed_cache()).
  *
- * @param string $key As built by sitemap_cache_key().
+ * $page is appended rather than folded into $key so store_sitemap_cache()'s
+ * pruning can tell sibling pages of the same generation (same $key, different
+ * $page) apart from an older generation's files (see
+ * sitemap_cache_generation()) — sibling pages must survive each other's writes,
+ * since a split sitemap caches one file per page.
+ *
+ * @param string $key  As built by sitemap_cache_key().
+ * @param int    $page The sitemap page this cache entry is for; 0 for the
+ *                      entry point (the single urlset, or the index).
  * @return string Absolute or data-dir-relative path to the cache file.
  */
-function sitemap_cache_path(string $key): string
+function sitemap_cache_path(string $key, int $page = 0): string
 {
-    return \Lamb\Bootstrap\data_dir() . '/cache/sitemap-' . $key . '.xml';
+    return \Lamb\Bootstrap\data_dir() . '/cache/sitemap-' . $key . '-' . $page . '.xml';
+}
+
+/**
+ * The generation portion of a sitemap cache filename — everything before an
+ * optional trailing `-<page>` page suffix — so store_sitemap_cache() can tell
+ * a sibling page of the current generation from a stale one.
+ *
+ * Falls back to the whole filename for anything not shaped like
+ * sitemap_cache_path()'s output, so an old-format cache file (from before
+ * pages existed) is still treated as its own distinct generation and pruned.
+ *
+ * @param string $filename Basename of a `sitemap-*.xml` cache file.
+ * @return string The generation key.
+ */
+function sitemap_cache_generation(string $filename): string
+{
+    if (preg_match('/^sitemap-([0-9a-f]{32})-\d+\.xml$/', $filename, $matches) === 1) {
+        return $matches[1];
+    }
+    return $filename;
 }
 
 /**
@@ -191,8 +322,11 @@ function sitemap_cache_path(string $key): string
  * time this runs, so an unwritable data directory costs the cache, not the
  * sitemap.
  *
- * Older keys are removed once the new one is in place, so the directory holds
- * one sitemap rather than one per edit.
+ * Older generations are removed once the new copy is in place, so the
+ * directory holds one sitemap's worth of pages rather than one per edit — but
+ * a sibling page of the *same* generation (see sitemap_cache_generation()) is
+ * kept, since a split sitemap's pages are written one request at a time and
+ * must not evict each other.
  *
  * Every call is `@`-suppressed on purpose. These are best-effort filesystem
  * operations on a path the operator controls, each already handled by its
@@ -218,8 +352,9 @@ function store_sitemap_cache(string $path, string $xml): void
         @unlink($tmp);
         return;
     }
+    $generation = sitemap_cache_generation(basename($path));
     foreach (glob($dir . '/sitemap-*.xml') ?: [] as $stale) {
-        if ($stale !== $path) {
+        if ($stale !== $path && sitemap_cache_generation(basename($stale)) !== $generation) {
             @unlink($stale);
         }
     }
@@ -244,15 +379,22 @@ function store_sitemap_cache(string $path, string $xml): void
  * because a concurrent request replacing the cache can unlink this key between
  * the is_readable() check and the open; losing that race just renders.
  *
- * @param string $path The cache path for the current key.
+ * @param string        $path   The cache path for the current key/page.
+ * @param callable|null $render Builds the document on a miss; defaults to the
+ *                              single, unpaginated urlset render_sitemap()
+ *                              produces for sitemap_urls(SITEMAP_ROOT).
+ *                              respond_sitemap() passes one that renders the
+ *                              index or the page slice this path is for.
  * @return void
  */
-function emit_sitemap(string $path): void
+function emit_sitemap(string $path, ?callable $render = null): void
 {
+    $render ??= static fn (): string => render_sitemap(sitemap_urls(SITEMAP_ROOT));
+
     $template = is_readable($path) ? @file_get_contents($path) : false;
     $miss = $template === false;
     if ($miss) {
-        $template = render_sitemap(sitemap_urls(SITEMAP_ROOT));
+        $template = $render();
     }
 
     echo str_replace(
@@ -280,17 +422,47 @@ function emit_sitemap(string $path): void
  * 200 — a first fetch, or one after an edit — is served from a file rather
  * than rebuilt.
  *
- * @return never
+ * Past SITEMAP_MAX_URLS visible entries, a single `<urlset>` would break
+ * sitemaps.org's 50,000-URL cap, so /sitemap.xml itself becomes a
+ * `<sitemapindex>` and each `/sitemap.xml/page/N` (fed in via the site's usual
+ * `/page/N` convention — see Http\extract_page_segment()) serves one slice.
+ * Under the cap there is exactly one page, and behaviour is unchanged: this
+ * request, with no page segment, serves the sitemap directly. A page number
+ * that does not exist — any page at all under the cap, or one past the last
+ * page once split — 404s the same way any other route does, via respond_404().
+ *
+ * @return array{title: string, intro: string, action: string, requested: string}|never
+ *         respond_404()'s view data for an out-of-range page; otherwise never
+ *         returns.
  */
-#[NoReturn]
-function respond_sitemap(): never
+function respond_sitemap(): array
 {
-    header('Content-Type: application/xml; charset=UTF-8');
     $updated = newest_visible_update() ?? \Lamb\now();
+    $page = (int) ($_GET['page'] ?? 0);
+    $page_count = sitemap_page_count(count_visible_posts() + 1);
+    $split = $page_count > 1;
+
+    if ($split ? $page > $page_count : $page >= 1) {
+        return respond_404([]);
+    }
+
+    header('Content-Type: application/xml; charset=UTF-8');
     feed_cache($updated);
-    emit_sitemap(sitemap_cache_path(
-        sitemap_cache_key($updated, \Lamb\Config\config_modified_timestamp())
-    ));
+    $path = sitemap_cache_path(sitemap_cache_key($updated, \Lamb\Config\config_modified_timestamp()), $page);
+
+    if (!$split) {
+        emit_sitemap($path);
+    } elseif ($page === 0) {
+        emit_sitemap($path, static fn (): string => render_sitemap_index(
+            SITEMAP_ROOT,
+            $page_count,
+            sitemap_date($updated)
+        ));
+    } else {
+        emit_sitemap($path, static fn (): string => render_sitemap(
+            sitemap_urls(SITEMAP_ROOT, $page)
+        ));
+    }
     die();
 }
 

--- a/src/response/discovery.php
+++ b/src/response/discovery.php
@@ -243,6 +243,15 @@ function newest_visible_update(): ?string
  * exactly when the validator does and a served copy always matches the ETag
  * sent with it — no staleness window to reason about.
  *
+ * $page_count is folded in too, because it can change independently of both:
+ * trashing/restoring a post that is not the newest, or a scheduled post
+ * crossing into visibility purely by clock, changes count_visible_posts()
+ * (and so whether /sitemap.xml is a <urlset> or a <sitemapindex>, and how many
+ * pages it has) without touching $updated. Without this, such a change left
+ * the key — and so the served document's shape — stale: a <sitemapindex>
+ * served after the count dropped back under the cap, or a <urlset> missing
+ * everything past the old count after it rose past the cap.
+ *
  * The site root is deliberately *not* part of the key. The cached document is
  * host-independent — it holds SITEMAP_ROOT where the root belongs, and
  * emit_sitemap() substitutes this request's ROOT_URL on the way out — so one
@@ -252,13 +261,16 @@ function newest_visible_update(): ?string
  * a poisoning, and evicting the honest entry with junk Hosts would disable
  * the cache outright. Substituting at render time removes both.
  *
- * @param string $updated   The newest visible post's stored datetime.
- * @param int    $config_ts The config's last-modified timestamp.
+ * @param string $updated    The newest visible post's stored datetime.
+ * @param int    $config_ts  The config's last-modified timestamp.
+ * @param int    $page_count The sitemap's current page count, as
+ *                            sitemap_page_count() computes it. Defaults to 1
+ *                            (unsplit) for callers that don't split.
  * @return string A filename-safe cache key.
  */
-function sitemap_cache_key(string $updated, int $config_ts): string
+function sitemap_cache_key(string $updated, int $config_ts, int $page_count = 1): string
 {
-    return md5($updated . '|' . $config_ts);
+    return md5($updated . '|' . $config_ts . '|' . $page_count);
 }
 
 /**
@@ -448,7 +460,10 @@ function respond_sitemap(): array
 
     header('Content-Type: application/xml; charset=UTF-8');
     feed_cache($updated);
-    $path = sitemap_cache_path(sitemap_cache_key($updated, \Lamb\Config\config_modified_timestamp()), $page);
+    $path = sitemap_cache_path(
+        sitemap_cache_key($updated, \Lamb\Config\config_modified_timestamp(), $page_count),
+        $page
+    );
 
     if (!$split) {
         emit_sitemap($path);

--- a/src/response/feeds.php
+++ b/src/response/feeds.php
@@ -186,9 +186,16 @@ function get_feed_data(): array
  * See response/README.md ("Conditional GET, ETag, and 304 caching").
  *
  * @param string $updated The feed's latest-updated datetime string.
+ * @param int    $shape   A discriminator for a response's structure when that can
+ *                        change without $updated moving — folded into the ETag so
+ *                        the change invalidates conditional GETs. The sitemap
+ *                        passes its page count (index vs urlset, and how many child
+ *                        pages), which count_visible_posts() can change while the
+ *                        newest post is untouched (e.g. a non-newest post trashed).
+ *                        0 (the default) leaves the ETag keyed on content alone.
  * @return void
  */
-function feed_cache(string $updated): void
+function feed_cache(string $updated, int $shape = 0): void
 {
     if (isset($_SESSION[SESSION_LOGIN])) {
         return;
@@ -197,7 +204,7 @@ function feed_cache(string $updated): void
     // Fold in config edits so changes to feed-affecting settings (title, menu
     // exclusions, …) invalidate cached feeds immediately.
     $config_ts = Config\config_modified_timestamp();
-    $ts = max(strtotime($updated) ?: 0, $config_ts);
+    $ts = max(strtotime($updated) ?: 0, $config_ts) + $shape;
     send_304_if_current($ts, $config_ts);
 }
 

--- a/tests/Unit/SitemapTest.php
+++ b/tests/Unit/SitemapTest.php
@@ -7,6 +7,7 @@ use RedBeanPHP\R;
 
 use function Lamb\Response\count_visible_posts;
 use function Lamb\Response\emit_sitemap;
+use function Lamb\Response\feed_cache;
 use function Lamb\Response\newest_visible_update;
 use function Lamb\Response\render_sitemap;
 use function Lamb\Response\render_sitemap_index;
@@ -256,6 +257,42 @@ class SitemapTest extends TestCase
 
         $this->assertNotSame($base, sitemap_cache_key('2026-06-02 09:00:00', 1000));
         $this->assertNotSame($base, sitemap_cache_key('2026-06-01 09:00:00', 2000));
+    }
+
+    public function testFeedCacheShapeDiscriminatorTurnsOverTheEtag(): void
+    {
+        // The disk cache key folds in page count; the emitted ETag must too, or a
+        // shape change (index<->urlset, page count) that leaves the newest post
+        // untouched is masked by a 304 and a crawler keeps serving itself a stale
+        // sitemap. Same $updated, different page count => different ETag.
+        if (!function_exists('xdebug_get_headers')) {
+            $this->markTestSkipped('needs xdebug_get_headers() to read emitted headers');
+        }
+
+        $updated       = '2026-06-01 09:00:00';
+        $_SESSION      = [];
+        unset($_SERVER['HTTP_IF_NONE_MATCH'], $_SERVER['HTTP_IF_MODIFIED_SINCE']);
+
+        header_remove();
+        feed_cache($updated, 1);
+        $onePage = $this->emittedEtag();
+
+        header_remove();
+        feed_cache($updated, 2);
+        $twoPages = $this->emittedEtag();
+
+        $this->assertNotNull($onePage);
+        $this->assertNotSame($onePage, $twoPages);
+    }
+
+    private function emittedEtag(): ?string
+    {
+        foreach (xdebug_get_headers() as $header) {
+            if (stripos($header, 'ETag:') === 0) {
+                return trim(substr($header, strlen('ETag:')));
+            }
+        }
+        return null;
     }
 
     public function testCacheKeyIsFilenameSafe(): void

--- a/tests/Unit/SitemapTest.php
+++ b/tests/Unit/SitemapTest.php
@@ -12,6 +12,7 @@ use function Lamb\Response\render_sitemap;
 use function Lamb\Response\render_sitemap_index;
 use function Lamb\Response\sitemap_cache_key;
 use function Lamb\Response\sitemap_cache_path;
+use function Lamb\Response\sitemap_date;
 use function Lamb\Response\sitemap_page_count;
 use function Lamb\Response\sitemap_urls;
 use function Lamb\Response\store_sitemap_cache;
@@ -544,5 +545,92 @@ class SitemapTest extends TestCase
 
         $this->assertFileDoesNotExist($dir . '/' . basename($oldPage));
         $this->assertFileExists($dir . '/' . basename($newPage));
+    }
+
+    /**
+     * Renders and caches the /sitemap.xml entry point (page 0) the way
+     * respond_sitemap() does — a <sitemapindex> when $total exceeds $cap, a
+     * plain <urlset> otherwise — into a private test cache dir rather than
+     * data_dir()'s real cache path.
+     */
+    private function emitEntryPoint(string $updated, int $config_ts, int $total, int $cap, string $dir): string
+    {
+        $page_count = sitemap_page_count($total, $cap);
+        $path = $dir . '/' . basename(sitemap_cache_path(
+            sitemap_cache_key($updated, $config_ts, $page_count),
+            0
+        ));
+
+        ob_start();
+        if ($page_count > 1) {
+            emit_sitemap($path, static fn (): string => render_sitemap_index(
+                SITEMAP_ROOT,
+                $page_count,
+                sitemap_date($updated)
+            ));
+        } else {
+            emit_sitemap($path);
+        }
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * sitemap_cache_key() must turn over when count_visible_posts() crosses the
+     * split boundary, even though $updated does not: trashing/restoring a
+     * non-newest post (or a scheduled post crossing into visibility) changes
+     * whether /sitemap.xml is a <urlset> or a <sitemapindex> without touching
+     * the newest visible `updated`. Before this, such a change left the cache
+     * key — and so the served document's shape — stale.
+     */
+    public function testCacheKeyAndServedShapeTrackVisibleCountNotJustNewestUpdate(): void
+    {
+        $this->makePost(['slug' => 'newest', 'updated' => '2026-06-05 09:00:00']);
+        $oldIds = [
+            $this->makePost(['slug' => 'old1', 'updated' => '2026-06-01 09:00:00']),
+            $this->makePost(['slug' => 'old2', 'updated' => '2026-06-02 09:00:00']),
+            $this->makePost(['slug' => 'old3', 'updated' => '2026-06-03 09:00:00']),
+        ];
+        $updated = newest_visible_update();
+        $dir = $this->cacheDir();
+        $cap = 2;
+
+        // Home + 4 posts = 5 entries over a cap of 2 → split.
+        $total = count_visible_posts() + 1;
+        $key1 = sitemap_cache_key($updated, 1000, sitemap_page_count($total, $cap));
+        $split = $this->emitEntryPoint($updated, 1000, $total, $cap, $dir);
+        $this->assertStringContainsString('<sitemapindex', $split);
+
+        // Soft-delete every non-newest post: the visible count drops back
+        // under the cap, but the newest visible `updated` — still 'newest' —
+        // does not change.
+        foreach ($oldIds as $id) {
+            $bean = R::load('post', $id);
+            $bean->deleted = 1;
+            R::store($bean);
+        }
+        $this->assertSame($updated, newest_visible_update());
+
+        $totalAfterDelete = count_visible_posts() + 1;
+        $key2 = sitemap_cache_key($updated, 1000, sitemap_page_count($totalAfterDelete, $cap));
+        $this->assertNotSame($key1, $key2, 'the cache key must change when the visible count re-crosses the cap');
+
+        $unsplit = $this->emitEntryPoint($updated, 1000, $totalAfterDelete, $cap, $dir);
+        $this->assertStringContainsString('<urlset', $unsplit);
+        $this->assertStringNotContainsString('<sitemapindex', $unsplit);
+
+        // And the reverse: restoring posts re-crosses back over the cap.
+        foreach (array_slice($oldIds, 0, 2) as $id) {
+            $bean = R::load('post', $id);
+            $bean->deleted = 0;
+            R::store($bean);
+        }
+        $this->assertSame($updated, newest_visible_update());
+
+        $totalAfterRestore = count_visible_posts() + 1;
+        $key3 = sitemap_cache_key($updated, 1000, sitemap_page_count($totalAfterRestore, $cap));
+        $this->assertNotSame($key2, $key3);
+
+        $resplit = $this->emitEntryPoint($updated, 1000, $totalAfterRestore, $cap, $dir);
+        $this->assertStringContainsString('<sitemapindex', $resplit);
     }
 }

--- a/tests/Unit/SitemapTest.php
+++ b/tests/Unit/SitemapTest.php
@@ -5,11 +5,14 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
+use function Lamb\Response\count_visible_posts;
 use function Lamb\Response\emit_sitemap;
 use function Lamb\Response\newest_visible_update;
 use function Lamb\Response\render_sitemap;
+use function Lamb\Response\render_sitemap_index;
 use function Lamb\Response\sitemap_cache_key;
 use function Lamb\Response\sitemap_cache_path;
+use function Lamb\Response\sitemap_page_count;
 use function Lamb\Response\sitemap_urls;
 use function Lamb\Response\store_sitemap_cache;
 
@@ -385,5 +388,161 @@ class SitemapTest extends TestCase
     {
         $xml = render_sitemap([['loc' => 'https://example.com/', 'lastmod' => null]]);
         $this->assertStringNotContainsString('<lastmod>', $xml);
+    }
+
+    // Sitemap index: sitemaps.org caps a single document at 50,000 URLs, so a
+    // site past that splits into an index of /sitemap.xml/page/N children.
+    // Seeding 50,000 posts is impractical here, so the cap is injectable
+    // throughout — sitemap_page_count() and sitemap_urls() take it as an
+    // optional param instead of always reading SITEMAP_MAX_URLS.
+
+    public function testCountVisiblePostsMatchesTheVisibleClause(): void
+    {
+        $this->makePost([]);
+        $this->makePost(['slug' => 'about']);
+        $this->makePost(['draft' => 1]);
+        $this->makePost(['deleted' => 1]);
+        $this->makePost(['created' => '2099-01-01 00:00:00']);
+
+        $this->assertSame(2, count_visible_posts());
+    }
+
+    public function testSitemapPageCountIsOneUnderTheCap(): void
+    {
+        $this->assertSame(1, sitemap_page_count(1, 2));
+        $this->assertSame(1, sitemap_page_count(2, 2));
+    }
+
+    public function testSitemapPageCountRoundsUpPastTheCap(): void
+    {
+        $this->assertSame(2, sitemap_page_count(3, 2));
+        $this->assertSame(2, sitemap_page_count(4, 2));
+        $this->assertSame(3, sitemap_page_count(5, 2));
+    }
+
+    public function testSitemapUrlsPageOneIncludesHomeAndTheFirstSlice(): void
+    {
+        // Cap of 2: page 1 holds the home entry plus one post (entry 0 is the
+        // home page, so page 1's post budget is cap - 1).
+        $this->makePost(['slug' => 'a', 'updated' => '2026-06-03 09:00:00']);
+        $this->makePost(['slug' => 'b', 'updated' => '2026-06-02 09:00:00']);
+        $this->makePost(['slug' => 'c', 'updated' => '2026-06-01 09:00:00']);
+
+        $locs = array_column(sitemap_urls(ROOT_URL, 1, 2), 'loc');
+
+        $this->assertSame([ROOT_URL . '/', ROOT_URL . '/a'], $locs);
+    }
+
+    public function testSitemapUrlsPageTwoOffsetsPastTheFirstSlice(): void
+    {
+        $this->makePost(['slug' => 'a', 'updated' => '2026-06-03 09:00:00']);
+        $this->makePost(['slug' => 'b', 'updated' => '2026-06-02 09:00:00']);
+        $this->makePost(['slug' => 'c', 'updated' => '2026-06-01 09:00:00']);
+
+        $locs = array_column(sitemap_urls(ROOT_URL, 2, 2), 'loc');
+
+        $this->assertSame([ROOT_URL . '/b', ROOT_URL . '/c'], $locs);
+    }
+
+    public function testSitemapUrlsLastPageReturnsTheRemainder(): void
+    {
+        $this->makePost(['slug' => 'a', 'updated' => '2026-06-04 09:00:00']);
+        $this->makePost(['slug' => 'b', 'updated' => '2026-06-03 09:00:00']);
+        $this->makePost(['slug' => 'c', 'updated' => '2026-06-02 09:00:00']);
+        $this->makePost(['slug' => 'd', 'updated' => '2026-06-01 09:00:00']);
+
+        // Total entries = home + 4 posts = 5; cap 2 → 3 pages (2, 2, 1), so page
+        // 3 gets only the one leftover post instead of a full slice of two.
+        $locs = array_column(sitemap_urls(ROOT_URL, 3, 2), 'loc');
+
+        $this->assertSame([ROOT_URL . '/d'], $locs);
+    }
+
+    public function testSitemapUrlsPageBeyondRangeIsEmpty(): void
+    {
+        $this->makePost(['slug' => 'a']);
+
+        $this->assertSame([], sitemap_urls(ROOT_URL, 5, 2));
+    }
+
+    public function testRenderSitemapIndexWrapsChildrenInSitemapindex(): void
+    {
+        $xml = render_sitemap_index(ROOT_URL, 2, '2026-06-01T09:00:00+00:00');
+
+        $this->assertStringContainsString('<?xml version="1.0" encoding="UTF-8"?>', $xml);
+        $this->assertStringContainsString(
+            '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+            $xml
+        );
+        $this->assertStringContainsString('</sitemapindex>', $xml);
+    }
+
+    public function testRenderSitemapIndexListsEachChildPageLoc(): void
+    {
+        $xml = render_sitemap_index(ROOT_URL, 2, null);
+
+        $this->assertStringContainsString('<loc>' . ROOT_URL . '/sitemap.xml/page/1</loc>', $xml);
+        $this->assertStringContainsString('<loc>' . ROOT_URL . '/sitemap.xml/page/2</loc>', $xml);
+    }
+
+    public function testRenderSitemapIndexAppliesTheSameLastmodToEveryChild(): void
+    {
+        $xml = render_sitemap_index(ROOT_URL, 2, '2026-06-01T09:00:00+00:00');
+
+        $this->assertSame(2, substr_count($xml, '<lastmod>2026-06-01T09:00:00+00:00</lastmod>'));
+    }
+
+    public function testRenderSitemapIndexOmitsLastmodWhenNull(): void
+    {
+        $xml = render_sitemap_index(ROOT_URL, 1, null);
+
+        $this->assertStringNotContainsString('<lastmod>', $xml);
+    }
+
+    public function testRenderSitemapIndexEscapesChildLocs(): void
+    {
+        $xml = render_sitemap_index('https://example.com/a?b=1&c=2', 1, null);
+
+        $this->assertStringContainsString('https://example.com/a?b=1&amp;c=2/sitemap.xml/page/1', $xml);
+        $this->assertStringNotContainsString('&c=2', $xml);
+    }
+
+    public function testCacheKeyIsSharedButPathsDifferPerPage(): void
+    {
+        $key = sitemap_cache_key('2026-06-01 09:00:00', 1000);
+
+        $this->assertNotSame(sitemap_cache_path($key, 1), sitemap_cache_path($key, 2));
+    }
+
+    public function testStoringASiblingPageDoesNotEvictAnotherPageOfTheSameGeneration(): void
+    {
+        $dir = $this->cacheDir();
+        $key = sitemap_cache_key('2026-06-01 09:00:00', 1000);
+        $page1 = sitemap_cache_path($key, 1);
+        $page2 = sitemap_cache_path($key, 2);
+
+        // Both cache files live in the temp cacheDir(), not data_dir()'s real
+        // cache path, so exercise the same prune logic store_sitemap_cache()
+        // uses directly rather than through it (which is pinned to data_dir()).
+        file_put_contents($dir . '/' . basename($page1), 'one');
+        store_sitemap_cache($dir . '/' . basename($page2), 'two');
+
+        $this->assertFileExists($dir . '/' . basename($page1));
+        $this->assertFileExists($dir . '/' . basename($page2));
+    }
+
+    public function testStoringANewGenerationEvictsAnOlderGenerationsPages(): void
+    {
+        $dir = $this->cacheDir();
+        $oldKey = sitemap_cache_key('2026-06-01 09:00:00', 1000);
+        $newKey = sitemap_cache_key('2026-06-02 09:00:00', 1000);
+        $oldPage = sitemap_cache_path($oldKey, 2);
+        $newPage = sitemap_cache_path($newKey, 1);
+
+        file_put_contents($dir . '/' . basename($oldPage), 'old');
+        store_sitemap_cache($dir . '/' . basename($newPage), 'new');
+
+        $this->assertFileDoesNotExist($dir . '/' . basename($oldPage));
+        $this->assertFileExists($dir . '/' . basename($newPage));
     }
 }


### PR DESCRIPTION
## Summary
Closes #671. sitemaps.org caps a single sitemap document at 50,000 URLs, but `sitemap_urls()` emitted every visible URL in one `<urlset>`, so a large site produced an over-cap sitemap.

`/sitemap.xml` now adapts to the site size:
- **At or under 50,000 URLs:** a single `<urlset>`, byte-for-byte as before.
- **Over 50,000 URLs:** a `<sitemapindex>` listing child sitemaps at `/sitemap.xml/page/N`, and each `/sitemap.xml/page/N` serves that page's `<urlset>` slice.

The child URLs reuse the site's existing `/page/N` pagination convention, so no routing changes were needed — `extract_page_segment()` strips the segment and the handler reads `$_GET['page']`. A page request against an unsplit site, or a page past the last one, returns 404.

## Details
- `SITEMAP_MAX_URLS` (50,000) added to `constants.php`.
- `sitemap_urls()` gains optional `$page`/`$cap` params (defaults preserve the unpaginated behaviour); slicing is done with SQL `LIMIT`/`OFFSET`, keeping the id/slug/updated-only memory guard from #664.
- New `count_visible_posts()`, `sitemap_page_count()`, `render_sitemap_index()`.
- The cache key and path now include the page number, and the page count, so a visible-count change that crosses the split boundary (e.g. trashing or restoring an older post) mints a new generation rather than serving a stale index or urlset. Generation-based pruning keeps sibling pages of the current generation.

## Test plan
- 19 new unit tests in `SitemapTest.php`: page-count math, `sitemap_urls()` slicing and boundaries (exactly the cap, cap+1, last partial page), `render_sitemap_index()` structure/escaping/lastmod, per-page cache paths, generation-based pruning, and the split↔unsplit transition (cache key and served document shape track the visible count, not just the newest `updated`).
- `composer lint`, `composer analyse` (PHPStan level 8): clean.
- `vendor/bin/codecept run Unit`: 2165 tests green. `vendor/bin/codecept run Acceptance`: 96 tests green.

## Docs
- `docs/search-engines.md` and `src/response/README.md` updated to document the index split.