### PR TITLE
Delegate enqueue_for_post()/ping_for_post()'s draft check to is_draft()

### DIFF
--- a/src/webmention.php
+++ b/src/webmention.php
@@ -482,7 +482,7 @@ function resolve_url(string $base, string $rel): string
  */
 function enqueue_for_post(OODBBean $bean): void
 {
-    if (!$bean->id || !empty($bean->feed_name) || !empty($bean->draft)) {
+    if (!$bean->id || !empty($bean->feed_name) || is_draft($bean)) {
         return;
     }
 

--- a/src/websub.php
+++ b/src/websub.php
@@ -8,6 +8,7 @@ use RedBeanPHP\OODBBean;
 use RedBeanPHP\R;
 
 use function Lamb\get_option;
+use function Lamb\is_draft;
 use function Lamb\is_scheduled;
 use function Lamb\set_option;
 
@@ -84,7 +85,7 @@ function ping_hub(?array $config = null, ?callable $sender = null): void
  */
 function ping_for_post(OODBBean $bean, ?array $config = null, ?callable $sender = null): void
 {
-    if (!$bean->id || !empty($bean->feed_name) || !empty($bean->draft)) {
+    if (!$bean->id || !empty($bean->feed_name) || is_draft($bean)) {
         return;
     }
     if (is_scheduled($bean)) {

--- a/tests/Unit/WebmentionSendTest.php
+++ b/tests/Unit/WebmentionSendTest.php
@@ -223,6 +223,28 @@ class WebmentionSendTest extends TestCase
         $this->assertSame(1, R::count('webmentionoutbox', ' status = ? ', ['pending']));
     }
 
+    /**
+     * enqueue_for_post() must ask is_draft() rather than re-deriving "is this
+     * a draft" with its own truthiness check. A `draft` column value that is
+     * truthy but not canonically `1` (never written by any real save path
+     * today, but not guarded against either) is not a draft per is_draft()'s
+     * own definition, so the mention must still be queued.
+     */
+    public function testEnqueueForPostQueuesWhenDraftColumnIsNonCanonicalTruthyValue(): void
+    {
+        $post = $this->dispenseReply('<p>A reply with no links</p>', 'https://other.example/their-post');
+        $post->draft = 2;
+        R::store($post);
+
+        enqueue_for_post($post);
+
+        $this->assertSame(
+            1,
+            R::count('webmentionoutbox', ' status = ? ', ['pending']),
+            'A non-canonical truthy draft value must not be treated as a draft'
+        );
+    }
+
     public function testEnqueueForPostSkipsFeedItems(): void
     {
         $post = R::dispense('post');

--- a/tests/Unit/WebsubTest.php
+++ b/tests/Unit/WebsubTest.php
@@ -121,6 +121,26 @@ class WebsubTest extends TestCase
         $this->assertFalse($called, 'Drafts, feed items, scheduled and unsaved posts must not ping the hub');
     }
 
+    /**
+     * ping_for_post() must ask is_draft() rather than re-deriving "is this a
+     * draft" with its own truthiness check. A `draft` column value that is
+     * truthy but not canonically `1` (never written by any real save path
+     * today, but not guarded against either) is not a draft per is_draft()'s
+     * own definition, so the hub must still be pinged.
+     */
+    public function testPingForPostPingsWhenDraftColumnIsNonCanonicalTruthyValue(): void
+    {
+        $bean = $this->storedPost();
+        $bean->draft = 2;
+
+        $pings = 0;
+        ping_for_post($bean, ['websub_hubs' => 'https://hub.example.com/'], function () use (&$pings): void {
+            $pings++;
+        });
+
+        $this->assertSame(2, $pings, 'A non-canonical truthy draft value must not be treated as a draft');
+    }
+
     private function storedPost(): \RedBeanPHP\OODBBean
     {
         $bean = R::dispense('post');


### PR DESCRIPTION
## Bug

`Webmention\enqueue_for_post()` (`src/webmention.php`) and `Websub\ping_for_post()` (`src/websub.php`) both decide whether a saved post triggers an outbound webmention or a WebSub ping. Both skip drafts. But both inline the draft test instead of calling the canonical `is_draft()` helper:

```php
if (!$bean->id || !empty($bean->feed_name) || !empty($bean->draft)) {
```

`is_draft()` (`($post->draft ?? null) == 1`) treats only an exact `1` as a draft; `!empty()` treats any truthy value as one. `webmention.php` already imports and uses `is_draft()` further down the same file. #720 delegated this line's scheduled half to `is_scheduled()` but left the draft half as a raw check in both files. This finishes that fix, matching the `is_deleted()` consolidation in #749 and `is_unpublished()` in #751.

These two checks are the only thing stopping a draft from queuing a webmention or pinging the hub. `save()`'s `notify` flag fires on every create and update, whether or not the post is a draft, so nothing upstream gates on draft status.

No live bug today. Every write path stores `0`, `1`, or `null` in the `draft` column, so `!empty()` and `is_draft()` agree on every value actually written. But they are not the same rule, so one new write path could make them disagree — the drift this fix removes.

## Fix

Replace both inline checks with `is_draft($bean)`, and add the `is_draft` import to `websub.php`.

## Verification

- Added a regression test to each function's existing suite (`WebmentionSendTest.php`, `WebsubTest.php`) that stores a post with `draft = 2` — truthy but not canonical — and asserts the mention is queued / the hub is pinged, per `is_draft()`'s own definition.
- Red-before/green-after: reverted the two `src/` changes only (kept the new tests), confirmed both new tests fail against the old inline check (`Failed asserting that 0 is identical to 1` / `...2`), reapplied the fix, confirmed both pass.
- Full suite: `vendor/bin/codecept run Unit` — 2151 tests, 3955 assertions, 0 failures (2 pre-existing unrelated skips).
- `composer lint` and `composer analyse` both pass clean on the diff.
- `php -l` clean on all four touched files.
