### PR TITLE
Declare the schema explicitly and freeze it

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -123,7 +123,134 @@ function bootstrap_db(string $data_dir): void
     R::exec('PRAGMA journal_mode=WAL');
     R::useWriterCache(true);
 
+    ensure_schema();
     ensure_post_columns();
+
+    // Frozen mode rejects a write to any column not declared in SCHEMA instead
+    // of silently adding it (RedBeanPHP's default fluid behaviour) — a typo'd
+    // or forgotten column becomes a thrown exception at write time rather than
+    // a schema drift nobody notices. Must come after ensure_schema() and
+    // ensure_post_columns(), which are themselves schema changes and would be
+    // refused too.
+    R::freeze(true);
+}
+
+/**
+ * Every table Lamb writes to, and the columns each one declares beyond the
+ * implicit `id INTEGER PRIMARY KEY AUTOINCREMENT`.
+ *
+ * This is what ensure_schema() creates tables from and R::freeze(true) (see
+ * bootstrap_db()) enforces against: a write naming a column not listed here
+ * throws instead of RedBeanPHP's default of silently adding it.
+ *
+ * Column types are advisory — SQLite is dynamically typed regardless of what
+ * a column is declared as — and are named for readability, matching what
+ * fluid mode would otherwise have inferred from the first value written.
+ */
+const SCHEMA = [
+    'post' => [
+        'body' => 'TEXT',
+        'slug' => 'TEXT',
+        'title' => 'TEXT',
+        'description' => 'TEXT',
+        'transformed' => 'TEXT',
+        'created' => 'TEXT',
+        'updated' => 'TEXT',
+        'version' => 'INTEGER',
+        'feed_name' => 'TEXT',
+        'feeditem_uuid' => 'TEXT',
+        'import_uuid' => 'TEXT',
+        'source_url' => 'TEXT',
+        'in_reply_to' => 'TEXT',
+        'syndicated_to' => 'TEXT',
+        'draft' => 'INTEGER',
+        'deleted' => 'INTEGER',
+        'deleted_at' => 'TEXT',
+        'feed_locked' => 'INTEGER',
+        'preview_token' => 'TEXT',
+        'preview_token_expires' => 'TEXT',
+    ],
+    'option' => [
+        'name' => 'TEXT',
+        'value' => 'TEXT',
+        'updated' => 'TEXT',
+    ],
+    'redirect' => [
+        'from_slug' => 'TEXT',
+        'to_url' => 'TEXT',
+    ],
+    'webmention' => [
+        'source' => 'TEXT',
+        'target' => 'TEXT',
+        'post_id' => 'INTEGER',
+        'type' => 'TEXT',
+        'author' => 'TEXT',
+        'content' => 'TEXT',
+        'status' => 'TEXT',
+        'created' => 'TEXT',
+        'verified_at' => 'TEXT',
+    ],
+    'webmentionoutbox' => [
+        'post_id' => 'INTEGER',
+        'source' => 'TEXT',
+        'target' => 'TEXT',
+        'endpoint' => 'TEXT',
+        'status' => 'TEXT',
+        'attempts' => 'INTEGER',
+        'created' => 'TEXT',
+        'processed_at' => 'TEXT',
+        'resend' => 'INTEGER',
+    ],
+    'feedstatus' => [
+        'feedkey' => 'TEXT',
+        'name' => 'TEXT',
+        'url' => 'TEXT',
+        'last_success' => 'INTEGER',
+        'last_item_date' => 'INTEGER',
+        'last_attempt' => 'INTEGER',
+        'last_error' => 'INTEGER',
+        'item_count' => 'INTEGER',
+        'error_message' => 'TEXT',
+    ],
+];
+
+/**
+ * Creates every table in SCHEMA that does not exist yet, and ALTER-adds any
+ * declared column an existing table is missing.
+ *
+ * The ALTER-add is what lets an installation that has been running in fluid
+ * mode upgrade to a frozen one: CREATE TABLE IF NOT EXISTS only helps a
+ * brand-new database. An existing lamb.db already has these tables, built one
+ * column at a time by fluid mode, and may be missing a column a later Lamb
+ * release added that no bean on this install has written yet. Skipping the
+ * ALTER and freezing anyway would turn that column's next write into a thrown
+ * exception where fluid mode would have quietly added it.
+ *
+ * Must run before R::freeze(true): CREATE TABLE and ALTER TABLE ADD COLUMN
+ * are themselves schema changes, which a frozen connection also refuses.
+ *
+ * @return void
+ */
+function ensure_schema(): void
+{
+    foreach (SCHEMA as $table => $columns) {
+        $definitions = [];
+        foreach ($columns as $name => $type) {
+            $definitions[] = "$name $type";
+        }
+        R::exec(sprintf(
+            'CREATE TABLE IF NOT EXISTS %s (id INTEGER PRIMARY KEY AUTOINCREMENT, %s)',
+            $table,
+            implode(', ', $definitions)
+        ));
+
+        $existing = array_column(R::getAll("PRAGMA table_info($table)"), 'name');
+        foreach ($columns as $name => $type) {
+            if (!in_array($name, $existing, true)) {
+                R::exec("ALTER TABLE $table ADD COLUMN $name $type");
+            }
+        }
+    }
 }
 
 /**

--- a/tests/Unit/SchemaFreezeTest.php
+++ b/tests/Unit/SchemaFreezeTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * bootstrap_db() declares every table/column up front (Bootstrap\SCHEMA) and
+ * ends by calling R::freeze(true), so an accidental column is rejected
+ * instead of silently created (issue tracked in the explicit-schema-freeze
+ * work). Both halves of that guarantee need a real R::setup() connection,
+ * which bootstrap_db() creates itself — running it here would clobber the
+ * shared :memory: connection the rest of the Unit suite depends on, so it
+ * runs in a subprocess (mirrors LoginThrottleTest's WAL check).
+ */
+class SchemaFreezeTest extends TestCase
+{
+    public function testFrozenSchemaAcceptsEveryDeclaredColumnAndRejectsAnUndeclaredOne(): void
+    {
+        $dir = sys_get_temp_dir() . '/lamb_schema_freeze_test_' . uniqid();
+
+        $script = <<<'PHP'
+        use RedBeanPHP\R;
+
+        require "vendor/autoload.php";
+        \Lamb\Bootstrap\bootstrap_db($argv[1]);
+
+        $beans = [
+            'post' => [
+                'body' => 'b', 'slug' => 's', 'title' => 't', 'description' => 'd',
+                'transformed' => 'x', 'created' => '2024-01-01', 'updated' => '2024-01-01',
+                'version' => 1, 'feed_name' => 'f', 'feeditem_uuid' => 'u',
+                'import_uuid' => 'i', 'source_url' => 'url', 'in_reply_to' => 'r',
+                'syndicated_to' => 'y', 'draft' => 0, 'deleted' => 0,
+                'deleted_at' => '2024-01-01', 'feed_locked' => 0,
+                'preview_token' => 'tok', 'preview_token_expires' => '2024-01-01',
+            ],
+            'option' => ['name' => 'n', 'value' => 'v', 'updated' => '2024-01-01 00:00:00'],
+            'redirect' => ['from_slug' => 'a', 'to_url' => 'b'],
+            'webmention' => [
+                'source' => 's', 'target' => 't', 'post_id' => 1, 'type' => 'like',
+                'author' => 'a', 'content' => 'c', 'status' => 'verified',
+                'created' => '2024-01-01', 'verified_at' => '2024-01-01',
+            ],
+            'webmentionoutbox' => [
+                'post_id' => 1, 'source' => 's', 'target' => 't', 'endpoint' => 'e',
+                'status' => 'pending', 'attempts' => 0, 'created' => '2024-01-01',
+                'processed_at' => '2024-01-01', 'resend' => 0,
+            ],
+            'feedstatus' => [
+                'feedkey' => 'k', 'name' => 'n', 'url' => 'u', 'last_success' => 1,
+                'last_item_date' => 1, 'last_attempt' => 1, 'last_error' => 0,
+                'item_count' => 0, 'error_message' => 'e',
+            ],
+        ];
+
+        foreach ($beans as $type => $columns) {
+            $bean = R::dispense($type);
+            foreach ($columns as $name => $value) {
+                $bean->$name = $value;
+            }
+            $id = R::store($bean);
+            $loaded = R::load($type, $id);
+            foreach ($columns as $name => $value) {
+                if ($loaded->$name != $value) {
+                    fwrite(STDERR, "MISMATCH $type.$name\n");
+                    exit(1);
+                }
+            }
+        }
+
+        try {
+            $bean = R::dispense('post');
+            $bean->slug = 'ok';
+            $bean->this_column_does_not_exist = 'nope';
+            R::store($bean);
+            fwrite(STDERR, "UNDECLARED COLUMN WAS ACCEPTED\n");
+            exit(1);
+        } catch (\RedBeanPHP\RedException\SQL $e) {
+            // Expected: frozen mode refuses the undeclared column.
+        }
+
+        echo "OK\n";
+        PHP;
+
+        $boot = new Process(['php', '-r', $script, $dir]);
+        $boot->run();
+
+        @unlink($dir . '/lamb.db');
+        @unlink($dir . '/lamb.db-wal');
+        @unlink($dir . '/lamb.db-shm');
+        if (is_dir($dir . '/sessions')) {
+            @rmdir($dir . '/sessions');
+        }
+        @rmdir($dir);
+
+        $this->assertSame(
+            "OK\n",
+            $boot->getOutput(),
+            "stdout:\n" . $boot->getOutput() . "\nstderr:\n" . $boot->getErrorOutput()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Robustness through an explicit schema. Every table was created lazily by RedBeanPHP fluid mode on first write — there was not a single `CREATE TABLE` in the codebase — so a typo'd or forgotten column silently became a new column and drifted the schema with nothing to notice. This declares all six tables and their columns up front and freezes the schema, so a write to an undeclared column throws at write time instead.

## What changed (`src/bootstrap.php`)

- **`SCHEMA`** — a declarative map of the six tables (`post`, `option`, `redirect`, `webmention`, `webmentionoutbox`, `feedstatus`) to their columns. This is now the readable, single source of truth for the schema.
- **`ensure_schema()`** — `CREATE TABLE IF NOT EXISTS` for a fresh install, plus an `ALTER TABLE ADD COLUMN` pass that migrates an existing fluid install missing a later-added column (otherwise its next frozen write would throw where fluid mode used to add the column quietly).
- **`R::freeze(true)`** at the end of `bootstrap_db()`, after both schema-setup functions. A write naming an undeclared column now throws `RedBeanPHP\RedException\SQL`.

The `feedstatus` table isn't in AGENTS.md's list of five tables — the audit that seeded `SCHEMA` found it (and three columns some paths write but the acceptance suite's first pass didn't: `option.updated`, `post.preview_token`, `post.preview_token_expires`). The acceptance suite, which now runs the whole app under freeze, caught all three.

## Test plan

- New `tests/Unit/SchemaFreezeTest.php` — bootstraps a fresh DB in a subprocess, stores and round-trips a bean of every one of the six types writing every declared column, then confirms a write to an undeclared column throws. (Subprocess because `bootstrap_db()` calls `R::setup()`, which would clobber the shared `:memory:` connection the rest of the Unit suite uses.)
- `vendor/bin/codecept run Unit` — 2185 tests, 0 failures (2 pre-existing skips).
- `vendor/bin/codecept run Acceptance` — 96 tests, 0 failures. This is the real integration gate: the app runs through `bootstrap_db` under freeze, exercising live post/redirect/webmention writes.
- `composer lint` (phpcs) and `composer analyse` (PHPStan level 8) — clean.

## Review

Reviewed for schema completeness against every write path, including the ones acceptance under-exercises (feed ingest, import, outbound webmention, micropub) and dynamic writes (`->{$var}`, `->import()`, RedBean own-lists / FK columns — none exist; `apply_frontmatter()`'s only dynamic path is allowlisted to declared `post` columns). Migration ordering and the freeze/tooling interactions checked. No missing column found.
