### PR TITLE
Drop the ALTERs ensure_schema() made unreachable (#818)

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -124,13 +124,13 @@ function bootstrap_db(string $data_dir): void
     R::useWriterCache(true);
 
     ensure_schema();
-    ensure_post_columns();
+    migrate_post_table();
 
     // Frozen mode rejects a write to any column not declared in SCHEMA instead
     // of silently adding it (RedBeanPHP's default fluid behaviour) — a typo'd
     // or forgotten column becomes a thrown exception at write time rather than
     // a schema drift nobody notices. Must come after ensure_schema() and
-    // ensure_post_columns(), which are themselves schema changes and would be
+    // migrate_post_table(), which are themselves schema changes and would be
     // refused too.
     R::freeze(true);
 }
@@ -254,35 +254,23 @@ function ensure_schema(): void
 }
 
 /**
- * Ensures the post table has the columns introduced by the soft-delete, draft
- * and export-import features.
- * Safe to call on any DB: no-ops if the table or columns don't exist yet.
+ * Runs the post table's one-time row migrations, then indexes it.
+ *
+ * Must be called after ensure_schema(), which is what guarantees the table and
+ * every SCHEMA column exist. This used to add `deleted`, `draft` and
+ * `import_uuid` itself, back when it was bootstrap_db()'s only schema step;
+ * ensure_schema() now ALTER-adds every declared column ahead of it, so those
+ * three branches could no longer fire and the columns it reads are already the
+ * post-ALTER set.
  *
  * @return void
  */
-function ensure_post_columns(): void
+function migrate_post_table(): void
 {
-    $postTableExists = (bool) R::getCell("SELECT name FROM sqlite_master WHERE type='table' AND name='post'");
-    if (!$postTableExists) {
-        return;
-    }
     $columns = array_column(R::getAll('PRAGMA table_info(post)'), 'name');
-    if (!in_array('deleted', $columns, true)) {
-        R::exec('ALTER TABLE post ADD COLUMN deleted INTEGER');
-    }
-    if (!in_array('draft', $columns, true)) {
-        R::exec('ALTER TABLE post ADD COLUMN draft INTEGER');
-    }
-    if (!in_array('import_uuid', $columns, true)) {
-        R::exec('ALTER TABLE post ADD COLUMN import_uuid TEXT');
-    }
     backfill_post_version($columns);
     backfill_imported_post_identity($columns);
-    // The backfills above want the columns as they were; the indexes want them
-    // as they now are, so the three the ALTERs just guaranteed are folded back
-    // in — otherwise indexing `draft`/`deleted` would lag a boot behind the
-    // upgrade that added them.
-    ensure_post_indexes(array_merge($columns, ['deleted', 'draft', 'import_uuid']));
+    ensure_post_indexes($columns);
 }
 
 /**
@@ -361,12 +349,12 @@ function ensure_post_indexes(array $columns): void
  * behind it (up to PDO's 60-second busy timeout) instead of being served under
  * a shared read lock. The probe is a read, so it does not.
  *
- * Also skipped when the column does not exist yet: a `post` table predating it
- * has nothing to stamp, and naming it in an UPDATE is an error rather than a
- * no-op. Runs from ensure_post_columns(), which has already established that
- * the table exists and collected its columns.
+ * Skipped when the column is absent, so the function is safe to call against a
+ * `post` table predating it: naming a missing column in an UPDATE is an error
+ * rather than a no-op. ensure_schema() declares `version`, so the guard never
+ * fires under bootstrap_db() — it is what keeps this callable in isolation.
  *
- * @param list<string> $columns Column names as they were before the ALTERs above.
+ * @param list<string> $columns Column names of the post table.
  */
 function backfill_post_version(array $columns): void
 {
@@ -396,7 +384,7 @@ function backfill_post_version(array $columns): void
  * correct — but it probes with a SELECT first, because an UPDATE that matches
  * nothing still takes a write lock (see backfill_post_version()).
  *
- * @param list<string> $columns Column names as they were before this call.
+ * @param list<string> $columns Column names of the post table.
  */
 function backfill_imported_post_identity(array $columns): void
 {

--- a/tests/Unit/ImportIdentityBackfillTest.php
+++ b/tests/Unit/ImportIdentityBackfillTest.php
@@ -5,10 +5,10 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
-use function Lamb\Bootstrap\ensure_post_columns;
+use function Lamb\Bootstrap\migrate_post_table;
 
 /**
- * Covers the one-time migration in ensure_post_columns() that moves posts
+ * Covers the one-time migration in migrate_post_table() that moves posts
  * stamped by the old WordPress/Known importers off the feed columns and onto
  * import_uuid.
  *
@@ -27,7 +27,10 @@ class ImportIdentityBackfillTest extends TestCase
         R::nuke();
         R::exec(
             'CREATE TABLE post (id INTEGER PRIMARY KEY AUTOINCREMENT, body TEXT,'
-            . ' feed_name TEXT, feeditem_uuid TEXT, source_url TEXT)'
+            // import_uuid is the migration's destination: both its probe and its
+            // UPDATE name it. ensure_schema() declares it in production now that
+            // migrate_post_table() no longer ALTER-adds it itself.
+            . ' feed_name TEXT, feeditem_uuid TEXT, source_url TEXT, import_uuid TEXT)'
         );
     }
 
@@ -50,7 +53,7 @@ class ImportIdentityBackfillTest extends TestCase
     }
 
     /**
-     * The write statements a call to ensure_post_columns() issues.
+     * The write statements a call to migrate_post_table() issues.
      *
      * SQLite takes a write lock for an UPDATE even when no row matches it, and
      * writers serialise — so a migration that runs unconditionally makes every
@@ -65,7 +68,7 @@ class ImportIdentityBackfillTest extends TestCase
     {
         R::debug(true, \RedBeanPHP\Logger\RDefault::C_LOGGER_ARRAY);
         try {
-            ensure_post_columns();
+            migrate_post_table();
             $logs = R::getDatabaseAdapter()->getDatabase()->getLogger()->getLogs();
         } finally {
             R::debug(false);
@@ -81,7 +84,7 @@ class ImportIdentityBackfillTest extends TestCase
     {
         // Steady state: the columns exist and no row needs either migration.
         $this->insert('', '', null);
-        ensure_post_columns();
+        migrate_post_table();
 
         $this->assertSame([], $this->writesDuringEnsureColumns());
     }
@@ -89,7 +92,7 @@ class ImportIdentityBackfillTest extends TestCase
     public function testTheIdentityBackfillWritesOnlyWhenARowMatches(): void
     {
         $this->insert('wordpress', md5('wordpress-https://old.example/?p=1'), null);
-        ensure_post_columns();
+        migrate_post_table();
 
         // First call migrated the row; a second has nothing left to do.
         $this->assertSame([], $this->writesDuringEnsureColumns());
@@ -99,7 +102,7 @@ class ImportIdentityBackfillTest extends TestCase
     {
         // Settle the schema first: the ALTERs that add deleted/draft/import_uuid
         // are writes too, and they are not what this measures.
-        ensure_post_columns();
+        migrate_post_table();
         R::exec('ALTER TABLE post ADD COLUMN version INTEGER');
         R::exec("INSERT INTO post (body, version) VALUES ('body', NULL)");
 
@@ -117,7 +120,7 @@ class ImportIdentityBackfillTest extends TestCase
         // A post table predating the version column has nothing to stamp, and
         // naming a missing column in an UPDATE is an error rather than a no-op.
         $this->insert('', '', null);
-        ensure_post_columns();
+        migrate_post_table();
 
         $this->assertSame([], $this->writesDuringEnsureColumns());
     }
@@ -127,7 +130,7 @@ class ImportIdentityBackfillTest extends TestCase
         $wp = $this->insert('wordpress', md5('wordpress-https://old.example/?p=1'), null);
         $known = $this->insert('known', md5('known-https://old.example/view/a'), null);
 
-        ensure_post_columns();
+        migrate_post_table();
 
         foreach ([$wp => 'wordpress-https://old.example/?p=1', $known => 'known-https://old.example/view/a'] as $id => $seed) {
             $row = $this->row($id);
@@ -141,7 +144,7 @@ class ImportIdentityBackfillTest extends TestCase
     {
         $id = $this->insert('wordpress', md5('wordpressitem-1'), 'https://feed.example/item-1');
 
-        ensure_post_columns();
+        migrate_post_table();
 
         $row = $this->row($id);
         $this->assertSame('wordpress', $row['feed_name']);
@@ -153,9 +156,9 @@ class ImportIdentityBackfillTest extends TestCase
     {
         $id = $this->insert('wordpress', md5('wordpress-https://old.example/?p=1'), null);
 
-        ensure_post_columns();
+        migrate_post_table();
         $first = $this->row($id);
-        ensure_post_columns();
+        migrate_post_table();
 
         $this->assertSame($first, $this->row($id));
     }
@@ -170,7 +173,7 @@ class ImportIdentityBackfillTest extends TestCase
         );
         $legacy = $this->insert('wordpress', $uuid, null);
 
-        ensure_post_columns();
+        migrate_post_table();
 
         $row = $this->row($legacy);
         $this->assertNull($row['import_uuid']);
@@ -182,7 +185,7 @@ class ImportIdentityBackfillTest extends TestCase
     {
         R::exec('DROP TABLE post');
 
-        ensure_post_columns();
+        migrate_post_table();
 
         $this->assertNull(R::getCell("SELECT name FROM sqlite_master WHERE type='table' AND name='post'"));
     }

--- a/tests/Unit/LambRestoreTest.php
+++ b/tests/Unit/LambRestoreTest.php
@@ -8,7 +8,8 @@ use RuntimeException;
 use Symfony\Component\Process\Process;
 use ZipArchive;
 
-use function Lamb\Bootstrap\ensure_post_columns;
+use function Lamb\Bootstrap\ensure_schema;
+use function Lamb\Bootstrap\migrate_post_table;
 use function Lamb\Export\build_export_archive;
 use function Lamb\Import\run_import;
 use function Lamb\Restore\apply_manifest_state;
@@ -132,12 +133,14 @@ class LambRestoreTest extends TestCase
         return array_column(R::getAll('PRAGMA table_info(post)'), 'name');
     }
 
-    public function testEnsurePostColumnsAddsTheImportUuidColumn(): void
+    public function testEnsureSchemaAddsTheImportUuidColumn(): void
     {
         R::exec('CREATE TABLE post (id INTEGER PRIMARY KEY AUTOINCREMENT, body TEXT)');
         $this->assertNotContains('import_uuid', $this->postColumns());
 
-        ensure_post_columns();
+        // migrate_post_table() used to ALTER this column in itself; adding every
+        // declared column to an existing table is ensure_schema()'s job now.
+        ensure_schema();
 
         $this->assertContains('import_uuid', $this->postColumns());
     }

--- a/tests/Unit/PostDraftVisibilityTest.php
+++ b/tests/Unit/PostDraftVisibilityTest.php
@@ -21,7 +21,8 @@ class PostDraftVisibilityTest extends TestCase
         // — which filters on `deleted` — resolves against a real column instead
         // of silently matching nothing in an isolated in-memory schema.
         R::store(R::dispense('post'));
-        \Lamb\Bootstrap\ensure_post_columns();
+        \Lamb\Bootstrap\ensure_schema();
+        \Lamb\Bootstrap\migrate_post_table();
         R::exec('DELETE FROM post');
     }
 

--- a/tests/Unit/PostIndexesTest.php
+++ b/tests/Unit/PostIndexesTest.php
@@ -5,12 +5,12 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
-use function Lamb\Bootstrap\ensure_post_columns;
+use function Lamb\Bootstrap\migrate_post_table;
 
 use const Lamb\Bootstrap\POST_INDEXES;
 
 /**
- * Covers the index creation in ensure_post_columns().
+ * Covers the index creation in migrate_post_table().
  *
  * RedBeanPHP's fluid mode creates columns but never indexes, so the lookups
  * every request runs — the slug the router resolves the path against, the
@@ -53,7 +53,7 @@ class PostIndexesTest extends TestCase
     }
 
     /**
-     * The DDL a call to ensure_post_columns() issues.
+     * The DDL a call to migrate_post_table() issues.
      *
      * @return list<string>
      */
@@ -61,7 +61,7 @@ class PostIndexesTest extends TestCase
     {
         R::debug(true, \RedBeanPHP\Logger\RDefault::C_LOGGER_ARRAY);
         try {
-            ensure_post_columns();
+            migrate_post_table();
             $logs = R::getDatabaseAdapter()->getDatabase()->getLogger()->getLogs();
         } finally {
             R::debug(false);
@@ -80,7 +80,7 @@ class PostIndexesTest extends TestCase
             'draft INTEGER', 'deleted INTEGER',
         ]);
 
-        ensure_post_columns();
+        migrate_post_table();
 
         $expected = array_keys(POST_INDEXES);
         sort($expected);
@@ -89,24 +89,26 @@ class PostIndexesTest extends TestCase
 
     public function testAColumnTheInstallDoesNotHaveIsSkipped(): void
     {
-        // A post table that predates the version column and has never ingested
-        // a feed: fluid mode adds those columns on the first write that needs
-        // them, and the next boot indexes them.
+        // A post table carrying only two of the indexed columns. Under
+        // bootstrap_db() this cannot happen — ensure_schema() runs first and
+        // declares them all — but ensure_post_indexes() must still skip a column
+        // that is absent, because naming it in a CREATE INDEX is an error rather
+        // than a no-op.
         $this->createPostTable(['slug TEXT', 'updated TEXT']);
 
-        ensure_post_columns();
+        migrate_post_table();
 
-        $this->assertSame(['idx_post_deleted', 'idx_post_draft', 'idx_post_slug', 'idx_post_updated'], $this->postIndexes());
+        $this->assertSame(['idx_post_slug', 'idx_post_updated'], $this->postIndexes());
     }
 
     public function testAColumnAddedLaterIsIndexedOnTheNextCall(): void
     {
         $this->createPostTable(['slug TEXT', 'updated TEXT']);
-        ensure_post_columns();
+        migrate_post_table();
         $this->assertNotContains('idx_post_version', $this->postIndexes());
 
         R::exec('ALTER TABLE post ADD COLUMN version INTEGER');
-        ensure_post_columns();
+        migrate_post_table();
 
         $this->assertContains('idx_post_version', $this->postIndexes());
     }
@@ -117,14 +119,14 @@ class PostIndexesTest extends TestCase
             'slug TEXT', 'updated TEXT', 'version INTEGER', 'feed_name TEXT',
             'draft INTEGER', 'deleted INTEGER', 'import_uuid TEXT',
         ]);
-        ensure_post_columns();
+        migrate_post_table();
 
         $this->assertSame([], $this->ddlDuringEnsureColumns());
     }
 
     public function testNothingIsCreatedWhenThePostTableDoesNotExist(): void
     {
-        ensure_post_columns();
+        migrate_post_table();
 
         $this->assertSame([], $this->postIndexes());
     }

--- a/tests/Unit/ResponseHandlersTest.php
+++ b/tests/Unit/ResponseHandlersTest.php
@@ -5,7 +5,8 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use RedBeanPHP\R;
 
-use function Lamb\Bootstrap\ensure_post_columns;
+use function Lamb\Bootstrap\ensure_schema;
+use function Lamb\Bootstrap\migrate_post_table;
 use function Lamb\Response\count_drafts;
 use function Lamb\Response\count_trash;
 use function Lamb\Response\listing_data;
@@ -591,8 +592,10 @@ class ResponseHandlersTest extends TestCase
         // Simulate a production DB that predates soft-delete: drop the column.
         R::exec('ALTER TABLE post DROP COLUMN deleted');
 
-        // ensure_post_columns() mirrors what bootstrap_db() does before any request.
-        ensure_post_columns();
+        // Mirror what bootstrap_db() does before any request: ensure_schema()
+        // puts the column back, then the row migrations run.
+        ensure_schema();
+        migrate_post_table();
 
         $post = R::dispense('post');
         $post->body    = 'Old post before soft-delete feature';


### PR DESCRIPTION
Closes #818. No breaking changes, no behaviour change.

## Why

`bootstrap_db()` calls `ensure_schema()` and then `ensure_post_columns()`. `ensure_schema()` ALTER-adds every column declared in `SCHEMA` — `deleted`, `draft` and `import_uuid` among them — so by the time `ensure_post_columns()` read `PRAGMA table_info(post)`, all three were present and its three `if (!in_array(…))` branches could not fire.

This is **not** old cruft. At `refs/tags/0.14.0`, `bootstrap_db()` is just `R::setup(...)`, `R::useWriterCache(true)`, `ensure_post_columns()` — no `ensure_schema()`, no `SCHEMA`, no `freeze(true)`, no WAL. Those ALTERs were the thing that upgraded an existing install in the last release. They died when `ensure_schema()` was inserted ahead of them, which is unreleased work.

## What changed

With the ALTERs gone the function ensures no column, so it is renamed **`ensure_post_columns()` → `migrate_post_table()`**: read the columns, run the two row backfills, index the table. Also removed:

- the `$postTableExists` probe — `ensure_schema()`'s `CREATE TABLE IF NOT EXISTS` has already run;
- `array_merge($columns, ['deleted', 'draft', 'import_uuid'])` before the index pass — `$columns` already holds them, so this only duplicated entries.

Two `@param` docs still said "column names as they were before the ALTERs above"; corrected.

## Tests

Several fixtures called `ensure_post_columns()` against a hand-built `post` table and leaned on those ALTERs, never calling `ensure_schema()`. That was a fixture gap rather than evidence the ALTERs were needed — `bootstrap_db()` is the only production caller and always runs `ensure_schema()` first. They now mirror the real boot sequence:

| Test | Change |
|---|---|
| `LambRestoreTest` | The `import_uuid` case was testing behaviour that moved, so it now tests `ensure_schema()` and is renamed to match |
| `ResponseHandlersTest`, `PostDraftVisibilityTest` | Call `ensure_schema()` before the migrations, as `bootstrap_db()` does |
| `ImportIdentityBackfillTest` | Fixture declares `import_uuid`, which the migration's own probe and UPDATE both name |
| `PostIndexesTest` | The skipped-column case expected `idx_post_deleted` / `idx_post_draft` only because the ALTERs created those columns for it. Its stated intent is that an *absent* column is skipped, so the expectation now says that |

## Verification

- `composer lint` — clean
- `composer analyse` — no errors
- `vendor/bin/codecept run Unit` — 2209 tests, 4064 assertions, green

Booted a genuinely old schema (a `post` table with no `deleted`/`draft`/`import_uuid`, one `version IS NULL` row, one `feed_name='wordpress'` row) before and after. Identical results:

```
version NULL rows left: 0
wordpress row after backfill: {"feed_name":null,"feeditem_uuid":null,"import_uuid":"uuid-1"}
indexes: idx_post_slug,idx_post_updated,idx_post_version,idx_post_feed_name,idx_post_draft,idx_post_deleted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsGk7c6JTurboxUXPRiZbf

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsGk7c6JTurboxUXPRiZbf)_