### PR TITLE
801: Restore an unsaved edit draft via a non-destructive link

### DIFF
--- a/src/scripts/logged_in/draft-autosave.js
+++ b/src/scripts/logged_in/draft-autosave.js
@@ -6,7 +6,11 @@ onLoaded(() => {
         if (!ta || !key) continue
         form.dataset.autosaveBound = '1'
 
-        restore(ta, key)
+        if (form.id === 'editform') {
+            offerRestore(ta, key)
+        } else {
+            restore(ta, key)
+        }
 
         let timer = null
         // ponytail: last-write-wins if the same draft is open in two tabs —
@@ -59,6 +63,35 @@ function restore(ta, key)
         ta.value = stored
         ta.dispatchEvent(new Event('input'))
     }
+}
+
+/**
+ * On the edit form the textarea is pre-filled with the server's post body, so
+ * a stored draft can never be restored silently — the server body may be
+ * newer (the post was edited elsewhere) than a stale local draft. Instead,
+ * surface a link that lets the author pull the draft in explicitly.
+ *
+ * @param {HTMLTextAreaElement} ta
+ * @param {string} key
+ * @returns {void}
+ */
+function offerRestore(ta, key)
+{
+    const stored = getItem(key)
+    if (!stored || stored === ta.value) return
+
+    const link = document.createElement('a')
+    link.href = '#'
+    link.className = 'restore-draft'
+    link.textContent = 'Restore unsaved changes'
+    link.on('click', ev => {
+        cancel(ev)
+        ta.value = stored
+        ta.dispatchEvent(new Event('input'))
+        removeItem(key)
+        link.remove()
+    })
+    ta.after(link)
 }
 
 /**

--- a/tests/js/draft-autosave.test.mjs
+++ b/tests/js/draft-autosave.test.mjs
@@ -104,6 +104,70 @@ test('edit form keyed by id', async () => {
   assert.equal(window.localStorage.getItem('lamb:autosave:new'), null)
 })
 
+test('edit form shows a restore link when the draft differs from the body', () => {
+  const { window, document } = load(`<!DOCTYPE html><body>${editForm(7, 'server body')}</body>`)
+  window.localStorage.setItem('lamb:autosave:edit:7', 'unsaved local draft')
+
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+
+  const link = document.querySelector('.restore-draft')
+  assert.ok(link, 'expected a restore-draft link')
+  assert.equal(link.textContent, 'Restore unsaved changes')
+  assert.equal(document.querySelector('textarea').value, 'server body')
+})
+
+test('clicking the restore link swaps in the draft, fires input, clears storage, and removes itself', () => {
+  const { window, document } = load(`<!DOCTYPE html><body>${editForm(7, 'server body')}</body>`)
+  window.localStorage.setItem('lamb:autosave:edit:7', 'unsaved local draft')
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+  const ta = document.querySelector('textarea')
+
+  let inputFired = false
+  ta.addEventListener('input', () => { inputFired = true })
+  document.querySelector('.restore-draft').dispatchEvent(new window.Event('click', { cancelable: true, bubbles: true }))
+
+  assert.equal(ta.value, 'unsaved local draft')
+  assert.equal(inputFired, true)
+  assert.equal(window.localStorage.getItem('lamb:autosave:edit:7'), null)
+  assert.equal(document.querySelector('.restore-draft'), null)
+})
+
+test('edit form shows no restore link when the draft matches the body or is absent', () => {
+  const { window, document } = load(`<!DOCTYPE html><body>${editForm(7, 'server body')}</body>`)
+  window.localStorage.setItem('lamb:autosave:edit:7', 'server body')
+
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+  assert.equal(document.querySelector('.restore-draft'), null)
+
+  const { window: window2, document: document2 } = load(`<!DOCTYPE html><body>${editForm(9, 'server body')}</body>`)
+  document2.dispatchEvent(new window2.Event('DOMContentLoaded'))
+  assert.equal(document2.querySelector('.restore-draft'), null)
+})
+
+test('body with HTML-special characters round-trips, so an equal draft shows no link', () => {
+  // edit.php escapes the body with htmlspecialchars before it reaches the
+  // textarea; the DOM decodes it back, so a stored draft equal to the raw text
+  // must compare equal. Pins the round-trip against an escape() change.
+  const raw = 'tom & jerry <b> "quoted"'
+  const { window, document } = load(`<!DOCTYPE html><body>${editForm(7, 'tom &amp; jerry &lt;b&gt; &quot;quoted&quot;')}</body>`)
+  assert.equal(document.querySelector('textarea').value, raw)
+  window.localStorage.setItem('lamb:autosave:edit:7', raw)
+
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+
+  assert.equal(document.querySelector('.restore-draft'), null)
+})
+
+test('entry form never shows a restore link', () => {
+  const { window, document } = load(`<!DOCTYPE html><body>${ENTRY_FORM}</body>`)
+  window.localStorage.setItem('lamb:autosave:new', 'restored draft')
+
+  document.dispatchEvent(new window.Event('DOMContentLoaded'))
+
+  assert.equal(document.querySelector('.restore-draft'), null)
+  assert.equal(document.querySelector('textarea').value, 'restored draft')
+})
+
 test('guarded storage', async () => {
   const { window, document } = setup(`<!DOCTYPE html><body>${ENTRY_FORM}</body>`)
   window.localStorage.setItem = () => { throw new Error('storage unavailable') }


### PR DESCRIPTION
Follow-up to #604, split out so the interaction can be tested on its own.

> **Stacked on #604** — base is `604-autosave-drafts`, so the diff shows only the restore-link change. I'll retarget this to `main` once #604 (#800) merges.

## What

#604 autosaves the editor text but only restores into an **empty** field, so it never clobbers a server-prefilled body. That means the edit form — which is pre-filled — never surfaced a saved draft: an interrupted edit was stored but invisible.

This adds, on the edit form only, a **"Restore unsaved changes"** link when a stored draft exists and differs from the pre-filled body. Clicking it swaps in the draft, fires `input` (so `growing-input.js` resizes), clears the stored draft, and removes the link.

## Why a link, not silent restore

If the post was edited in another tab or on another device, the server body is newer than a stale local draft. Blindly restoring would overwrite the good version. The link makes restore a deliberate choice.

## How

- JS-only: the link is created and inserted with `ta.after(link)` — **no template or CSS change**. `edit.php` is untouched.
- The entry form keeps its existing restore-if-empty path; the link path is gated to `#editform`.
- Reuses #604's guarded `getItem`/`removeItem` and the shared `cancel(ev)` helper for the `href="#"` click.

## Tests

`tests/js/draft-autosave.test.mjs` — link shown when draft differs, absent when it matches or is missing, click restores + fires input + clears storage + removes the link, entry form never shows the link, and an **HTML-special-character body round-trips** so an equal draft shows no link (pins the entity decode against a future `escape()` change). `pnpm test` green.

Closes #801