### PR TITLE
WXR import: drop numeric slugs even without a redirectable old path

### DIFF
--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -230,7 +230,7 @@ function import_item(array $item, callable $downloader, bool $dry_run = false, ?
         : prepare_imported_html($body_html, (string) $item['created'], $downloader);
     $markdown = html_to_markdown($prepared);
     $tags = array_values(array_map(static fn($t): string => (string) $t, (array) ($item['tags'] ?? [])));
-    $slug = wordpress_status_path($item) !== null ? '' : (string) ($item['slug'] ?? '');
+    $slug = is_numeric_wordpress_slug($item) ? '' : (string) ($item['slug'] ?? '');
     $body = build_post_body((string) $item['title'], $markdown, $tags, $slug);
 
     $bean = populate_bean($body, null, null, $bean);
@@ -252,21 +252,44 @@ function import_item(array $item, callable $downloader, bool $dry_run = false, ?
 }
 
 /**
- * Returns the original WP path (slashes trimmed) when `<wp:post_name>` is
- * purely numeric — e.g. `26`, `633`. WordPress hands these out when a post
- * has no title (the post id leaks into the URL). Pinning such a slug locally
- * produces a Lamb URL like `/26`, which visually collides with the canonical
- * `/status/<id>` shape and can shadow it on lookup.
+ * True when `<wp:post_name>` is purely numeric — e.g. `26`, `633`. WordPress
+ * hands these out when a post has no title (the post id leaks into the
+ * slug column), regardless of the site's permalink structure: even a site
+ * using the default "Plain" structure (`<link>` shaped as a bare `?p=59`
+ * query string, no path at all) still records this numeric post_name
+ * internally. Pinning such a slug locally produces a Lamb URL like `/26`,
+ * which visually collides with the canonical `/status/<id>` shape and can
+ * shadow it on lookup.
  *
- * Instead we drop the slug, let the post fall through to its `/status/<id>`
- * permalink, and capture the original WP path as a redirect.
+ * Deliberately independent of whether {@see wordpress_status_path} can also
+ * derive an old redirect path from `<link>` — those are two different
+ * questions. A "Plain"-permalink site has no old path worth redirecting
+ * from, but the slug still needs dropping.
+ *
+ * @param array<string, mixed> $item
+ */
+function is_numeric_wordpress_slug(array $item): bool
+{
+    $slug = trim((string) ($item['slug'] ?? ''));
+    return $slug !== '' && ctype_digit($slug);
+}
+
+/**
+ * Returns the original WP path (slashes trimmed) when `<wp:post_name>` is
+ * purely numeric (see {@see is_numeric_wordpress_slug}) and `<link>` carries
+ * a usable path to redirect from.
+ *
+ * The slug is always dropped for a numeric post_name — see
+ * is_numeric_wordpress_slug() — but a redirect can only be captured when the
+ * source site's permalink structure put the old path somewhere ("Plain"
+ * permalinks don't; the post falls through to /status/<id> with no old path
+ * to redirect away from).
  *
  * @param array<string, mixed> $item
  */
 function wordpress_status_path(array $item): ?string
 {
-    $slug = trim((string) ($item['slug'] ?? ''));
-    if ($slug === '' || !ctype_digit($slug)) {
+    if (!is_numeric_wordpress_slug($item)) {
         return null;
     }
     $path = parse_url((string) ($item['link'] ?? ''), PHP_URL_PATH);

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -878,6 +878,41 @@ XML;
         $this->assertSame('/status/' . $bean->id, (string) $redirect->to_url);
     }
 
+    /**
+     * A site using WordPress's default ("Plain") permalink structure exports
+     * <link> as a bare query string (`?p=59`), which carries no path to
+     * redirect from — but <wp:post_name> still records the numeric post-id
+     * leak internally regardless of permalink structure. The slug must be
+     * dropped exactly as it is when a pretty-permalink <link> is present,
+     * even though there is no old path to capture as a redirect.
+     */
+    public function testImportItemDropsNumericSlugEvenWhenLinkHasNoUsablePath(): void
+    {
+        if (!class_exists(\League\HTMLToMarkdown\HtmlConverter::class)) {
+            $this->markTestSkipped('league/html-to-markdown is not installed');
+        }
+        $item = [
+            'title' => '',
+            'guid' => 'https://oldsite.example/?p=59',
+            'link' => 'https://oldsite.example/?p=59',
+            'created' => '2024-03-03 10:00:00',
+            'updated' => '2024-03-03 10:00:00',
+            'content' => '<p>Status body.</p>',
+            'tags' => [],
+            'status' => 'publish',
+            'post_type' => 'post',
+            'slug' => '59',
+        ];
+
+        $bean = import_item($item, fn() => null, false);
+
+        $this->assertNotNull($bean);
+        $this->assertSame('', (string) $bean->slug);
+        $this->assertStringNotContainsString('slug:', (string) $bean->body);
+        // No usable old path to redirect from — nothing should be stored.
+        $this->assertNull(R::findOne('redirect', ' from_slug = ? ', ['?p=59']));
+    }
+
     public function testImportItemDropsNumericSlugAndRedirectsFromNonStatusPath(): void
     {
         if (!class_exists(\League\HTMLToMarkdown\HtmlConverter::class)) {


### PR DESCRIPTION
## Bug

`wordpress_status_path()` (`src/wordpress.php`) handles one WordPress export shape: a title-less post whose `<wp:post_name>` is purely numeric. WordPress puts the post id in the slug column when there's no title to build a slug from. Pinning that slug locally would produce a Lamb URL like `/26`, which collides with the canonical `/status/<id>` shape and can shadow it on lookup. So the importer should always drop it and fall through to `/status/<id>`.

The function conflated two separate questions:

1. Is `<wp:post_name>` purely numeric? This is what should gate slug-dropping.
2. Can we also derive a redirect path from `<link>`?

It returned `null` when either was false, and `import_item()` read that single result to decide whether to drop the slug:

```php
$slug = wordpress_status_path($item) !== null ? '' : (string) ($item['slug'] ?? '');
```

## Why it's reachable

A WordPress site on the default Plain permalink structure exports `<link>` as a bare query string, e.g. `<link>https://oldsite.example/?p=59</link>` — no path. WordPress still records the numeric `post_name` internally. So a title-less post from such a site is exactly the documented case (numeric slug `59`), but `wordpress_status_path()` returns `null` because `parse_url('?p=59', PHP_URL_PATH)` yields no path — not because the slug isn't numeric. `import_item()` then reads `null` as "not the numeric case" and keeps the slug, reproducing the `/59` vs `/status/<id>` shadowing the function exists to prevent. Plain permalinks are the out-of-the-box WordPress default, so this is common, not an edge case.

## Fix

Split the numeric-slug detection into its own function, `is_numeric_wordpress_slug()`, and call it directly from `import_item()` for the slug-dropping decision. `wordpress_status_path()` now delegates to it for the numeric test and keeps its original job: deriving an old path to redirect from, which can legitimately be `null` when `<link>` has no usable path.

No other behaviour changes: existing redirect tests for pretty-permalink sources (`/status/59/`, `/bugs/26/`) still pass unchanged.

## Verification

- Standalone reproduction script (not committed) calling `Lamb\WordPress\import_item()` directly with an item shaped like the scenario above (`link` = `guid` = `https://oldsite.example/?p=59`, `slug` = `'59'`). Before the fix: `bean->slug` was `'59'`. After: `bean->slug` is `''`.
- Regression test added to `tests/Unit/WordPressImportTest.php` (`testImportItemDropsNumericSlugEvenWhenLinkHasNoUsablePath`), asserting the slug is dropped, no `slug:` line is written to the body, and no redirect row is stored (there's no old path to redirect from).
- Confirmed red-before/green-after against `git show HEAD:src/wordpress.php` (fails: expected `''`, got `'59'`) and against the fix (passes).
- Full suite: `vendor/bin/codecept run Unit` — 2150 tests / 3957 assertions, 0 failures (up from 2149/3953 on `main`, the one new test).
- `vendor/bin/phpstan analyse` — no errors.
- `composer lint` (`phpcs`) — clean.
