### PR TITLE
Delegate the Restore/Delete-link deleted check to is_deleted()

### DIFF
--- a/src/theme.php
+++ b/src/theme.php
@@ -497,7 +497,7 @@ function render_post_list(bool $hide_author): void
             <?= syndication_links($bean) ?>
 
             <?php if (isset($_SESSION[SESSION_LOGIN])) : ?>
-                <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
+                <small><?= link_source($bean) ?> <?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= \Lamb\is_deleted($bean) ? action_restore($bean) : action_delete($bean) ?></small>
             <?php endif; ?>
         </article>
         <?php // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect -- leading whitespace here is literal output, preserved from the pre-extraction template

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -3,6 +3,7 @@
 global $data;
 global $template;
 
+use function Lamb\is_deleted;
 use function Lamb\Theme\action_delete;
 use function Lamb\Theme\action_edit;
 use function Lamb\Theme\action_preview;
@@ -40,7 +41,7 @@ else :
             <div class="e-content"><?= anchor_headings($bean->transformed, !empty($bean->title) ? 3 : 2) ?></div>
             <?= syndication_links($bean) ?>
             <footer>
-                <small><?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= $bean->deleted ? action_restore($bean) : action_delete($bean) ?></small>
+                <small><?= action_preview($bean) ?> <?= action_edit($bean) ?> <?= is_deleted($bean) ? action_restore($bean) : action_delete($bean) ?></small>
             </footer>
         </article>
         <?php

--- a/src/themes/base/parts/edit.php
+++ b/src/themes/base/parts/edit.php
@@ -2,6 +2,7 @@
 
 global $data;
 
+use function Lamb\is_deleted;
 use function Lamb\Theme\action_delete;
 use function Lamb\Theme\csrf_token;
 use function Lamb\Theme\escape;
@@ -26,7 +27,7 @@ if (isset($_SESSION[SESSION_LOGIN]) && $post->id > 0) :
         <input type="hidden" name="<?= HIDDEN_CSRF_NAME ?>" value="<?= csrf_token() ?>"/>
     </form>
 
-    <?php if (!$post->deleted) : ?>
+    <?php if (!is_deleted($post)) : ?>
     <small><?= action_delete($post) ?></small>
     <?php endif; ?>
     <?php

--- a/tests/Unit/ThemeEditPartTest.php
+++ b/tests/Unit/ThemeEditPartTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use RedBeanPHP\R;
+
+/**
+ * Covers the base theme's edit part, specifically its Delete-link visibility.
+ *
+ * The template used to decide whether to show the Delete action with the raw
+ * `$post->deleted` truthy check instead of the canonical is_deleted()
+ * predicate ((bean->deleted ?? null) == 1) -- the same predicate used
+ * everywhere else a post's deleted state is asked (is_viewable(),
+ * is_publicly_visible(), the Restore-vs-Delete choice in _items.php). A
+ * non-canonical truthy value (e.g. deleted = 2) would previously hide the
+ * Delete link even though is_deleted() says the post is not deleted.
+ */
+class ThemeEditPartTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!R::testConnection()) {
+            R::setup('sqlite::memory:');
+        }
+        R::freeze(false);
+        R::nuke();
+
+        if (!defined('ROOT_URL')) {
+            define('ROOT_URL', 'http://localhost');
+        }
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        global $data;
+        $_SESSION = [];
+        $data     = [];
+    }
+
+    private function render(int|bool|null $deleted): string
+    {
+        $post = R::dispense('post');
+        $post->body    = 'Hello world';
+        $post->deleted = $deleted;
+        R::store($post);
+
+        global $data;
+        $data = ['post' => $post];
+        $_SESSION[SESSION_LOGIN] = true;
+
+        ob_start();
+        include dirname(__DIR__, 2) . '/src/themes/base/parts/edit.php';
+        return (string) ob_get_clean();
+    }
+
+    public function testDeleteLinkShownForACanonicallyLivePost(): void
+    {
+        $html = $this->render(null);
+        $this->assertStringContainsString('form-delete', $html);
+    }
+
+    public function testDeleteLinkHiddenForACanonicallyDeletedPost(): void
+    {
+        $html = $this->render(1);
+        $this->assertStringNotContainsString('form-delete', $html);
+    }
+
+    public function testDeleteLinkShownForANonCanonicalTruthyDeletedValue(): void
+    {
+        // deleted = 2 is truthy but not the canonical "1" is_deleted() checks
+        // for -- is_deleted() says this post is NOT deleted, so the Delete
+        // link must still show.
+        $html = $this->render(2);
+        $this->assertStringContainsString('form-delete', $html);
+    }
+}

--- a/tests/Unit/ThemeItemsEscapeTest.php
+++ b/tests/Unit/ThemeItemsEscapeTest.php
@@ -33,19 +33,20 @@ class ThemeItemsEscapeTest extends TestCase
         $_SESSION = [];
     }
 
-    private function renderStatusItem(string $title): string
+    private function renderStatusItem(string $title, int|bool|null $deleted = false): string
     {
         $bean = R::dispense('post');
         $bean->title = $title;
         $bean->transformed = '<p>body</p>';
         $bean->created = '2024-01-01 12:00:00';
-        $bean->deleted = false;
+        $bean->deleted = $deleted;
         R::store($bean);
 
         global $data, $template, $config;
         $config = ['menu_items' => []];
         $data = ['posts' => [$bean]];
         $template = 'status';
+        $_SESSION[SESSION_LOGIN] = true;
 
         ob_start();
         include dirname(__DIR__, 2) . '/src/themes/base/parts/_items.php';
@@ -63,5 +64,26 @@ class ThemeItemsEscapeTest extends TestCase
     {
         $html = $this->renderStatusItem('Hello World');
         $this->assertStringContainsString('Hello World', $html);
+    }
+
+    /**
+     * The base theme's _items.php picked Restore-vs-Delete with the raw
+     * `$bean->deleted` truthy check instead of the canonical is_deleted()
+     * predicate ((bean->deleted ?? null) == 1). A non-canonical truthy value
+     * (deleted = 2) would previously still show Restore even though
+     * is_deleted() says the post is not deleted -- pin the delegation.
+     */
+    public function testNonCanonicalDeletedValueShowsDeleteNotRestore(): void
+    {
+        $html = $this->renderStatusItem('Hello World', 2);
+        $this->assertStringContainsString('form-delete', $html);
+        $this->assertStringNotContainsString('form-restore', $html);
+    }
+
+    public function testCanonicalDeletedValueShowsRestoreNotDelete(): void
+    {
+        $html = $this->renderStatusItem('Hello World', 1);
+        $this->assertStringContainsString('form-restore', $html);
+        $this->assertStringNotContainsString('form-delete', $html);
     }
 }

--- a/tests/Unit/ThemeModernItemsPartTest.php
+++ b/tests/Unit/ThemeModernItemsPartTest.php
@@ -202,4 +202,37 @@ class ThemeModernItemsPartTest extends TestCase
         $loggedIn = $this->render('2026', 'tag', [$bean]);
         $this->assertStringContainsString('<small>', $loggedIn);
     }
+
+    /**
+     * render_post_list() decided Restore-vs-Delete with the raw
+     * `$bean->deleted` truthy check instead of the canonical is_deleted()
+     * predicate ((bean->deleted ?? null) == 1). A non-canonical truthy value
+     * (deleted = 2) would previously still show Restore even though
+     * is_deleted() says the post is not deleted -- pin the delegation.
+     */
+    public function testNonCanonicalDeletedValueShowsDeleteNotRestore(): void
+    {
+        $_SESSION[SESSION_LOGIN] = true;
+        $bean = $this->makeBean('T', '<p>b</p>', '2024-01-01 12:00:00');
+        $bean->deleted = 2;
+        R::store($bean);
+
+        $html = $this->render('2026', 'tag', [$bean]);
+
+        $this->assertStringContainsString('form-delete', $html);
+        $this->assertStringNotContainsString('form-restore', $html);
+    }
+
+    public function testCanonicalDeletedValueShowsRestoreNotDelete(): void
+    {
+        $_SESSION[SESSION_LOGIN] = true;
+        $bean = $this->makeBean('T', '<p>b</p>', '2024-01-01 12:00:00');
+        $bean->deleted = 1;
+        R::store($bean);
+
+        $html = $this->render('2026', 'tag', [$bean]);
+
+        $this->assertStringContainsString('form-restore', $html);
+        $this->assertStringNotContainsString('form-delete', $html);
+    }
 }


### PR DESCRIPTION
## Bug

Three call sites in the theme layer decide whether to show **Restore** or **Delete** for a post using the raw check `$bean->deleted` / `$post->deleted`, instead of the canonical `is_deleted()` predicate (`($post->deleted ?? null) == 1`) used everywhere else a post's deleted state matters (`is_viewable()`, `is_publicly_visible()`, `preview_token_valid()`):

- `render_post_list()` in `src/theme.php` — shared by the 2024/2026 themes' `_items.php`, extracted in #731
- `src/themes/base/parts/_items.php` — the base theme's own copy of the same ternary
- `src/themes/base/parts/edit.php` — `if (!$post->deleted)` gating the Delete link

These render on every logged-in post list, status page, and edit page — hot paths, not edge cases.

No live bug today. Every write path stores `0`, `1`, or `null` in the `deleted` column (`soft_delete_post()`/`restore_post()` in `src/response/posts.php`), so the raw check and `is_deleted()` agree on every value actually written. But a non-canonical value like `deleted = 2` would make them disagree: the raw check shows **Restore** (implying the post is trashed) while `is_deleted()` says it is not, and `edit.php` hides **Delete** for a post that still needs it. Same drift as #749, #751, and #779.

## Fix

Replace the raw check with `is_deleted($bean)` at all three sites, adding `use function Lamb\is_deleted;` to the two theme parts that lacked it. `theme.php` uses the existing fully-qualified `\Lamb\is_deleted(...)` style already established there.

## Verification

- Standalone script requiring the real `src/` files, showing the divergence for `deleted = 2`: the raw check says "deleted", `is_deleted()` says "not deleted".
- A second script rendered all three real call sites for a `deleted = 2` post — red before the fix (Restore shown / Delete hidden), green after (all three agree with `is_deleted()`).
- Regression tests pinning both the canonical (`deleted = 1`) and non-canonical (`deleted = 2`) cases:
  - `tests/Unit/ThemeModernItemsPartTest.php` (`render_post_list()`, both themes)
  - `tests/Unit/ThemeItemsEscapeTest.php` (base theme's `_items.php`)
  - new `tests/Unit/ThemeEditPartTest.php` (base theme's `edit.php`)
- Ran the new and changed test methods against this branch's real source — all pass. The full pre-existing `ThemeModernItemsPartTest.php` suite, including its byte-for-byte HTML fixture pins, is unchanged and still passing, confirming no behaviour change for canonical values.
- `php -l` clean on all six touched files.
- `vendor/bin/phpcs` (the `composer lint` command) clean across the repo.
- `vendor/bin/phpstan analyse` (level 8) clean across `src/`.

**Environment note:** this session ran in an isolated git worktree with no local `vendor/`. The shared checkout's `vendor/autoload.php` hardcodes absolute paths back to the shared checkout's own `src/`, so a plain `vendor/bin/codecept` run would test the unmodified shared files, not this branch's. The red/green scripts and the new test methods were run through a custom bootstrap that loads this worktree's own `src/` instead; `phpcs`/`phpstan` took this worktree's paths directly. Run the full `vendor/bin/codecept run Unit` in CI against the pushed branch to confirm no regression the reflection-based spot run missed.
