### PR TITLE
Add unit coverage for the /_cron run: extract run_feed_cycle() (#706)

### DIFF
--- a/src/network.php
+++ b/src/network.php
@@ -99,6 +99,79 @@ function webmention_line(array $sent): string
     );
 }
 
+/**
+ * Crawls every due feed, then drains the notification queues and advances the
+ * run watermark.
+ *
+ * Extracted from process_feeds() so the run's orchestration is unit-testable —
+ * process_feeds() itself is not, because it sends a header, takes a file lock
+ * and ends in exit()/die(). Every collaborator is injectable so a test drives
+ * the loop and drains without touching the network; real /_cron requests get
+ * the production collaborators from the defaults, and the output is byte-for-byte
+ * what process_feeds() emitted inline before.
+ *
+ * The watermark advance and both drains run in a `finally`, so a feed that fails
+ * — or the loop throwing outright — can never starve webmention/WebSub delivery.
+ * The watermark is advanced before draining so a partial run still rate-limits
+ * the next one even if a drain throws; the drains then retry on the next run.
+ *
+ * @param array<string, string>|null $feeds Feed name => URL map (default get_feeds()).
+ * @param callable(string, string): array{ok: bool, items: int, error: ?string}|null $crawler
+ *        Per-feed crawler (default crawl_feed_guarded(), which never throws).
+ * @param callable(): int|null $websub_drain WebSub drain returning the ping count
+ *        (default ping_scheduled_publishes()).
+ * @param callable(): array{sent: int, failed: int, skipped: int, cancelled: int}|null $webmention_drain
+ *        Outbound-webmention drain (default process_outbound()).
+ * @param callable(int): void|null $advance_watermark Persists the run timestamp
+ *        (default writes the last_processed_date option).
+ * @param callable(string): void|null $output Output sink (default echo).
+ * @param callable(): int|null $clock Current Unix timestamp (default time()).
+ * @return void
+ */
+function run_feed_cycle(
+    ?array $feeds = null,
+    ?callable $crawler = null,
+    ?callable $websub_drain = null,
+    ?callable $webmention_drain = null,
+    ?callable $advance_watermark = null,
+    ?callable $output = null,
+    ?callable $clock = null
+): void {
+    $feeds ??= get_feeds();
+    $crawler ??= static fn(string $name, string $url): array => crawl_feed_guarded($name, $url);
+    $websub_drain ??= static fn(): int => \Lamb\Websub\ping_scheduled_publishes();
+    $webmention_drain ??= static fn(): array => \Lamb\Webmention\process_outbound();
+    $output ??= static function (string $line): void {
+        echo $line;
+    };
+    $clock ??= static fn(): int => time();
+    $advance_watermark ??= static function (int $timestamp): void {
+        set_option(get_option('last_processed_date', 0), $timestamp);
+    };
+
+    try {
+        $output("Updating feeds..." . PHP_EOL);
+        foreach ($feeds as $name => $url) {
+            flush();
+            $status = feed_status_bean($name, $url);
+            if (!feed_fetch_due((int)$status->last_attempt, $clock())) {
+                $output('Skipped ' . $url . PHP_EOL);
+                continue;
+            }
+
+            $output(crawl_line($name, $crawler($name, $url)));
+        }
+    } finally {
+        $advance_watermark($clock());
+
+        $output(count_line(
+            $websub_drain(),
+            'WebSub: pinged hub for %d scheduled post(s) now published.'
+        ));
+        $output(webmention_line($webmention_drain()));
+    }
+}
+
 #[NoReturn] function process_feeds(): void
 {
     header('Content-Type: text/plain');
@@ -133,8 +206,6 @@ function webmention_line(array $sent): string
         die('Already running, try again later.');
     }
 
-    $feeds = get_feeds();
-
     $cron_last_updated = get_option('last_processed_date', 0);
     if (!cron_run_due((int)$cron_last_updated->value, time())) {
         die('Too often, try again later.');
@@ -144,33 +215,13 @@ function webmention_line(array $sent): string
     echo count_line(prune_feed_status(), 'Pruned %d stale feed status row(s).');
     echo count_line(\Lamb\flatten_redirects(), 'Flattened %d redirect(s).');
 
-    try {
-        echo("Updating feeds..." . PHP_EOL);
-        foreach ($feeds as $name => $url) {
-            flush();
-            $status = feed_status_bean($name, $url);
-            if (!feed_fetch_due((int)$status->last_attempt, time())) {
-                echo('Skipped ' . $url . PHP_EOL);
-                continue;
-            }
-
-            echo crawl_line($name, crawl_feed_guarded($name, $url));
-        }
-    } finally {
-        // Advance the watermark first, before draining: a partial run must
-        // rate-limit the next one even if a drain itself throws, otherwise the
-        // starvation loop just moves from the crawl to the drain. The drains then
-        // retry on the next scheduled run rather than re-running immediately.
-        set_option($cron_last_updated, (int)date('U'));
-
-        // Drain notifications even if the crawl loop threw or was cut short, so
-        // feed fetching cannot starve webmention/WebSub delivery.
-        echo count_line(
-            \Lamb\Websub\ping_scheduled_publishes(),
-            'WebSub: pinged hub for %d scheduled post(s) now published.'
-        );
-        echo webmention_line(\Lamb\Webmention\process_outbound());
-    }
+    // Reuse the option bean already fetched for the rate-limit check rather than
+    // re-reading it, and keep date('U') as the run timestamp (== time()).
+    run_feed_cycle(
+        advance_watermark: static function (int $timestamp) use ($cron_last_updated): void {
+            set_option($cron_last_updated, $timestamp);
+        },
+    );
 
     exit('Done');
 }

--- a/tests/Unit/RunFeedCycleTest.php
+++ b/tests/Unit/RunFeedCycleTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+use function Lamb\Network\feed_status_bean;
+use function Lamb\Network\run_feed_cycle;
+
+/**
+ * process_feeds() cannot be unit-tested directly — it calls header(), takes a
+ * file lock and ends in exit()/die() — so the orchestration it delegates to
+ * run_feed_cycle() (a failing feed must not abort the run, a good feed
+ * alongside it still ingests, both drains always run, the watermark still
+ * advances) is exercised here instead, with every collaborator injected so
+ * nothing touches the network.
+ */
+class RunFeedCycleTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+    }
+
+    /** @return callable(): int */
+    private function noopWebsubDrain(): callable
+    {
+        return fn(): int => 0;
+    }
+
+    /** @return callable(): array{sent: int, failed: int, skipped: int, cancelled: int} */
+    private function noopWebmentionDrain(): callable
+    {
+        return fn(): array => ['sent' => 0, 'failed' => 0, 'skipped' => 0, 'cancelled' => 0];
+    }
+
+    /** @return callable(string): void */
+    private function collectingOutput(array &$lines): callable
+    {
+        return function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        };
+    }
+
+    private function due(string $name, string $url, int $lastAttempt = 0): void
+    {
+        $status = feed_status_bean($name, $url);
+        $status->last_attempt = $lastAttempt;
+        R::store($status);
+    }
+
+    public function testAFailingFeedProducesAFailedLine(): void
+    {
+        $this->due('bad', 'https://example.com/bad');
+        $lines = [];
+
+        run_feed_cycle(
+            feeds: ['bad' => 'https://example.com/bad'],
+            crawler: fn(string $name, string $url): array => ['ok' => false, 'items' => 0, 'error' => 'boom'],
+            websub_drain: $this->noopWebsubDrain(),
+            webmention_drain: $this->noopWebmentionDrain(),
+            output: $this->collectingOutput($lines)
+        );
+
+        $this->assertStringContainsString('FAILED: bad - boom', implode('', $lines));
+    }
+
+    public function testAGoodFeedAlongsideAFailingOneStillIngests(): void
+    {
+        $this->due('bad', 'https://example.com/bad');
+        $this->due('good', 'https://example.com/good');
+        $lines = [];
+
+        run_feed_cycle(
+            feeds: ['bad' => 'https://example.com/bad', 'good' => 'https://example.com/good'],
+            crawler: fn(string $name, string $url): array => $name === 'bad'
+                ? ['ok' => false, 'items' => 0, 'error' => 'boom']
+                : ['ok' => true, 'items' => 3, 'error' => null],
+            websub_drain: $this->noopWebsubDrain(),
+            webmention_drain: $this->noopWebmentionDrain(),
+            output: $this->collectingOutput($lines)
+        );
+
+        $report = implode('', $lines);
+        $this->assertStringContainsString('FAILED: bad - boom', $report);
+        $this->assertStringContainsString('OK: good - 3 item(s) ingested', $report);
+    }
+
+    public function testTheRunReachesTheDrainsEvenWhenAFeedFails(): void
+    {
+        $this->due('bad', 'https://example.com/bad');
+        $drained = false;
+        $lines = [];
+
+        run_feed_cycle(
+            feeds: ['bad' => 'https://example.com/bad'],
+            crawler: fn(string $name, string $url): array => ['ok' => false, 'items' => 0, 'error' => 'boom'],
+            websub_drain: function () use (&$drained): int {
+                $drained = true;
+                return 0;
+            },
+            webmention_drain: $this->noopWebmentionDrain(),
+            output: $this->collectingOutput($lines)
+        );
+
+        $this->assertTrue($drained);
+    }
+
+    public function testTheWatermarkSetterReceivesTheAdvancedTimestamp(): void
+    {
+        $now = time();
+        $seen = null;
+        $lines = [];
+
+        run_feed_cycle(
+            feeds: [],
+            websub_drain: $this->noopWebsubDrain(),
+            webmention_drain: $this->noopWebmentionDrain(),
+            advance_watermark: function (int $timestamp) use (&$seen): void {
+                $seen = $timestamp;
+            },
+            output: $this->collectingOutput($lines),
+            clock: fn(): int => $now
+        );
+
+        $this->assertSame($now, $seen);
+    }
+
+    public function testBothDrainsRunEvenWhenTheCrawlLoopThrows(): void
+    {
+        $this->due('exploding', 'https://example.com/exploding');
+        $websubRan = false;
+        $webmentionRan = false;
+        $lines = [];
+
+        try {
+            run_feed_cycle(
+                feeds: ['exploding' => 'https://example.com/exploding'],
+                crawler: function (): array {
+                    throw new \RuntimeException('unexpected crawl failure');
+                },
+                websub_drain: function () use (&$websubRan): int {
+                    $websubRan = true;
+                    return 0;
+                },
+                webmention_drain: function () use (&$webmentionRan): array {
+                    $webmentionRan = true;
+                    return ['sent' => 0, 'failed' => 0, 'skipped' => 0, 'cancelled' => 0];
+                },
+                output: $this->collectingOutput($lines)
+            );
+            $this->fail('Expected the unguarded crawler throw to propagate.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('unexpected crawl failure', $e->getMessage());
+        }
+
+        $this->assertTrue($websubRan);
+        $this->assertTrue($webmentionRan);
+    }
+
+    public function testAFeedNotYetDueIsSkippedWithoutCallingTheCrawler(): void
+    {
+        $this->due('recent', 'https://example.com/recent', time());
+        $called = false;
+        $lines = [];
+
+        run_feed_cycle(
+            feeds: ['recent' => 'https://example.com/recent'],
+            crawler: function () use (&$called): array {
+                $called = true;
+                return ['ok' => true, 'items' => 1, 'error' => null];
+            },
+            websub_drain: $this->noopWebsubDrain(),
+            webmention_drain: $this->noopWebmentionDrain(),
+            output: $this->collectingOutput($lines)
+        );
+
+        $this->assertFalse($called);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #706. `process_feeds()` (the `/_cron` handler) is not unit-reachable — it sends a header, takes a file lock and ends in `exit()`/`die()` — so the run's orchestration was covered only by a manual two-install test and could regress silently. Only `crawl_feed_guarded()` had unit coverage.

This extracts the crawl loop plus the drains-in-a-`finally` and the watermark advance into a new `run_feed_cycle()`, with every collaborator injectable (feeds, crawler, both drains, watermark setter, output sink, clock). `process_feeds()` keeps the header, lock, rate gate, maintenance lines and `exit('Done')`, and calls `run_feed_cycle()` for the crawl + drain body. Real `/_cron` requests are unchanged — the defaults are the production collaborators and the output is byte-for-byte the same.

I chose the refactor-to-testable-unit path the issue offers rather than a Playwright/acceptance test: the acceptance route needs an SSRF opt-in for a loopback fixture host, and adding a private-host bypass to the fail-closed guard is not worth it for a test. The unit approach pins the same orchestration properties with no network and no security surface.

## Test plan
New `tests/Unit/RunFeedCycleTest.php` drives `run_feed_cycle()` with injected closures — no network — and pins:
- a failing feed produces a `FAILED` line;
- a good feed alongside a failing one still ingests;
- the run reaches the drains even when a feed fails;
- the watermark setter receives the advanced timestamp;
- both drains run even when the crawl loop throws (and the throw still propagates);
- a not-yet-due feed is skipped without calling the crawler.

- `vendor/bin/codecept run Unit`: 2155 tests green (+6 new), 2 pre-existing skips, no failures.
- `phpcs`: clean. `phpstan` (level 8): no errors.