### PR TITLE
793: Add an attach-file control for inserting photos from a phone

### DIFF
--- a/docs/first-post.md
+++ b/docs/first-post.md
@@ -28,7 +28,7 @@ You don't create tags anywhere — writing one is enough.
 
 ## Drag in an image
 
-Drag an image file from your desktop onto the text box. Lamb uploads it and drops a Markdown image link at your cursor, so you can keep typing around it. Pasting an image from the clipboard — a screenshot, say — does the same thing.
+Drag an image file from your desktop onto the text box. Lamb uploads it and drops a Markdown image link at your cursor, so you can keep typing around it. Pasting an image from the clipboard — a screenshot, say — does the same thing, as does the attach button next to the text box, which is the easiest way to add a photo from a phone.
 
 JPEG and PNG files are re-encoded to WebP on upload to keep them small; the link points at the converted file. GIF, WebP, and AVIF are kept as they are. For the full picture, including video and size limits, see [Media]({{ site.baseurl }}{% link media.md %}).
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -9,10 +9,11 @@ Lamb lets you add images and video to posts without leaving the editor. Uploaded
 
 ## Adding images
 
-When logged in, there are two ways to add an image to the post editor:
+When logged in, there are three ways to add an image to the post editor:
 
 - **Drag and drop** one or more image files onto the editor textarea.
 - **Paste** an image straight from the clipboard, for example a screenshot.
+- **Attach** a file using the attach button next to the editor, which opens the device's file picker — on a phone this offers Take Photo, Photo Library, or Choose File.
 
 Either way the file is uploaded and a markdown image link (`![name](url)`) is inserted at the cursor. Pasted screenshots arrive without a real filename, so each is given a unique name before upload.
 

--- a/src/scripts/logged_in/upload-image.js
+++ b/src/scripts/logged_in/upload-image.js
@@ -17,6 +17,14 @@ onLoaded(() => {
         cancel(ev)
         handleFiles(files, ta)
     })
+
+    const attach = $('.attach-image-input')
+    if (attach) {
+        attach.on('change', () => {
+            if (attach.files.length > 0) handleFiles(attach.files, ta)
+            attach.value = '' // let the same file be picked again
+        })
+    }
 })
 
 /**

--- a/src/theme.php
+++ b/src/theme.php
@@ -604,6 +604,32 @@ function sanitize_filename($filename): string
 }
 
 /**
+ * Returns the markup for a file-picker control that hands picked files to
+ * upload-image.js, which uploads them the same way as a drag-and-drop or
+ * paste.
+ *
+ * The input has no name attribute on purpose: it must never attach its value
+ * to the surrounding form's own submission, since JS uploads it separately.
+ *
+ * accept is a generic wildcard, not a specific extension list: iOS Safari
+ * only transcodes an HEIC photo to JPEG when accept is generic, handing over
+ * raw HEIC otherwise — which safe_upload_extension() would reject.
+ *
+ * @param string $id Element id, shared between the label's for and the input
+ *                    (distinct per form so two forms on one page don't clash).
+ * @return string
+ */
+function attach_image_control(string $id): string
+{
+    $id = escape($id);
+
+    return <<<HTML
+        <label for="{$id}" class="attach-image">Attach photo</label>
+        <input type="file" id="{$id}" class="attach-image-input" multiple accept="image/*,video/*">
+        HTML;
+}
+
+/**
  * Renders the quick-post entry form. Does nothing when the user is not logged in.
  *
  * @return void
@@ -616,6 +642,7 @@ function the_entry_form(): void
                 <label>
                     <textarea placeholder="What's happening?" name="contents" required><?= preload_text() ?></textarea>
                 </label>
+                <?= attach_image_control('attach-entry') ?>
                 <input type="submit" name="submit" value="<?= SUBMIT_CREATE ?>">
                 <input type="hidden" name="<?= HIDDEN_CSRF_NAME ?>" value="<?= csrf_token() ?>"/>
             </form>

--- a/src/themes/2024/styles/styles.css
+++ b/src/themes/2024/styles/styles.css
@@ -293,6 +293,35 @@ section {
     }
 }
 
+/* Visually hidden but still keyboard-focusable, same clip technique as
+   .screen-reader-text above. label.attach-image is the visible, styled
+   control. */
+.attach-image-input {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    word-wrap: normal !important;
+}
+
+label.attach-image {
+    display: inline-block;
+    min-height: 44px;
+    min-width: 44px;
+    box-sizing: border-box;
+    padding: 0.6em 1em;
+    margin: 0.5em 0;
+    line-height: 1.6;
+    cursor: pointer;
+    border: 1px solid var(--shadow);
+    border-radius: 4px;
+}
+
 textarea {
     font: 12px/1.4em "DejaVu Sans Mono", monospace;
     width: 100%;

--- a/src/themes/2026/styles/styles.css
+++ b/src/themes/2026/styles/styles.css
@@ -709,6 +709,40 @@ section.entry-form {
     margin: 0 0 var(--s-7);
 }
 
+/* Visually hidden but still keyboard-focusable — display:none would drop it
+   from the tab order. label.attach-image is the visible, styled control. */
+.attach-image-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+label.attach-image {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    min-width: 44px;
+    padding: var(--s-2) var(--s-4);
+    margin: 0 0 var(--s-3);
+    font: 500 var(--text-sm)/1 var(--font-mono);
+    color: var(--ink);
+    background: var(--paper-raised);
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background-color var(--t-fast) var(--ease-out-quart);
+}
+
+label.attach-image:hover {
+    background: var(--paper);
+}
+
 textarea {
     font: 400 var(--text-sm)/1.5 var(--font-mono);
     /* Geist Mono ligates triple characters (###, ---, ===); the fused glyph

--- a/src/themes/base/parts/edit.php
+++ b/src/themes/base/parts/edit.php
@@ -4,6 +4,7 @@ global $data;
 
 use function Lamb\is_deleted;
 use function Lamb\Theme\action_delete;
+use function Lamb\Theme\attach_image_control;
 use function Lamb\Theme\csrf_token;
 use function Lamb\Theme\escape;
 
@@ -22,6 +23,7 @@ if (isset($_SESSION[SESSION_LOGIN]) && $post->id > 0) :
         <label for="contents">Contents</label><textarea placeholder="What's happening?" name="contents" required
                                                         id="contents"
         ><?= $body ?></textarea>
+        <?= attach_image_control('attach-edit') ?>
         <input type="hidden" name="id" value="<?= (int) $post->id ?>"/>
         <input type="submit" form="editform" name="submit" value="<?= $submitLabel ?>">
         <input type="hidden" name="<?= HIDDEN_CSRF_NAME ?>" value="<?= csrf_token() ?>"/>

--- a/tests/Unit/ThemeAssetsTest.php
+++ b/tests/Unit/ThemeAssetsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 
 use function Lamb\Theme\asset_version;
+use function Lamb\Theme\attach_image_control;
 use function Lamb\Theme\minify_css;
 use function Lamb\Theme\redirect_to;
 use function Lamb\Theme\rewrite_css_urls;
@@ -255,6 +256,45 @@ class ThemeAssetsTest extends TestCase
     {
         $out = styles_markup('/no/such/file.css', 'http://localhost/themes/x/styles/styles.css', 'http://localhost/themes/x/styles/');
         $this->assertStringContainsString('<link rel="stylesheet"', $out);
+    }
+
+    // -------------------------------------------------------------------------
+    // attach_image_control
+    // -------------------------------------------------------------------------
+
+    public function testAttachImageControlRendersFileInputWithAcceptAndMultiple(): void
+    {
+        $out = attach_image_control('attach-entry');
+
+        $this->assertStringContainsString('type="file"', $out);
+        $this->assertStringContainsString('multiple', $out);
+        $this->assertStringContainsString('accept=', $out);
+    }
+
+    public function testAttachImageControlLabelForMatchesInputId(): void
+    {
+        $out = attach_image_control('attach-entry');
+
+        $this->assertMatchesRegularExpression('/<label for="attach-entry"[^>]*>/', $out);
+        $this->assertMatchesRegularExpression('/<input[^>]*id="attach-entry"/', $out);
+    }
+
+    public function testAttachImageControlInputHasNoNameAttribute(): void
+    {
+        // Nothing must attach this input's value to the surrounding form's own
+        // submission — uploads go through /upload via JS, not a form post.
+        $out = attach_image_control('attach-entry');
+
+        preg_match('/<input[^>]*type="file"[^>]*>/', $out, $m);
+        $this->assertNotEmpty($m, 'file input not found in output');
+        $this->assertStringNotContainsString('name=', $m[0]);
+    }
+
+    public function testAttachImageControlEscapesId(): void
+    {
+        $out = attach_image_control('attach"entry');
+
+        $this->assertStringNotContainsString('attach"entry', $out);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/js/upload-image.test.mjs
+++ b/tests/js/upload-image.test.mjs
@@ -176,6 +176,71 @@ test('handleFiles falls back to the status when the endpoint sends no message', 
   assert.match(document.querySelector('.flash.upload-error').textContent, /Upload failed \(500\)/)
 })
 
+test('attach control uploads a single picked file at the cursor', async () => {
+  const { window, document } = load(
+    '<!DOCTYPE html><body><form><textarea></textarea><input type="file" class="attach-image-input"></form></body>'
+  )
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+  const ta = document.querySelector('textarea')
+  ta.value = 'abcd'
+  ta.setSelectionRange(2, 2)
+  const attach = document.querySelector('.attach-image-input')
+
+  let posted
+  window.fetch = (url, opts) => {
+    posted = { url, opts }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve('![](/img.webp)') })
+  }
+
+  Object.defineProperty(attach, 'files', { value: [new window.File(['x'], 'a.png', { type: 'image/png' })], configurable: true })
+  attach.dispatchEvent(new window.Event('change'))
+  await flush()
+
+  assert.equal(posted.url, '/upload')
+  assert.equal(ta.value, 'ab![](/img.webp)cd')
+})
+
+test('attach control uploads multiple picked files as separate imageFiles[] entries', async () => {
+  const { window, document } = load(
+    '<!DOCTYPE html><body><form><textarea></textarea><input type="file" class="attach-image-input"></form></body>'
+  )
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+  const ta = document.querySelector('textarea')
+  const attach = document.querySelector('.attach-image-input')
+
+  let posted
+  window.fetch = (url, opts) => {
+    posted = { url, opts }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve('![](/img.webp)') })
+  }
+
+  const files = [
+    new window.File(['x'], 'a.png', { type: 'image/png' }),
+    new window.File(['y'], 'b.png', { type: 'image/png' }),
+  ]
+  Object.defineProperty(attach, 'files', { value: files, configurable: true })
+  attach.dispatchEvent(new window.Event('change'))
+  await flush()
+
+  assert.equal(posted.opts.body.getAll('imageFiles[]').length, 2)
+})
+
+test('attach control clears its value after picking, so the same file fires again', async () => {
+  const { window, document } = load(
+    '<!DOCTYPE html><body><form><textarea></textarea><input type="file" class="attach-image-input"></form></body>'
+  )
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+  const attach = document.querySelector('.attach-image-input')
+
+  window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve('![](/img.webp)') })
+
+  Object.defineProperty(attach, 'files', { value: [new window.File(['x'], 'a.png', { type: 'image/png' })], configurable: true })
+  attach.dispatchEvent(new window.Event('change'))
+  await flush()
+
+  assert.equal(attach.value, '')
+})
+
 test('handleFiles does not stack repeated failures, and clears on success', async () => {
   const { window, document, api } = load('<!DOCTYPE html><body><form><textarea></textarea></form></body>')
   const ta = document.querySelector('textarea')


### PR DESCRIPTION
## What

Adds a keyboard-reachable **attach photo** button to the entry form and the edit form. Tapping it opens the OS file picker — on iOS and Android that offers *Take Photo*, *Photo Library* and *Choose File* natively, so a phone author can insert or shoot a photo without a detour through another app or the clipboard.

## How

- New `attach_image_control(string $id): string` helper in `src/theme.php`, rendered in both editors (`the_entry_form()` and `parts/edit.php`) with distinct ids.
- The `change` handler in `upload-image.js` reuses the existing `handleFiles()` path, so **nothing changes in `src/response/upload.php`**. Drag-drop and paste are untouched.
- The file `<input>` carries **no `name`**, so it is never submitted with the post — uploads go over `fetch('/upload')`. A unit test pins this so a regression that adds `name` is caught.
- Visually hidden but keyboard-focusable input with a `<label for>` button (≥44px tap target) in both the 2024 and 2026 themes.
- `accept="image/*,video/*"` (generic wildcards) so Safari transcodes iPhone HEIC to JPEG; specific types make it hand over raw HEIC, which the server allowlist refuses. A rejected type still surfaces the endpoint's own message in the existing `.flash.upload-error` notice.

## Tests

- `tests/js/upload-image.test.mjs` — change handler: single file, multiple files (separate `imageFiles[]` entries), value reset so the same file re-fires.
- `tests/Unit/ThemeAssetsTest.php` — markup carries `type=file`/`multiple`/`accept`, label `for` matches the input id, and **no `name`**.
- `pnpm test` 40/40; `codecept run Unit` 2190 green; phpcs + phpstan (level 8) clean.

## Needs a real-device check before merge

The HEIC→JPEG transcode is iOS Safari's own behaviour and can't be verified in CI. Worth confirming on a real iPhone that a photo picked from the library uploads and inserts before merging.

Closes #793