### PR TITLE
Show one empty-state message on search, not two

### DIFF
--- a/src/theme.php
+++ b/src/theme.php
@@ -453,8 +453,13 @@ function render_post_list(bool $hide_author): void
     // PHP tag is part of the rendered HTML, so it cannot be re-indented for
     // being nested inside a function without changing the output.
     if (empty($data['posts'])) :
-        ?><p>Sorry no items found.</p>
+        // Search and tag pages set $data['intro'] ("No results found.") which
+        // already states the empty case; skip our own message then so the two
+        // don't double up.
+        if (empty($data['intro'])) :
+            ?><p>Sorry no items found.</p>
     <?php // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect -- leading whitespace here is literal output, preserved from the pre-extraction template
+        endif;
     else :
         // Wrap the list in <ul>/<li> only when there is more than one post, so a
         // single post renders as a bare <article>. Computed once; the menu-item

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -19,8 +19,13 @@ use function Lamb\Theme\the_reply_context;
 use function Lamb\Theme\title_link;
 
 if (empty($data['posts'])) :
-    ?><p>Sorry no items found.</p>
-    <?php
+    // Search and tag pages set $data['intro'] ("No results found.") which
+    // already states the empty case; only fall back to our own message when
+    // nothing else does, so the two don't double up.
+    if (empty($data['intro'])) :
+        ?><p>Sorry no items found.</p>
+        <?php
+    endif;
 else :
     foreach ($data['posts'] as $bean) :
         /** @var \RedBeanPHP\OODBBean $bean */

--- a/tests/Unit/EmptyListMessageTest.php
+++ b/tests/Unit/EmptyListMessageTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Search and tag pages set $data['intro'] ("No results found.") to state the
+ * empty case; the post-list renderers used to also print their own "Sorry no
+ * items found." fallback, so an empty search showed both. The fallback now
+ * only appears when nothing else states the empty case.
+ */
+class EmptyListMessageTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        global $data, $template;
+        $data = [];
+        $template = null;
+    }
+
+    private function renderPartial(array $dataArr): string
+    {
+        global $data, $template;
+        $data = $dataArr;
+        $template = 'search';
+
+        ob_start();
+        include dirname(__DIR__, 2) . '/src/themes/base/parts/_items.php';
+        return (string) ob_get_clean();
+    }
+
+    private function renderThemeList(array $dataArr): string
+    {
+        global $data, $template;
+        $data = $dataArr;
+        $template = 'search';
+
+        ob_start();
+        \Lamb\Theme\render_post_list(false);
+        return (string) ob_get_clean();
+    }
+
+    public function testPartialOmitsFallbackWhenIntroStatesEmptiness(): void
+    {
+        $html = $this->renderPartial(['posts' => [], 'intro' => 'No results found.']);
+        $this->assertStringNotContainsString('Sorry no items found.', $html);
+    }
+
+    public function testPartialKeepsFallbackWhenNoIntro(): void
+    {
+        $html = $this->renderPartial(['posts' => []]);
+        $this->assertStringContainsString('Sorry no items found.', $html);
+    }
+
+    public function testThemeListOmitsFallbackWhenIntroStatesEmptiness(): void
+    {
+        $html = $this->renderThemeList(['posts' => [], 'intro' => 'No results found.']);
+        $this->assertStringNotContainsString('Sorry no items found.', $html);
+    }
+
+    public function testThemeListKeepsFallbackWhenNoIntro(): void
+    {
+        $html = $this->renderThemeList(['posts' => []]);
+        $this->assertStringContainsString('Sorry no items found.', $html);
+    }
+}


### PR DESCRIPTION
## Problem

An empty search showed two stacked messages:

> Searched for "werwer"
>
> No results found.
>
> Sorry no items found.

## Cause

The search/tag response sets `$data['intro']` to "No results found." (`get_results()` in `src/response/feeds.php`), and the post-list renderer *also* prints its own "Sorry no items found." fallback whenever the list is empty. Both fire.

## Fix

Both post-list renderers — `render_post_list()` (2024/2026 themes) and the base theme's `_items.php` partial — now skip their fallback when `$data['intro']` already states the empty case. A plain listing that sets no intro still shows the fallback, so nothing loses its empty-state message.

## Tests

New `EmptyListMessageTest` covers both renderers, both directions (intro set → no fallback; no intro → fallback kept). Verified red-green. Full Unit suite (2209), PHPStan level 8 and phpcs all clean.