### PR TITLE
Import renamed images by their bytes, not the URL extension

### DIFF
--- a/src/import.php
+++ b/src/import.php
@@ -697,6 +697,12 @@ function default_image_downloader(string $url, string $sub_path): ?string
     if (!response_is_image($response['headers'])) {
         return null;
     }
+    // Trust the bytes over the URL's extension: a WordPress media file renamed
+    // at the source (real PNG bytes under a `.jpg` name) would otherwise be
+    // rejected by persist_image_bytes()'s content-vs-extension gate and left
+    // remote. Fall back to the URL extension when the bytes don't sniff as a
+    // known image — persist_image_bytes() then rejects the mismatch as before.
+    $ext = \Lamb\Response\image_ext_for_bytes($response['body']) ?? $ext;
     return \Lamb\Response\persist_image_bytes($response['body'], $ext, $dest_dir, $seed);
 }
 

--- a/src/response/upload.php
+++ b/src/response/upload.php
@@ -252,6 +252,32 @@ function sniff_bytes_content_type(string $bytes): string|false
 }
 
 /**
+ * Maps raw image bytes to the canonical upload extension for their actual
+ * format, or null when the bytes aren't a recognised raster image.
+ *
+ * The import downloader trusts this over the URL's extension: WordPress media
+ * libraries routinely serve a renamed file (real PNG bytes under a `.jpg`
+ * name), which persist_image_bytes()'s content-vs-extension gate would
+ * otherwise reject, leaving the image remote. Sniffing the bytes and passing
+ * the matching extension keeps that gate at full strength — a scripted payload
+ * sniffs as text/html and maps to null, so it still fails downstream.
+ *
+ * @param string $bytes Raw image bytes, fully buffered in memory.
+ * @return string|null A lower-case extension from IMAGE_UPLOAD_EXTENSIONS, or null.
+ */
+function image_ext_for_bytes(string $bytes): ?string
+{
+    return match (sniff_bytes_content_type($bytes)) {
+        'image/jpeg' => 'jpg',
+        'image/png'  => 'png',
+        'image/gif'  => 'gif',
+        'image/webp' => 'webp',
+        'image/avif', 'image/heif', 'image/heic' => 'avif',
+        default => null,
+    };
+}
+
+/**
  * Whether an uploaded image of the given extension should be re-encoded to WebP.
  *
  * Only JPEG and PNG are converted: they are common, lossy/lossless raster formats

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -16,6 +16,7 @@ use function Lamb\Import\rewrite_image_links;
 use function Lamb\Import\sanitize_html;
 use function Lamb\Post\on;
 use function Lamb\Post\reset_subscribers;
+use function Lamb\Response\image_ext_for_bytes;
 use function Lamb\Response\persist_image_bytes;
 use function Lamb\Theme\link_source;
 use function Lamb\WordPress\extract_items;
@@ -1164,6 +1165,32 @@ XML;
         } finally {
             rmdir($dir);
         }
+    }
+
+    public function testImageExtForBytesReflectsActualFormatNotName(): void
+    {
+        // Regression: a WordPress media file renamed at the source — real PNG
+        // bytes served under a `.jpg` name (mime-type image/png in the WXR) —
+        // must be recognised by its bytes. Deriving the extension from the URL
+        // alone hands persist_image_bytes() a 'jpg' that its content gate
+        // rejects against the PNG bytes, leaving the image remote.
+        $png = imagecreatetruecolor(4, 4);
+        ob_start();
+        imagepng($png);
+        $pngBytes = (string) ob_get_clean();
+        imagedestroy($png);
+
+        $jpeg = imagecreatetruecolor(4, 4);
+        ob_start();
+        imagejpeg($jpeg);
+        $jpegBytes = (string) ob_get_clean();
+        imagedestroy($jpeg);
+
+        $this->assertSame('png', image_ext_for_bytes($pngBytes));
+        $this->assertSame('jpg', image_ext_for_bytes($jpegBytes));
+        // A scripted payload must not be mapped to any image extension, so the
+        // content gate still rejects it downstream.
+        $this->assertNull(image_ext_for_bytes('<html><script>alert(1)</script></html>'));
     }
 
     public function testDefaultImageDownloaderBlocksLoopbackDestination(): void


### PR DESCRIPTION
## Problem

Found during a real WordPress→Lamb import on puffin (vandragt.com): images inside Gutenberg gallery blocks weren't downloaded to `src/assets`, while standalone images were. The post body kept the remote URL.

## Root cause

Not the gallery structure or the byte/time cap. The failing image is a **file renamed at the source**: real PNG bytes served under a `.jpg` name (the WXR metadata even records `mime-type: image/png`). The gallery `<img>` carries `data-full-url="…04b96b86…559.jpg"`, so `pick_image_url()` correctly picks it — but `default_image_downloader()` derives `$ext='jpg'` from the URL path and hands that to `persist_image_bytes()`, whose content-vs-extension gate `upload_content_allowed('image/png', 'jpg')` correctly rejects the mismatch and returns `null`. The node is left remote. Standalone images downloaded because their bytes matched their names.

## Fix

The gate is a genuine trust boundary — it stops HTML/SVG landing under an image extension on the site's own origin — so it keeps full strength. Instead the **import boundary** now trusts the downloaded bytes over the URL's extension:

- New `image_ext_for_bytes()` sniffs the bytes and returns the canonical upload extension (`image/png` → `png`, …), or `null` when they aren't a recognised raster image.
- `default_image_downloader()` prefers that over the URL extension, falling back to the URL extension when sniffing yields no image type — so a scripted payload sniffs as `text/html`, maps to `null`, and still fails the gate downstream.

Since jpg/png both re-encode to WebP via `imagecreatefromstring()` (which detects format from the bytes regardless of the claimed extension), the promoted PNG now converts and lands in `src/assets`.

## Tests

Red-green: `testImageExtForBytesReflectsActualFormatNotName` covers PNG bytes → `png`, JPEG → `jpg`, and an HTML payload → `null` (still rejected). Full Unit (2205), Functional and Acceptance (96) suites pass; PHPStan level 8 and phpcs clean.

Reported by a peer session mid-import; this is the fix-forward they asked for.