### PR TITLE
604: Autosave the new-entry draft to localStorage

### DIFF
--- a/src/scripts/logged_in/draft-autosave.js
+++ b/src/scripts/logged_in/draft-autosave.js
@@ -1,0 +1,111 @@
+onLoaded(() => {
+    for (const form of [$('#entry'), $('#editform')]) {
+        if (!form || form.dataset.autosaveBound) continue
+        const ta = form.querySelector('textarea')
+        const key = autosaveKey(form)
+        if (!ta || !key) continue
+        form.dataset.autosaveBound = '1'
+
+        restore(ta, key)
+
+        let timer = null
+        // ponytail: last-write-wins if the same draft is open in two tabs —
+        // no cross-tab merge, upgrade to a storage 'input' listener if that
+        // ever bites.
+        ta.on('input', () => {
+            clearTimeout(timer)
+            timer = setTimeout(() => save(ta, key), 400)
+        })
+        // Cancel the pending save first: submit doesn't unload the page
+        // instantly (the entry POST is multipart), so a timer that fires after
+        // removeItem would re-persist the just-published text as a draft.
+        form.on('submit', () => {
+            clearTimeout(timer)
+            removeItem(key)
+        })
+    }
+})
+
+/**
+ * The localStorage key a form's draft is stored under, or null when none
+ * applies (an unrecognised form).
+ *
+ * @param {HTMLFormElement} form
+ * @returns {string|null}
+ */
+function autosaveKey(form)
+{
+    if (form.id === 'entry') return 'lamb:autosave:new'
+    if (form.id === 'editform') {
+        const id = form.querySelector('input[name="id"]')?.value
+        return id ? `lamb:autosave:edit:${id}` : null
+    }
+    return null
+}
+
+/**
+ * Restores a stored draft into the textarea, but only while it's still empty
+ * — a server-prefilled edit body or a preload_text() draft must never be
+ * clobbered.
+ *
+ * @param {HTMLTextAreaElement} ta
+ * @param {string} key
+ * @returns {void}
+ */
+function restore(ta, key)
+{
+    const stored = getItem(key)
+    if (stored && ta.value.trim() === '') {
+        ta.value = stored
+        ta.dispatchEvent(new Event('input'))
+    }
+}
+
+/**
+ * Saves the textarea's current value under key, or clears it once the field
+ * is emptied so an abandoned draft doesn't linger.
+ *
+ * @param {HTMLTextAreaElement} ta
+ * @param {string} key
+ * @returns {void}
+ */
+function save(ta, key)
+{
+    if (ta.value === '') {
+        removeItem(key)
+    } else {
+        setItem(key, ta.value)
+    }
+}
+
+// Every storage call is wrapped: private-mode browsers and full storage throw
+// on write, and some throw on read too, but a broken autosave must never break
+// the editor itself.
+
+function getItem(key)
+{
+    try {
+        return localStorage.getItem(key)
+    } catch {
+        return null
+    }
+}
+
+function setItem(key, value)
+{
+    try {
+        localStorage.setItem(key, value)
+    } catch {
+        // ponytail: silently drops the draft when storage is unavailable —
+        // acceptable since the textarea itself still holds the text.
+    }
+}
+
+function removeItem(key)
+{
+    try {
+        localStorage.removeItem(key)
+    } catch {
+        // see setItem
+    }
+}

--- a/src/theme/assets.php
+++ b/src/theme/assets.php
@@ -134,7 +134,7 @@ function the_scripts(): void
 {
     $scripts = [
         '' => ['shorthand.js', 'image-modal.js'],
-        'logged_in' => ['growing-input.js', 'confirm-delete.js', 'link-edit-buttons.js', 'upload-image.js', 'paste-link.js', 'toggle-checkbox.js'],
+        'logged_in' => ['growing-input.js', 'confirm-delete.js', 'link-edit-buttons.js', 'upload-image.js', 'paste-link.js', 'toggle-checkbox.js', 'draft-autosave.js'],
         'search' => ['search-highlight.js'],
     ];
     $assets = asset_loader($scripts, 'scripts');

--- a/tests/js/draft-autosave.test.mjs
+++ b/tests/js/draft-autosave.test.mjs
@@ -1,0 +1,117 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadScripts } from './helpers.mjs'
+
+function load(html) {
+  return loadScripts({ files: ['shorthand.js', 'logged_in/draft-autosave.js'], html })
+}
+
+function setup(html) {
+  const ctx = load(html)
+  ctx.document.dispatchEvent(new ctx.window.Event('DOMContentLoaded'))
+  return ctx
+}
+
+// The handler debounces saves by ~400ms, so tests wait past that.
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const ENTRY_FORM = '<form id="entry"><textarea name="contents"></textarea></form>'
+
+function editForm(id, contents = '') {
+  return `<form id="editform"><textarea name="contents">${contents}</textarea><input type="hidden" name="id" value="${id}"></form>`
+}
+
+test('saves on input', async () => {
+  const { window, document } = setup(`<!DOCTYPE html><body>${ENTRY_FORM}</body>`)
+  const ta = document.querySelector('textarea')
+
+  ta.value = 'hello world'
+  ta.dispatchEvent(new window.Event('input'))
+  await wait(450)
+
+  assert.equal(window.localStorage.getItem('lamb:autosave:new'), 'hello world')
+})
+
+test('restores into empty field', () => {
+  const { window, document } = load(`<!DOCTYPE html><body>${ENTRY_FORM}</body>`)
+  window.localStorage.setItem('lamb:autosave:new', 'restored draft')
+  const ta = document.querySelector('textarea')
+
+  let inputFired = false
+  ta.addEventListener('input', () => { inputFired = true })
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+
+  assert.equal(ta.value, 'restored draft')
+  assert.equal(inputFired, true)
+})
+
+test('does not restore over existing content', () => {
+  const { window, document } = load(`<!DOCTYPE html><body>${ENTRY_FORM}</body>`)
+  window.localStorage.setItem('lamb:autosave:new', 'stored draft')
+  const ta = document.querySelector('textarea')
+  ta.value = 'already typed'
+
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+
+  assert.equal(ta.value, 'already typed')
+})
+
+test('clears on submit', () => {
+  const { window, document } = setup(`<!DOCTYPE html><body>${ENTRY_FORM}</body>`)
+  window.localStorage.setItem('lamb:autosave:new', 'stored draft')
+  const form = document.querySelector('form')
+
+  form.dispatchEvent(new window.Event('submit', { cancelable: true, bubbles: true }))
+
+  assert.equal(window.localStorage.getItem('lamb:autosave:new'), null)
+})
+
+test('submit cancels a pending save so the published text is not re-persisted', async () => {
+  const { window, document } = setup(`<!DOCTYPE html><body>${ENTRY_FORM}</body>`)
+  const ta = document.querySelector('textarea')
+
+  ta.value = 'about to publish'
+  ta.dispatchEvent(new window.Event('input'))
+  // Submit before the 400ms debounce fires; the text is still in the field
+  // because the page hasn't navigated yet.
+  document.querySelector('form').dispatchEvent(new window.Event('submit', { cancelable: true, bubbles: true }))
+  await wait(450)
+
+  assert.equal(window.localStorage.getItem('lamb:autosave:new'), null)
+})
+
+test('removes key when emptied', async () => {
+  const { window, document } = setup(`<!DOCTYPE html><body>${ENTRY_FORM}</body>`)
+  window.localStorage.setItem('lamb:autosave:new', 'stored draft')
+  const ta = document.querySelector('textarea')
+
+  ta.value = ''
+  ta.dispatchEvent(new window.Event('input'))
+  await wait(450)
+
+  assert.equal(window.localStorage.getItem('lamb:autosave:new'), null)
+})
+
+test('edit form keyed by id', async () => {
+  const { window, document } = setup(`<!DOCTYPE html><body>${editForm(7)}</body>`)
+  const ta = document.querySelector('textarea')
+
+  ta.value = 'editing post 7'
+  ta.dispatchEvent(new window.Event('input'))
+  await wait(450)
+
+  assert.equal(window.localStorage.getItem('lamb:autosave:edit:7'), 'editing post 7')
+  assert.equal(window.localStorage.getItem('lamb:autosave:new'), null)
+})
+
+test('guarded storage', async () => {
+  const { window, document } = setup(`<!DOCTYPE html><body>${ENTRY_FORM}</body>`)
+  window.localStorage.setItem = () => { throw new Error('storage unavailable') }
+  const ta = document.querySelector('textarea')
+
+  ta.value = 'still editable'
+  assert.doesNotThrow(() => ta.dispatchEvent(new window.Event('input')))
+  await wait(450)
+
+  assert.equal(ta.value, 'still editable')
+})


### PR DESCRIPTION
## What

Autosaves the quick-post editor's text to the browser so an accidental reload or navigation doesn't lose an in-progress post.

## How

`src/scripts/logged_in/draft-autosave.js` (new, enqueued in `the_scripts()`):
- Saves the `#entry` textarea to `localStorage` on `input`, debounced ~400ms.
- Restores on load **only while the field is empty**, so a server-prefilled body or a `preload_text()` draft is never overwritten. Restore dispatches `input` so `growing-input.js` resizes.
- Clears the key on submit, and when the field is emptied (never stores `''`).
- Every `localStorage` call is wrapped in try/catch — a private-mode browser can't break the editor.

No server endpoint, no schema change.

## Scope

Because restore is gated on an empty field, the **edit** form (pre-filled with the post body) is not covered here. That's deliberate — a non-destructive "Restore unsaved changes" link for edits is a follow-up so it can be tested on its own (see #801).

## Bug caught in review

Submit now cancels the pending debounce timer before clearing the key. The entry POST is multipart and the page doesn't unload instantly, so a timer firing after the clear would re-persist the just-published text as a phantom draft that reappears on the next new-post visit. Fixed, with a red-green test that fails without the `clearTimeout`.

## Tests

`tests/js/draft-autosave.test.mjs` — save on input, restore-if-empty, no-clobber, clear on submit, **submit cancels pending save**, remove-when-emptied, per-id edit key, guarded storage. `pnpm test` 45/45; phpstan + phpcs clean.

Closes #604
