### PR TITLE
Apply DNS_RESOLVE_TIMEOUT at process boot, not just inside resolve_host_ips()

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -8,6 +8,8 @@ use Dotenv\Repository\RepositoryBuilder;
 use RuntimeException;
 use RedBeanPHP\R;
 
+use function Lamb\Http\apply_dns_resolve_timeout;
+
 /**
  * Loads the project's .env file into the process environment for the dev server.
  *
@@ -87,12 +89,20 @@ function login_password(): string
 /**
  * Initializes the database by configuring the SQLite connection and setting up the writer cache.
  *
+ * Also applies the DNS resolver timeout (see Http\apply_dns_resolve_timeout()) as
+ * the first thing any entry point does: glibc's resolver only honours a RES_OPTIONS
+ * change made *before* the process's first hostname lookup, and this runs before
+ * index.php/bin/lamb do anything else network-shaped, so it wins that race no
+ * matter which code ends up resolving a host first later in the process's life.
+ *
  * @param string $data_dir The directory path where the database file will be stored.
  * @return void
  * @throws RuntimeException If the specified directory cannot be created.
  */
 function bootstrap_db(string $data_dir): void
 {
+    apply_dns_resolve_timeout();
+
     if (!is_dir($data_dir)) {
         // 0750, not 0777: this directory holds lamb.db and the session files, so
         // only the web-server user has any business reading it. Under a permissive

--- a/src/http.php
+++ b/src/http.php
@@ -219,8 +219,36 @@ const DEFAULT_FETCH_TIMEOUT = 30;
  * resolves. Still finite either way: bounded by process_feeds()'s overall
  * 1800s /_cron time limit (see network.php), just a larger per-feed delay
  * than FEED_FETCH_TIMEOUT alone suggests when a resolver is unreachable.
+ *
+ * "Applied" only actually holds when {@see apply_dns_resolve_timeout} wins the
+ * race to be the process's first hostname resolution — see its docblock.
  */
 const DNS_RESOLVE_TIMEOUT = 5;
+
+/**
+ * Applies DNS_RESOLVE_TIMEOUT to the process via RES_OPTIONS.
+ *
+ * glibc's resolver reads RES_OPTIONS only once — the first time anything in
+ * the process resolves a hostname — then caches that state; a later putenv()
+ * call is silently ignored once that has already happened (confirmed by
+ * timing a black-holed lookup before and after a second putenv() in the same
+ * process: the second call kept the first call's timeout). So the call that
+ * actually matters is whichever one runs before the process's *first* hostname
+ * resolution, by any code path — see Bootstrap\bootstrap_db(), which calls
+ * this before any other Lamb code has a chance to resolve anything, so it
+ * wins that race regardless of which function ends up making the process's
+ * first DNS lookup (a Micropub bearer token's introspectToken(), an inbound
+ * webmention fetch, a /_cron feed fetch, …). resolve_host_ips() below still
+ * calls this on every invocation too, which is what actually takes effect
+ * when nothing has resolved a host yet (e.g. a standalone script that calls
+ * it directly without bootstrapping first) and is otherwise a harmless no-op.
+ *
+ * @return void
+ */
+function apply_dns_resolve_timeout(): void
+{
+    putenv('RES_OPTIONS=timeout:' . DNS_RESOLVE_TIMEOUT . ' attempts:2');
+}
 
 /**
  * The timeout a single request runs under: the caller's when it named one,
@@ -350,8 +378,11 @@ function resolve_host_ips(string $host): array
     // Bound the resolver: neither call below takes a timeout, so a black-holed
     // nameserver would otherwise block unbounded and hold the /_cron flock the
     // whole time (#707). glibc honours RES_OPTIONS; where it does not (musl) the
-    // libc default is already finite, so this only ever tightens the wait.
-    putenv('RES_OPTIONS=timeout:' . DNS_RESOLVE_TIMEOUT . ' attempts:2');
+    // libc default is already finite, so this only ever tightens the wait. See
+    // apply_dns_resolve_timeout() for why this call is a no-op once the process
+    // has already resolved a host elsewhere — bootstrap_db() is what makes the
+    // bound actually apply in that case.
+    apply_dns_resolve_timeout();
 
     $records = @dns_get_record($host, DNS_A + DNS_AAAA);
     if (is_array($records) && $records !== []) {

--- a/tests/Unit/HttpTest.php
+++ b/tests/Unit/HttpTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+use function Lamb\Http\apply_dns_resolve_timeout;
 use function Lamb\Http\extract_page_segment;
 use function Lamb\Http\get_request_uri;
 use function Lamb\Http\resolve_host_ips;
@@ -188,5 +189,26 @@ class HttpTest extends TestCase
         resolve_host_ips('nonexistent.invalid');
 
         $this->assertStringContainsString('timeout:5 attempts:2', (string) getenv('RES_OPTIONS'));
+    }
+
+    /**
+     * apply_dns_resolve_timeout() is what resolve_host_ips() and
+     * Bootstrap\bootstrap_db() both call to set this bound — pinned directly
+     * (rather than only indirectly via resolve_host_ips() above) so a future
+     * edit that changes the RES_OPTIONS string can't silently drift between
+     * the two callers. bootstrap_db() calling this as its first line — before
+     * any other Lamb code has a chance to resolve a host — is what actually
+     * makes the bound reliable: glibc's resolver only honours a RES_OPTIONS
+     * change made before the process's first hostname lookup, and a real,
+     * timed reproduction (a black-holed nameserver, an unrelated
+     * file_get_contents() resolving first) confirmed that a *second*
+     * putenv() call in the same process is silently ignored — see
+     * apply_dns_resolve_timeout()'s docblock.
+     */
+    public function testApplyDnsResolveTimeoutSetsResOptionsEnvVar(): void
+    {
+        apply_dns_resolve_timeout();
+
+        $this->assertSame('timeout:5 attempts:2', getenv('RES_OPTIONS'));
     }
 }

--- a/tests/Unit/SessionBootstrapTest.php
+++ b/tests/Unit/SessionBootstrapTest.php
@@ -215,4 +215,44 @@ class SessionBootstrapTest extends TestCase
             @rmdir($data_dir);
         }
     }
+
+    /**
+     * bootstrap_db() must apply the DNS resolver timeout (Http\apply_dns_resolve_timeout())
+     * as its first action, before doing anything else — including before opening the
+     * SQLite connection. glibc's resolver only honours a RES_OPTIONS change made
+     * before the process's *first* hostname lookup, so this only actually bounds
+     * DNS the way DNS_RESOLVE_TIMEOUT's docblock promises when it wins that race
+     * against every other Lamb code path (a real, timed reproduction against a
+     * black-holed nameserver confirmed a second, later putenv() call is silently
+     * ignored — see apply_dns_resolve_timeout()'s docblock in src/http.php).
+     *
+     * Run in a subprocess (like BinLambTest's data-dir helper) rather than calling
+     * bootstrap_db() in-process: it opens a real RedBeanPHP/SQLite connection via
+     * the global R:: facade, which would clobber the shared connection every other
+     * test in this process depends on.
+     */
+    public function testBootstrapDbAppliesDnsResolveTimeoutBeforeAnythingElse(): void
+    {
+        $root = rtrim(\codecept_root_dir(), '/');
+        $data_dir = sys_get_temp_dir() . '/lamb-bootstrap-db-test-' . getmypid();
+
+        $process = new \Symfony\Component\Process\Process(
+            [
+                'php',
+                '-r',
+                "define('ROOT_DIR', '$root/src'); require '$root/vendor/autoload.php'; "
+                . "\\Lamb\\Bootstrap\\bootstrap_db('$data_dir'); "
+                . "echo getenv('RES_OPTIONS');",
+            ],
+            $root
+        );
+
+        try {
+            $process->mustRun();
+            $this->assertSame('timeout:5 attempts:2', $process->getOutput());
+        } finally {
+            @unlink($data_dir . '/lamb.db');
+            @rmdir($data_dir);
+        }
+    }
 }


### PR DESCRIPTION
## Bug

`resolve_host_ips()`'s inline comment and `DNS_RESOLVE_TIMEOUT`'s own docblock (`src/http.php`) both claim every DNS lookup made through it is bounded to ~10s per nameserver, via a `putenv('RES_OPTIONS=...')` call made right before `dns_get_record()`. This bound exists specifically for issue #707: a black-holed resolver must not hold the `/_cron` flock indefinitely.

That bound is **unreliable in a persistent worker process** — php-fpm and FrankenPHP, both documented production deployment targets in `AGENTS.md`. glibc's resolver reads `RES_OPTIONS` only once, the first time *anything* in the process resolves a hostname, then caches that state. A later `putenv()` call — including `resolve_host_ips()`'s own, on every subsequent invocation in the same worker — is silently ignored.

## Why this is reachable, not theoretical

Micropub's `introspectToken()` calls `Http\fetch()` **without** the `pin` option (see `fetch()`'s own docblock: "Every other caller (Micropub's `introspectToken`) is unaffected"), so it resolves its token endpoint's hostname via plain `file_get_contents()` — with no `RES_OPTIONS` override of its own. Any Micropub POST with a bearer token is exactly this code path.

`/_cron`'s `process_feeds()` resolves one host per configured feed within a single process. In a persistent worker that has already served an earlier Micropub request (or any other un-pinned outbound call) before its next `/_cron` tick, the resolver is already locked to whatever the **system's real default** happens to be — not the documented ~10s bound — for the rest of that worker's life.

## Verified with a real, timed reproduction (no mocking)

Using a temporary `/etc/resolv.conf` pointed at a local black-holed UDP "nameserver" (never responds) and the real `src/http.php`:

- **Red (current `main`):** an unrelated `file_get_contents()` to a bad host resolves first (6.01s, the sandbox's real `timeout:2 attempts:3`). `resolve_host_ips()` (which queries A+AAAA, i.e. two lookups) then took **12.01s** (2×6.01s) — silently inheriting the earlier call's timeout, not the intended 2×10s=20s.
- **Green (this fix):** calling the new `apply_dns_resolve_timeout()` first (as `Bootstrap\bootstrap_db()` now does) made **both** the unrelated call (10.01s) and `resolve_host_ips()` (20.02s = 2×10.01s) consistently hit the intended ~10s/query bound, regardless of call order.

## Fix

Extracts the `putenv()` call into `Http\apply_dns_resolve_timeout()` and calls it as the **first line** of `Bootstrap\bootstrap_db()` — the one function every entry point (`index.php`, `bin/lamb`) calls before doing anything else network-shaped. This wins the race to be the process's first hostname resolution regardless of which code ends up needing DNS next, so every later caller in that worker's life — including `introspectToken()`'s plain fetch — inherits the correct bound. `resolve_host_ips()` keeps its own call too (harmless, and still load-bearing for a standalone script that never bootstraps).

Docblocks updated to state the actual guarantee and point at why (matching this repo's precedent for `DNS_RESOLVE_TIMEOUT` in #767 — correct the claim rather than re-architect around a platform limitation, since there's no PHP-exposed way to force glibc's resolver to re-init on demand).

## Tests

- `tests/Unit/HttpTest.php`: `testApplyDnsResolveTimeoutSetsResOptionsEnvVar` — pins the extracted function's `RES_OPTIONS` string directly.
- `tests/Unit/SessionBootstrapTest.php`: `testBootstrapDbAppliesDnsResolveTimeoutBeforeAnythingElse` — runs `bootstrap_db()` in a subprocess (it opens a real RedBeanPHP/SQLite connection via the global `R::` facade, so it can't run in the shared test process) and asserts `RES_OPTIONS` is set on return.
- `vendor/bin/codecept run Unit` — 2151 tests, 0 failures (2 skipped, unchanged from baseline).
- `vendor/bin/codecept run Acceptance` — 96 tests, 0 failures.
- `vendor/bin/phpstan analyse` — no errors. `composer lint` (`phpcs`) — clean.
- `php -l` clean on every touched file.
