### PR TITLE
Fix developer-environment fragility: phpcs registration, gitignore, worktree docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 *.db
 *.db.bak*
+# SQLite WAL sidecar files (journal_mode=WAL, see bootstrap_db()).
+*.db-wal
+*.db-shm
 /tests/Support/Data/sessions/
+# Acceptance runs set LAMB_DATA_DIR here, so the app's cache lands under it.
+/tests/Support/Data/cache/
 /.docker/*.env
 /data/cache/
 /data/*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,17 @@ PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$HOME/.cache/ms-playwright/chromium-1208/chr
 - Chromium executable: `~/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome` (note `chrome-linux64`; version dir may differ per machine — check `ls ~/.cache/ms-playwright/`)
 - Script: `scripts/screenshot.mjs [path] [outdir]`
 
+### Worktrees
+
+Run `composer install` inside each git worktree. Don't share or symlink one
+checkout's `vendor/` into another: Composer's generated autoloader resolves to
+the checkout that created it, so a worktree pointed at another checkout's
+`vendor/` silently runs and tests that checkout's `src/`, not the worktree's —
+green tests against the wrong code. A per-worktree `composer install` also
+registers the PHPCompatibility standard for that checkout (handled on install
+by the `phpcodesniffer-composer-installer` plugin), so `composer lint` works
+without any global phpcs config.
+
 ## Dependencies
 
 Dependabot (`.github/dependabot.yml`) watches all five ecosystems weekly —

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "squizlabs/php_codesniffer": "^3.10",
     "vlucas/phpdotenv": "^5.6",
     "symfony/process": "^7.4",
-    "phpstan/phpstan": "^2.0"
+    "phpstan/phpstan": "^2.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
   },
   "autoload": {
     "psr-4": {
@@ -89,8 +90,6 @@
     }
   },
   "scripts": {
-    "post-install-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
-    "post-update-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
     "lint": "vendor/bin/phpcs .",
     "fix": "vendor/bin/phpcbf .",
     "analyse": "vendor/bin/phpstan analyse --memory-limit=256M",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b26fb99407320e2840267a5182f562ea",
+    "content-hash": "d8b6b37376e818de6e60ab31181060e2",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -1469,6 +1469,102 @@
                 "source": "https://github.com/Codeception/Stub/tree/4.3.0"
             },
             "time": "2026-02-06T15:19:04+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "graham-campbell/result-type",


### PR DESCRIPTION
## Summary

Fixes three things that made the local dev/test loop untrustworthy — the kind of friction where you stop believing a green run.

## `devbox run` aborting in worktrees (park #133)

`composer.json`'s `post-install-cmd`/`post-update-cmd` ran:

```
vendor/bin/phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility
```

That writes a **CWD-relative** path into a global phpcs config and exits **255** in a worktree, and because it's a composer post-install hook, the non-zero abort kills the whole `devbox run -- vendor/bin/codecept` / `composer …` before the real command runs — no output. It stalled a coder for ~2h on #706.

Replaced with the **`dealerdirect/phpcodesniffer-composer-installer`** plugin — already listed in `config.allow-plugins` but never actually required. It registers the PHPCompatibility standard on every `composer install`, per checkout, writing `installed_paths` as `../../phpcompatibility/php-compatibility` (relative to the phpcs install dir, so it resolves regardless of CWD). Both fragile scripts are deleted.

Verified: wiped `CodeSniffer.conf`, ran `composer install`, and the plugin regenerated it; `phpcs -i` lists PHPCompatibility and `composer lint` / `composer analyse` are clean — with no post-install script.

## gitignore gaps

- **Test cache (park #132):** acceptance runs set `LAMB_DATA_DIR=tests/Support/Data`, so the app's cache lands in `tests/Support/Data/cache/`, which wasn't ignored — a local full-suite run left untracked files a `git add -A` would sweep in.
- **WAL sidecars:** enabling `journal_mode=WAL` means SQLite writes `lamb.db-wal` / `lamb.db-shm`, which `*.db` doesn't match. Same untracked-artifact risk.

Both are now ignored.

## Worktree autoloader trap

Documented in AGENTS.md: each worktree needs its own `composer install`. A shared or symlinked `vendor/` makes Composer's generated autoloader resolve to the checkout that created it, so a worktree silently runs and tests another checkout's `src/` — green tests against the wrong code (the trap noted in #788's environment note).

## Test plan

- `composer validate --strict` — valid.
- `composer lint` (phpcs, PHPCompatibility resolved by the plugin) and `composer analyse` (PHPStan level 8) — clean.
- `vendor/bin/codecept run Unit` — 2186 tests, 0 failures (2 pre-existing skips).

No production code changes — build tooling, `.gitignore`, and docs only.

Closes the work tracked in park #132 and #133.
