### PR TITLE
Force busy_timeout=0 for the login-throttle reservation's write lock

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -102,6 +102,15 @@ function bootstrap_db(string $data_dir): void
         }
     }
     R::setup(sprintf("sqlite:%s/lamb.db", $data_dir));
+    // WAL lets a writer commit without waiting for concurrent readers. The login
+    // throttle's reserve_login_attempt() forces busy_timeout=0 so a contended
+    // reservation fails closed instead of stalling; without WAL its COMMIT takes
+    // an EXCLUSIVE lock that any page-render read holds off, so an ordinary
+    // concurrent visitor would make a correct-password login refuse. WAL narrows
+    // that refusal to a genuine concurrent writer, which is the intent.
+    // ponytail: WAL needs a local filesystem; self-hosted installs on NFS would
+    // fall back to the slower rollback journal and lose this guarantee.
+    R::exec('PRAGMA journal_mode=WAL');
     R::useWriterCache(true);
 
     ensure_post_columns();

--- a/src/response/README.md
+++ b/src/response/README.md
@@ -99,6 +99,18 @@ retrying cannot extend a block. `client_ip()` reads `REMOTE_ADDR` only; see
 [AGENTS.md](../../AGENTS.md)'s Security section for why `X-Forwarded-For` is
 not trusted here.
 
+The peek only rejects an already-blocked client; the race-free gate is
+`reserve_login_attempt()`, which takes a `BEGIN IMMEDIATE` write lock and
+checks-and-increments the counter atomically before bcrypt. Without it a
+concurrent burst from one IP could all read the same under-limit count and each
+run `password_verify()`, serialising only on the write — the bcrypt pile-up the
+throttle exists to stop. SQLite's busy handler is left at the host default
+(tens of seconds), so the reservation forces `busy_timeout = 0` for that
+critical section: a contended lock then refuses immediately (the client retries)
+instead of stalling every attempt behind the lock and reopening the pile-up. The
+lazy prune runs inside that same zero-timeout window on purpose — a prune that
+blocked on contention would reopen it just as surely.
+
 Post-login, `local_redirect_target()` constrains `?redirect_to=` to a local
 path so the parameter can't be turned into an open redirect — the same
 protocol-relative-path check reappears in `posts.php` (see below), because a

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -376,37 +376,71 @@ function login_throttle_retry_after(string $ip, int $now): int
  * RedBeanPHP\Facade::begin()), so the lock is taken with a raw statement
  * instead.
  *
+ * Neither PHP nor RedBeanPHP ever configures SQLite's busy handler, so the
+ * connection keeps whatever a bare `new PDO('sqlite:...')` defaults to on the
+ * host's SQLite build — commonly tens of seconds, not 0. Left alone, a
+ * contended BEGIN IMMEDIATE below would silently *block* for that long
+ * instead of throwing: every concurrent attempt in a burst would still queue
+ * up and eventually reach password_verify() once its turn came, exactly the
+ * bcrypt pile-up this function exists to prevent, just spread out in time
+ * instead of parallel. Forcing busy_timeout to 0 for this critical section
+ * (restored below, so the rest of the request — and prune's own writes above
+ * this point once contended — keep the host's normal, forgiving timeout)
+ * turns that stall back into the immediate refusal the catch below expects.
+ * Verified by driving concurrent real HTTP `/login` requests against a
+ * `php -S` server while a second connection held the write lock: before this
+ * change the request blocked for the lock's full hold time before still
+ * running bcrypt; after, it refuses immediately.
+ *
  * @param string $ip  Client address.
  * @param int    $now Current Unix timestamp.
  * @return int Seconds to wait before the client may attempt again (0 = reserved, go ahead).
  */
 function reserve_login_attempt(string $ip, int $now): int
 {
-    prune_login_throttle($now);
+    $previous_busy_timeout = (int) R::getCell('PRAGMA busy_timeout');
+    R::exec('PRAGMA busy_timeout = 0');
+    $in_transaction = false;
 
     try {
+        prune_login_throttle($now);
+
         R::exec('BEGIN IMMEDIATE');
-    } catch (SQL $e) {
-        // Another request already holds the write lock: refuse this attempt
-        // rather than let it through unreserved, which would reopen the exact
-        // race this function exists to close. The refused client just retries.
-        return 1;
-    }
+        $in_transaction = true;
 
-    $bean  = \Lamb\get_option(login_throttle_key($ip), '');
-    $state = decode_throttle_state($bean->value);
-    $retry_after = throttle_retry_after($state, $now);
-    if ($retry_after > 0) {
+        $bean  = \Lamb\get_option(login_throttle_key($ip), '');
+        $state = decode_throttle_state($bean->value);
+        $retry_after = throttle_retry_after($state, $now);
+        if ($retry_after > 0) {
+            R::exec('COMMIT');
+            return $retry_after;
+        }
+
+        $count = $state['expires'] > $now ? $state['count'] + 1 : 1;
+        \Lamb\set_option($bean, encode_throttle_state($count, $now + LOGIN_THROTTLE_WINDOW));
+
         R::exec('COMMIT');
-        return $retry_after;
+
+        return 0;
+    } catch (SQL) {
+        // Another request already holds the write lock (either for the
+        // reservation itself or for one of prune's own deletes above): refuse
+        // this attempt rather than let it through unreserved, which would
+        // reopen the exact race this function exists to close. The refused
+        // client just retries.
+        if ($in_transaction) {
+            try {
+                R::exec('ROLLBACK');
+            } catch (SQL) {
+                // Best-effort only; the busy_timeout restore below still runs
+                // regardless, and a stuck transaction on this connection would
+                // fail every later query in the request loudly enough to notice.
+            }
+        }
+        return 1;
+    } finally {
+        R::exec('PRAGMA busy_timeout = ' . $previous_busy_timeout);
     }
-
-    $count = $state['expires'] > $now ? $state['count'] + 1 : 1;
-    \Lamb\set_option($bean, encode_throttle_state($count, $now + LOGIN_THROTTLE_WINDOW));
-
-    R::exec('COMMIT');
-
-    return 0;
 }
 
 /**

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -357,40 +357,18 @@ function login_throttle_retry_after(string $ip, int $now): int
 /**
  * Reserves an attempt slot for a client, atomically with the threshold check,
  * starting a fresh window when the previous one has lapsed, and prunes rows
- * left behind by other clients.
+ * left behind by other clients (pruning rides on the write path since that is
+ * the only thing that creates the rows).
  *
- * Pruning rides on the write path because that is the only thing that creates
- * these rows: a burst of attempts from many addresses cleans up after itself
- * once each window lapses, so the `option` table doesn't keep a permanent row
- * per address that ever probed the login form.
- *
- * The check and increment are atomic and must both complete before
- * password_verify(). The old design peeked at an unlocked counter before
- * bcrypt and incremented only after a wrong password, so a concurrent burst
- * from one IP could all read the same under-limit count, all run bcrypt, and
- * only serialise on the write — spending far more than
- * LOGIN_THROTTLE_MAX_FAILURES real password_verify() calls per window.
- * Reserving the slot before bcrypt refuses the surplus up front.
+ * A BEGIN IMMEDIATE write lock makes the check-and-increment atomic before
+ * bcrypt, with busy_timeout forced to 0 (restored in `finally`) so a contended
+ * lock refuses promptly instead of stalling bcrypt behind it; the prune shares
+ * that zero-timeout window deliberately. Why each of those matters — the
+ * pre-bcrypt reservation, busy_timeout=0, the deliberately-refused prune — is
+ * in response/README.md ("Login: a sessionless page with its own CSRF model").
  *
  * R::begin()/R::commit() are no-ops in this app's fluid mode (see
- * RedBeanPHP\Facade::begin()), so the lock is taken with a raw statement
- * instead.
- *
- * Neither PHP nor RedBeanPHP ever configures SQLite's busy handler, so the
- * connection keeps whatever a bare `new PDO('sqlite:...')` defaults to on the
- * host's SQLite build — commonly tens of seconds, not 0. Left alone, a
- * contended BEGIN IMMEDIATE below would silently *block* for that long
- * instead of throwing: every concurrent attempt in a burst would still queue
- * up and eventually reach password_verify() once its turn came, exactly the
- * bcrypt pile-up this function exists to prevent, just spread out in time
- * instead of parallel. Forcing busy_timeout to 0 for this critical section
- * (restored below, so the rest of the request — and prune's own writes above
- * this point once contended — keep the host's normal, forgiving timeout)
- * turns that stall back into the immediate refusal the catch below expects.
- * Verified by driving concurrent real HTTP `/login` requests against a
- * `php -S` server while a second connection held the write lock: before this
- * change the request blocked for the lock's full hold time before still
- * running bcrypt; after, it refuses immediately.
+ * RedBeanPHP\Facade::begin()), so the lock is taken with a raw statement.
  *
  * @param string $ip  Client address.
  * @param int    $now Current Unix timestamp.

--- a/tests/Unit/LoginThrottleTest.php
+++ b/tests/Unit/LoginThrottleTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
+use Symfony\Component\Process\Process;
 
 use function Lamb\Response\clear_login_failures;
 use function Lamb\Response\client_ip;
@@ -293,6 +294,60 @@ class LoginThrottleTest extends TestCase
         $lock->exec('BEGIN IMMEDIATE');
 
         return $lock;
+    }
+
+    /**
+     * Reproduces the conditions reserve_login_attempt() actually runs under in
+     * production, unlike holdWriteLockOnAContendedConnection() above: this
+     * test never forces busy_timeout on the RedBean side, so the connection
+     * keeps whatever a bare `new PDO('sqlite:...')` defaults to on this host —
+     * the same thing a real deployment never overrides either. The write lock
+     * is held by a genuinely separate OS process (not a second connection in
+     * this same process) so a regression that blocks instead of refusing
+     * fails this test in bounded time (the hold's length) instead of hanging
+     * the suite for the host's full default busy_timeout.
+     */
+    public function testReserveLoginAttemptRefusesPromptlyUnderContentionWithoutTestForcedBusyTimeout(): void
+    {
+        $this->contendedDbFile = tempnam(sys_get_temp_dir(), 'lamb_throttle_test_');
+
+        $key = 'contended_' . uniqid();
+        R::addDatabase($key, 'sqlite:' . $this->contendedDbFile);
+        R::selectDatabase($key);
+        R::freeze(false);
+        // Deliberately not forcing busy_timeout here — see docblock above.
+
+        $holdSeconds = 2;
+        $holder = new Process([
+            'php',
+            '-r',
+            '$pdo = new PDO("sqlite:' . $this->contendedDbFile . '"); '
+                . '$pdo->exec("BEGIN IMMEDIATE"); '
+                . 'usleep(' . ($holdSeconds * 1_000_000) . '); '
+                . '$pdo->exec("COMMIT");',
+        ]);
+        $holder->start();
+        // Let the subprocess actually acquire BEGIN IMMEDIATE before racing it.
+        usleep(300_000);
+
+        $started = microtime(true);
+        $retry_after = reserve_login_attempt('203.0.113.7', 1_000);
+        $elapsed = microtime(true) - $started;
+
+        $holder->wait();
+
+        // Refused (not silently let through)...
+        $this->assertGreaterThan(0, $retry_after);
+        // ...and refused promptly. A regression that stops forcing
+        // busy_timeout to 0 for this critical section would instead block
+        // for the lock holder's full hold time before still admitting the
+        // attempt — the exact bcrypt-pileup race this function exists to
+        // close, just serialised across the stall instead of parallel.
+        $this->assertLessThan(
+            $holdSeconds,
+            $elapsed,
+            'reserve_login_attempt() blocked on lock contention instead of refusing promptly'
+        );
     }
 
     // The refusal message tells the owner when to come back

--- a/tests/Unit/LoginThrottleTest.php
+++ b/tests/Unit/LoginThrottleTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 use Symfony\Component\Process\Process;
 
+use function Lamb\Bootstrap\bootstrap_db;
 use function Lamb\Response\clear_login_failures;
 use function Lamb\Response\client_ip;
 use function Lamb\Response\decode_throttle_state;
@@ -348,6 +349,38 @@ class LoginThrottleTest extends TestCase
             $elapsed,
             'reserve_login_attempt() blocked on lock contention instead of refusing promptly'
         );
+    }
+
+    public function testBootstrapDbEnablesWalSoLoginCommitsSurviveConcurrentReaders(): void
+    {
+        // reserve_login_attempt() forces busy_timeout=0, so its COMMIT must not
+        // stall on a concurrent reader — it has to fail only against a real
+        // writer. WAL lets a writer commit while readers hold the file; a
+        // regression to the rollback journal would let an ordinary page-render
+        // read make a correct-password login refuse. Run bootstrap_db() in a
+        // subprocess: it calls R::setup(), which would clobber this suite's
+        // shared :memory: default connection.
+        $dir = sys_get_temp_dir() . '/lamb_wal_test_' . uniqid();
+
+        $boot = new Process([
+            'php',
+            '-r',
+            'require "vendor/autoload.php"; \Lamb\Bootstrap\bootstrap_db($argv[1]);',
+            $dir,
+        ]);
+        $boot->mustRun();
+
+        // WAL is a persisted property of the file, so a fresh connection sees it.
+        $pdo  = new PDO('sqlite:' . $dir . '/lamb.db');
+        $mode = (string) $pdo->query('PRAGMA journal_mode')->fetchColumn();
+        $pdo  = null;
+
+        @unlink($dir . '/lamb.db');
+        @unlink($dir . '/lamb.db-wal');
+        @unlink($dir . '/lamb.db-shm');
+        @rmdir($dir);
+
+        $this->assertSame('wal', strtolower($mode));
     }
 
     // The refusal message tells the owner when to come back


### PR DESCRIPTION
## Bug

`reserve_login_attempt()` (#766) documents and tests a fail-closed contention path: when another request already holds the `option` table's write lock, `BEGIN IMMEDIATE` is supposed to throw immediately so the attempt is refused rather than let through. That test (`testReserveLoginAttemptRefusesRatherThanThrowingWhenTheWriteLockIsHeld`) only reproduces this by manually forcing `PRAGMA busy_timeout = 0` on both connections — production code never does this.

A bare `new PDO('sqlite:...')` (which is all `bootstrap_db()` ever creates) keeps whatever busy_timeout the host's SQLite build defaults to — 60000ms (60s) on this container, confirmed with:

```php
$pdo = new PDO("sqlite:...");
$pdo->query('PRAGMA busy_timeout')->fetchColumn(); // => 60000
```

With that default, a contended `BEGIN IMMEDIATE` doesn't throw — it silently *blocks* until the lock frees or 60s passes. That defeats the design intent: the request just queues instead of being refused, still runs `password_verify()` once its turn comes (the exact bcrypt pile-up #742/#766 exist to prevent, just serialised across the stall instead of parallel), and ties up a web-server worker/connection for the wait. `prune_login_throttle()`'s per-row `R::trash()` calls, which run before the `BEGIN IMMEDIATE`, were also unguarded against this contention.

## Verified over real HTTP

Started `php -S 127.0.0.1:8747 -t src`, held the SQLite write lock on `data/lamb.db` from a second, independent OS process (`BEGIN IMMEDIATE` + sleep), then fired a real concurrent wrong-password `POST /login` at the live server:

- **Before the fix:** the request blocked for the full 6s lock hold, then proceeded normally past the throttle and ran `password_verify()` — `200` "Password is incorrect" after ~5.8s.
- **After the fix:** the request refuses in ~5ms — `429` "Too many failed attempts. Try again in 1 minute."

## Fix

Forces `busy_timeout` to `0` around the reservation's critical section (prune + `BEGIN IMMEDIATE` + read/write/`COMMIT`) in `reserve_login_attempt()`, restoring the connection's previous value in a `finally` block so the rest of the request (and every other route) keeps its normal, forgiving timeout. Also rolls back a partially-opened transaction before returning the refusal, since a caught busy error can now genuinely leave one open.

## Tests

- Added `testReserveLoginAttemptRefusesPromptlyUnderContentionWithoutTestForcedBusyTimeout` to `tests/Unit/LoginThrottleTest.php`: unlike the existing contention test, it does **not** force `busy_timeout` on the RedBean side (reproducing real production conditions), and holds the write lock from a genuine separate OS process (`Symfony\Component\Process\Process`, already a dev dependency) so a regression fails in bounded time (the hold's length) instead of hanging the suite. Confirmed **red** against the pre-fix code (assertion failure: `retry_after` was `0`, and it took the full 2s hold instead of refusing promptly) and **green** after.
- Full suite: `vendor/bin/codecept run Unit` — 2150 tests (2149 + 1 new), 0 failures, 2 skipped (unchanged from baseline).
- `vendor/bin/codecept run Acceptance` — 96 tests, 0 failures (includes `LoginCest`).
- `vendor/bin/phpstan analyse` — no errors. `composer lint` (`phpcs`) — clean.


## Update: WAL fix for a reader-vs-COMMIT regression

Review of this branch found that `busy_timeout=0` was reasoned about only for the `BEGIN IMMEDIATE` writer-vs-writer case. But the reservation's `COMMIT` upgrades to an EXCLUSIVE lock, which SQLite cannot take while any other connection holds a read lock. The DB runs in the default rollback journal (no WAL), so with `busy_timeout=0` that `COMMIT` returns `SQLITE_BUSY` immediately against an ordinary concurrent reader — a second visitor merely rendering a page could make a correct-password login refuse with the throttle message.

Fixed by enabling WAL at setup (`PRAGMA journal_mode=WAL` in `bootstrap_db()`): a writer commits without waiting for readers, so `busy_timeout=0` now refuses only on a genuine concurrent writer, which is the intent. Added `testBootstrapDbEnablesWalSoLoginCommitsSurviveConcurrentReaders` (runs `bootstrap_db()` in a subprocess, asserts the file's `journal_mode` is `wal`).

Full suite re-run on the fix: `vendor/bin/codecept run Unit` — 2151 tests, 0 failures (2 pre-existing skips); `vendor/bin/codecept run Acceptance` — 96 tests, 0 failures. `composer lint` and `composer analyse` (level 8) clean.
