### PR TITLE
442: Generate srcset variants for uploaded images

### DIFF
--- a/src/LambDown.php
+++ b/src/LambDown.php
@@ -14,6 +14,21 @@ class LambDown extends Parsedown
     private $imageSizeResolver = null;
 
     /**
+     * Resolves an image `src` to its responsive `srcset` candidates, or null
+     * when there is nothing to offer a browser a choice between.
+     *
+     * @var (callable(string): (list<array{url: string, width: int}>|null))|null
+     */
+    private $srcsetResolver = null;
+
+    /**
+     * The default `sizes` value for an image carrying a `srcset` — the
+     * content column's rendered width in the 2026 theme (max-width ~44rem),
+     * full viewport width below that.
+     */
+    private const DEFAULT_SIZES = '(max-width: 700px) 100vw, 700px';
+
+    /**
      * The checked state of each checkbox the last text() call rendered, in
      * document order.
      *
@@ -264,6 +279,25 @@ class LambDown extends Parsedown
     }
 
     /**
+     * Supplies the lookup used to add a responsive `srcset`/`sizes` pair to
+     * images.
+     *
+     * Injected for the same reason as setImageSizeResolver(): the parser
+     * stays a pure string→string transform, and unit tests can pass a stub
+     * instead of writing real files. Callers wire in Response\asset_srcset();
+     * with no resolver set, or one returning fewer than two candidates, no
+     * srcset/sizes are emitted and the markup is unchanged.
+     *
+     * @param (callable(string): (list<array{url: string, width: int}>|null))|null $resolver
+     *        Receives an image `src`, returns an ordered list of ['url' => …, 'width' => …] or null.
+     * @return void
+     */
+    public function setSrcsetResolver(?callable $resolver): void
+    {
+        $this->srcsetResolver = $resolver;
+    }
+
+    /**
      * Inject lazy-loading attributes on every inline image so post bodies
      * with embedded screenshots do not block first paint on the homepage.
      *
@@ -291,7 +325,7 @@ class LambDown extends Parsedown
             return $image;
         }
 
-        $image['element']['attributes'] += $this->intrinsicDimensions($src) + [
+        $image['element']['attributes'] += $this->intrinsicDimensions($src) + $this->srcsetAttributes($src) + [
             'loading'  => 'lazy',
             'decoding' => 'async',
         ];
@@ -325,6 +359,35 @@ class LambDown extends Parsedown
         return [
             'width'  => (string) (int) $size[0],
             'height' => (string) (int) $size[1],
+        ];
+    }
+
+    /**
+     * The `srcset`/`sizes` attributes for an image, or none when its resolver
+     * is unset or yields fewer than two candidates to choose between.
+     *
+     * @param string $src The image's `src` attribute.
+     * @return array<string, string> `srcset`/`sizes`, or an empty array.
+     */
+    private function srcsetAttributes(string $src): array
+    {
+        if ($this->srcsetResolver === null) {
+            return [];
+        }
+
+        $candidates = ($this->srcsetResolver)($src);
+        if ($candidates === null || count($candidates) < 2) {
+            return [];
+        }
+
+        $srcset = implode(', ', array_map(
+            static fn(array $c): string => sprintf('%s %dw', $c['url'], $c['width']),
+            $candidates
+        ));
+
+        return [
+            'srcset' => $srcset,
+            'sizes'  => self::DEFAULT_SIZES,
         ];
     }
 

--- a/src/lamb.php
+++ b/src/lamb.php
@@ -510,6 +510,9 @@ function render_body(string $body): string
     // lazily-loaded image. Resolved once here, at parse time, and cached in
     // `transformed` — not per request.
     $parser->setImageSizeResolver(Response\asset_dimensions(...));
+    // Stamp a responsive srcset/sizes on the same images, so the browser can
+    // pick a smaller variant instead of always downloading the full-size WebP.
+    $parser->setSrcsetResolver(Response\asset_srcset(...));
 
     return $parser->text(trim($content));
 }

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -274,6 +274,60 @@ function should_convert_to_webp(?string $ext, ?bool $gd_available = null): bool
 }
 
 /**
+ * The longest-edge widths generated as WebP variants alongside the main
+ * asset, for responsive `srcset` (#442).
+ *
+ * The single source of truth for both generation (store_webp_variants(), the
+ * two convert_to_webp*() callers below) and render-time reconstruction
+ * (asset_srcset()): the resolver only has the main asset's URL to work from,
+ * so it must guess the variant filenames rather than look them up, and both
+ * ends of that guess have to agree.
+ *
+ * @return list<int> Longest-edge widths, narrowest first.
+ */
+function webp_variant_widths(): array
+{
+    return [800, 1200];
+}
+
+/**
+ * Generates "$seed-$width.webp" variants beside an already-written main WebP
+ * asset, for every width in webp_variant_widths() narrower than the source's
+ * longest edge (no upscaling, and no duplicate of the full-size main asset).
+ *
+ * $encode abstracts over the two source shapes callers have (a file path vs.
+ * bytes already in memory) so this one loop drives both: store_webp_copy()
+ * binds it to convert_to_webp($src_path, ...), persist_image_bytes() to
+ * convert_to_webp_from_bytes($bytes, ...) — reusing each encoder's own
+ * decompression-bomb guard rather than re-implementing the resize here.
+ *
+ * Best-effort: the main asset already succeeded by the time this runs, so a
+ * variant that fails to encode is skipped silently instead of failing the
+ * whole upload.
+ *
+ * ponytail: each variant re-decodes the source from scratch (one decode per
+ * width) rather than resampling once from a shared decoded buffer. Fine at
+ * upload-time volume; decode-once-resample-thrice is the upgrade if upload
+ * latency ever becomes a complaint.
+ *
+ * @param callable(string, int): bool $encode       fn(string $dest_path, int $max_dimension): bool,
+ *                                                   bound to the caller's source.
+ * @param int                         $longest_edge The source's longest edge, in pixels.
+ * @param string                      $dest_dir     Destination directory (no trailing slash).
+ * @param string                      $seed         The hashed base filename (without extension).
+ * @return void
+ */
+function store_webp_variants(callable $encode, int $longest_edge, string $dest_dir, string $seed): void
+{
+    foreach (webp_variant_widths() as $width) {
+        if ($width >= $longest_edge) {
+            continue;
+        }
+        $encode(sprintf('%s/%s-%d.webp', $dest_dir, $seed, $width), $width);
+    }
+}
+
+/**
  * Persists raw image bytes under $dest_dir, preferring a WebP re-encode and
  * falling back to the original bytes when conversion isn't possible.
  *
@@ -304,6 +358,17 @@ function persist_image_bytes(string $bytes, string $ext, string $dest_dir, strin
     if (should_convert_to_webp($ext)) {
         $webp_fn = $seed . '.webp';
         if (convert_to_webp_from_bytes($bytes, "$dest_dir/$webp_fn")) {
+            $size = @getimagesizefromstring($bytes);
+            if (is_array($size) && $size[0] > 0 && $size[1] > 0) {
+                store_webp_variants(
+                    static fn(string $dest_path, int $max): bool =>
+                        convert_to_webp_from_bytes($bytes, $dest_path, max_dimension: $max),
+                    max($size[0], $size[1]),
+                    $dest_dir,
+                    $seed
+                );
+            }
+
             return $webp_fn;
         }
     }
@@ -355,11 +420,22 @@ function store_webp_copy(string $src_path, string $ext, string $dest_dir, string
     }
 
     $webp_fn = $seed . '.webp';
-    if (convert_to_webp($src_path, sprintf('%s/%s', $dest_dir, $webp_fn))) {
-        return $webp_fn;
+    if (!convert_to_webp($src_path, sprintf('%s/%s', $dest_dir, $webp_fn))) {
+        return null;
     }
 
-    return null;
+    $size = @getimagesize($src_path);
+    if (is_array($size) && $size[0] > 0 && $size[1] > 0) {
+        store_webp_variants(
+            static fn(string $dest_path, int $max): bool =>
+                convert_to_webp($src_path, $dest_path, max_dimension: $max),
+            max($size[0], $size[1]),
+            $dest_dir,
+            $seed
+        );
+    }
+
+    return $webp_fn;
 }
 
 /**
@@ -690,4 +766,79 @@ function asset_dimensions(string $url): ?array
     }
 
     return [(int) $size[0], (int) $size[1]];
+}
+
+/**
+ * The responsive `srcset` candidates for a locally stored WebP asset, given
+ * the URL a post body points at: the original plus any generated variants
+ * (see webp_variant_widths(), store_webp_variants()), each measured for its
+ * true width — or null when there are fewer than two to choose between.
+ *
+ * The counterpart to asset_dimensions(): reuses the exact same scheme/host
+ * rejection and realpath() containment check on every candidate before it is
+ * touched, since a variant's filename is built by string-editing an
+ * attacker-writable post-body URL rather than looked up from a manifest.
+ *
+ * Widths are never read off the filename: with longest-edge scaling, a
+ * portrait source's "-800" variant measures narrower than 800px once
+ * decoded, so only getimagesize() on the actual file is trustworthy.
+ *
+ * @param string $url The `src` from a post body's Markdown image.
+ * @return list<array{url: string, width: int}>|null Ordered narrowest-first, or null.
+ */
+function asset_srcset(string $url): ?array
+{
+    if (!defined('ROOT_DIR')) {
+        return null;
+    }
+    $parts = parse_url($url);
+    if ($parts === false || isset($parts['scheme']) || isset($parts['host'])) {
+        return null;
+    }
+    $path = $parts['path'] ?? '';
+    if (!str_starts_with($path, '/assets/') || !str_ends_with($path, '.webp')) {
+        return null;
+    }
+
+    $assets_root = realpath(ROOT_DIR . '/assets');
+    $file = realpath(ROOT_DIR . rawurldecode($path));
+    if ($assets_root === false || $file === false) {
+        return null;
+    }
+    if (!str_starts_with($file, $assets_root . DIRECTORY_SEPARATOR)) {
+        return null;
+    }
+
+    $seed = basename($file, '.webp');
+    $dir = dirname($file);
+    $candidates = [$path => $file];
+    foreach (webp_variant_widths() as $width) {
+        $variant_path = dirname($path) . sprintf('/%s-%d.webp', $seed, $width);
+        $candidates[$variant_path] = sprintf('%s/%s-%d.webp', $dir, $seed, $width);
+    }
+
+    $srcset = [];
+    foreach ($candidates as $candidate_path => $candidate_file) {
+        // Re-contain every candidate individually: the main asset's path was
+        // already proven safe above, but a symlink swapped in between calls
+        // (or one variant name colliding with something outside assets/)
+        // must not get a free pass from the sibling check.
+        $real = realpath($candidate_file);
+        if ($real === false || !str_starts_with($real, $assets_root . DIRECTORY_SEPARATOR)) {
+            continue;
+        }
+        $size = @getimagesize($real);
+        if (!is_array($size) || (int) $size[0] <= 0) {
+            continue;
+        }
+        $srcset[] = ['url' => $candidate_path, 'width' => (int) $size[0]];
+    }
+
+    if (count($srcset) < 2) {
+        return null;
+    }
+
+    usort($srcset, static fn(array $a, array $b): int => $a['width'] <=> $b['width']);
+
+    return $srcset;
 }

--- a/tests/Unit/LambDownTest.php
+++ b/tests/Unit/LambDownTest.php
@@ -277,4 +277,52 @@ class LambDownTest extends TestCase
         $this->assertFalse($called);
         $this->assertStringNotContainsString('width=', $html);
     }
+
+    public function testImageGetsSrcsetFromResolver(): void
+    {
+        $this->parser->setSrcsetResolver(static fn(string $src): array => [
+            ['url' => '/assets/2026/07/photo-800.webp', 'width' => 800],
+            ['url' => '/assets/2026/07/photo.webp', 'width' => 1600],
+        ]);
+
+        $html = $this->parser->text('![photo](/assets/2026/07/photo.webp)');
+        $this->assertStringContainsString(
+            'srcset="/assets/2026/07/photo-800.webp 800w, /assets/2026/07/photo.webp 1600w"',
+            $html
+        );
+        $this->assertStringContainsString('sizes="(max-width: 700px) 100vw, 700px"', $html);
+    }
+
+    public function testImageWithoutSrcsetResolverHasNoSrcset(): void
+    {
+        $html = $this->parser->text('![photo](/assets/2026/07/photo.webp)');
+        $this->assertStringNotContainsString('srcset=', $html);
+        $this->assertStringNotContainsString('sizes=', $html);
+    }
+
+    public function testSrcsetResolverReturningNullOmitsSrcset(): void
+    {
+        // Fewer than two candidates (or an unresolvable src) must render exactly
+        // as before, not with a single-source srcset.
+        $this->parser->setSrcsetResolver(static fn(string $src): ?array => null);
+
+        $html = $this->parser->text('![photo](/assets/2026/07/photo.webp)');
+        $this->assertStringNotContainsString('srcset=', $html);
+    }
+
+    public function testVideoIsNotPassedToSrcsetResolver(): void
+    {
+        $called = false;
+        $this->parser->setSrcsetResolver(static function (string $src) use (&$called): ?array {
+            $called = true;
+            return [
+                ['url' => '/a-800.webp', 'width' => 800],
+                ['url' => '/a.webp', 'width' => 1600],
+            ];
+        });
+
+        $html = $this->parser->text('![clip](/assets/2026/07/clip.mp4)');
+        $this->assertFalse($called);
+        $this->assertStringNotContainsString('srcset=', $html);
+    }
 }

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 use function Lamb\Response\accept_upload_batch;
 use function Lamb\Response\asset_dimensions;
+use function Lamb\Response\asset_srcset;
 use function Lamb\Response\asset_url;
 use function Lamb\Response\convert_to_webp;
 use function Lamb\Response\convert_to_webp_from_bytes;
@@ -13,6 +14,7 @@ use function Lamb\Response\get_upload_dir;
 use function Lamb\Response\image_decoder_for_type;
 use function Lamb\Response\max_upload_pixels;
 use function Lamb\Response\normalize_uploaded_files;
+use function Lamb\Response\persist_image_bytes;
 use function Lamb\Response\safe_upload_extension;
 use function Lamb\Response\upload_subpath;
 use function Lamb\Response\scaled_dimensions;
@@ -611,6 +613,75 @@ class UploadTest extends TestCase
         $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash.jpg');
     }
 
+    // store_webp_variants (via store_webp_copy/persist_image_bytes) — responsive
+    // srcset variants generated alongside the main WebP asset (#442).
+    // webp_variant_widths() ([800, 1200]) is the single source of truth for both
+    // generation here and reconstruction in asset_srcset().
+
+    public function testStoreWebpCopyGeneratesVariantsForOversizedSource(): void
+    {
+        $src = $this->makePng(2000, 1000);
+
+        $result = store_webp_copy($src, 'png', $this->tempRootDir, 'seedhash');
+
+        $this->assertSame('seedhash.webp', $result);
+        $this->assertFileExists($this->tempRootDir . '/seedhash-800.webp');
+        $this->assertFileExists($this->tempRootDir . '/seedhash-1200.webp');
+
+        [$w800] = getimagesize($this->tempRootDir . '/seedhash-800.webp');
+        [$w1200] = getimagesize($this->tempRootDir . '/seedhash-1200.webp');
+        [$wMain] = getimagesize($this->tempRootDir . '/seedhash.webp');
+
+        $this->assertSame(800, $w800);
+        $this->assertSame(1200, $w1200);
+        $this->assertLessThan($wMain, $w1200);
+    }
+
+    public function testPersistImageBytesGeneratesVariantsForOversizedSource(): void
+    {
+        $src = $this->makePng(2000, 1000);
+        $bytes = (string) file_get_contents($src);
+
+        $result = persist_image_bytes($bytes, 'png', $this->tempRootDir, 'seedhash2');
+
+        $this->assertSame('seedhash2.webp', $result);
+        $this->assertFileExists($this->tempRootDir . '/seedhash2-800.webp');
+        $this->assertFileExists($this->tempRootDir . '/seedhash2-1200.webp');
+    }
+
+    public function testStoreWebpCopySkipsVariantsForSmallSource(): void
+    {
+        // Longest edge (40px) is below both variant widths: no upscale.
+        $src = $this->makePng(40, 30);
+
+        store_webp_copy($src, 'png', $this->tempRootDir, 'seedhash3');
+
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash3-800.webp');
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash3-1200.webp');
+    }
+
+    public function testStoreWebpCopyGeneratesOnlySmallerVariantForMidSizedSource(): void
+    {
+        // Longest edge (1000px) clears 800 but not 1200.
+        $src = $this->makePng(1000, 600);
+
+        store_webp_copy($src, 'png', $this->tempRootDir, 'seedhash4');
+
+        $this->assertFileExists($this->tempRootDir . '/seedhash4-800.webp');
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash4-1200.webp');
+    }
+
+    public function testStoreWebpCopyWritesNoVariantsForNonConvertedType(): void
+    {
+        $src = $this->makePng(2000, 1000);
+
+        $result = store_webp_copy($src, 'gif', $this->tempRootDir, 'seedhash5');
+
+        $this->assertNull($result);
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash5-800.webp');
+        $this->assertFileDoesNotExist($this->tempRootDir . '/seedhash5-1200.webp');
+    }
+
     // asset_dimensions — pixel size of a locally stored asset, for intrinsic
     // width/height attributes on rendered <img> tags.
 
@@ -683,6 +754,74 @@ class UploadTest extends TestCase
         imagefill($im, 0, 0, imagecolorallocate($im, 10, 120, 200));
         imagepng($im, $path);
         imagedestroy($im);
+    }
+
+    // asset_srcset — the responsive srcset candidates for a locally stored WebP
+    // asset: the original plus any generated variants, each measured for its
+    // true width (never trusted from the filename — see webp_variant_widths()).
+
+    public function testAssetSrcsetReturnsOriginalAndVariantsOrderedByWidth(): void
+    {
+        $sub_path = upload_subpath();
+        $dir = get_upload_dir($sub_path);
+        $src = $this->makePng(2000, 1000);
+        $seed = 'srcset_' . uniqid();
+
+        store_webp_copy($src, 'png', $dir, $seed);
+
+        $srcset = asset_srcset(asset_url($sub_path, "$seed.webp"));
+
+        $this->assertNotNull($srcset);
+        $this->assertSame([800, 1200, 1600], array_column($srcset, 'width'));
+        $this->assertSame(asset_url($sub_path, "$seed-800.webp"), $srcset[0]['url']);
+        $this->assertSame(asset_url($sub_path, "$seed-1200.webp"), $srcset[1]['url']);
+        $this->assertSame(asset_url($sub_path, "$seed.webp"), $srcset[2]['url']);
+
+        @unlink("$dir/$seed.webp");
+        @unlink("$dir/$seed-800.webp");
+        @unlink("$dir/$seed-1200.webp");
+    }
+
+    public function testAssetSrcsetReturnsNullWhenNoVariantsExist(): void
+    {
+        $sub_path = upload_subpath();
+        $dir = get_upload_dir($sub_path);
+        $src = $this->makePng(40, 30);
+        $seed = 'nosrcset_' . uniqid();
+
+        store_webp_copy($src, 'png', $dir, $seed);
+
+        $this->assertNull(asset_srcset(asset_url($sub_path, "$seed.webp")));
+
+        @unlink("$dir/$seed.webp");
+    }
+
+    public function testAssetSrcsetReturnsNullForNonWebpAsset(): void
+    {
+        $sub_path = upload_subpath();
+        $dir = get_upload_dir($sub_path);
+        $filename = 'notwebp_' . uniqid() . '.png';
+        $this->writePng("$dir/$filename", 640, 480);
+
+        $this->assertNull(asset_srcset(asset_url($sub_path, $filename)));
+
+        @unlink("$dir/$filename");
+    }
+
+    public function testAssetSrcsetReturnsNullForARemoteUrl(): void
+    {
+        $this->assertNull(asset_srcset('https://example.com/assets/2026/07/photo.webp'));
+        $this->assertNull(asset_srcset('//example.com/assets/2026/07/photo.webp'));
+    }
+
+    public function testAssetSrcsetReturnsNullForPathTraversal(): void
+    {
+        $this->assertNull(asset_srcset('/assets/../../../etc/passwd'));
+        $this->assertNull(asset_srcset('/assets/%2e%2e/%2e%2e/etc/passwd'));
+        // A .webp suffix passes the extension gate, so this exercises the
+        // realpath() containment check rather than the early ext reject.
+        $this->assertNull(asset_srcset('/assets/../../../etc/passwd.webp'));
+        $this->assertNull(asset_srcset('/assets/../../secret.webp'));
     }
 
     // accept_upload_batch — the whole batch is judged before anything is stored


### PR DESCRIPTION
## What

Uploads were re-encoded to a single 1600px WebP, so phones downloaded the full-size image and the rendered markup carried no `srcset`/`sizes`. This generates smaller WebP variants on upload and emits a responsive `srcset` at render time.

## How

**On upload** (`src/response/upload.php`):
- `webp_variant_widths()` → `[800, 1200]` (one source of truth for generation and render).
- `store_webp_variants()` writes `<seed>-800.webp` / `<seed>-1200.webp` beside the main `<seed>.webp`, wired into both upload source shapes — file path (`store_webp_copy`) and in-memory bytes (`persist_image_bytes`), covering web upload, the Micropub media endpoint, inline Micropub photos and WordPress import.
- Skips a width that is **not smaller** than the source (no upscaling, no duplicate full-size), and is a no-op for types the pipeline doesn't convert (GIF/AVIF/already-WebP/small images). Best-effort: a failed variant is skipped and never blocks publishing.

**At render** (`src/LambDown.php`, wired in `src/lamb.php`):
- `asset_srcset()` reconstructs the set from a known `/assets/…/<seed>.webp` URL by deterministic naming — no manifest, no DB. Every candidate path is contained with the same `realpath()` + prefix check `asset_dimensions()` uses **before** any read, and each file's **real** width is measured with `getimagesize()` (portrait variants are narrower than their target edge).
- A srcset resolver mirroring the existing image-size resolver adds `srcset` + a default `sizes` of `(max-width: 700px) 100vw, 700px` to `<img>`. `<video>` never gets `srcset`. Images without variants (all existing posts, non-WebP) render byte-identical to before.

## Security

`asset_srcset()` string-edits an attacker-controllable post-body URL into candidate filenames, so containment is critical. Each candidate (main + variants) is independently `realpath()`'d and checked against the assets root before `getimagesize()`, exactly as `asset_dimensions()` does. Reviewed at opus (upload.php is a trust boundary); traversal test covers both non-`.webp` and `.webp`-suffixed escape attempts.

## Tests

Red-green TDD: variant files at each threshold (40px → none, 1000px → 800 only, 2000px → both), non-converted-type no-op, `asset_srcset()` happy path + null cases (no variants / non-webp / remote / traversal), `<img>` gets `srcset` and `<video>` doesn't. `codecept run Unit` 2200 green; phpcs + phpstan (level 8, baseline untouched) clean.

## Known ceiling

Each variant re-decodes the source (one decode per width) rather than resampling from a shared buffer — fine at upload volume; `ponytail:` comment names the decode-once-resample-thrice upgrade. No backfill of existing posts (out of scope).

Closes #442