### PR TITLE
Pin the jekyll-serve image to the last Ruby 3 build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
         "e2e": "pnpm exec playwright test",
         "docs": [
             "Composer\\Config::disableProcessTimeout",
-            "docker run --rm -v \"$PWD/docs:/site\" -v \"$PWD/.jekyll-bundle:/usr/local/bundle\" -p 4000:4000 bretfisher/jekyll-serve"
+            "docker run --rm -v \"$PWD/docs:/site\" -v \"$PWD/.jekyll-bundle:/usr/local/bundle\" -p 4000:4000 bretfisher/jekyll-serve:stable-20260315-2119a31"
         ]
     }
 }


### PR DESCRIPTION
`docker run bretfisher/jekyll-serve` (via `composer docs` / `viv run docs`) fails since the `latest` tag moved to Ruby 4.0: `csv` is no longer a default gem and Jekyll 3.9, which github-pages pins, requires it bare.

Pin the image to `stable-20260315-2119a31`, the last Ruby 3 build, so local docs builds keep matching GitHub Pages.

If you ran the broken image already, clear the stale cache once before retrying:

```sh
rm -rf .jekyll-bundle docs/Gemfile.lock
```

Tested: docs serve on http://localhost:4000/lamb/ with HTTP 200.
