### PR TITLE
Guard is_draft()/is_deleted() against raw-column drift with a test

### DIFF
--- a/tests/Unit/DraftDeletedPredicateGuardTest.php
+++ b/tests/Unit/DraftDeletedPredicateGuardTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit;
+
+use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Guards the canonical is_draft()/is_deleted() predicates against drift.
+ *
+ * A post's draft and deleted state each have one source of truth: is_draft()
+ * and is_deleted() in lamb.php, both `== 1`. Inlining a raw truthiness test on
+ * the column instead — `!empty($bean->draft)`, `if (!$post->deleted)`, a bare
+ * `$post->deleted ?` ternary — is the "recomputed state" drift the scheduled
+ * bug scan kept re-finding and fixing one call site at a time (#749, #751,
+ * #779, #788). `!empty()`/truthiness treats any non-zero value as set, while
+ * the predicates only accept exactly 1, so the two disagree the moment a
+ * non-canonical value reaches the column. This fails the build the moment a
+ * new raw test appears, so the fix is made once at the keyboard rather than
+ * later in a review round.
+ *
+ * Writes (`$bean->draft = 1`), the predicate definitions themselves
+ * (`?? null) == 1`), and value serialisation (`(bool) $bean->deleted` in the
+ * exporter) are not decisions, so the pattern deliberately leaves them alone.
+ */
+class DraftDeletedPredicateGuardTest extends TestCase
+{
+    // Matches the three drift idioms — empty()/!empty() on the column, a `!`
+    // truthiness test, and a bare ternary condition — while the negative
+    // lookahead skips the predicates' own `?? null`.
+    private const FORBIDDEN = '/(empty\(\s*[$A-Za-z_>\[\]\'-]*->(draft|deleted)\b'
+        . '|!\s*[$A-Za-z_>\[\]\'-]*->(draft|deleted)\b'
+        . '|->(draft|deleted)\s*\?(?!\?))/';
+
+    public function testNoRawDraftOrDeletedTruthinessTestsOutsideThePredicates(): void
+    {
+        $violations = [];
+        foreach ($this->phpFilesUnderSrc() as $file) {
+            foreach (file($file, FILE_IGNORE_NEW_LINES) as $i => $line) {
+                if (preg_match(self::FORBIDDEN, $line)) {
+                    $violations[] = sprintf('%s:%d  %s', $file, $i + 1, trim($line));
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $violations,
+            "Raw draft/deleted truthiness test found — call is_draft()/is_deleted() instead:\n"
+                . implode("\n", $violations)
+        );
+    }
+
+    /**
+     * Every `.php` file under src/, themes included.
+     *
+     * @return iterable<string> Absolute file paths.
+     */
+    private function phpFilesUnderSrc(): iterable
+    {
+        $src = dirname(__DIR__, 2) . '/src';
+        $walk = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($src, FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($walk as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                yield $file->getPathname();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Turns a recurring bug-scan category into a one-time preventive guard.

The scheduled `/bugsweep` keeps re-finding the same "recomputed state" drift: a call site that answers "is this post a draft / deleted?" with a raw truthiness test on the column instead of the canonical predicate, then a PR fixes that single site. It has happened at least four times — `is_deleted()` in #749, `is_unpublished()` in #751, `is_draft()` in #779, and the theme-layer `is_deleted()` sites in #788. `!empty()` / bare truthiness treats any non-zero value as set, while `is_draft()`/`is_deleted()` accept exactly `1`, so the two silently disagree the moment a non-canonical value reaches the column.

This adds a unit test that scans `src/` (themes included) for the three drift idioms and fails the build on any new one, pointing the author at `is_draft()`/`is_deleted()`. Detection in a review round becomes prevention at the keyboard, and the scan stops generating this category of PR.

## What it catches / allows

Fails on: `empty($x->draft)` / `!empty($x->deleted)`, a `!` truthiness test (`!$post->deleted`), and a bare ternary condition (`$post->deleted ? …`). A negative lookahead skips the predicates' own `?? null` reads.

Leaves alone (not decisions): writes (`$bean->draft = 1`), the `is_draft()`/`is_deleted()` definitions, and the exporter's `(bool) $bean->deleted` serialisation.

## Test plan

- `vendor/bin/codecept run Unit DraftDeletedPredicateGuardTest` — green on current `src/` (0 violations).
- Verified red: planting `!empty($bean->deleted)` in `src/post.php` fails the test with the exact `file:line` and the fix hint; reverted.
- `composer lint` and `composer analyse` (PHPStan level 8) — clean.

No production code changes — this is a guard only.
