### PR TITLE
Read the acceptance database through a copy, not the live file

### DIFF
--- a/tests/Support/Helper/Acceptance.php
+++ b/tests/Support/Helper/Acceptance.php
@@ -16,8 +16,14 @@ use Codeception\TestInterface;
  * search expecting "No results found.") and cause spurious failures on re-runs.
  *
  * Deleting the database before each test gives every test a clean slate. The
- * server recreates the schema on the next request (RedBeanPHP fluid mode), and
- * the deletion happens while no request is in flight, so it is safe.
+ * server recreates the schema on the next request (ensure_schema()), and the
+ * deletion happens while no request is in flight, so it is safe.
+ *
+ * Never open the live file from here. The server may run as another user
+ * (www-data in the release image and under php-fpm) and the database is in WAL
+ * mode, so a connection from this process creates lamb.db-wal/-shm owned by the
+ * test runner. The server can then no longer write them and every request
+ * fails with "attempt to write a readonly database". Reads go through a copy.
  */
 class Acceptance extends Module
 {
@@ -42,7 +48,29 @@ class Acceptance extends Module
         $db = dirname(__DIR__) . '/Data/lamb.db';
         $this->assertFileExists($db, 'Expected the acceptance database to exist');
 
-        $pdo = new \PDO('sqlite:' . $db, null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+        // The server closes its connection at the end of each request, which
+        // checkpoints the WAL into the main file, so the copy is complete.
+        $copy = tempnam(sys_get_temp_dir(), 'lamb-acceptance-');
+        $this->assertTrue(copy($db, $copy), 'Expected to copy the acceptance database');
+        try {
+            $pdo = new \PDO('sqlite:' . $copy, null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+            return $this->fetchPostColumn($pdo, $id, $column);
+        } finally {
+            $pdo = null;
+            @unlink($copy);
+        }
+    }
+
+    /**
+     * Fetches one column of a post row over an open connection.
+     *
+     * @param \PDO   $pdo    Connection to a copy of the acceptance database.
+     * @param int    $id     Post id.
+     * @param string $column Column name, test-supplied.
+     * @return mixed The column value, or false when the row is missing.
+     */
+    private function fetchPostColumn(\PDO $pdo, int $id, string $column): mixed
+    {
         // The column name is test-supplied, never request data; quote it so a
         // reserved word still parses.
         $stmt = $pdo->prepare('SELECT "' . str_replace('"', '', $column) . '" FROM post WHERE id = ?');


### PR DESCRIPTION
Unblocks #830 (Release 0.15.0-rc1): both `release-verify` jobs failed with 57 of 96 acceptance tests, and the container logged `SQLSTATE[HY000]: General error: 8 attempt to write a readonly database` from `ensure_schema()` on every request after `EditPostCest`.

## Cause

`Tests\Support\Helper\Acceptance::grabPostColumn()` opened `lamb.db` directly from the test runner. Since #780 the database runs in WAL mode, so that read-only connection creates `lamb.db-wal` and `lamb.db-shm` owned by the runner's uid with the database's 0644 mode, and can't remove them on close. The server runs as www-data in the release image and under php-fpm, can't write the sidecars, and fails at boot from then on. The built-in-server run in `ci` is unaffected because server and runner share a uid.

Reproduced locally against the release image: with the old helper, 57/96 fail, sidecars appear owned by uid 1000, and the site stays 500 even after deleting `lamb.db`. With this change, 96/96 pass and no sidecars appear.

## Fix

Copy the database to a temp file and query the copy. The server closes its connection at the end of each request, which checkpoints the WAL into the main file, so the copy is complete.

The same hazard applies to real installs that run `bin/lamb` as a different user from the web server; that is #831.

Tests: `codecept run Acceptance` locally 96/96; phpcs and phpstan clean.
