### PR TITLE
Drop the login throttle's busy_timeout dance now WAL covers it

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -112,12 +112,12 @@ function bootstrap_db(string $data_dir): void
         }
     }
     R::setup(sprintf("sqlite:%s/lamb.db", $data_dir));
-    // WAL lets a writer commit without waiting for concurrent readers. The login
-    // throttle's reserve_login_attempt() forces busy_timeout=0 so a contended
-    // reservation fails closed instead of stalling; without WAL its COMMIT takes
-    // an EXCLUSIVE lock that any page-render read holds off, so an ordinary
-    // concurrent visitor would make a correct-password login refuse. WAL narrows
-    // that refusal to a genuine concurrent writer, which is the intent.
+    // WAL lets a writer commit without waiting for concurrent readers. Without
+    // it, the login throttle's reserve_login_attempt() COMMIT takes an EXCLUSIVE
+    // lock that any page-render read holds off, so an ordinary concurrent visitor
+    // could make a correct-password login stall or fail. Under WAL that
+    // reservation only ever contends with another writer, keeping its lock hold
+    // to the microseconds of a counter update.
     // ponytail: WAL needs a local filesystem; self-hosted installs on NFS would
     // fall back to the slower rollback journal and lose this guarantee.
     R::exec('PRAGMA journal_mode=WAL');

--- a/src/response/README.md
+++ b/src/response/README.md
@@ -104,12 +104,12 @@ The peek only rejects an already-blocked client; the race-free gate is
 checks-and-increments the counter atomically before bcrypt. Without it a
 concurrent burst from one IP could all read the same under-limit count and each
 run `password_verify()`, serialising only on the write — the bcrypt pile-up the
-throttle exists to stop. SQLite's busy handler is left at the host default
-(tens of seconds), so the reservation forces `busy_timeout = 0` for that
-critical section: a contended lock then refuses immediately (the client retries)
-instead of stalling every attempt behind the lock and reopening the pile-up. The
-lazy prune runs inside that same zero-timeout window on purpose — a prune that
-blocked on contention would reopen it just as surely.
+throttle exists to stop. The database runs in WAL mode (see `bootstrap_db()`),
+so this lock only ever contends with another writer, never with the page-render
+reads that share the connection: a contended login waits the microseconds of the
+other writer's counter update, and bcrypt runs only after the reservation
+returns, never behind the lock. Any throw in the critical section rolls the
+transaction back, so the shared connection is never left mid-transaction.
 
 Post-login, `local_redirect_target()` constrains `?redirect_to=` to a local
 path so the parameter can't be turned into an open redirect — the same

--- a/src/response/auth.php
+++ b/src/response/auth.php
@@ -361,11 +361,16 @@ function login_throttle_retry_after(string $ip, int $now): int
  * the only thing that creates the rows).
  *
  * A BEGIN IMMEDIATE write lock makes the check-and-increment atomic before
- * bcrypt, with busy_timeout forced to 0 (restored in `finally`) so a contended
- * lock refuses promptly instead of stalling bcrypt behind it; the prune shares
- * that zero-timeout window deliberately. Why each of those matters — the
- * pre-bcrypt reservation, busy_timeout=0, the deliberately-refused prune — is
- * in response/README.md ("Login: a sessionless page with its own CSRF model").
+ * bcrypt: without it a concurrent burst from one address could all read the
+ * same under-limit count and each run password_verify(), the pile-up the
+ * throttle exists to stop. Under WAL (see bootstrap_db()) the lock only contends
+ * with another writer, so a contended login briefly waits for that writer's
+ * counter update — microseconds — and bcrypt runs after this returns, never
+ * behind the lock. See response/README.md ("Login: a sessionless page with its
+ * own CSRF model").
+ *
+ * Any throw in the critical section rolls the transaction back in `finally`, so
+ * the shared connection is never left mid-transaction to poison later queries.
  *
  * R::begin()/R::commit() are no-ops in this app's fluid mode (see
  * RedBeanPHP\Facade::begin()), so the lock is taken with a raw statement.
@@ -376,21 +381,17 @@ function login_throttle_retry_after(string $ip, int $now): int
  */
 function reserve_login_attempt(string $ip, int $now): int
 {
-    $previous_busy_timeout = (int) R::getCell('PRAGMA busy_timeout');
-    R::exec('PRAGMA busy_timeout = 0');
-    $in_transaction = false;
+    prune_login_throttle($now);
 
+    R::exec('BEGIN IMMEDIATE');
+    $committed = false;
     try {
-        prune_login_throttle($now);
-
-        R::exec('BEGIN IMMEDIATE');
-        $in_transaction = true;
-
         $bean  = \Lamb\get_option(login_throttle_key($ip), '');
         $state = decode_throttle_state($bean->value);
         $retry_after = throttle_retry_after($state, $now);
         if ($retry_after > 0) {
             R::exec('COMMIT');
+            $committed = true;
             return $retry_after;
         }
 
@@ -398,26 +399,20 @@ function reserve_login_attempt(string $ip, int $now): int
         \Lamb\set_option($bean, encode_throttle_state($count, $now + LOGIN_THROTTLE_WINDOW));
 
         R::exec('COMMIT');
+        $committed = true;
 
         return 0;
-    } catch (SQL) {
-        // Another request already holds the write lock (either for the
-        // reservation itself or for one of prune's own deletes above): refuse
-        // this attempt rather than let it through unreserved, which would
-        // reopen the exact race this function exists to close. The refused
-        // client just retries.
-        if ($in_transaction) {
+    } finally {
+        if (!$committed) {
             try {
                 R::exec('ROLLBACK');
             } catch (SQL) {
-                // Best-effort only; the busy_timeout restore below still runs
-                // regardless, and a stuck transaction on this connection would
-                // fail every later query in the request loudly enough to notice.
+                // A rollback that itself fails leaves later queries erroring
+                // loudly, the right signal for the genuine DB fault that is the
+                // only way to reach here now WAL keeps routine contention from
+                // throwing.
             }
         }
-        return 1;
-    } finally {
-        R::exec('PRAGMA busy_timeout = ' . $previous_busy_timeout);
     }
 }
 

--- a/tests/Unit/LoginThrottleTest.php
+++ b/tests/Unit/LoginThrottleTest.php
@@ -30,9 +30,6 @@ use function Lamb\Response\throttle_retry_after;
  */
 class LoginThrottleTest extends TestCase
 {
-    /** @var string|null Path of the file-backed DB from a contention test, if any. */
-    private ?string $contendedDbFile = null;
-
     protected function setUp(): void
     {
         if (!R::testConnection()) {
@@ -47,12 +44,6 @@ class LoginThrottleTest extends TestCase
     protected function tearDown(): void
     {
         unset($_SERVER['REMOTE_ADDR']);
-
-        if ($this->contendedDbFile !== null) {
-            R::selectDatabase('default');
-            @unlink($this->contendedDbFile);
-            $this->contendedDbFile = null;
-        }
     }
 
     // client_ip — the single source of the client address for logging + throttling
@@ -209,44 +200,8 @@ class LoginThrottleTest extends TestCase
         $this->assertNull(R::findOne('option', ' name = ? ', [login_throttle_key('203.0.113.7')]));
     }
 
-    // Concurrent-write safety — a contended lock must refuse the attempt (not
-    // throw, and not let it through unreserved) when another connection
-    // already holds the write lock
-
-    public function testReserveLoginAttemptRefusesRatherThanThrowingWhenTheWriteLockIsHeld(): void
-    {
-        // A single shared connection can't simulate this: SQLite silently
-        // accepts a nested BEGIN IMMEDIATE on the same connection, so the
-        // contention has to come from a genuinely separate connection.
-        $lock = $this->holdWriteLockOnAContendedConnection();
-
-        try {
-            $retry_after = reserve_login_attempt('203.0.113.7', 1_000);
-        } finally {
-            $lock->exec('COMMIT');
-        }
-
-        // Refused (not silently let through): a contended reservation must
-        // fail *closed*, otherwise the very race this function exists to
-        // close reopens under lock contention.
-        $this->assertGreaterThan(0, $retry_after);
-        $this->assertNull(R::findOne('option', ' name = ? ', [login_throttle_key('203.0.113.7')]));
-    }
-
-    public function testReserveLoginAttemptStillCountsOnceTheLockIsFree(): void
-    {
-        $lock = $this->holdWriteLockOnAContendedConnection();
-        reserve_login_attempt('203.0.113.7', 1_000); // Contended: refused, no row.
-        $lock->exec('COMMIT'); // Release the lock.
-
-        // The refused attempt above left no row; this one, with no contention,
-        // must still start a fresh counter rather than staying silently broken.
-        reserve_login_attempt('203.0.113.7', 1_000);
-
-        $bean = R::findOne('option', ' name = ? ', [login_throttle_key('203.0.113.7')]);
-        $this->assertNotNull($bean);
-        $this->assertSame(['count' => 1, 'expires' => 1_000 + LOGIN_THROTTLE_WINDOW], decode_throttle_state($bean->value));
-    }
+    // Concurrent-write safety — the atomic check-and-increment caps admissions
+    // at the limit even under a burst from one address
 
     public function testReserveLoginAttemptCapsConcurrentAdmissionsAtTheLimit(): void
     {
@@ -265,99 +220,27 @@ class LoginThrottleTest extends TestCase
         $this->assertSame(LOGIN_THROTTLE_MAX_FAILURES, $admitted);
     }
 
-    /**
-     * Points the RedBean facade at a throwaway file-backed SQLite database and
-     * takes its write lock from a second, independent PDO connection to the
-     * same file — real cross-connection contention, which a single shared
-     * connection cannot produce. `busy_timeout=0` on the RedBean side turns
-     * the resulting "database is locked" error into an immediate SQL exception
-     * instead of a multi-second stall.
-     *
-     * tearDown() restores the `default` connection and removes the file.
-     *
-     * @return PDO The lock-holding connection; the caller releases it with
-     *              `$lock->exec('COMMIT')` once the contended call is made.
-     */
-    private function holdWriteLockOnAContendedConnection(): PDO
+    public function testReserveLoginAttemptLeavesNoOpenTransaction(): void
     {
-        $this->contendedDbFile = tempnam(sys_get_temp_dir(), 'lamb_throttle_test_');
+        // The reservation must commit (or roll back) cleanly and leave the
+        // shared connection with no open transaction — a dangling BEGIN would
+        // make the next one throw "cannot start a transaction within a
+        // transaction" and poison every later query in the request.
+        reserve_login_attempt('203.0.113.7', 1_000);
 
-        // A fresh key per call: RedBean refuses to re-register an existing one,
-        // and each test needs its own throwaway file anyway.
-        $key = 'contended_' . uniqid();
-        R::addDatabase($key, 'sqlite:' . $this->contendedDbFile);
-        R::selectDatabase($key);
-        R::freeze(false);
-        R::exec('PRAGMA busy_timeout = 0');
+        R::exec('BEGIN IMMEDIATE');
+        R::exec('ROLLBACK');
 
-        $lock = new PDO('sqlite:' . $this->contendedDbFile);
-        $lock->exec('PRAGMA busy_timeout = 0');
-        $lock->exec('BEGIN IMMEDIATE');
-
-        return $lock;
-    }
-
-    /**
-     * Reproduces the conditions reserve_login_attempt() actually runs under in
-     * production, unlike holdWriteLockOnAContendedConnection() above: this
-     * test never forces busy_timeout on the RedBean side, so the connection
-     * keeps whatever a bare `new PDO('sqlite:...')` defaults to on this host —
-     * the same thing a real deployment never overrides either. The write lock
-     * is held by a genuinely separate OS process (not a second connection in
-     * this same process) so a regression that blocks instead of refusing
-     * fails this test in bounded time (the hold's length) instead of hanging
-     * the suite for the host's full default busy_timeout.
-     */
-    public function testReserveLoginAttemptRefusesPromptlyUnderContentionWithoutTestForcedBusyTimeout(): void
-    {
-        $this->contendedDbFile = tempnam(sys_get_temp_dir(), 'lamb_throttle_test_');
-
-        $key = 'contended_' . uniqid();
-        R::addDatabase($key, 'sqlite:' . $this->contendedDbFile);
-        R::selectDatabase($key);
-        R::freeze(false);
-        // Deliberately not forcing busy_timeout here — see docblock above.
-
-        $holdSeconds = 2;
-        $holder = new Process([
-            'php',
-            '-r',
-            '$pdo = new PDO("sqlite:' . $this->contendedDbFile . '"); '
-                . '$pdo->exec("BEGIN IMMEDIATE"); '
-                . 'usleep(' . ($holdSeconds * 1_000_000) . '); '
-                . '$pdo->exec("COMMIT");',
-        ]);
-        $holder->start();
-        // Let the subprocess actually acquire BEGIN IMMEDIATE before racing it.
-        usleep(300_000);
-
-        $started = microtime(true);
-        $retry_after = reserve_login_attempt('203.0.113.7', 1_000);
-        $elapsed = microtime(true) - $started;
-
-        $holder->wait();
-
-        // Refused (not silently let through)...
-        $this->assertGreaterThan(0, $retry_after);
-        // ...and refused promptly. A regression that stops forcing
-        // busy_timeout to 0 for this critical section would instead block
-        // for the lock holder's full hold time before still admitting the
-        // attempt — the exact bcrypt-pileup race this function exists to
-        // close, just serialised across the stall instead of parallel.
-        $this->assertLessThan(
-            $holdSeconds,
-            $elapsed,
-            'reserve_login_attempt() blocked on lock contention instead of refusing promptly'
-        );
+        // Reached here without an exception, and a fresh reservation still works.
+        $this->assertSame(0, reserve_login_attempt('198.51.100.9', 1_000));
     }
 
     public function testBootstrapDbEnablesWalSoLoginCommitsSurviveConcurrentReaders(): void
     {
-        // reserve_login_attempt() forces busy_timeout=0, so its COMMIT must not
-        // stall on a concurrent reader — it has to fail only against a real
-        // writer. WAL lets a writer commit while readers hold the file; a
+        // reserve_login_attempt()'s COMMIT must not stall on a concurrent
+        // reader. WAL lets a writer commit while readers hold the file; a
         // regression to the rollback journal would let an ordinary page-render
-        // read make a correct-password login refuse. Run bootstrap_db() in a
+        // read block or fail a correct-password login. Run bootstrap_db() in a
         // subprocess: it calls R::setup(), which would clobber this suite's
         // shared :memory: default connection.
         $dir = sys_get_temp_dir() . '/lamb_wal_test_' . uniqid();


### PR DESCRIPTION
## Summary

Robustness through simplification: now that the login throttle runs under WAL, delete the `busy_timeout=0` machinery that WAL made redundant. Net −122 lines, and the auth path loses a whole class of subtle failure.

`reserve_login_attempt()` forced `busy_timeout=0` around its `BEGIN IMMEDIATE` reservation so a contended write lock would fail closed rather than stall. Two problems with that:

- **It guarded a stall that never existed.** bcrypt runs *after* the reservation returns, never inside the lock — so the "stalling every attempt behind the lock" the zero timeout defended against couldn't happen. The only thing inside the lock is a counter read-increment, measured in microseconds.
- **It introduced its own regression.** With the connection in the default rollback journal, the reservation's `COMMIT` takes an EXCLUSIVE lock that any concurrent *reader* (a second visitor rendering a page) holds off. Under `busy_timeout=0` that returned `SQLITE_BUSY` immediately, refusing a correct-password login with the throttle message.

WAL (added in the same PR that shipped the busy_timeout change) is the real fix: a writer commits without waiting for readers, so the reservation only ever contends with another *writer*, briefly, for the counter update. With WAL in place the busy_timeout save/set/restore, the fail-closed refusal path, and the flaky cross-process contention test are all redundant.

## What changed

- `reserve_login_attempt()`: removed the `PRAGMA busy_timeout` save/set/restore and the fail-closed `catch`. A `finally`-block rollback replaces it, so **any** throw in the critical section (not just `SQL`) rolls the transaction back — closing #792 (dangling transaction on a non-`SQL` throw).
- Deleted the two contention tests that asserted the removed fail-closed behaviour, including the flaky cross-process one (park #134): it forced `busy_timeout` and a subprocess lock to test a mechanism that no longer exists. The in-process cap test still pins the anti-pile-up property.
- Added `testReserveLoginAttemptLeavesNoOpenTransaction` to pin the no-dangling-transaction guarantee.
- Updated `bootstrap.php`'s WAL comment and `response/README.md`'s login section to describe the WAL-based reasoning instead of the deleted busy_timeout window.

## Test plan

- `vendor/bin/codecept run Unit` — 2184 tests, 0 failures (2 pre-existing skips). The throttle suite runs in 0.37s, down from 2.5s (the 2s flaky contention test is gone).
- `vendor/bin/codecept run Acceptance` — 96 tests, 0 failures (includes `LoginCest`).
- `composer lint` (phpcs) and `composer analyse` (PHPStan level 8) — clean.

Closes #792. Resolves the flaky test tracked in the local park (#134).
