### PR TITLE
Turn the 404 page's search suggestion into words

### DIFF
--- a/src/themes/base/parts/404.php
+++ b/src/themes/base/parts/404.php
@@ -6,8 +6,10 @@ use function Lamb\Theme\page_title;
 
 global $data;
 
-// Request-controlled, so escaped at both output sites below.
+// Request-controlled, so escaped at both output sites below. Search ANDs
+// space-separated words, so a path's slashes and hyphens become spaces.
 $requested = (string) ($data['requested'] ?? '');
+$terms     = trim((string) preg_replace('/[^\p{L}\p{N}]+/u', ' ', $requested));
 ?>
 <?= page_title() ?>
 
@@ -15,6 +17,6 @@ $requested = (string) ($data['requested'] ?? '');
     <?= page_intro() ?>
 </section>
 
-<?php if ($requested !== '') : ?>
-<p>Why not try <a href="/search/<?= escape(rawurlencode($requested)) ?>">searching for <?= escape($requested) ?></a></p>
+<?php if ($terms !== '') : ?>
+<p>Why not try <a href="/search/<?= escape(rawurlencode($terms)) ?>">searching for <?= escape($terms) ?></a></p>
 <?php endif; ?>

--- a/tests/Unit/Theme404PartTest.php
+++ b/tests/Unit/Theme404PartTest.php
@@ -50,8 +50,24 @@ class Theme404PartTest extends TestCase
     {
         $html = $this->render('missing-post');
 
-        $this->assertStringContainsString('/search/missing-post', $html);
-        $this->assertStringContainsString('searching for missing-post', $html);
+        $this->assertStringContainsString('/search/missing%20post', $html);
+        $this->assertStringContainsString('searching for missing post', $html);
+    }
+
+    public function testTurnsPathSeparatorsIntoSearchWords(): void
+    {
+        $html = $this->render('technology/truly-muting-gmail-conversations');
+
+        $this->assertStringContainsString(
+            '/search/technology%20truly%20muting%20gmail%20conversations',
+            $html
+        );
+        $this->assertStringNotContainsString('%2F', $html);
+    }
+
+    public function testOmitsTheSuggestionWhenThePathHasNoWords(): void
+    {
+        $this->assertStringNotContainsString('/search/', $this->render('/-_/'));
     }
 
     public function testDoesNotSuggestSearchingForTheLiteral404(): void
@@ -71,7 +87,7 @@ class Theme404PartTest extends TestCase
         $html = $this->render('"><script>alert(1)</script>');
 
         $this->assertStringNotContainsString('<script>', $html);
-        $this->assertStringContainsString('&lt;script&gt;', $html);
+        $this->assertStringContainsString('searching for script alert 1 script', $html);
     }
 
     public function testRendersTheHumanTitleRatherThanAStatusLine(): void


### PR DESCRIPTION
A request for a redirected-but-missing path such as `/technology/truly-muting-gmail-conversations` produced a 404 whose search link was `/search/technology%2Ftruly-muting-gmail-conversations`. Search treats the whole segment as one word, so it found nothing, while `/search/technology%20truly-muting-gmail-conversations` finds the post.

The 404 part now replaces every run of non-alphanumeric characters with a space before building the link and the link text, and omits the suggestion when no words remain. Search ANDs the words, so slashes and hyphens both become word boundaries.

Tests: two new cases in `Theme404PartTest`, the escape case updated since angle brackets no longer survive to output. Full codecept, phpcs and phpstan pass.
