### PR TITLE
Surface an unwritable asset dir instead of a silent null on import

### DIFF
--- a/src/import.php
+++ b/src/import.php
@@ -672,7 +672,15 @@ function default_image_downloader(string $url, string $sub_path): ?string
         }
     }
     // 0755, not 0777: only the user running the import needs to write here.
-    if (!is_dir($dest_dir) && !mkdir($dest_dir, 0755, true) && !is_dir($dest_dir)) {
+    // @-silenced because the failure is handled explicitly just below with a
+    // clearer message; the native mkdir() warning would only duplicate it.
+    if (!is_dir($dest_dir) && !@mkdir($dest_dir, 0755, true) && !is_dir($dest_dir)) {
+        // Distinct from the fetch/validate failures below: a dest-dir that
+        // can't be created is almost always ownership/permissions (e.g. a
+        // web-server user importing into an assets/YYYY dir owned by someone
+        // else), which otherwise looks identical to a 404 or a bad image and
+        // leaves the source URL silently remote.
+        error_log(sprintf('import: cannot create asset directory %s (check ownership/permissions); leaving %s remote', $dest_dir, $url));
         return null;
     }
     // $url is embedded in the WXR file being imported — an untrusted export

--- a/src/theme.php
+++ b/src/theme.php
@@ -453,8 +453,13 @@ function render_post_list(bool $hide_author): void
     // PHP tag is part of the rendered HTML, so it cannot be re-indented for
     // being nested inside a function without changing the output.
     if (empty($data['posts'])) :
-        ?><p>Sorry no items found.</p>
+        // Search and tag pages set $data['intro'] ("No results found.") which
+        // already states the empty case; skip our own message then so the two
+        // don't double up.
+        if (empty($data['intro'])) :
+            ?><p>Sorry no items found.</p>
     <?php // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect -- leading whitespace here is literal output, preserved from the pre-extraction template
+        endif;
     else :
         // Wrap the list in <ul>/<li> only when there is more than one post, so a
         // single post renders as a bare <article>. Computed once; the menu-item

--- a/src/themes/base/parts/_items.php
+++ b/src/themes/base/parts/_items.php
@@ -19,8 +19,13 @@ use function Lamb\Theme\the_reply_context;
 use function Lamb\Theme\title_link;
 
 if (empty($data['posts'])) :
-    ?><p>Sorry no items found.</p>
-    <?php
+    // Search and tag pages set $data['intro'] ("No results found.") which
+    // already states the empty case; only fall back to our own message when
+    // nothing else does, so the two don't double up.
+    if (empty($data['intro'])) :
+        ?><p>Sorry no items found.</p>
+        <?php
+    endif;
 else :
     foreach ($data['posts'] as $bean) :
         /** @var \RedBeanPHP\OODBBean $bean */

--- a/tests/Unit/EmptyListMessageTest.php
+++ b/tests/Unit/EmptyListMessageTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Search and tag pages set $data['intro'] ("No results found.") to state the
+ * empty case; the post-list renderers used to also print their own "Sorry no
+ * items found." fallback, so an empty search showed both. The fallback now
+ * only appears when nothing else states the empty case.
+ */
+class EmptyListMessageTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        global $data, $template;
+        $data = [];
+        $template = null;
+    }
+
+    private function renderPartial(array $dataArr): string
+    {
+        global $data, $template;
+        $data = $dataArr;
+        $template = 'search';
+
+        ob_start();
+        include dirname(__DIR__, 2) . '/src/themes/base/parts/_items.php';
+        return (string) ob_get_clean();
+    }
+
+    private function renderThemeList(array $dataArr): string
+    {
+        global $data, $template;
+        $data = $dataArr;
+        $template = 'search';
+
+        ob_start();
+        \Lamb\Theme\render_post_list(false);
+        return (string) ob_get_clean();
+    }
+
+    public function testPartialOmitsFallbackWhenIntroStatesEmptiness(): void
+    {
+        $html = $this->renderPartial(['posts' => [], 'intro' => 'No results found.']);
+        $this->assertStringNotContainsString('Sorry no items found.', $html);
+    }
+
+    public function testPartialKeepsFallbackWhenNoIntro(): void
+    {
+        $html = $this->renderPartial(['posts' => []]);
+        $this->assertStringContainsString('Sorry no items found.', $html);
+    }
+
+    public function testThemeListOmitsFallbackWhenIntroStatesEmptiness(): void
+    {
+        $html = $this->renderThemeList(['posts' => [], 'intro' => 'No results found.']);
+        $this->assertStringNotContainsString('Sorry no items found.', $html);
+    }
+
+    public function testThemeListKeepsFallbackWhenNoIntro(): void
+    {
+        $html = $this->renderThemeList(['posts' => []]);
+        $this->assertStringContainsString('Sorry no items found.', $html);
+    }
+}

--- a/tests/Unit/WordPressImportTest.php
+++ b/tests/Unit/WordPressImportTest.php
@@ -1206,4 +1206,43 @@ XML;
         $this->assertNull(default_image_downloader('http://127.0.0.1/evil.jpg', '2024/03'));
         $this->assertNull(default_image_downloader('http://169.254.169.254/evil.png', '2024/03'));
     }
+
+    public function testDefaultImageDownloaderLogsWhenAssetDirCannotBeCreated(): void
+    {
+        // A dest-dir mkdir failure (e.g. assets/YYYY owned by another user and
+        // not group-writable) must not masquerade as a 404 or a bad image: it
+        // returns null like any other failure, but a permissions problem is
+        // invisible without a distinct signal. Force the failure deterministically
+        // — parent path component is a file, so mkdir fails for any user, root
+        // included — and assert the diagnostic reaches the log.
+        if (!defined('ROOT_DIR')) {
+            define('ROOT_DIR', sys_get_temp_dir() . '/lamb_wp_import_' . uniqid('', true));
+        }
+        $assets = ROOT_DIR . '/assets';
+        if (!is_dir($assets)) {
+            mkdir($assets, 0755, true);
+        }
+        // sub_path '9999/01' → parent ROOT_DIR/assets/9999; make that a FILE so
+        // creating the month dir under it can never succeed.
+        $blocker = "$assets/9999";
+        file_put_contents($blocker, 'not a directory');
+
+        $log = sys_get_temp_dir() . '/lamb_imglog_' . uniqid('', true);
+        $prev = ini_set('error_log', $log);
+        try {
+            $result = default_image_downloader('https://example.com/photo.jpg', '9999/01');
+            $this->assertNull($result);
+            $this->assertStringContainsString(
+                'asset directory',
+                (string) @file_get_contents($log),
+                'expected a dest-dir failure to be logged, not a silent null'
+            );
+        } finally {
+            if ($prev !== false) {
+                ini_set('error_log', $prev);
+            }
+            @unlink($blocker);
+            @unlink($log);
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`default_image_downloader()` returns `null` on any failure — a 404, a non-image body, *and* a dest-dir it can't create. That last case is almost always ownership/permissions (a web-server user importing into an `assets/YYYY` directory owned by another user, not group-writable), and it's invisible: the image is left silently remote and looks exactly like a failed fetch.

This actually cost about an hour of bisecting on a real vandragt.com import — one standalone image stayed remote while its siblings localised, and every check (URL, HTTP 200, `Content-Type: image/jpeg`, byte sniff, WebP conversion) passed. The cause was `assets/2020/` owned by the wrong user from an earlier import run, so `mkdir assets/2020/06` failed as `www-data`. A one-line signal there would have turned the hour into a grep.

## Fix

Log a distinct diagnostic naming the directory before returning `null`, so a permissions problem is greppable and no longer masquerades as a bad image. Behaviour is otherwise unchanged — the import still continues and leaves that one URL remote. The native `mkdir()` `E_WARNING` is `@`-silenced because it would only duplicate the clearer message.

## Test

`testDefaultImageDownloaderLogsWhenAssetDirCannotBeCreated` forces the failure deterministically — a parent path component is a file, so `mkdir` fails for any user, root included (CI-safe) — and asserts the diagnostic reaches the log. Verified red-green. Full Unit suite (2210), PHPStan level 8 and phpcs all clean.

Surfaced by a peer session debugging a real import; this is the fix-forward for the "silent null" they flagged.