### PR TITLE
Normalise composer.json indentation and key order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,113 +1,113 @@
 {
-  "name": "svandragt/lamb",
-  "description": "Micro blogging like an animal",
-  "license": "GPL-3.0-or-later",
-  "type": "project",
-  "authors": [
-    {
-      "name": "Sander van Dragt",
-      "email": "sander@vandragt.com"
-    }
-  ],
-  "require": {
-    "php": ">=8.4",
-    "ext-curl": "*",
-    "ext-gettext": "*",
-    "ext-mbstring": "*",
-    "ext-pdo_mysql": "*",
-    "ext-pdo_sqlite": "*",
-    "ext-simplexml": "*",
-    "erusev/parsedown": "^1.7",
-    "gabordemooij/redbean": "^5.7",
-    "league/html-to-markdown": "^5.1",
-    "simplepie/simplepie": "^1.8",
-    "symfony/yaml": "^7.0",
-    "taproot/micropub-adapter": "^0.1.3",
-    "phiki/phiki": "^2.2"
-  },
-  "require-dev": {
-    "codeception/codeception": "^5.1",
-    "codeception/module-asserts": "*",
-    "codeception/module-phpbrowser": "*",
-    "phpcompatibility/php-compatibility": "^9.3",
-    "squizlabs/php_codesniffer": "^3.10",
-    "vlucas/phpdotenv": "^5.6",
-    "symfony/process": "^7.4",
-    "phpstan/phpstan": "^2.0",
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Lamb\\": "src/"
-    },
-    "files": [
-      "src/constants.php",
-      "src/bootstrap.php",
-      "src/config.php",
-      "src/export.php",
-      "src/highlight.php",
-      "src/http.php",
-      "src/import.php",
-      "src/known.php",
-      "src/lamb.php",
-      "src/routes.php",
-      "src/network.php",
-      "src/network/status.php",
-      "src/network/sources.php",
-      "src/network/ingest.php",
-      "src/network/json_feed.php",
-      "src/post.php",
-      "src/restore.php",
-      "src/response.php",
-      "src/response/auth.php",
-      "src/response/discovery.php",
-      "src/response/export.php",
-      "src/response/feeds.php",
-      "src/response/posts.php",
-      "src/response/upload.php",
-      "src/security.php",
-      "src/theme.php",
-      "src/theme/assets.php",
-      "src/theme/formatting.php",
-      "src/theme/meta.php",
-      "src/micropub.php",
-      "src/webmention.php",
-      "src/websub.php",
-      "src/wordpress.php"
-    ]
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Tests\\": "tests/"
-    }
-  },
-  "config": {
-    "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
-    },
-    "audit": {
-      "abandoned": "report"
-    }
-  },
-  "scripts": {
-    "lint": "vendor/bin/phpcs .",
-    "fix": "vendor/bin/phpcbf .",
-    "analyse": "vendor/bin/phpstan analyse --memory-limit=256M",
-    "serve": [
-      "Composer\\Config::disableProcessTimeout",
-      "php -S 0.0.0.0:8747 -t src"
+    "name": "svandragt/lamb",
+    "description": "Micro blogging like an animal",
+    "license": "GPL-3.0-or-later",
+    "type": "project",
+    "authors": [
+        {
+            "name": "Sander van Dragt",
+            "email": "sander@vandragt.com"
+        }
     ],
-    "serve:frankenphp": "sudo -E frankenphp run",
-    "serve:nginx": "sudo systemctl nginx start",
-    "test": "vendor/bin/codecept run",
-    "coverage": [
-      "vendor/bin/codecept run Unit --coverage-xml",
-      "php check-coverage.php tests/_output/coverage.xml 70"
-    ],
-    "e2e": "pnpm exec playwright test",
-    "docs": [
-      "Composer\\Config::disableProcessTimeout",
-      "docker run --rm -v \"$PWD/docs:/site\" -v \"$PWD/.jekyll-bundle:/usr/local/bundle\" -p 4000:4000 bretfisher/jekyll-serve"
-    ]
-  }
+    "require": {
+        "php": ">=8.4",
+        "ext-curl": "*",
+        "ext-gettext": "*",
+        "ext-mbstring": "*",
+        "ext-pdo_mysql": "*",
+        "ext-pdo_sqlite": "*",
+        "ext-simplexml": "*",
+        "erusev/parsedown": "^1.7",
+        "gabordemooij/redbean": "^5.7",
+        "league/html-to-markdown": "^5.1",
+        "phiki/phiki": "^2.2",
+        "simplepie/simplepie": "^1.8",
+        "symfony/yaml": "^7.0",
+        "taproot/micropub-adapter": "^0.1.3"
+    },
+    "require-dev": {
+        "codeception/codeception": "^5.1",
+        "codeception/module-asserts": "*",
+        "codeception/module-phpbrowser": "*",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "phpcompatibility/php-compatibility": "^9.3",
+        "phpstan/phpstan": "^2.0",
+        "squizlabs/php_codesniffer": "^3.10",
+        "symfony/process": "^7.4",
+        "vlucas/phpdotenv": "^5.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "Lamb\\": "src/"
+        },
+        "files": [
+            "src/constants.php",
+            "src/bootstrap.php",
+            "src/config.php",
+            "src/export.php",
+            "src/highlight.php",
+            "src/http.php",
+            "src/import.php",
+            "src/known.php",
+            "src/lamb.php",
+            "src/routes.php",
+            "src/network.php",
+            "src/network/status.php",
+            "src/network/sources.php",
+            "src/network/ingest.php",
+            "src/network/json_feed.php",
+            "src/post.php",
+            "src/restore.php",
+            "src/response.php",
+            "src/response/auth.php",
+            "src/response/discovery.php",
+            "src/response/export.php",
+            "src/response/feeds.php",
+            "src/response/posts.php",
+            "src/response/upload.php",
+            "src/security.php",
+            "src/theme.php",
+            "src/theme/assets.php",
+            "src/theme/formatting.php",
+            "src/theme/meta.php",
+            "src/micropub.php",
+            "src/webmention.php",
+            "src/websub.php",
+            "src/wordpress.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "abandoned": "report"
+        }
+    },
+    "scripts": {
+        "lint": "vendor/bin/phpcs .",
+        "fix": "vendor/bin/phpcbf .",
+        "analyse": "vendor/bin/phpstan analyse --memory-limit=256M",
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "php -S 0.0.0.0:8747 -t src"
+        ],
+        "serve:frankenphp": "sudo -E frankenphp run",
+        "serve:nginx": "sudo systemctl nginx start",
+        "test": "vendor/bin/codecept run",
+        "coverage": [
+            "vendor/bin/codecept run Unit --coverage-xml",
+            "php check-coverage.php tests/_output/coverage.xml 70"
+        ],
+        "e2e": "pnpm exec playwright test",
+        "docs": [
+            "Composer\\Config::disableProcessTimeout",
+            "docker run --rm -v \"$PWD/docs:/site\" -v \"$PWD/.jekyll-bundle:/usr/local/bundle\" -p 4000:4000 bretfisher/jekyll-serve"
+        ]
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8b6b37376e818de6e60ab31181060e2",
+    "content-hash": "fdb759e88d10c2a29643faf3066f09fb",
     "packages": [
         {
             "name": "erusev/parsedown",


### PR DESCRIPTION
Two-space indent throughout and alphabetical keys in `require` / `require-dev`, as `composer require` writes them. No dependency changes.